### PR TITLE
Fix uniswap trade type mismatch

### DIFF
--- a/ui/lib/uniswap/hooks/useUniversalRouter.tsx
+++ b/ui/lib/uniswap/hooks/useUniversalRouter.tsx
@@ -7,6 +7,7 @@ import {
   SwapType,
 } from '@uniswap/smart-order-router'
 import { SwapRouter, UniswapTrade } from '@uniswap/universal-router-sdk-v2'
+import type { Trade as RouterTrade } from '@uniswap/router-sdk'
 import { ethers } from 'ethers'
 import { useContext } from 'react'
 import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
@@ -70,7 +71,7 @@ export function useUniversalRouter(
     }
 
     const params = SwapRouter.swapCallParameters(
-      new UniswapTrade(swapRoute.trade, options),
+      new UniswapTrade(swapRoute.trade as unknown as RouterTrade, options),
       options
     )
 


### PR DESCRIPTION
## Summary
- fix incompatible Trade types when building Universal Router parameters

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_688bfd864d4c83238bcd6fdc7696f97c