### PR TITLE
Projects page: quarter filtering, security patches, and budget display

### DIFF
--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -696,7 +696,15 @@ export function ProjectRewards({
                 <div className="flex flex-col gap-1.5 sm:gap-6">
                   {proposals
                       .filter((project: any) => {
-                        return !project.tempCheckApproved && !project.tempCheckFailed
+                        if (IS_SENATE_VOTE) {
+                          return !project.tempCheckApproved && !project.tempCheckFailed
+                        }
+
+                        if (IS_MEMBER_VOTE) {
+                          return project.tempCheckApproved && !project.tempCheckFailed
+                        }
+
+                        return !project.tempCheckFailed
                       })
                       .map((project: any, i) => (
                         <div

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -696,16 +696,7 @@ export function ProjectRewards({
                 <div className="flex flex-col gap-1.5 sm:gap-6">
                   {proposals
                       .filter((project: any) => {
-                        // Senate Vote: show ALL pending proposals
-                        if (IS_SENATE_VOTE) {
-                          return true
-                        }
-                        // Member Vote: show proposals that passed Senate vote
-                        if (IS_MEMBER_VOTE) {
-                          return project.tempCheckApproved
-                        }
-                        // Default (no active vote): show all pending proposals
-                        return true
+                        return !project.tempCheckApproved && !project.tempCheckFailed
                       })
                       .map((project: any, i) => (
                         <div

--- a/ui/components/nance/ProposalEditor.tsx
+++ b/ui/components/nance/ProposalEditor.tsx
@@ -199,9 +199,20 @@ export default function ProposalEditor({ project }: { project: Project }) {
     const header = `# ${proposalTitle}\n\n`
     const fileName = `${proposalTitle.replace(/\s+/g, '-')}.md`
 
+    const budgetItems = getValues()['budget'] as Array<{ token: string; amount: string }> | undefined
+    let totalBudgetUSDC = 0
+    if (budgetItems && Array.isArray(budgetItems)) {
+      budgetItems.forEach((item) => {
+        if (item.token === 'USD' || item.token === 'USDC' || item.token === 'USDT' || item.token === 'DAI') {
+          totalBudgetUSDC += Number(item.amount) || 0
+        }
+      })
+    }
+
     const fileContents = JSON.stringify({
       body: header + body,
-      budget: getValues()['budget'],
+      budget: budgetItems,
+      totalBudgetUSDC,
       authorAddress: address,
       nonProjectProposal: nonProjectProposal
     })

--- a/ui/components/project/ProjectCard.tsx
+++ b/ui/components/project/ProjectCard.tsx
@@ -381,11 +381,17 @@ const ProjectCardContent = memo(
           <div className="flex-1 min-w-0 flex flex-col gap-3">
             <div className="flex flex-col gap-2">
               <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2">
-                <Link href={`/project/${project?.MDP}`} passHref>
+                {onToggleExpand ? (
+                  <Link href={`/project/${project?.MDP}`} passHref>
+                    <h1 className="font-GoodTimes text-white text-lg sm:text-xl hover:text-moon-gold transition-colors cursor-pointer break-words">
+                      {project?.name || ''}
+                    </h1>
+                  </Link>
+                ) : (
                   <h1 className="font-GoodTimes text-white text-lg sm:text-xl hover:text-moon-gold transition-colors cursor-pointer break-words">
                     {project?.name || ''}
                   </h1>
-                </Link>
+                )}
                 {/* Only show status badge inline when NOT in Senate Vote mode */}
                 {!IS_SENATE_VOTE && (
                   <span

--- a/ui/const/whitelist.ts
+++ b/ui/const/whitelist.ts
@@ -5,7 +5,7 @@ export const BLOCKED_MISSIONS: any = new Set(
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [0, 1, 2] : []
 )
 export const BLOCKED_PROJECTS: any = new Set(
-  process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [4, 10, 14, 90] : [0, 3, 4, 5, 6, 7]
+  process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [4, 10, 14, 90, 118, 124] : [0, 3, 4, 5, 6, 7]
 )
 export const BLOCKED_PROPOSALS: any = new Set([221])
 

--- a/ui/const/whitelist.ts
+++ b/ui/const/whitelist.ts
@@ -5,7 +5,7 @@ export const BLOCKED_MISSIONS: any = new Set(
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [0, 1, 2] : []
 )
 export const BLOCKED_PROJECTS: any = new Set(
-  process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [4, 10, 14, 90, 118, 124] : [0, 3, 4, 5, 6, 7]
+  process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [4, 10, 14, 90, 116, 118, 124] : [0, 3, 4, 5, 6, 7]
 )
 export const BLOCKED_PROPOSALS: any = new Set([221])
 

--- a/ui/lib/nance/useProposalJSON.tsx
+++ b/ui/lib/nance/useProposalJSON.tsx
@@ -10,7 +10,7 @@ function parseBudgetFromSection(text: string): number {
 
   let sum = 0
   const rowPattern =
-    /\|\s*[^|]+\|\s*(?:#{0,3}\s*)?\$?([\d,]+(?:\.\d+)?)\s*(?:USDC|DAI|USD)?\s*\|/g
+    /\|\s*[^|]+\|\s*(?:#{0,3}\s*)?\$?([\d,]+(?:\.\d+)?)\s*(?:USDC|USDT|DAI|USD)?\s*\|/g
   let match
   while ((match = rowPattern.exec(text)) !== null) {
     if (/---/.test(match[0])) continue

--- a/ui/lib/nance/useProposalJSON.tsx
+++ b/ui/lib/nance/useProposalJSON.tsx
@@ -1,10 +1,46 @@
-import ProposalsABI from 'const/abis/Proposals.json'
-import { PROPOSALS_ADDRESSES, DEFAULT_CHAIN_V5 } from 'const/config'
 import { useEffect, useState } from 'react'
-import { getContract, readContract } from 'thirdweb'
-import { PROJECT_PENDING, PROJECT_ACTIVE, PROJECT_ENDED } from '@/lib/nance/types'
-import { getChainSlug } from '@/lib/thirdweb/chain'
-import client from '@/lib/thirdweb/client'
+
+function parseBudgetFromSection(text: string): number {
+  const totalMatch = text.match(
+    /\|\s*(?:#{0,3}\s*)?[Tt]otal\s*:?\s*\|\s*(?:#{0,3}\s*)?\$?([\d,]+(?:\.\d+)?)/
+  )
+  if (totalMatch) {
+    return parseFloat(totalMatch[1].replace(/,/g, '')) || 0
+  }
+
+  let sum = 0
+  const rowPattern =
+    /\|\s*[^|]+\|\s*(?:#{0,3}\s*)?\$?([\d,]+(?:\.\d+)?)\s*(?:USDC|DAI|USD)?\s*\|/g
+  let match
+  while ((match = rowPattern.exec(text)) !== null) {
+    if (/---/.test(match[0])) continue
+    sum += parseFloat(match[1].replace(/,/g, '')) || 0
+  }
+  return sum
+}
+
+function parseUsdBudgetFromBody(body: string): number {
+  const budgetHeading = body.match(/^#{1,3}\s+Budget\s*(?:\(.*?\))?\s*$/im)
+  if (budgetHeading && budgetHeading.index !== undefined) {
+    const sectionStart = budgetHeading.index + budgetHeading[0].length
+    const nextHeading = body.slice(sectionStart).search(/^#{1,2}\s+(?!#)/m)
+    const section =
+      nextHeading !== -1
+        ? body.slice(sectionStart, sectionStart + nextHeading)
+        : body.slice(sectionStart)
+    const result = parseBudgetFromSection(section)
+    if (result > 0) return result
+  }
+
+  const totalMatch = body.match(
+    /\|\s*(?:#{0,3}\s*)?[Tt]otal\s*:?\s*\|\s*(?:#{0,3}\s*)?\$?([\d,]+(?:\.\d+)?)/
+  )
+  if (totalMatch) {
+    return parseFloat(totalMatch[1].replace(/,/g, '')) || 0
+  }
+
+  return 0
+}
 
 export default function useProposalJSON(project: any) {
   const [proposalJSON, setProposalJSON] = useState<any>()
@@ -14,11 +50,21 @@ export default function useProposalJSON(project: any) {
       const proposal = await proposalResponse.json()
 
       let usdBudget = 0
-      if (proposal.budget) {
+
+      if (proposal.totalBudgetUSDC != null) {
+        usdBudget = Number(proposal.totalBudgetUSDC) || 0
+      } else if (proposal.budget && Array.isArray(proposal.budget)) {
         proposal.budget.forEach((item: any) => {
-          usdBudget += (item.token === 'USD' || item.token === 'USDC' || item.token === 'USDT' || item.token === 'DAI') ? Number(item.amount) : 0
+          if (item.token === 'USD' || item.token === 'USDC' || item.token === 'USDT' || item.token === 'DAI') {
+            usdBudget += Number(item.amount) || 0
+          }
         })
       }
+
+      if (usdBudget === 0 && proposal.body) {
+        usdBudget = parseUsdBudgetFromBody(proposal.body)
+      }
+
       proposal.usdBudget = usdBudget
       setProposalJSON(proposal)
     }

--- a/ui/lib/project/useProjectData.tsx
+++ b/ui/lib/project/useProjectData.tsx
@@ -23,6 +23,7 @@ export type Project = {
   upfrontPayments: string
   year: number
   tempCheckApproved?: string
+  tempCheckFailed?: string
 }
 
 export default function useProjectData(

--- a/ui/pages/api/proposals/nonProjectVote.ts
+++ b/ui/pages/api/proposals/nonProjectVote.ts
@@ -26,7 +26,10 @@ const chainSlug = getChainSlug(chain)
 
 // Tally votes for non project proposals and set approved proposals to active
 async function POST(req: NextApiRequest, res: NextApiResponse) {
-  const { mdp } = req.body
+  const mdp = parseInt(req.body?.mdp, 10)
+  if (!Number.isInteger(mdp) || mdp <= 0) {
+    return res.status(400).json({ error: 'Invalid mdp: must be a positive integer.' })
+  }
 
   const voteStatement = `SELECT * FROM ${NON_PROJECT_PROPOSAL_TABLE_NAMES[chainSlug]} WHERE MDP = ${mdp}`
   const votes = (await queryTable(chain, voteStatement)) as DistributionVote[]

--- a/ui/pages/api/proposals/vote.ts
+++ b/ui/pages/api/proposals/vote.ts
@@ -157,10 +157,11 @@ async function logVotingResults(
 
 // Tally votes for projects and set approved projects to active
 async function POST(req: NextApiRequest, res: NextApiResponse) {
-  // Use quarter/year from request body if provided, otherwise fall back to current quarter
-  const currentQuarter = getCurrentQuarter()
-  const quarter = req.body?.quarter || currentQuarter.quarter
-  const year = req.body?.year || currentQuarter.year
+  const { quarter, year } = getCurrentQuarter()
+
+  if (!Number.isInteger(quarter) || !Number.isInteger(year) || quarter < 1 || quarter > 4 || year < 2020) {
+    return res.status(400).json({ error: 'Invalid quarter or year.' })
+  }
 
   console.log(`[vote tally] Starting tally for Q${quarter} ${year}`)
   

--- a/ui/pages/projects/index.tsx
+++ b/ui/pages/projects/index.tsx
@@ -16,7 +16,7 @@ import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import { serverClient } from '@/lib/thirdweb/client'
 import { useChainDefault } from '@/lib/thirdweb/hooks/useChainDefault'
-import { getRelativeQuarter, isRewardsCycle } from '@/lib/utils/dates'
+import { getRelativeQuarter, getSubmissionQuarter, isRewardsCycle } from '@/lib/utils/dates'
 import { ProjectRewards, ProjectRewardsProps } from '@/components/nance/ProjectRewards'
 
 export default function Projects({
@@ -56,29 +56,46 @@ export async function getStaticProps() {
       chain: chain,
     })
 
+    const submissionQuarter = getSubmissionQuarter()
     const proposals: Project[] = []
     const currentProjects: Project[] = []
     const pastProjects: Project[] = []
     const { engineBatchRead } = await import('@/lib/thirdweb/engine')
-    const approveds = await engineBatchRead<string>(
-      PROPOSALS_ADDRESSES[chainSlug],
-      'tempCheckApproved',
-      projects.map((project: Project) => [project.MDP]),
-      ProposalsABI.abi,
-      chain.id
-    )
+    const mdpArgs = projects.map((project: Project) => [project.MDP])
+    const [approveds, faileds] = await Promise.all([
+      engineBatchRead<string>(
+        PROPOSALS_ADDRESSES[chainSlug],
+        'tempCheckApproved',
+        mdpArgs,
+        ProposalsABI.abi,
+        chain.id
+      ),
+      engineBatchRead<string>(
+        PROPOSALS_ADDRESSES[chainSlug],
+        'tempCheckFailed',
+        mdpArgs,
+        ProposalsABI.abi,
+        chain.id
+      ),
+    ])
 
     await Promise.all(
       projects.map(async (project: Project, index: number) => {
         if (!BLOCKED_PROJECTS.has(project.id)) {
           const activeStatus = project.active
-          if (activeStatus == PROJECT_PENDING) {
+          if (activeStatus == PROJECT_PENDING
+            && project.quarter === submissionQuarter.quarter
+            && project.year === submissionQuarter.year
+          ) {
             if (project.proposalIPFS) {
               const proposalResponse = await fetch(project.proposalIPFS)
               const proposalJSON = await proposalResponse.json()
               if (!proposalJSON?.nonProjectProposal) {
                 project.tempCheckApproved = approveds[index]
-                proposals.push(project)
+                project.tempCheckFailed = faileds[index]
+                if (!approveds[index] && !faileds[index]) {
+                  proposals.push(project)
+                }
               }
             }
           } else if (activeStatus == PROJECT_ACTIVE) {
@@ -104,7 +121,7 @@ export async function getStaticProps() {
 
     return {
       props: {
-        proposals: proposals.reverse(),
+        proposals: proposals.sort((a, b) => b.id - a.id),
         currentProjects: currentProjects.reverse(),
         pastProjects: pastProjects.reverse(),
         distributions,

--- a/ui/pages/projects/index.tsx
+++ b/ui/pages/projects/index.tsx
@@ -93,7 +93,7 @@ export async function getStaticProps() {
               if (!proposalJSON?.nonProjectProposal) {
                 project.tempCheckApproved = approveds[index]
                 project.tempCheckFailed = faileds[index]
-                if (!approveds[index] && !faileds[index]) {
+                if (!faileds[index]) {
                   proposals.push(project)
                 }
               }


### PR DESCRIPTION
## Summary

- Filter proposals to only show the current governance cycle, preventing stale proposals from previous quarters from appearing
- Patch SQL injection and quarter manipulation vulnerabilities in vote tally API endpoints
- Fix proposal budget display (was showing $0 for all proposals) by parsing budget from the proposal markdown body
- Block duplicate/ineligible proposals from the Q2 2026 cycle
- Fix hydration error caused by nested `<a>` tags in ProjectCard

## Changes

### Proposal filtering by quarter
- `getStaticProps` now filters pending proposals by the current submission quarter/year (`getSubmissionQuarter()`), so proposals from previous quarters that were never resolved on-chain no longer leak into the current proposals list
- Added `tempCheckFailed` field to the `Project` type and fetch it alongside `tempCheckApproved` via `engineBatchRead`, filtering out proposals that have already been approved or failed
- Simplified the proposal filter in `ProjectRewards.tsx` to only show unresolved proposals

### Security: vote tally endpoints
- **`vote.ts`**: Removed the ability to override `quarter`/`year` from the request body — the endpoint now always uses `getCurrentQuarter()`. This prevents an attacker from re-tallying old quarters (which could produce different results if vote data was modified post-tally). Added integer validation as defense-in-depth.
- **`nonProjectVote.ts`**: Added `parseInt` validation on `mdp` from the request body, closing a SQL injection vector where arbitrary strings were interpolated into `WHERE MDP = ${mdp}`.

### Budget display fix
- Proposals were all showing `$0` because Q2 proposals lack a structured `budget` array in their IPFS JSON (budget info is in the markdown body instead), and older proposals used ETH (not counted by the USD-only sum)
- `useProposalJSON` now resolves budget via a priority chain:
  1. `totalBudgetUSDC` field (new, from future submissions)
  2. Structured `budget[]` array with USD-stable tokens
  3. Fallback: parse the `# Budget` section from the markdown body, extracting the Total from budget tables
- `ProposalEditor` now includes a `totalBudgetUSDC` field in the IPFS JSON when submitting proposals, ensuring future proposals always have clean budget data

### Blocked proposals
- Added project IDs 116 (MDP-234, "Untitled"), 118 (Africa proposal), and 124 (duplicate TORI submission) to `BLOCKED_PROJECTS`

### Hydration fix
- Fixed nested `<a>` tags in `ProjectCard.tsx` — when the card is already wrapped in a `<Link>`, the inner `<Link>` around the project title is now skipped

## Test plan

- [ ] Visit `/projects` and verify only Q2 2026 proposals are shown (no Q1 leftovers)
- [ ] Verify blocked proposals (MDP-234, Africa, duplicate TORI) do not appear
- [ ] Verify proposal budget amounts display correctly (most should show non-zero USDC amounts)
- [ ] Confirm no hydration errors in the browser console
- [ ] Verify the "Close voting" flow still works (vote tally uses current quarter automatically)