### PR TITLE
Add progress bar and confetti to fees page

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -88,6 +88,7 @@
     "react-infinite-scroll-component": "^6.1.0",
     "react-markdown": "^9.0.1",
     "react-paginate": "^8.2.0",
+    "canvas-confetti": "^1.6.0",
     "react-use": "^17.3.2",
     "recharts": "^2.15.1",
     "rehype-autolink-headings": "^7.1.0",


### PR DESCRIPTION
## Summary
- add canvas-confetti dependency
- show weekly progress bar using rc-progress
- fire space-themed confetti after successful check‑in

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68716312a4648323b516df42c244bdf8