### PR TITLE
Update fee page for multi-chain support

### DIFF
--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -163,7 +163,10 @@ export const VMOONEY_FAUCET_ADDRESSES: Index = {
 }
 
 export const FEE_HOOK_ADDRESSES: Index = {
-    sepolia: sepoliaConfig.FeeHook,
+  sepolia: sepoliaConfig.FeeHook,
+  'arbitrum-sepolia': arbitrumSepoliaConfig.FeeHook,
+  arbitrum: arbitrumConfig.FeeHook,
+  base: baseConfig.FeeHook,
 }
 
 export const REVNET_ADDRESSES: Index = {


### PR DESCRIPTION
## Summary
- expand `FEE_HOOK_ADDRESSES` with arbitrum, base and arb-sepolia
- calculate liquidity rewards across multiple chains
- allow checking in and distributing fees for all chains when balances exist

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68505f7dce04832390918e70d92a9126