### PR TITLE
Remove ETH awarded amount from projects page header

### DIFF
--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -171,13 +171,7 @@ export default function ProjectProfile({
                 </div>
               </div>
             </div>
-            <div
-              id="project-stats-container"
-              className="flex items-center gap-2 "
-            >
-              <p>{`Awarded: ${totalBudget} ETH`}</p>
-              <Image src={'/coins/ETH.svg'} width={15} height={15} alt="ETH" />
-            </div>
+
           </div>
         </div>
       </Frame>


### PR DESCRIPTION
Removing the confusing 'ETH awarded amount' from the project page as discussed.