### PR TITLE
fix pretty links for citizens and teams

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -305,7 +305,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         await tagToNetworkSignup(citizenData.email)
 
         const citizenNFT = await waitForERC721(citizenContract, +mintedTokenId)
-        const citizenName = citizenNFT?.metadata.name as string
+        const citizenName = citizenData.name
         const citizenPrettyLink = generatePrettyLinkWithId(
           citizenName,
           mintedTokenId

--- a/ui/components/onboarding/CreateTeam.tsx
+++ b/ui/components/onboarding/CreateTeam.tsx
@@ -483,7 +483,7 @@ export default function CreateTeam({ selectedChain, setSelectedTier }: any) {
                             teamContract,
                             mintedTokenId
                           )
-                          const teamName = teamNFT?.metadata.name as string
+                          const teamName = teamData.name
                           const teamPrettyLink = generatePrettyLink(teamName)
                           setTimeout(async () => {
                             await sendDiscordMessage(


### PR DESCRIPTION
- Thirdweb doesn't resolve NFT metadata properly after a Citizen/Team NFT is issued. Don't read the name from the NFT metadata when routing after minting.