### PR TITLE
Fix: CitizenTable Unauthenticated Write Access

### DIFF
--- a/subscription-contracts/src/tables/CitizenTableV2.sol
+++ b/subscription-contracts/src/tables/CitizenTableV2.sol
@@ -5,6 +5,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {TablelandDeployments} from "@evm-tableland/contracts/utils/TablelandDeployments.sol";
 import {SQLHelpers} from "@evm-tableland/contracts/utils/SQLHelpers.sol";
 import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {NFTURITemplateGenerator} from "./NFTURITemplateGenerator.sol";
 
 contract MoonDAOCitizenTable is ERC721Holder, Ownable {
@@ -75,7 +76,7 @@ contract MoonDAOCitizenTable is ERC721Holder, Ownable {
         );
     }
 
-    // Let anyone insert into the table
+    // Only Citizen contract or Owner can insert into the table
     function insertIntoTable(uint256 id, string memory name, string memory description, string memory image, string memory location, string memory discord, string memory twitter, string memory instagram, string memory linkedin, string memory website, string memory _view, string memory formId, address owner) external onlyOperators {
         string memory setters = string.concat(
             string.concat(
@@ -120,6 +121,12 @@ contract MoonDAOCitizenTable is ERC721Holder, Ownable {
     }
 
     function updateTableDynamic(uint256 id, string[] memory columns, string[] memory values) external {
+        require(
+            msg.sender == owner() ||
+            msg.sender == _citizenAddress ||
+            IERC721(_citizenAddress).ownerOf(id) == msg.sender,
+            "Only Admin, Citizen contract, or Citizen owner can update"
+        );
         require(columns.length == values.length, "Columns and values length mismatch");
 
         // Manually create key-value pairs for setters
@@ -144,6 +151,12 @@ contract MoonDAOCitizenTable is ERC721Holder, Ownable {
 
     // Delete a row from the table by ID 
     function deleteFromTable(uint256 id) external {
+        require(
+            msg.sender == owner() ||
+            msg.sender == _citizenAddress ||
+            IERC721(_citizenAddress).ownerOf(id) == msg.sender,
+            "Only Admin, Citizen contract, or Citizen owner can delete"
+        );
         // Specify filters for which row to delete
         string memory filters = string.concat(
             "id=",

--- a/subscription-contracts/test/CitizenTableV2.t.sol
+++ b/subscription-contracts/test/CitizenTableV2.t.sol
@@ -4,15 +4,33 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
 import "../src/tables/CitizenTableV2.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+// Mock ERC721 to simulate citizen NFT ownership
+contract MockCitizenNFT is ERC721 {
+    constructor() ERC721("MockCitizen", "MCTZ") {}
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+}
 
 contract MoonDAOCitizenTableTest is Test {
     MoonDAOCitizenTable private moonDAOCitizenTable;
+    MockCitizenNFT private mockCitizenNFT;
     address private owner = address(0x123);
+    address private citizenOwner = address(0x456);
+    address private attacker = address(0x789);
 
     function setUp() public {
         vm.startPrank(owner);
         moonDAOCitizenTable = new MoonDAOCitizenTable("CITIZENTABLEV2");
+        mockCitizenNFT = new MockCitizenNFT();
+        moonDAOCitizenTable.setCitizenAddress(address(mockCitizenNFT));
         vm.stopPrank();
+
+        // Mint citizen NFT #1 to citizenOwner
+        mockCitizenNFT.mint(citizenOwner, 1);
     }
 
     function testAddMultipleColumns() public {
@@ -24,7 +42,7 @@ contract MoonDAOCitizenTableTest is Test {
         vm.stopPrank();
     }
 
-    function testDynamicUpdate() public {
+    function testDynamicUpdateAsOwner() public {
         vm.startPrank(owner);
 
         string[] memory columns = new string[](2);
@@ -35,8 +53,60 @@ contract MoonDAOCitizenTableTest is Test {
         updateValues[0] = "updatedValue1";
         updateValues[1] = "updatedValue2";
 
-         moonDAOCitizenTable.updateTableDynamic(1, columns, updateValues);
-    
+        moonDAOCitizenTable.updateTableDynamic(1, columns, updateValues);
+
+        vm.stopPrank();
+    }
+
+    function testDynamicUpdateAsCitizenOwner() public {
+        vm.startPrank(citizenOwner);
+
+        string[] memory columns = new string[](2);
+        columns[0] = "name";
+        columns[1] = "description";
+
+        string[] memory updateValues = new string[](2);
+        updateValues[0] = "My Name";
+        updateValues[1] = "My Bio";
+
+        moonDAOCitizenTable.updateTableDynamic(1, columns, updateValues);
+
+        vm.stopPrank();
+    }
+
+    function testDynamicUpdateRevertsForUnauthorizedUser() public {
+        vm.startPrank(attacker);
+
+        string[] memory columns = new string[](1);
+        columns[0] = "name";
+
+        string[] memory updateValues = new string[](1);
+        updateValues[0] = "HACKED";
+
+        vm.expectRevert("Only Admin, Citizen contract, or Citizen owner can update");
+        moonDAOCitizenTable.updateTableDynamic(1, columns, updateValues);
+
+        vm.stopPrank();
+    }
+
+    function testDeleteFromTableRevertsForUnauthorizedUser() public {
+        vm.startPrank(attacker);
+
+        vm.expectRevert("Only Admin, Citizen contract, or Citizen owner can delete");
+        moonDAOCitizenTable.deleteFromTable(1);
+
+        vm.stopPrank();
+    }
+
+    function testDeleteFromTableAsOwner() public {
+        vm.startPrank(owner);
+        moonDAOCitizenTable.deleteFromTable(1);
+        vm.stopPrank();
+    }
+
+    function testDeleteFromTableAsCitizenOwner() public {
+        vm.startPrank(citizenOwner);
+        moonDAOCitizenTable.deleteFromTable(1);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
Adds missing access control to updateTableDynamic and deleteFromTable in CitizenTableV2.sol. Previously, anyone with an Ethereum wallet could modify or delete any citizen's profile data on the live Arbitrum mainnet contract — no authentication required.

The Problem
The MoonDAOCitizenTable contract had two unprotected external functions:

Function	Risk
updateTableDynamic	Any caller could overwrite any citizen's name, bio, image, socials, etc.
deleteFromTable	Any caller could permanently delete any citizen's profile
This was an oversight — insertIntoTable was already protected with onlyOperators, and the equivalent TeamTableV2 contract correctly enforced permissions on all three operations.

The Fix
Both functions now require the caller to be one of:

Contract owner (admin)
Citizen NFT contract (_citizenAddress) — for programmatic operations
The actual citizen NFT token owner — users can only modify their own profile
This mirrors the access control pattern already used in TeamTableV2.

Changes
CitizenTableV2.sol

Added IERC721 import for ownerOf check
Added access control require to updateTableDynamic
Added access control require to deleteFromTable
Fixed stale comment on insertIntoTable (said "Let anyone insert" but was already protected)
CitizenTableV2.t.sol

Added MockCitizenNFT for ownership simulation
Added tests: admin can update/delete ✅
Added tests: citizen NFT owner can update/delete their own profile ✅
Added tests: unauthorized caller is reverted ❌
Deployment Required
The current contract at 0x0Eb1dF01b34cEDAFB3148f07D013793b557470d1 is not upgradeable. A new contract must be deployed and citizen data migrated. Until redeployment, the vulnerability remains live.