### PR TITLE
fix bug with cross chain pay

### DIFF
--- a/subscription-contracts/script/CrossChainPay.s.sol
+++ b/subscription-contracts/script/CrossChainPay.s.sol
@@ -9,19 +9,9 @@ contract CrossChainPayDeploy is Script, Config {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         address deployer = vm.addr(deployerPrivateKey);
         vm.startBroadcast(deployerPrivateKey);
-        // Use 0 for chain dependent stargate router address then set after to maintain
-        // deterministic deploys.
-        bytes memory constructorArgs = abi.encode(
-            deployer,
-            JB_V5_MULTI_TERMINAL,
-            address(0)
-        );
-        (address payAddress, bytes32 salt) =
-            Miner.find(CREATE2_DEPLOYER, 0xda0, type(CrossChainPay).creationCode, constructorArgs);
+        bytes32 salt = bytes32(abi.encode(0xda0)); // ~ H(4) A(a) T(7) S(5)
         CrossChainPay pay = new CrossChainPay{salt: salt}(deployer, JB_V5_MULTI_TERMINAL, address(0));
         pay.setStargateRouter(STARGATE_POOLS[block.chainid]);
-
-        require(address(pay) == payAddress, "Fee hook address mismatch");
 
         // For testing, call crossChainPay with a small amount
         if (block.chainid == OPT_SEP){

--- a/subscription-contracts/src/CrossChainPay.sol
+++ b/subscription-contracts/src/CrossChainPay.sol
@@ -108,7 +108,7 @@ contract CrossChainPay is ILayerZeroComposer, Ownable {
             _metadata
         );
         bytes memory extraOptions = composeMsg.length > 0
-            ? OptionsBuilder.newOptions().addExecutorLzComposeOption(0, 800_000, uint128(_amount * 998 / 1_000)) // compose gas limit
+            ? OptionsBuilder.newOptions().addExecutorLzComposeOption(0, 800_000, 0) // compose gas limit
             : bytes("");
         IStargate.SendParam memory sendParam = IStargate.SendParam({
             dstEid: _dstEid,
@@ -150,7 +150,7 @@ contract CrossChainPay is ILayerZeroComposer, Ownable {
         );
 
         bytes memory extraOptions = composeMsg.length > 0
-            ? OptionsBuilder.newOptions().addExecutorLzComposeOption(0, 800_000, uint128(_amount * 998 / 1_000)) // compose gas limit
+            ? OptionsBuilder.newOptions().addExecutorLzComposeOption(0, 800_000, 0) // compose gas limit
             : bytes("");
         IStargate.SendParam memory sendParam = IStargate.SendParam({
             dstEid: _dstEid,
@@ -181,8 +181,8 @@ contract CrossChainPay is ILayerZeroComposer, Ownable {
             string memory memo,
             bytes memory metadata
         ) = abi.decode(_composeMessage, (uint256, address, uint256, string, bytes));
-
-        uint256 tokenCount = jbMultiTerminal.pay{value: msg.value}(
+        uint contractBalance = address(this).balance;
+        uint256 tokenCount = jbMultiTerminal.pay{value: contractBalance}(
             projectId,
             JBConstants.NATIVE_TOKEN,
             0,
@@ -191,7 +191,7 @@ contract CrossChainPay is ILayerZeroComposer, Ownable {
             memo,
             metadata
         );
-        emit CrossChainPayReceived(projectId, msg.value, beneficiary);
+        emit CrossChainPayReceived(projectId, contractBalance, beneficiary);
     }
 
     // Admin functions

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -417,7 +417,7 @@ export const CITIZEN_CROSS_CHAIN_MINT_ADDRESSES: Index = {
 
 // Shared across chains
 export const MISSION_CROSS_CHAIN_PAY_ADDRESS =
-  '0xa2ca498075Ec3a57cd1E407aFF88A495F838Bd5E'
+  '0x32D7ceD515A27CB60c6dcAd47225A7f300134983'
 
 export const LAYERZERO_SOURCE_CHAIN_TO_DESTINATION_EID: {
   [key: string]: number
@@ -429,8 +429,8 @@ export const LAYERZERO_SOURCE_CHAIN_TO_DESTINATION_EID: {
 }
 
 // LayerZero limit: 0.24 ETH maximum per transaction (total including fees)
-export const LAYERZERO_MAX_ETH = 0.24
-export const LAYERZERO_MAX_CONTRIBUTION_ETH = 0.1038
+export const LAYERZERO_MAX_ETH = 100
+export const LAYERZERO_MAX_CONTRIBUTION_ETH = 100
 
 //GCP HSM Signer used for XP oracle verification, citizen referrals and gasless transactions
 export const GCP_HSM_SIGNER_ADDRESS =


### PR DESCRIPTION
only pass native eth through stargate, don't pass it to the compose call. then use the contract balance to pay for the tokens on the destination. this allows us to avoid the layerzero limit.