### PR TITLE
Add USD conversion to MissionTokenSwapV4

### DIFF
--- a/ui/components/uniswap/MissionTokenSwapV4.tsx
+++ b/ui/components/uniswap/MissionTokenSwapV4.tsx
@@ -1,14 +1,49 @@
 import { ArrowDownIcon } from '@heroicons/react/20/solid'
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import toast from 'react-hot-toast'
 import { useUniswapV4 } from '@/lib/uniswap/hooks/useUniswapV4'
 import { PrivyWeb3Button } from '../privy/PrivyWeb3Button'
+import useETHPrice from '@/lib/etherscan/useETHPrice'
 
 export default function MissionTokenSwapV4({ token }: { token: any }) {
+  const [usdInput, setUsdInput] = useState('')
   const [amountIn, setAmountIn] = useState('')
   const [amountOut, setAmountOut] = useState<string>()
   const { quote, swap } = useUniswapV4(token.tokenAddress, token.tokenDecimals)
+  const { data: ethUsdPrice } = useETHPrice(1, 'ETH_TO_USD')
+
+  const formatWithCommas = useCallback((value: string) => {
+    if (!value) return ''
+    const num = parseFloat(value)
+    if (isNaN(num)) return value
+    return num.toLocaleString('en-US')
+  }, [])
+
+  const formattedUsdInput = formatWithCommas(usdInput)
+
+  const calculateEthAmount = useCallback(() => {
+    if (!usdInput || !ethUsdPrice || isNaN(Number(usdInput))) return '0.0000'
+    const ethAmount = (Number(usdInput) / ethUsdPrice).toFixed(6)
+    return parseFloat(ethAmount).toLocaleString('en-US', {
+      minimumFractionDigits: 6,
+      maximumFractionDigits: 6,
+    })
+  }, [usdInput, ethUsdPrice])
+
+  const handleUsdInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const inputValue = e.target.value.replace(/[^0-9]/g, '')
+      if (inputValue.length > 7) return
+      setUsdInput(inputValue)
+      if (inputValue === '' || !ethUsdPrice) {
+        setAmountIn('')
+        return
+      }
+      setAmountIn((Number(inputValue) / ethUsdPrice).toFixed(6))
+    },
+    [ethUsdPrice]
+  )
 
   useEffect(() => {
     async function fetchQuote() {
@@ -31,23 +66,24 @@ export default function MissionTokenSwapV4({ token }: { token: any }) {
           <div className="flex justify-between items-start">
             <h3 className="text-sm opacity-60">You pay</h3>
           </div>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Image
-                src="/icons/eth.svg"
-                alt="ETH"
-                width={24}
-                height={24}
-                className="w-5 h-5"
+          <div className="flex justify-between sm:items-center flex-col sm:flex-row">
+            <div className="flex items-center gap-1">
+              <span className="text-xl font-bold">$</span>
+              <input
+                type="text"
+                className="bg-transparent border-none outline-none text-xl font-bold min-w-[1ch] w-auto [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                value={formattedUsdInput}
+                onChange={handleUsdInputChange}
+                placeholder="0"
+                maxLength={9}
+                style={{ width: `${Math.max(formattedUsdInput.length || 1, 1)}ch` }}
               />
-              <span className="text-xl font-bold">ETH</span>
+              <span className="text-xl font-bold">USD</span>
             </div>
-            <input
-              className="bg-transparent text-right flex-1 focus:outline-none text-xl font-bold"
-              placeholder="0.0"
-              value={amountIn}
-              onChange={(e) => setAmountIn(e.target.value)}
-            />
+            <div className="flex mt-2 sm:mt-0 gap-2 items-center sm:bg-[#111C42] rounded-full sm:px-3 py-1">
+              <Image src="/icons/eth.svg" alt="ETH" width={16} height={16} className="w-5 h-5 bg-light-cool rounded-full" />
+              <span className="text-base">{calculateEthAmount()} ETH</span>
+            </div>
           </div>
         </div>
         <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- update MissionTokenSwapV4 to accept USD input
- convert USD amount to ETH using `useETHPrice`
- display calculated ETH value beside the USD input

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a925757b883239fc8858dd641a099