### PR TITLE
Team Creator V3 & Team Member Passthrough Module fix 

### DIFF
--- a/subscription-contracts/foundry.toml
+++ b/subscription-contracts/foundry.toml
@@ -12,6 +12,9 @@ fs_permissions = [
 bytecode_hash = "none"
 cbor_metadata = false
 always_use_create_2_factory = true
+optimizer = true
+optimizer_runs = 200
+via_ir = true
 
 
 [rpc_endpoints]

--- a/subscription-contracts/script/TeamAssignPassthrough.s.sol
+++ b/subscription-contracts/script/TeamAssignPassthrough.s.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import {MoonDAOTeam} from "../src/ERC5643.sol";
+import {IHats} from "@hats/Interfaces/IHats.sol";
+import {HatsModuleFactory} from "@hats-module/HatsModuleFactory.sol";
+import {PassthroughModule} from "../src/PassthroughModule.sol";
+import {deployModuleInstance} from "@hats-module/utils/DeployFunctions.sol";
+
+contract TeamAssignPassthroughScript is Script {
+    
+    address constant HATS_ADDRESS = 0x3bc1A0Ad72417f2d411118085256fC53CBdDd137;
+    address constant HATS_MODULE_FACTORY_ADDRESS = 0x0a3f85fa597B6a967271286aA0724811acDF5CD9;
+    address constant CORRECT_HATS_PASSTHROUGH_ADDRESS = 0x050079a8fbFCE76818C62481BA015b89567D2d35;
+    address constant TEAM_ADDRESS = 0xAB2C354eC32880C143e87418f80ACc06334Ff55F;
+    
+    IHats public hats;
+    HatsModuleFactory public hatsModuleFactory;
+    MoonDAOTeam public moonDAOTeam;
+    
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        
+        vm.startBroadcast(deployerPrivateKey);
+        
+        hats = IHats(HATS_ADDRESS);
+        hatsModuleFactory = HatsModuleFactory(HATS_MODULE_FACTORY_ADDRESS);
+        moonDAOTeam = MoonDAOTeam(TEAM_ADDRESS);
+        
+        // Array of token IDs that need fixing
+        uint256[] memory tokenIds = getTokenIdsToFix();
+        
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            fixPassthroughModule(tokenIds[i]);
+        }
+        
+        vm.stopBroadcast();
+    }
+    
+    function fixPassthroughModule(uint256 tokenId) internal {
+        console.log("Fixing passthrough module for token ID:", tokenId);
+        
+        // Get the current hat IDs for this team - split into separate calls
+        uint256 teamManagerHat = _getTeamManagerHat(tokenId);
+        uint256 teamMemberHat = _getTeamMemberHat(tokenId);
+        
+        console.log("Team Manager Hat:", teamManagerHat);
+        console.log("Team Member Hat:", teamMemberHat);
+        
+        // Deploy new passthrough module - separated into its own function
+        address newModuleAddress = _deployPassthroughModule(teamMemberHat, teamManagerHat);
+        
+        // Update hat eligibility and toggle - separated function calls
+        _updateHatModule(teamMemberHat, newModuleAddress);
+        
+        console.log("Token ID:", tokenId);
+        console.log("New passthrough module:", newModuleAddress);
+        console.log("--------------------------------");
+    }
+    
+    function _getTeamManagerHat(uint256 tokenId) private view returns (uint256) {
+        uint256 hat = moonDAOTeam.teamManagerHat(tokenId);
+        require(hat != 0, "Invalid manager hat");
+        return hat;
+    }
+    
+    function _getTeamMemberHat(uint256 tokenId) private view returns (uint256) {
+        uint256 hat = moonDAOTeam.teamMemberHat(tokenId);
+        require(hat != 0, "Invalid member hat");
+        return hat;
+    }
+    
+    function _deployPassthroughModule(uint256 memberHat, uint256 managerHat) private returns (address) {
+        PassthroughModule memberPassthroughModule = PassthroughModule(deployModuleInstance(hatsModuleFactory, CORRECT_HATS_PASSTHROUGH_ADDRESS, memberHat, abi.encodePacked(managerHat), "", 0));
+        return address(memberPassthroughModule);
+    }
+    
+    function _updateHatModule(uint256 memberHat, address moduleAddress) private {
+        hats.changeHatEligibility(memberHat, moduleAddress);
+        hats.changeHatToggle(memberHat, moduleAddress);
+    }
+    
+    function getTokenIdsToFix() internal pure returns (uint256[] memory) {
+        // Replace this array with the actual token IDs that need fixing
+        uint256[] memory tokenIds = new uint256[](5);
+        
+        tokenIds[0] = 15;
+        tokenIds[1] = 16; 
+        tokenIds[2] = 17;
+        tokenIds[3] = 18;
+        tokenIds[4] = 19;
+        
+        return tokenIds;
+    }
+}

--- a/subscription-contracts/script/TeamCreatorSepolia.s.sol
+++ b/subscription-contracts/script/TeamCreatorSepolia.s.sol
@@ -18,17 +18,16 @@ import {MoonDAOTeamCreator} from "../src/MoonDAOTeamCreator.sol";
 import {IHats} from "@hats/Interfaces/IHats.sol";
 
 
-contract TeamCreatorScript is Script {
+contract TeamCreatorSepoliaScript is Script {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         address authorizedSignerAddress = vm.envAddress("AUTHORIZED_SIGNER_ADDRESS");
-        address daoSafeAddress = vm.envAddress("DAO_SAFE_ADDRESS");
 
         vm.startBroadcast(deployerPrivateKey);
 
-        address TEAM_ADDRESS = 0xAB2C354eC32880C143e87418f80ACc06334Ff55F;
-        address TEAM_TABLE_ADDRESS = 0x36A57e45A1F8e378AA3e35bD8799bBfB5b4C00b3;
-        address WHITELIST_ADDRESS = 0x203ca831edec28b7657A022b8aFe5d28b6BE6Eda;
+        address TEAM_ADDRESS = 0x21d2C4bEBd1AEb830277F8548Ae30F505551f961;
+        address TEAM_TABLE_ADDRESS = 0x6227dBa1e0AbBf6bdc5855327D2293012b91cfeB;
+        address WHITELIST_ADDRESS = 0xBB22b6bfb410e62BC103CA6cAcc342bEe42117aA;
         
         address HATS_ADDRESS = 0x3bc1A0Ad72417f2d411118085256fC53CBdDd137;
         address HATS_MODULE_FACTORY_ADDRESS = 0x0a3f85fa597B6a967271286aA0724811acDF5CD9;
@@ -37,16 +36,15 @@ contract TeamCreatorScript is Script {
         address GNOSIS_SAFE_PROXY_FACTORY_ADDRESS = 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2;
          
         IHats hats = IHats(HATS_ADDRESS);
-        uint256 moonDaoTeamAdminHatId = 0x0000002a00010000000000000000000000000000000000000000000000000000;
+        uint256 moonDaoTeamAdminHatId = 0x0000018200020000000000000000000000000000000000000000000000000000;
 
         address[] memory authorizedSigners = new address[](1);
-        authorizedSigners[0] = address(authorizedSignerAddress);   
-        
+        authorizedSigners[0] = address(authorizedSignerAddress);
+
         MoonDAOTeamCreator creator = new MoonDAOTeamCreator(HATS_ADDRESS, HATS_MODULE_FACTORY_ADDRESS, HATS_PASSTHROUGH_ADDRESS, TEAM_ADDRESS, GNOSIS_SINGLETON_ADDRESS, GNOSIS_SAFE_PROXY_FACTORY_ADDRESS, TEAM_TABLE_ADDRESS, WHITELIST_ADDRESS, authorizedSigners);
 
+        creator.setOpenAccess(true);
         creator.setMoonDaoTeamAdminHatId(moonDaoTeamAdminHatId);
-
-        creator.transferOwnership(daoSafeAddress);
 
         vm.stopBroadcast();
     }

--- a/ui/components/onboarding/CreateTeam.tsx
+++ b/ui/components/onboarding/CreateTeam.tsx
@@ -493,17 +493,26 @@ export default function CreateTeam({ selectedChain, setSelectedTier }: any) {
                           contract: teamCreatorContract,
                           method: 'createMoonDAOTeam' as string,
                           params: [
-                            'ipfs://' + adminHatMetadataIpfsHash,
-                            'ipfs://' + managerHatMetadataIpfsHash,
-                            'ipfs://' + memberHatMetadataIpfsHash,
-                            teamData.name,
-                            teamData.description,
-                            'ipfs://' + newImageIpfsHash,
-                            teamData.twitter,
-                            teamData.communications,
-                            teamData.website,
-                            teamData.view,
-                            teamData.formResponseId,
+                            // HatURIs struct
+                            {
+                              adminHatURI: 'ipfs://' + adminHatMetadataIpfsHash,
+                              managerHatURI:
+                                'ipfs://' + managerHatMetadataIpfsHash,
+                              memberHatURI:
+                                'ipfs://' + memberHatMetadataIpfsHash,
+                            },
+                            // TeamMetadata struct
+                            {
+                              name: teamData.name,
+                              bio: teamData.description,
+                              image: 'ipfs://' + newImageIpfsHash,
+                              twitter: teamData.twitter,
+                              communications: teamData.communications,
+                              website: teamData.website,
+                              _view: teamData.view,
+                              formId: teamData.formResponseId,
+                            },
+                            // members array
                             [],
                           ],
                           value: cost,

--- a/ui/const/abis/MoonDAOTeamCreator.json
+++ b/ui/const/abis/MoonDAOTeamCreator.json
@@ -24,7 +24,12 @@
         "type": "address"
       },
       { "internalType": "address", "name": "_table", "type": "address" },
-      { "internalType": "address", "name": "_whitelist", "type": "address" }
+      { "internalType": "address", "name": "_whitelist", "type": "address" },
+      {
+        "internalType": "address[]",
+        "name": "_authorizedSigners",
+        "type": "address[]"
+      }
     ],
     "stateMutability": "nonpayable",
     "type": "constructor"
@@ -70,21 +75,96 @@
     "type": "function"
   },
   {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "authorizedSigners",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
-      { "internalType": "string", "name": "adminHatURI", "type": "string" },
-      { "internalType": "string", "name": "managerHatURI", "type": "string" },
-      { "internalType": "string", "name": "memberHatURI", "type": "string" },
-      { "internalType": "string", "name": "name", "type": "string" },
-      { "internalType": "string", "name": "bio", "type": "string" },
-      { "internalType": "string", "name": "image", "type": "string" },
-      { "internalType": "string", "name": "twitter", "type": "string" },
-      { "internalType": "string", "name": "communications", "type": "string" },
-      { "internalType": "string", "name": "website", "type": "string" },
-      { "internalType": "string", "name": "_view", "type": "string" },
-      { "internalType": "string", "name": "formId", "type": "string" },
+      {
+        "components": [
+          { "internalType": "string", "name": "adminHatURI", "type": "string" },
+          {
+            "internalType": "string",
+            "name": "managerHatURI",
+            "type": "string"
+          },
+          { "internalType": "string", "name": "memberHatURI", "type": "string" }
+        ],
+        "internalType": "struct MoonDAOTeamCreator.HatURIs",
+        "name": "hatURIs",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          { "internalType": "string", "name": "name", "type": "string" },
+          { "internalType": "string", "name": "bio", "type": "string" },
+          { "internalType": "string", "name": "image", "type": "string" },
+          { "internalType": "string", "name": "twitter", "type": "string" },
+          {
+            "internalType": "string",
+            "name": "communications",
+            "type": "string"
+          },
+          { "internalType": "string", "name": "website", "type": "string" },
+          { "internalType": "string", "name": "_view", "type": "string" },
+          { "internalType": "string", "name": "formId", "type": "string" }
+        ],
+        "internalType": "struct MoonDAOTeamCreator.TeamMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      },
       { "internalType": "address[]", "name": "members", "type": "address[]" }
     ],
     "name": "createMoonDAOTeam",
+    "outputs": [
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "internalType": "uint256", "name": "childHatId", "type": "uint256" }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "creator", "type": "address" },
+      {
+        "components": [
+          { "internalType": "string", "name": "adminHatURI", "type": "string" },
+          {
+            "internalType": "string",
+            "name": "managerHatURI",
+            "type": "string"
+          },
+          { "internalType": "string", "name": "memberHatURI", "type": "string" }
+        ],
+        "internalType": "struct MoonDAOTeamCreator.HatURIs",
+        "name": "hatURIs",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          { "internalType": "string", "name": "name", "type": "string" },
+          { "internalType": "string", "name": "bio", "type": "string" },
+          { "internalType": "string", "name": "image", "type": "string" },
+          { "internalType": "string", "name": "twitter", "type": "string" },
+          {
+            "internalType": "string",
+            "name": "communications",
+            "type": "string"
+          },
+          { "internalType": "string", "name": "website", "type": "string" },
+          { "internalType": "string", "name": "_view", "type": "string" },
+          { "internalType": "string", "name": "formId", "type": "string" }
+        ],
+        "internalType": "struct MoonDAOTeamCreator.TeamMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      },
+      { "internalType": "address[]", "name": "members", "type": "address[]" }
+    ],
+    "name": "createMoonDAOTeamFor",
     "outputs": [
       { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
       { "internalType": "uint256", "name": "childHatId", "type": "uint256" }
@@ -109,6 +189,90 @@
   {
     "inputs": [],
     "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_authorizedSigner",
+        "type": "address"
+      },
+      { "internalType": "bool", "name": "_authorized", "type": "bool" }
+    ],
+    "name": "setAuthorizedSigner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_gnosisSafeProxyFactory",
+        "type": "address"
+      }
+    ],
+    "name": "setGnosisSafeProxyFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_gnosisSingleton",
+        "type": "address"
+      }
+    ],
+    "name": "setGnosisSingleton",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_hats", "type": "address" }
+    ],
+    "name": "setHats",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_hatsModuleFactory",
+        "type": "address"
+      }
+    ],
+    "name": "setHatsModuleFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_hatsPassthrough",
+        "type": "address"
+      }
+    ],
+    "name": "setHatsPassthrough",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_moonDAOTeam", "type": "address" }
+    ],
+    "name": "setMoonDAOTeam",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -225,9 +225,11 @@ export const TEAM_ADDRESSES: Index = {
 }
 
 export const TEAM_CREATOR_ADDRESSES: Index = {
-  arbitrum: '0x40C44A32e92358B3407629B1a69225b1858Bc5fe',
-  sepolia: '0x1eafC528435e49Af2b3E970A12Ab2Dddb929bAc1',
+  arbitrum: '0xb11017A04dB4503066Bfbb8acB6a71Fc26869C9d', //v3
+  sepolia: '0xbb33d877005aA1bF00F9216ec6bad66ff93eBE86', //v3
 }
+// team creator arb v2: 0x40C44A32e92358B3407629B1a69225b1858Bc5fe
+// team creator arb v1: 0x203f481336A212Eff43E84761792E307975Cf27b
 
 export const TEAM_TABLE_ADDRESSES: Index = {
   arbitrum: '0x36A57e45A1F8e378AA3e35bD8799bBfB5b4C00b3',

--- a/ui/const/teams.ts
+++ b/ui/const/teams.ts
@@ -1,0 +1,34 @@
+//New passthrough addresses for teams created with the v2 team creator
+export const TEAM_CREATOR_V2_PASSTHROUGH_MODULE_PATCHED_ADDRESSES: Record<
+  string,
+  Record<number, string>
+> = {
+  arbitrum: {
+    15: '0xe3f0bc3e9fc76c69ed4e2f22f7951ea2a4bea4a4',
+    16: '0xdee1c92c65d55fb996e6132d5130f53fb2c911ef',
+    17: '0x2c136b28a0bcf72d543a0cb0e67c67cf6a56dfbf',
+    18: '0x00cfa2c2f8edb042bd50c5fdc3c7a66124f87e4a',
+    19: '0x1319d8263fd6d76fcc5f9f740c92e3b076927eea',
+  },
+  sepolia: {
+    0: '0x01d17b30c0e0a1b4fde0820e40cc9b8c2168ef26',
+    1: '0x162ac8e0d52a8ce05aed9d6b01463835b0536bee',
+    2: '0xe7dd98dfde8aa4105d0ad56938f2b82f887aa5f7',
+    3: '0xeb6600149751d54f812f30dbf5a4498c7365da58',
+    4: '0x36402c9e2b53088eb0b9c76b07f581435d947011',
+    5: '0xb979c684d725bed03fe93e6452c5a0463424d7ae',
+    6: '0x35a2d805fad7c657ce25014538f4d0b7129100e5',
+    7: '0x0312d377fd99999fc1942e6a8beff2cdd2735796',
+    8: '0xdb415563be9f2603314a709349d75eac3c9abd56',
+    9: '0xf670cea960fccba9d00e3372ae030e23dd50671a',
+    10: '0x2167246641ecfc04467cb4babd07c8071531487d',
+    11: '0xb30295b434e7e143bf55a8e801269f96ffaa7c00',
+    12: '0xc31f917e3ff9638d422ee90bfb8c7d746441a2f0',
+    13: '0x09ce9f11e4da99a0253485ed14f59f64fcf2df7f',
+    14: '0x89ea0d675f4a99ff6dbe952b3242d588ec18598d',
+    15: '0x311ee64e5f7347ae95c800fcadb9a68cfe298955',
+    16: '0x54c600c6fb63e02a797fcfbe7ad96936cb362782',
+    17: '0x3b36dd9433b8c535977a31c6ad83f2fb1386e265',
+    18: '0x934fb95eb26ca52f2efedfb92ff0196a8c8e5240',
+  },
+}


### PR DESCRIPTION
- Team Creator V3: Allow authorized signers to create teams for other wallets (gasless/cross-chain), refactor params, add setters
- Fix team member hat passthrough module for teams deployed with team creator v2 so that managers can remove members