### PR TITLE
Add time weighted reward accounting to FeeHook

### DIFF
--- a/fee-hook/README.md
+++ b/fee-hook/README.md
@@ -8,6 +8,8 @@
 - After swaps, fees are automatically withdrawn once a threshold is hit.
 - If the pool is not on the destination chain, the fees are sent to the FeeHook contract on the destination chain using layerzero.
 - vMOONEY holders can claim their fees using the withdrawFees function.
+- Withdraw amounts are calculated using the time weighted average of each
+  holder's vMOONEY balance.
 
 ## Local Testing
 ```

--- a/fee-hook/src/FeeHook.sol
+++ b/fee-hook/src/FeeHook.sol
@@ -45,6 +45,10 @@ contract FeeHook is BaseHook, OApp, FunctionsClient{
     uint32 gasLimit = 300000;
     uint64 subscriptionId; // Chainlink subscription ID
     bytes32 donID; // DON ID for Chainlink Functions
+    mapping(address => uint256) public balanceTimeWeighted;
+    mapping(address => uint256) public lastBalanceUpdate;
+    uint256 public supplyTimeWeighted;
+    uint256 public lastSupplyUpdate;
     // Event to log responses
     event Withdraw(
         bytes32 indexed requestId,
@@ -106,6 +110,7 @@ contract FeeHook is BaseHook, OApp, FunctionsClient{
         vMooneyAddress = _vMooneyAddress;
         donID = _donID;
         subscriptionId = _subscriptionId;
+        lastSupplyUpdate = block.timestamp;
     }
 
     function getHookPermissions() public pure override returns (Hooks.Permissions memory) {
@@ -288,10 +293,21 @@ contract FeeHook is BaseHook, OApp, FunctionsClient{
         (uint256 totalSupply, uint256 userBalance) = abi.decode(response, (uint256, uint256));
         require(totalSupply > 0, "Total supply is zero");
         require(userBalance > 0, "User balance is zero");
-        uint256 userProportion = userBalance * 1e18 / totalSupply; // Multiply by 1e18 to preserve precision
-        uint256 allocated = (userProportion * totalReceived) / 1e18; // Divide by 1e18 to normalize
+        uint256 ts = block.timestamp;
         address withdrawAddress = requestIdToSender[requestId];
         require(withdrawAddress != address(0), "Unknown requestId");
+        // Update time weighted values
+        if (lastSupplyUpdate != 0) {
+            supplyTimeWeighted += totalSupply * (ts - lastSupplyUpdate);
+        }
+        lastSupplyUpdate = ts;
+        if (lastBalanceUpdate[withdrawAddress] != 0) {
+            balanceTimeWeighted[withdrawAddress] += userBalance * (ts - lastBalanceUpdate[withdrawAddress]);
+        }
+        lastBalanceUpdate[withdrawAddress] = ts;
+        require(supplyTimeWeighted > 0, "No supply history");
+        uint256 userProportion = (balanceTimeWeighted[withdrawAddress] * 1e18) / supplyTimeWeighted;
+        uint256 allocated = (userProportion * totalReceived) / 1e18;
         uint256 withdrawnByUser = totalWithdrawnPerUser[withdrawAddress];
         uint256 withdrawAmount = allocated - withdrawnByUser;
         require(withdrawAmount > 0, "Nothing to withdraw");


### PR DESCRIPTION
## Summary
- update FeeHook to track time weighted average vMOONEY balances
- adjust withdraw logic to use these values
- document the new behaviour in README

## Testing
- `forge test` *(fails: command not found)*
- `npm test` *(no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_6841e9dd90a8832381d97aee7b74d88e