### PR TITLE
Fix reward estimate

### DIFF
--- a/fee-hook/src/FeeHook.sol
+++ b/fee-hook/src/FeeHook.sol
@@ -186,13 +186,20 @@ contract FeeHook is BaseHook, Ownable {
         uint256 length = checkedIn.length;
 
         uint256 total;
+        bool isUserCheckedIn;
         for (uint256 i = 0; i < length; i++) {
-            total += IERC20(vMooneyAddress).balanceOf(checkedIn[i]);
+            address addr = checkedIn[i];
+            if (addr == user) isUserCheckedIn = true;
+            total += IERC20(vMooneyAddress).balanceOf(addr);
         }
 
-        uint256 fees = address(this).balance;
         uint256 bal = IERC20(vMooneyAddress).balanceOf(user);
+        if (!isUserCheckedIn) {
+            total += bal;
+        }
         if (total == 0 || bal == 0) return 0;
+
+        uint256 fees = address(this).balance;
         return (fees * bal) / total;
     }
 


### PR DESCRIPTION
## Summary
- prevent inflated reward prediction by adding the user's balance to the denominator when they're not checked in

## Testing
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e92a05f4c83239a807a40b983dc8c