### PR TITLE
Add weekly fee distribution workflow

### DIFF
--- a/.github/workflows/weekly-fee-distribution.yml
+++ b/.github/workflows/weekly-fee-distribution.yml
@@ -1,0 +1,38 @@
+name: Weekly Fee Distribution
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Run apply_patch.sh
+        run: |
+          chmod +x ./fee-hook/apply_patch.sh
+          ./fee-hook/apply_patch.sh
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Install npm dependencies
+        run: |
+          cd fee-hook && npm install --legacy-peer-deps
+      - name: Build contracts
+        run: |
+          cd fee-hook && forge build --sizes --via-ir --optimize --optimizer-runs 200
+      - name: Distribute fees
+        env:
+          PRIVATE_KEY: ${{ secrets.FEEHOOK_PRIVATE_KEY }}
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+        run: |
+          cd fee-hook
+          forge script script/DistributeFees.s.sol --rpc-url https://11155111.rpc.thirdweb.com/${{ secrets.THIRDWEB_CLIENT_ID }} --broadcast --via-ir -vvvv

--- a/fee-hook/script/DistributeFees.s.sol
+++ b/fee-hook/script/DistributeFees.s.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "../src/FeeHook.sol";
+import {Config} from "./base/Config.sol";
+
+/// @notice Script to distribute weekly fees to checked in users
+contract DistributeFees is Script, Config {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        address payable hookAddress = payable(FEE_HOOK_ADDRESSES[block.chainid]);
+        FeeHook feeHook = FeeHook(hookAddress);
+        feeHook.distributeFees();
+
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
## Summary
- add a Solidity script to call `distributeFees`
- schedule a weekly GitHub Action that runs the script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849ce866d78832398ddc06c77af13fc