### PR TITLE
Fix Oracle Proof Replay Attack via claimId Malleability

### DIFF
--- a/xp/src/verifiers/HasBoughtAMarketplaceListingStaged.sol
+++ b/xp/src/verifiers/HasBoughtAMarketplaceListingStaged.sol
@@ -116,11 +116,11 @@ contract HasBoughtAMarketplaceListingStaged is XPOracleVerifier, StagedXPVerifie
         override(IXPVerifier, StagedXPVerifier)
         returns (bytes32)
     {
-        (uint256 purchases, uint256 amount, uint256 validAfterTs, uint256 validBefore,) =
+        (uint256 purchases,, uint256 validAfterTs, uint256 validBefore,) =
             abi.decode(context, (uint256, uint256, uint256, uint256, bytes));
 
-        // Use your original claimId format for backwards compatibility
-        bytes32 contextHash = keccak256(abi.encode(purchases, amount, validAfterTs, validBefore));
+        // FIX: Only include oracle-verified fields in claimId to prevent replay via amount malleability
+        bytes32 contextHash = keccak256(abi.encode(purchases, validAfterTs, validBefore));
         return keccak256(abi.encodePacked(address(this), user, contextHash));
     }
 

--- a/xp/src/verifiers/HasCompletedCitizenProfile.sol
+++ b/xp/src/verifiers/HasCompletedCitizenProfile.sol
@@ -35,10 +35,10 @@ contract HasCompletedCitizenProfile is XPOracleVerifier {
     }
 
     function claimId(address user, bytes calldata context) external view returns (bytes32) {
-        (uint256 profileCompleteness, uint256 amount, uint256 validAfterTs, uint256 validBefore,) =
+        (uint256 profileCompleteness,, uint256 validAfterTs, uint256 validBefore,) =
             abi.decode(context, (uint256, uint256, uint256, uint256, bytes));
-        // Keep amount in the claimId for backwards compatibility even if ignored
-        bytes32 contextHash = keccak256(abi.encode(profileCompleteness, amount, validAfterTs, validBefore));
+        // FIX: Only include oracle-verified fields in claimId to prevent replay via amount malleability
+        bytes32 contextHash = keccak256(abi.encode(profileCompleteness, validAfterTs, validBefore));
         return keccak256(abi.encodePacked(address(this), user, contextHash));
     }
 

--- a/xp/src/verifiers/HasContributedStaged.sol
+++ b/xp/src/verifiers/HasContributedStaged.sol
@@ -118,11 +118,11 @@ contract HasContributedStaged is XPOracleVerifier, StagedXPVerifier {
         override(IXPVerifier, StagedXPVerifier)
         returns (bytes32)
     {
-        (uint256 contributions, uint256 amount, uint256 validAfterTs, uint256 validBefore,) =
+        (uint256 contributions,, uint256 validAfterTs, uint256 validBefore,) =
             abi.decode(context, (uint256, uint256, uint256, uint256, bytes));
 
-        // Use your original claimId format for backwards compatibility
-        bytes32 contextHash = keccak256(abi.encode(contributions, amount, validAfterTs, validBefore));
+        // FIX: Only include oracle-verified fields in claimId to prevent replay via amount malleability
+        bytes32 contextHash = keccak256(abi.encode(contributions, validAfterTs, validBefore));
         return keccak256(abi.encodePacked(address(this), user, contextHash));
     }
 

--- a/xp/src/verifiers/HasCreatedATeam.sol
+++ b/xp/src/verifiers/HasCreatedATeam.sol
@@ -35,10 +35,10 @@ contract HasCreatedATeam is XPOracleVerifier {
     }
 
     function claimId(address user, bytes calldata context) external view returns (bytes32) {
-        (uint256 teamsCreated, uint256 amount, uint256 validAfterTs, uint256 validBefore,) =
+        (uint256 teamsCreated,, uint256 validAfterTs, uint256 validBefore,) =
             abi.decode(context, (uint256, uint256, uint256, uint256, bytes));
-        // Keep amount in the claimId for backwards compatibility even if ignored
-        bytes32 contextHash = keccak256(abi.encode(teamsCreated, amount, validAfterTs, validBefore));
+        // FIX: Only include oracle-verified fields in claimId to prevent replay via amount malleability
+        bytes32 contextHash = keccak256(abi.encode(teamsCreated, validAfterTs, validBefore));
         return keccak256(abi.encodePacked(address(this), user, contextHash));
     }
 

--- a/xp/src/verifiers/HasJoinedATeam.sol
+++ b/xp/src/verifiers/HasJoinedATeam.sol
@@ -33,10 +33,10 @@ contract HasJoinedATeam is XPOracleVerifier {
     }
 
     function claimId(address user, bytes calldata context) external view returns (bytes32) {
-        (uint256 teamsJoined, uint256 amount, uint256 validAfterTs, uint256 validBefore,) =
+        (uint256 teamsJoined,, uint256 validAfterTs, uint256 validBefore,) =
             abi.decode(context, (uint256, uint256, uint256, uint256, bytes));
-        // Keep amount in the claimId for backwards compatibility even if ignored
-        bytes32 contextHash = keccak256(abi.encode(teamsJoined, amount, validAfterTs, validBefore));
+        // FIX: Only include oracle-verified fields in claimId to prevent replay via amount malleability
+        bytes32 contextHash = keccak256(abi.encode(teamsJoined, validAfterTs, validBefore));
         return keccak256(abi.encodePacked(address(this), user, contextHash));
     }
 

--- a/xp/src/verifiers/HasSubmittedIssue.sol
+++ b/xp/src/verifiers/HasSubmittedIssue.sol
@@ -36,10 +36,10 @@ contract HasSubmittedIssue is XPOracleVerifier {
     }
 
     function claimId(address user, bytes calldata context) external view returns (bytes32) {
-        (uint256 issueCount, uint256 amount, uint256 validAfterTs, uint256 validBefore,) =
+        (uint256 issueCount,, uint256 validAfterTs, uint256 validBefore,) =
             abi.decode(context, (uint256, uint256, uint256, uint256, bytes));
-        // Keep amount in the claimId for backwards compatibility even if ignored
-        bytes32 contextHash = keccak256(abi.encode(issueCount, amount, validAfterTs, validBefore));
+        // FIX: Only include oracle-verified fields in claimId to prevent replay via amount malleability
+        bytes32 contextHash = keccak256(abi.encode(issueCount, validAfterTs, validBefore));
         return keccak256(abi.encodePacked(address(this), user, contextHash));
     }
 

--- a/xp/src/verifiers/HasSubmittedPRStaged.sol
+++ b/xp/src/verifiers/HasSubmittedPRStaged.sol
@@ -114,11 +114,11 @@ contract HasSubmittedPRStaged is XPOracleVerifier, StagedXPVerifier {
         override(IXPVerifier, StagedXPVerifier)
         returns (bytes32)
     {
-        (uint256 prCount, uint256 amount, uint256 validAfterTs, uint256 validBefore,) =
+        (uint256 prCount,, uint256 validAfterTs, uint256 validBefore,) =
             abi.decode(context, (uint256, uint256, uint256, uint256, bytes));
 
-        // Use your original claimId format for backwards compatibility
-        bytes32 contextHash = keccak256(abi.encode(prCount, amount, validAfterTs, validBefore));
+        // FIX: Only include oracle-verified fields in claimId to prevent replay via amount malleability
+        bytes32 contextHash = keccak256(abi.encode(prCount, validAfterTs, validBefore));
         return keccak256(abi.encodePacked(address(this), user, contextHash));
     }
 

--- a/xp/src/verifiers/HasVotedStaged.sol
+++ b/xp/src/verifiers/HasVotedStaged.sol
@@ -113,11 +113,11 @@ contract HasVotedStaged is XPOracleVerifier, StagedXPVerifier {
         override(IXPVerifier, StagedXPVerifier)
         returns (bytes32)
     {
-        (uint256 votes, uint256 amount, uint256 validAfterTs, uint256 validBefore,) =
+        (uint256 votes,, uint256 validAfterTs, uint256 validBefore,) =
             abi.decode(context, (uint256, uint256, uint256, uint256, bytes));
 
-        // Use your original claimId format for backwards compatibility
-        bytes32 contextHash = keccak256(abi.encode(votes, amount, validAfterTs, validBefore));
+        // FIX: Only include oracle-verified fields in claimId to prevent replay via amount malleability
+        bytes32 contextHash = keccak256(abi.encode(votes, validAfterTs, validBefore));
         return keccak256(abi.encodePacked(address(this), user, contextHash));
     }
 

--- a/xp/src/verifiers/HasVotingPowerStaged.sol
+++ b/xp/src/verifiers/HasVotingPowerStaged.sol
@@ -119,11 +119,11 @@ contract HasVotingPowerStaged is XPOracleVerifier, StagedXPVerifier {
         override(IXPVerifier, StagedXPVerifier)
         returns (bytes32)
     {
-        (uint256 votingPower, uint256 amount, uint256 validAfterTs, uint256 validBefore,) =
+        (uint256 votingPower,, uint256 validAfterTs, uint256 validBefore,) =
             abi.decode(context, (uint256, uint256, uint256, uint256, bytes));
 
-        // Use your original claimId format for backwards compatibility
-        bytes32 contextHash = keccak256(abi.encode(votingPower, amount, validAfterTs, validBefore));
+        // FIX: Only include oracle-verified fields in claimId to prevent replay via amount malleability
+        bytes32 contextHash = keccak256(abi.encode(votingPower, validAfterTs, validBefore));
         return keccak256(abi.encodePacked(address(this), user, contextHash));
     }
 


### PR DESCRIPTION
Fix Critical Oracle Proof Replay Attack via claimId Malleability

Fixes a critical vulnerability allowing unlimited XP/token theft through replay attacks.

Problem

Oracle signatures only verified hash(metric) but claimId included unverified amount field
Attackers could modify amount to generate new claimId while reusing valid signatures
Enabled unlimited claims from single legitimate proof, draining reward pools
Solution

Removed amount field from claimId computation in all 9 affected verifiers
claimId now only includes oracle-verified fields: (metric, validAfter, validBefore)
Prevents replay attacks while maintaining legitimate functionality
Files Changed

HasJoinedATeam.sol
HasCompletedCitizenProfile.sol
HasCreatedATeam.sol
HasSubmittedIssue.sol
HasVotedStaged.sol
HasVotingPowerStaged.sol
HasContributedStaged.sol
HasSubmittedPRStaged.sol
HasBoughtAMarketplaceListingStaged.sol
Impact

✅ Prevents unlimited token theft
✅ All existing tests pass
⚠️ Breaking: Existing pending proofs