### PR TITLE
fix(next/config): add snapshot avatar cdn

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -12,6 +12,7 @@ module.exports = nextTranslate({
       'b507f59d2508ebfb5e70996008095782.ipfscdn.io',
       'r2.comfy.icu',
       'cdn.discordapp.com',
+      'cdn.stamp.fyi'
     ],
   },
   async redirects() {


### PR DESCRIPTION
Lost cdn.stamp.fyi in `next.config.js` somewhere

Add back in to fix these broken images

<img width="507" alt="image" src="https://github.com/user-attachments/assets/9c290d97-0421-4704-87e0-87c4044e8292">
