### PR TITLE
Update weekly cron time

### DIFF
--- a/.github/workflows/weekly-fee-distribution.yml
+++ b/.github/workflows/weekly-fee-distribution.yml
@@ -2,7 +2,8 @@ name: Weekly Fee Distribution
 
 on:
   schedule:
-    - cron: '0 0 * * 0'
+    # Run at 1pm Pacific Time every Thursday (21:00 UTC)
+    - cron: '0 21 * * 4'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- set weekly fee distribution action to run at 1pm Pacific Time (21:00 UTC) on Thursdays

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b51885f208323af8641493eb71aaa