### PR TITLE
Add uniswap v4 swap component

### DIFF
--- a/ui/components/mission/MissionTokenPoolBuy.tsx
+++ b/ui/components/mission/MissionTokenPoolBuy.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import { useV4Router } from '@/lib/uniswap/hooks/useV4Router'
+import { PrivyWeb3Button } from '../privy/PrivyWeb3Button'
+
+export default function MissionTokenPoolBuy({ tokenAddress }: { tokenAddress: string }) {
+  const [amount, setAmount] = useState('')
+  const { swap } = useV4Router(parseFloat(amount) || 0, tokenAddress)
+
+  return (
+    <div className="w-full max-w-md p-4 rounded-xl bg-black/20 border border-white/10">
+      <h3 className="text-white mb-2">Buy from Pool</h3>
+      <input
+        className="w-full p-2 mb-4 rounded bg-black text-white"
+        placeholder="Amount ETH"
+        value={amount}
+        onChange={(e) => setAmount(e.target.value)}
+      />
+      <PrivyWeb3Button
+        label="Swap"
+        className="w-full bg-blue-600 text-white py-2 rounded"
+        action={swap}
+        isDisabled={!amount || parseFloat(amount) <= 0}
+      />
+    </div>
+  )
+}

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -361,6 +361,26 @@ export const UNIVERSAL_ROUTER_ADDRESSES: Index = {
   'base-sepolia-testnet': '0x050E797f3625EC8785265e1d9BDd4799b97528A1',
 }
 
+export const UNISWAP_V4_ROUTER_ADDRESSES: Index = {
+  ethereum: '0x66a9893cC07D91D95644AEDD05D03f95e1dBA8Af',
+  arbitrum: '0xA51afAFe0263b40EdaEf0Df8781eA9aa03E381a3',
+  base: '0x6fF5693b99212Da76ad316178A184AB56D299b43',
+  polygon: '0x1095692A6237d83C6a72F3F5eFEdb9A670C49223',
+  sepolia: '0x3A9D48AB9751398BbFa63ad67599Bb04e4BdF98b',
+  'arbitrum-sepolia': '0xeFd1D4bD4cf1e86Da286BB4CB1B8BcED9C10BA47',
+}
+
+export const UNISWAP_V4_LP_FEE: { [key: string]: number } = {
+  ethereum: 10000,
+  arbitrum: 10000,
+  base: 10000,
+  polygon: 10000,
+  sepolia: 500000,
+  'arbitrum-sepolia': 500000,
+}
+
+export const UNISWAP_V4_TICK_SPACING = 100
+
 export const CITIZEN_CROSS_CHAIN_MINT_ADDRESSES: Index = {
   'arbitrum-sepolia': '0xF4f865fA947376f47C74ffD05dd59763c0824bAD',
   ethereum: '0xDc07FbCcF7Dd55014C8A2a605C671d01137B4937',

--- a/ui/lib/uniswap/hooks/useV4Router.tsx
+++ b/ui/lib/uniswap/hooks/useV4Router.tsx
@@ -1,0 +1,61 @@
+import { useWallets } from '@privy-io/react-auth'
+import { ethers } from 'ethers'
+import { useContext } from 'react'
+import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
+import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
+import client from '@/lib/thirdweb/client'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import PrivyWalletContext from '../../privy/privy-wallet-context'
+import {
+  UNISWAP_V4_ROUTER_ADDRESSES,
+  FEE_HOOK_ADDRESSES,
+  UNISWAP_V4_LP_FEE,
+  UNISWAP_V4_TICK_SPACING,
+  ZERO_ADDRESS,
+} from '../../../const/config'
+
+export function useV4Router(amountIn: number, tokenOut: string) {
+  const { selectedWallet } = useContext(PrivyWalletContext)
+  const { wallets } = useWallets()
+  const { selectedChain } = useContext(ChainContextV5)
+  const chainSlug = getChainSlug(selectedChain)
+
+  async function swap() {
+    const provider = ethers5Adapter.provider.toEthers({ client, chain: selectedChain })
+    const signer = provider.getSigner(wallets[selectedWallet]?.address)
+    const router = new ethers.Contract(
+      UNISWAP_V4_ROUTER_ADDRESSES[chainSlug],
+      ['function execute(bytes,bytes[],uint256) payable'],
+      signer
+    )
+
+    const amount = ethers.utils.parseEther(String(amountIn))
+
+    const poolKey = [
+      ZERO_ADDRESS,
+      tokenOut,
+      UNISWAP_V4_LP_FEE[chainSlug],
+      UNISWAP_V4_TICK_SPACING,
+      FEE_HOOK_ADDRESSES[chainSlug],
+    ]
+
+    const actions = ethers.utils.solidityPack(['uint8','uint8','uint8'], [12, 21, 23])
+
+    const params0 = ethers.utils.defaultAbiCoder.encode(
+      ['tuple(address,address,uint24,int24,address)', 'bool', 'uint128', 'uint256', 'bytes'],
+      [poolKey, true, amount, 0, '0x']
+    )
+    const params1 = ethers.utils.defaultAbiCoder.encode(['address', 'uint128'], [ZERO_ADDRESS, amount])
+    const params2 = ethers.utils.defaultAbiCoder.encode(['address', 'uint128'], [tokenOut, 0])
+
+    const inputs = [
+      ethers.utils.defaultAbiCoder.encode(['bytes', 'bytes[]'], [actions, [params0, params1, params2]]),
+    ]
+
+    const deadline = Math.floor(Date.now() / 1000) + 80
+
+    return router.execute('0x10', inputs, deadline, { value: amount })
+  }
+
+  return { swap }
+}

--- a/ui/pages/mission/[tokenId].tsx
+++ b/ui/pages/mission/[tokenId].tsx
@@ -73,6 +73,7 @@ import { Mission } from '@/components/mission/MissionCard'
 import MissionFundingProgressBar from '@/components/mission/MissionFundingProgressBar'
 import MissionInfo from '@/components/mission/MissionInfo'
 import MissionPayRedeem from '@/components/mission/MissionPayRedeem'
+import MissionTokenPoolBuy from '@/components/mission/MissionTokenPoolBuy'
 import MissionProfileHeader from '@/components/mission/MissionProfileHeader'
 import MissionStat from '@/components/mission/MissionStat'
 import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
@@ -542,6 +543,11 @@ export default function MissionProfile({
                     jbTokensContract={jbTokensContract}
                     refreshBackers={refreshBackers}
                   />
+                  {stage === 4 && token?.tokenAddress && (
+                    <div className="p-4">
+                      <MissionTokenPoolBuy tokenAddress={token.tokenAddress} />
+                    </div>
+                  )}
                 </div>
               ) : (
                 <div className="p-4 text-center">


### PR DESCRIPTION
## Summary
- expose uniswap v4 router addresses and fees in config
- add hook to perform v4 swaps
- new `MissionTokenPoolBuy` component for post‑mission token buys
- show the swap component after missions finish

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688411977448832385b0f3bb3c9bbe11