### PR TITLE
Senate vote + retroactive rewards UI prep

### DIFF
--- a/ui/components/home/SignedInDashboard.tsx
+++ b/ui/components/home/SignedInDashboard.tsx
@@ -38,7 +38,7 @@ import {
   TEAM_ADDRESSES,
   USD_BUDGET,
 } from 'const/config'
-import { BLOCKED_PROJECTS } from 'const/whitelist'
+import { BLOCKED_MDPS, BLOCKED_PROJECTS } from 'const/whitelist'
 import {
   getMissionMinimumUsdGoal,
   MISSION_MINIMUM_GOAL_TOOLTIP,
@@ -184,7 +184,7 @@ export default function SignedInDashboard({
   const proposals = []
   const currentProjects = []
   for (let i = 0; i < projects.length; i++) {
-    if (!BLOCKED_PROJECTS.has(projects[i].id)) {
+    if (!BLOCKED_PROJECTS.has(projects[i].id) && !BLOCKED_MDPS.has(projects[i].MDP)) {
       const activeStatus = projects[i].active
       if (activeStatus == PROJECT_PENDING) {
         proposals.push(projects[i])

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -19,6 +19,7 @@ import {
 import useStakedEth from 'lib/utils/hooks/useStakedEth'
 import _ from 'lodash'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState, useEffect, useMemo } from 'react'
 import toast from 'react-hot-toast'
@@ -88,6 +89,7 @@ export function ProjectRewards({
   const [rewardVotingActive, setRewardVotingActive] = useState(false)
   const [approvalVotingActive, setApprovalVotingActive] = useState(false)
   const { quarter, year } = getRelativeQuarter(rewardVotingActive ? -1 : 0)
+  const { quarter: currentQuarter, year: currentYear } = getRelativeQuarter(0)
   const { quarter: submissionQuarter, year: submissionYear } = getSubmissionQuarter()
 
   const [edit, setEdit] = useState(false)
@@ -603,10 +605,219 @@ export function ProjectRewards({
           branded={false}
         >
           <div className="mt-8 md:mt-12 flex flex-col gap-3 sm:gap-6">
+            {/* Project System Intro */}
+            <div className="bg-black/20 rounded-none sm:rounded-xl px-3 py-4 sm:p-5 border-y sm:border border-white/10">
+              <div className="flex flex-col gap-4">
+                <h2 className="font-GoodTimes text-white text-base sm:text-lg">
+                  The Project System
+                </h2>
+                <p className="text-sm sm:text-base text-gray-300 leading-relaxed">
+                  Each quarter, contributors submit project proposals that go through a Senate
+                  Vote for approval and a Member Vote for prioritization. Approved projects are
+                  funded upfront, and once complete, submit a final report to earn retroactive
+                  rewards based on community voting.
+                </p>
+
+                {/* Phase Timeline */}
+                {(() => {
+                  const phases = [
+                    {
+                      id: 'submit',
+                      label: 'Submit',
+                      subtitle: 'Proposal',
+                      active: !IS_SENATE_VOTE && !IS_MEMBER_VOTE,
+                      icon: (
+                        <svg
+                          className="w-4 h-4 sm:w-5 sm:h-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M15.232 5.232l3.536 3.536M9 13h3l8-8a2.828 2.828 0 00-4-4l-8 8v3zM5 19h14"
+                          />
+                        </svg>
+                      ),
+                    },
+                    {
+                      id: 'senate',
+                      label: 'Senate',
+                      subtitle: 'Review',
+                      active: IS_SENATE_VOTE,
+                      icon: (
+                        <svg
+                          className="w-4 h-4 sm:w-5 sm:h-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M12 3l8 4v5c0 4.418-3.582 8-8 9-4.418-1-8-4.582-8-9V7l8-4z"
+                          />
+                        </svg>
+                      ),
+                    },
+                    {
+                      id: 'member',
+                      label: 'Member',
+                      subtitle: 'Vote',
+                      active: IS_MEMBER_VOTE,
+                      icon: (
+                        <svg
+                          className="w-4 h-4 sm:w-5 sm:h-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                          />
+                        </svg>
+                      ),
+                    },
+                    {
+                      id: 'build',
+                      label: 'Build',
+                      subtitle: 'Execute',
+                      active: false,
+                      icon: (
+                        <svg
+                          className="w-4 h-4 sm:w-5 sm:h-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M13 10V3L4 14h7v7l9-11h-7z"
+                          />
+                        </svg>
+                      ),
+                    },
+                    {
+                      id: 'retro',
+                      label: 'Retroactive',
+                      subtitle: 'Rewards',
+                      active: IS_MEMBER_VOTE && rewardVotingActive,
+                      icon: (
+                        <svg
+                          className="w-4 h-4 sm:w-5 sm:h-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                          />
+                        </svg>
+                      ),
+                    },
+                  ]
+
+                  return (
+                    <div className="w-full pt-3 pb-1">
+                      <div className="flex items-start justify-between gap-1 sm:gap-2">
+                        {phases.map((phase, idx) => (
+                          <div
+                            key={phase.id}
+                            className="flex items-start flex-1 min-w-0"
+                          >
+                            <div className="flex flex-col items-center flex-1 min-w-0">
+                              <div className="relative">
+                                <div
+                                  className={`w-8 h-8 sm:w-11 sm:h-11 rounded-full flex items-center justify-center border-2 transition-all ${
+                                    phase.active
+                                      ? 'bg-gradient-to-br from-blue-500 to-purple-600 border-white/40 text-white shadow-[0_0_20px_rgba(99,102,241,0.5)]'
+                                      : 'bg-white/5 border-white/15 text-gray-500'
+                                  }`}
+                                >
+                                  {phase.icon}
+                                </div>
+                                {phase.active && (
+                                  <span className="pointer-events-none absolute -top-0.5 -right-0.5 flex h-2.5 w-2.5">
+                                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                                    <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-emerald-400" />
+                                  </span>
+                                )}
+                              </div>
+                              <div className="mt-2 flex flex-col items-center w-full px-0.5">
+                                <span
+                                  className={`text-[10px] sm:text-xs font-RobotoMono font-semibold uppercase tracking-wider leading-tight text-center truncate max-w-full ${
+                                    phase.active ? 'text-white' : 'text-gray-500'
+                                  }`}
+                                >
+                                  {phase.label}
+                                </span>
+                                <span
+                                  className={`hidden sm:inline text-[10px] sm:text-xs leading-tight text-center truncate max-w-full ${
+                                    phase.active ? 'text-blue-300' : 'text-gray-600'
+                                  }`}
+                                >
+                                  {phase.subtitle}
+                                </span>
+                                {phase.active && (
+                                  <span className="mt-1 px-1.5 py-0.5 rounded-sm text-[9px] font-RobotoMono font-bold uppercase tracking-wider bg-emerald-400/20 text-emerald-300 border border-emerald-400/30">
+                                    Now
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                            {idx < phases.length - 1 && (
+                              <div
+                                className={`h-0.5 flex-shrink-0 w-3 sm:w-auto sm:flex-1 mt-[16px] sm:mt-[22px] mx-0.5 sm:mx-1 rounded-full ${
+                                  phase.active || phases[idx + 1].active
+                                    ? 'bg-gradient-to-r from-blue-500/60 to-purple-600/60'
+                                    : 'bg-white/10'
+                                }`}
+                              />
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )
+                })()}
+
+                <Link
+                  href="/project-system-docs"
+                  className="inline-flex items-center gap-1.5 text-sm text-blue-400 hover:text-blue-300 transition-colors w-fit"
+                >
+                  Learn how the project system works
+                  <svg
+                    className="w-3.5 h-3.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M17 8l4 4m0 0l-4 4m4-4H3"
+                    />
+                  </svg>
+                </Link>
+              </div>
+            </div>
+
             {/* Condensed Top Section - Rewards + Create Button */}
             <div className="bg-black/20 rounded-none sm:rounded-xl px-1 py-2 sm:p-4 border-y sm:border border-white/10">
               <div className="flex flex-col md:flex-row md:items-center justify-between gap-2 sm:gap-4 mb-2 sm:mb-4 px-1 sm:px-0">
-                <h1 className="font-GoodTimes text-white/80 text-base sm:text-lg">{`Q${quarter}: ${year} Rewards`}</h1>
+                <h1 className="font-GoodTimes text-white/80 text-base sm:text-lg">{`Q${currentQuarter}: ${currentYear} Rewards`}</h1>
                 {IS_SENATE_VOTE && proposalsOwnerStatus === 'error' && (
                   <div className="flex items-center gap-2">
                     <span className="text-amber-500 text-sm">Unable to check permissions</span>

--- a/ui/components/project/AuthorCitizenLink.tsx
+++ b/ui/components/project/AuthorCitizenLink.tsx
@@ -1,0 +1,107 @@
+import { getNFT } from 'thirdweb/extensions/erc721'
+import { readContract } from 'thirdweb'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { useENS } from '@/lib/utils/hooks/useENS'
+import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
+
+type AuthorCitizenLinkProps = {
+  authorAddress: string
+  citizenContract: any
+  authorName?: string | null
+  compact?: boolean
+}
+
+export default function AuthorCitizenLink({
+  authorAddress,
+  citizenContract,
+  authorName,
+  compact = false,
+}: AuthorCitizenLinkProps) {
+  const [citizenMeta, setCitizenMeta] = useState<any>(null)
+  const { data: ensData } = useENS(authorAddress)
+  const shortAddress = `${authorAddress.slice(0, 6)}...${authorAddress.slice(-4)}`
+
+  useEffect(() => {
+    async function resolve() {
+      if (!authorAddress || !citizenContract?.address) return
+      try {
+        const tokenId = await readContract({
+          contract: citizenContract,
+          method: 'getOwnedToken' as string,
+          params: [authorAddress],
+        })
+        const nft = await getNFT({
+          contract: citizenContract,
+          tokenId: BigInt(tokenId.toString()),
+        })
+        if (
+          nft?.metadata?.name &&
+          nft.metadata.name !== 'Failed to load NFT metadata'
+        ) {
+          setCitizenMeta({ ...nft.metadata, id: nft.id.toString() })
+        }
+      } catch {
+        // Not a citizen or contract call failed
+      }
+    }
+    resolve()
+  }, [authorAddress, citizenContract])
+
+  const displayName = citizenMeta?.name || authorName || null
+  const addressLabel = ensData?.name || shortAddress
+  const avatarSrc =
+    citizenMeta?.image || `https://cdn.stamp.fyi/avatar/${authorAddress}`
+  const href = citizenMeta
+    ? `/citizen/${generatePrettyLinkWithId(citizenMeta.name, citizenMeta.id)}`
+    : undefined
+
+  const etherscanUrl = `https://etherscan.io/address/${authorAddress}`
+  const linkHref = href || etherscanUrl
+  const linkProps = href
+    ? {}
+    : { target: '_blank' as const, rel: 'noopener noreferrer' }
+
+  const containerClasses = compact
+    ? 'flex items-center gap-1.5 h-7 bg-white/5 border border-white/10 rounded-lg px-2 hover:bg-white/10 transition-colors group min-w-0'
+    : 'flex items-center gap-2 h-7 sm:h-9 bg-white/5 border border-white/10 rounded-lg px-2 sm:px-3 hover:bg-white/10 transition-colors group min-w-0'
+
+  const avatarWrapperClasses = compact
+    ? 'w-5 h-5 rounded-full overflow-hidden flex-shrink-0'
+    : 'w-5 h-5 sm:w-6 sm:h-6 rounded-full overflow-hidden flex-shrink-0'
+
+  const displayNameClasses = compact
+    ? 'text-xs text-gray-300 group-hover:text-white transition-colors truncate'
+    : 'text-xs sm:text-sm text-gray-300 group-hover:text-white transition-colors truncate'
+
+  const addressClasses = compact
+    ? 'text-[11px] font-mono text-gray-500 group-hover:text-gray-300 transition-colors hidden md:inline'
+    : 'text-xs sm:text-sm font-mono text-gray-500 group-hover:text-gray-300 transition-colors hidden sm:inline'
+
+  return (
+    <Link
+      href={linkHref}
+      {...linkProps}
+      className="no-underline"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className={containerClasses}>
+        <div className={avatarWrapperClasses}>
+          <img
+            src={
+              avatarSrc.startsWith('ipfs://')
+                ? `https://ipfs.io/ipfs/${avatarSrc.replace('ipfs://', '')}`
+                : avatarSrc
+            }
+            alt={displayName || addressLabel}
+            width={24}
+            height={24}
+            className="w-full h-full object-cover"
+          />
+        </div>
+        {displayName && <span className={displayNameClasses}>{displayName}</span>}
+        <span className={addressClasses}>{addressLabel}</span>
+      </div>
+    </Link>
+  )
+}

--- a/ui/components/project/AuthorCitizenLink.tsx
+++ b/ui/components/project/AuthorCitizenLink.tsx
@@ -56,8 +56,11 @@ export default function AuthorCitizenLink({
     ? `/citizen/${generatePrettyLinkWithId(citizenMeta.name, citizenMeta.id)}`
     : undefined
 
-  const etherscanUrl = `https://etherscan.io/address/${authorAddress}`
-  const linkHref = href || etherscanUrl
+  const explorerBaseUrl =
+    citizenContract?.chain?.blockExplorers?.[0]?.url?.replace(/\/$/, '') ||
+    'https://arbiscan.io'
+  const explorerAddressUrl = `${explorerBaseUrl}/address/${authorAddress}`
+  const linkHref = href || explorerAddressUrl
   const linkProps = href
     ? {}
     : { target: '_blank' as const, rel: 'noopener noreferrer' }

--- a/ui/components/project/ProjectCard.tsx
+++ b/ui/components/project/ProjectCard.tsx
@@ -2,8 +2,14 @@
 import { trimActionsFromBody } from '@nance/nance-sdk'
 import { usePrivy } from '@privy-io/react-auth'
 import confetti from 'canvas-confetti'
+import CitizenABI from 'const/abis/Citizen.json'
 import ProposalsABI from 'const/abis/Proposals.json'
-import { DEFAULT_CHAIN_V5, PROPOSALS_ADDRESSES, IS_SENATE_VOTE } from 'const/config'
+import {
+  CITIZEN_ADDRESSES,
+  DEFAULT_CHAIN_V5,
+  PROPOSALS_ADDRESSES,
+  IS_SENATE_VOTE,
+} from 'const/config'
 import Link from 'next/link'
 import React, { useContext, memo, useState, useMemo, useEffect } from 'react'
 import { prepareContractCall, sendAndConfirmTransaction, readContract } from 'thirdweb'
@@ -21,6 +27,7 @@ import { normalizeJsonString } from '@/lib/utils/rewards'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
+import AuthorCitizenLink from '@/components/project/AuthorCitizenLink'
 import { LoadingSpinner } from '../layout/LoadingSpinner'
 import NumberStepper from '../layout/NumberStepper'
 import StandardButton from '../layout/StandardButton'
@@ -318,6 +325,7 @@ const ProjectCardContent = memo(
     active,
     isExpanded,
     onToggleExpand,
+    citizenContract,
   }: any) => {
     const proposalJSON = useProposalJSON(project)
     const account = useActiveAccount()
@@ -328,6 +336,11 @@ const ProjectCardContent = memo(
     )
     const description =
       project && project.MDP < 13 ? project.description : project?.description || ''
+
+    const authorName = useMemo(() => {
+      const body = proposalJSON?.body || ''
+      return body.match(/^Author:\s*(.+)$/m)?.[1]?.trim() || null
+    }, [proposalJSON?.body])
 
     // State for senator votes (passed up from SenateVoteButtons)
     const [senatorVotes, setSenatorVotes] = useState<any[]>([])
@@ -381,17 +394,42 @@ const ProjectCardContent = memo(
           <div className="flex-1 min-w-0 flex flex-col gap-3">
             <div className="flex flex-col gap-2">
               <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-2">
-                {onToggleExpand ? (
-                  <Link href={`/project/${project?.MDP}`} passHref>
+                <div className="flex flex-col gap-1.5 min-w-0">
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    {project?.MDP !== undefined && project?.MDP !== null && (
+                      <span
+                        data-testid="project-mdp-number"
+                        className="w-fit px-2 py-0.5 rounded-md text-[11px] font-semibold font-mono tracking-wider uppercase bg-moon-indigo/30 text-moon-gold border border-moon-gold/30"
+                      >
+                        MDP-{project.MDP}
+                      </span>
+                    )}
+                    {proposalJSON?.authorAddress && (
+                      <div
+                        data-testid="project-author"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <AuthorCitizenLink
+                          authorAddress={proposalJSON.authorAddress}
+                          citizenContract={citizenContract}
+                          authorName={authorName}
+                          compact
+                        />
+                      </div>
+                    )}
+                  </div>
+                  {onToggleExpand ? (
+                    <Link href={`/project/${project?.MDP}`} passHref>
+                      <h1 className="font-GoodTimes text-white text-lg sm:text-xl hover:text-moon-gold transition-colors cursor-pointer break-words">
+                        {project?.name || ''}
+                      </h1>
+                    </Link>
+                  ) : (
                     <h1 className="font-GoodTimes text-white text-lg sm:text-xl hover:text-moon-gold transition-colors cursor-pointer break-words">
                       {project?.name || ''}
                     </h1>
-                  </Link>
-                ) : (
-                  <h1 className="font-GoodTimes text-white text-lg sm:text-xl hover:text-moon-gold transition-colors cursor-pointer break-words">
-                    {project?.name || ''}
-                  </h1>
-                )}
+                  )}
+                </div>
                 {/* Only show status badge inline when NOT in Senate Vote mode */}
                 {!IS_SENATE_VOTE && (
                   <span
@@ -547,6 +585,12 @@ export default function ProjectCard({
   const { authenticated } = usePrivy()
 
   const { selectedChain } = useContext(ChainContextV5)
+  const chainSlug = getChainSlug(selectedChain)
+  const citizenContract = useContract({
+    address: CITIZEN_ADDRESSES[chainSlug],
+    abi: CitizenABI as any,
+    chain: selectedChain,
+  })
   const hats = useSubHats(selectedChain, adminHatId, !!project?.eligible)
   const wearers = useUniqueHatWearers(hats)
 
@@ -612,6 +656,7 @@ export default function ProjectCard({
           active={active}
           isExpanded={isExpanded}
           onToggleExpand={() => setIsExpanded(!isExpanded)}
+          citizenContract={citizenContract}
         />
       ) : (
         <Link href={`/project/${project?.MDP}`} passHref className="h-full">
@@ -621,6 +666,7 @@ export default function ProjectCard({
             isVotingPeriod={isVotingPeriod}
             active={active}
             isExpanded={false}
+            citizenContract={citizenContract}
           />
         </Link>
       )}

--- a/ui/components/project/ProjectCard.tsx
+++ b/ui/components/project/ProjectCard.tsx
@@ -18,6 +18,7 @@ import { useSubHats } from '@/lib/hats/useSubHats'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
 import { PROJECT_ACTIVE, PROJECT_PENDING } from '@/lib/nance/types'
 import useProposalJSON from '@/lib/nance/useProposalJSON'
+import { getProjectDisplayName } from '@/lib/project/getProjectDisplayName'
 import useProjectData, { Project } from '@/lib/project/useProjectData'
 import useProposalData from '@/lib/project/useProposalData'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -342,6 +343,11 @@ const ProjectCardContent = memo(
       return body.match(/^Author:\s*(.+)$/m)?.[1]?.trim() || null
     }, [proposalJSON?.body])
 
+    const displayName = useMemo(
+      () => getProjectDisplayName(project, proposalJSON),
+      [project, proposalJSON]
+    )
+
     // State for senator votes (passed up from SenateVoteButtons)
     const [senatorVotes, setSenatorVotes] = useState<any[]>([])
     const [senatorVotesLoading, setSenatorVotesLoading] = useState(false)
@@ -421,12 +427,12 @@ const ProjectCardContent = memo(
                   {onToggleExpand ? (
                     <Link href={`/project/${project?.MDP}`} passHref>
                       <h1 className="font-GoodTimes text-white text-lg sm:text-xl hover:text-moon-gold transition-colors cursor-pointer break-words">
-                        {project?.name || ''}
+                        {displayName}
                       </h1>
                     </Link>
                   ) : (
                     <h1 className="font-GoodTimes text-white text-lg sm:text-xl hover:text-moon-gold transition-colors cursor-pointer break-words">
-                      {project?.name || ''}
+                      {displayName}
                     </h1>
                   )}
                 </div>

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -645,7 +645,7 @@ export const PROJECT_SYSTEM_CONFIG = {
 // Set IS_SENATE_VOTE to true during Senate Vote phase - shows proposals with "Temperature Check" status
 // Set IS_MEMBER_VOTE to true during Member Vote phase - shows proposals with "Voting" status (passed Senate vote)
 // Only one should be true at a time, or both false when no voting is active
-export const IS_SENATE_VOTE = false
+export const IS_SENATE_VOTE = true
 export const IS_MEMBER_VOTE = false
 
 // Quarterly budget in USD (stablecoins)

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -158,12 +158,10 @@ export const SENATORS_LIST: { [key: string]: Senator[] } = {
     { address: '0xf2Befa4B9489c1ef75E069D16A6F829F71B4B988', name: 'Frank' },
     { address: '0x8687AB2FF3188F961828FC2131b6150Ee97Bedce', name: 'Kara' },
     { address: '0xB87b8c495d3DAE468d4351621b69d2eC10E656FE', name: 'Alex' },
-    { address: '0x4CBf10c36b481d6afF063070E35b4F42E7Aad201', name: 'EngiBob' },
     { address: '0x529Bd2351476ba114f9D60E71A020A9F0b99f047', name: 'Anastasia' },
-    { address: '0xe2d3aC725E6FFE2b28a9ED83bedAaf6672f2C801', name: 'Eiman' },
     { address: '0x8A7fD7F4B1A77A606DFdD229c194B1F22De868Ff', name: 'Daniel' },
-    { address: '0x86c779b3741e83A36A2a236780d436E4EC673Af4', name: 'Titan' },
     { address: '0x08B3e694caA2F1fcF8eF71095CED1326f3454B89', name: 'Jade' },
+    { address: '0x47cc4c7fef42187f9f7901838f316b033e92be05', name: 'Rina' },
   ],
   sepolia: [
     { address: '0x08B3e694caA2F1fcF8eF71095CED1326f3454B89', name: 'Test Senator 1' },

--- a/ui/const/whitelist.ts
+++ b/ui/const/whitelist.ts
@@ -7,6 +7,11 @@ export const BLOCKED_MISSIONS: any = new Set(
 export const BLOCKED_PROJECTS: any = new Set(
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [4, 10, 14, 90, 116, 118, 124] : [0, 3, 4, 5, 6, 7]
 )
+export const BLOCKED_MDPS: any = new Set(
+  process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
+    ? [229, 233, 238, 243, 246, 247]
+    : []
+)
 export const BLOCKED_PROPOSALS: any = new Set([221])
 
 export const FEATURED_TEAMS: any = [6, 7, 8, 13, 1, 9, 5, 4, 2]

--- a/ui/cypress/integration/lib/project/use-proposal-data.cy.tsx
+++ b/ui/cypress/integration/lib/project/use-proposal-data.cy.tsx
@@ -90,14 +90,14 @@ describe('useProposalData configuration', () => {
   })
 
   describe('Mainnet Configuration', () => {
-    it('arbitrum chain should have 9 senators', () => {
+    it('arbitrum chain should have 7 senators', () => {
       const arbitrumSenators = SENATORS_LIST['arbitrum'] || []
-      expect(arbitrumSenators.length).to.equal(9)
+      expect(arbitrumSenators.length).to.equal(7)
     })
 
     it('arbitrum senators should have correct names', () => {
       const arbitrumSenators = SENATORS_LIST['arbitrum'] || []
-      const expectedNames = ['Frank', 'Kara', 'Alex', 'EngiBob', 'Anastasia', 'Eiman', 'Daniel', 'Titan', 'Jade']
+      const expectedNames = ['Frank', 'Kara', 'Alex', 'Anastasia', 'Daniel', 'Jade', 'Rina']
       const actualNames = arbitrumSenators.map((s: any) => s.name)
 
       expectedNames.forEach(name => {

--- a/ui/lib/project/getProjectDisplayName.ts
+++ b/ui/lib/project/getProjectDisplayName.ts
@@ -1,0 +1,76 @@
+import type { Project } from '@/lib/project/useProjectData'
+
+const UNTITLED_FALLBACK = 'Untitled Project'
+
+const UNTITLED_PATTERN = /^\s*untitled\b/i
+
+function isUntitledLike(value: string | undefined | null): boolean {
+  if (!value) return true
+  const trimmed = value.trim()
+  if (!trimmed) return true
+  return UNTITLED_PATTERN.test(trimmed)
+}
+
+function cleanLine(line: string): string {
+  return line
+    .replace(/^\s*#+\s*/, '')
+    .replace(/^\s*\*+\s*/, '')
+    .replace(/\*{1,3}/g, '')
+    .replace(/^\s*>+\s*/, '')
+    .replace(/\[(.*?)\]\(.*?\)/g, '$1')
+    .trim()
+}
+
+function isTemplateBoilerplate(line: string): boolean {
+  if (!line) return true
+  if (/^author\s*:/i.test(line)) return true
+  if (/^date\s*:/i.test(line)) return true
+  if (/^please\s+read\b/i.test(line)) return true
+  if (/^moondao\b/i.test(line)) return true
+  return false
+}
+
+function extractTitleFromBody(body: string | undefined | null): string | null {
+  if (!body) return null
+
+  const h1Regex = /^\s*#\s+(.+?)\s*$/m
+  const h1Match = body.match(h1Regex)
+  const h1Title = h1Match?.[1]?.trim() || null
+
+  if (h1Title && !isUntitledLike(h1Title)) return h1Title
+
+  const afterH1Index =
+    h1Match && h1Match.index !== undefined
+      ? h1Match.index + h1Match[0].length
+      : 0
+  const rest = body.slice(afterH1Index)
+
+  const lines = rest.split(/\r?\n/)
+  for (const raw of lines) {
+    const line = cleanLine(raw)
+    if (!line) continue
+    if (isTemplateBoilerplate(line)) continue
+    if (isUntitledLike(line)) continue
+    if (line.length > 200) return line.slice(0, 200).trim()
+    return line
+  }
+
+  return h1Title
+}
+
+export function getProjectDisplayName(
+  project: Partial<Project> | undefined | null,
+  proposalJSON?: { title?: string; body?: string } | null
+): string {
+  const rawName = (project?.name || '').trim()
+  if (rawName && !isUntitledLike(rawName)) return rawName
+
+  const proposalTitle =
+    typeof proposalJSON?.title === 'string' ? proposalJSON.title.trim() : ''
+  if (proposalTitle && !isUntitledLike(proposalTitle)) return proposalTitle
+
+  const bodyTitle = extractTitleFromBody(proposalJSON?.body)
+  if (bodyTitle && !isUntitledLike(bodyTitle)) return bodyTitle
+
+  return rawName || UNTITLED_FALLBACK
+}

--- a/ui/lib/project/getProjectDisplayName.ts
+++ b/ui/lib/project/getProjectDisplayName.ts
@@ -72,5 +72,5 @@ export function getProjectDisplayName(
   const bodyTitle = extractTitleFromBody(proposalJSON?.body)
   if (bodyTitle && !isUntitledLike(bodyTitle)) return bodyTitle
 
-  return rawName || UNTITLED_FALLBACK
+  return rawName && !isUntitledLike(rawName) ? rawName : UNTITLED_FALLBACK
 }

--- a/ui/pages/governance-proposals.tsx
+++ b/ui/pages/governance-proposals.tsx
@@ -4,7 +4,7 @@ import {
   PROJECT_TABLE_NAMES,
   PROPOSALS_ADDRESSES,
 } from 'const/config'
-import { BLOCKED_PROJECTS } from 'const/whitelist'
+import { BLOCKED_MDPS, BLOCKED_PROJECTS } from 'const/whitelist'
 import { gql, GraphQLClient } from 'graphql-request'
 import { GetStaticProps } from 'next'
 import { useState } from 'react'
@@ -243,7 +243,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
     await Promise.all(
       projects.map(async (project: Project, index: number) => {
-        if (BLOCKED_PROJECTS.has(project.id)) return
+        if (BLOCKED_PROJECTS.has(project.id) || BLOCKED_MDPS.has(project.MDP)) return
 
         if (!project.proposalIPFS) return
 

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -21,10 +21,8 @@ import { useRouter } from 'next/router'
 import { useContext, useEffect, useState } from 'react'
 import { getContract, readContract } from 'thirdweb'
 import { getRpcUrlForChain } from 'thirdweb/chains'
-import { getNFT } from 'thirdweb/extensions/erc721'
 import { useActiveAccount } from 'thirdweb/react'
 import { useSubHats } from '@/lib/hats/useSubHats'
-import { useENS } from '@/lib/utils/hooks/useENS'
 import { PROJECT_PENDING } from '@/lib/nance/types'
 import { getProposalStatus, STATUS_CONFIG, STATUS_DISPLAY_LABELS, ProposalStatus } from '@/lib/nance/useProposalStatus'
 import useProjectData, { Project } from '@/lib/project/useProjectData'
@@ -37,7 +35,6 @@ import { serverClient } from '@/lib/thirdweb/client'
 import { useChainDefault } from '@/lib/thirdweb/hooks/useChainDefault'
 import useContract from '@/lib/thirdweb/hooks/useContract'
 import { fetchTotalVMOONEYs } from '@/lib/tokens/hooks/useTotalVMOONEY'
-import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
 import { runQuadraticVoting } from '@/lib/utils/rewards'
 import Container from '@/components/layout/Container'
 import ContentLayout from '@/components/layout/ContentLayout'
@@ -50,83 +47,11 @@ import ProposalVotes from '@/components/nance/ProposalVotes'
 
 import VotingResults from '@/components/nance/VotingResults'
 import ProposalEditSection from '@/components/nance/ProposalEditSection'
+import AuthorCitizenLink from '@/components/project/AuthorCitizenLink'
 import TempCheck from '@/components/project/TempCheck'
 import TeamManageMembers from '@/components/subscription/TeamManageMembers'
 import TeamMembers from '@/components/subscription/TeamMembers'
 import TeamTreasury from '@/components/subscription/TeamTreasury'
-
-function AuthorCitizenLink({
-  authorAddress,
-  citizenContract,
-  authorName,
-}: {
-  authorAddress: string
-  citizenContract: any
-  authorName?: string | null
-}) {
-  const [citizenMeta, setCitizenMeta] = useState<any>(null)
-  const { data: ensData } = useENS(authorAddress)
-  const shortAddress = `${authorAddress.slice(0, 6)}...${authorAddress.slice(-4)}`
-
-  useEffect(() => {
-    async function resolve() {
-      if (!authorAddress || !citizenContract?.address) return
-      try {
-        const tokenId = await readContract({
-          contract: citizenContract,
-          method: 'getOwnedToken' as string,
-          params: [authorAddress],
-        })
-        const nft = await getNFT({
-          contract: citizenContract,
-          tokenId: BigInt(tokenId.toString()),
-        })
-        if (nft?.metadata?.name && nft.metadata.name !== 'Failed to load NFT metadata') {
-          setCitizenMeta({ ...nft.metadata, id: nft.id.toString() })
-        }
-      } catch {
-        // Not a citizen or contract call failed
-      }
-    }
-    resolve()
-  }, [authorAddress, citizenContract])
-
-  const displayName = citizenMeta?.name || authorName || null
-  const addressLabel = ensData?.name || shortAddress
-  const avatarSrc =
-    citizenMeta?.image || `https://cdn.stamp.fyi/avatar/${authorAddress}`
-  const href = citizenMeta
-    ? `/citizen/${generatePrettyLinkWithId(citizenMeta.name, citizenMeta.id)}`
-    : undefined
-
-  const etherscanUrl = `https://etherscan.io/address/${authorAddress}`
-  const linkHref = href || etherscanUrl
-  const linkProps = href ? {} : { target: '_blank' as const, rel: 'noopener noreferrer' }
-
-  return (
-    <Link href={linkHref} {...linkProps} className="no-underline">
-      <div className="flex items-center gap-2 h-7 sm:h-9 bg-white/5 border border-white/10 rounded-lg px-2 sm:px-3 hover:bg-white/10 transition-colors group min-w-0">
-        <div className="w-5 h-5 sm:w-6 sm:h-6 rounded-full overflow-hidden flex-shrink-0">
-          <img
-            src={avatarSrc.startsWith('ipfs://') ? `https://ipfs.io/ipfs/${avatarSrc.replace('ipfs://', '')}` : avatarSrc}
-            alt={displayName || addressLabel}
-            width={24}
-            height={24}
-            className="w-full h-full object-cover"
-          />
-        </div>
-        {displayName && (
-          <span className="text-xs sm:text-sm text-gray-300 group-hover:text-white transition-colors truncate">
-            {displayName}
-          </span>
-        )}
-        <span className="text-xs sm:text-sm font-mono text-gray-500 group-hover:text-gray-300 transition-colors hidden sm:inline">
-          {addressLabel}
-        </span>
-      </div>
-    </Link>
-  )
-}
 
 function ProposalStatusBadge({ status }: { status: ProposalStatus }) {
   const config = STATUS_CONFIG[status as keyof typeof STATUS_CONFIG] || {

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -13,7 +13,7 @@ import {
   NON_PROJECT_PROPOSAL_TABLE_NAMES,
   PROJECT_TABLE_NAMES,
 } from 'const/config'
-import { BLOCKED_PROJECTS } from 'const/whitelist'
+import { BLOCKED_MDPS, BLOCKED_PROJECTS } from 'const/whitelist'
 import { GetServerSideProps } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -400,12 +400,18 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query: pa
 
       let projects = (
         await queryTable(chain, `SELECT * FROM ${projectTableName} WHERE MDP = ${tokenId}`)
-      ).filter((p: Project) => !BLOCKED_PROJECTS.has(Number(p.id)))
+      ).filter(
+        (p: Project) =>
+          !BLOCKED_PROJECTS.has(Number(p.id)) && !BLOCKED_MDPS.has(Number(p.MDP))
+      )
 
       if (!projects[0]) {
         projects = (
           await queryTable(chain, `SELECT * FROM ${projectTableName} WHERE id = ${tokenId}`)
-        ).filter((p: Project) => !BLOCKED_PROJECTS.has(Number(p.id)))
+        ).filter(
+          (p: Project) =>
+            !BLOCKED_PROJECTS.has(Number(p.id)) && !BLOCKED_MDPS.has(Number(p.MDP))
+        )
       }
 
       if (projects[0]) {

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -25,6 +25,7 @@ import { useActiveAccount } from 'thirdweb/react'
 import { useSubHats } from '@/lib/hats/useSubHats'
 import { PROJECT_PENDING } from '@/lib/nance/types'
 import { getProposalStatus, STATUS_CONFIG, STATUS_DISPLAY_LABELS, ProposalStatus } from '@/lib/nance/useProposalStatus'
+import { getProjectDisplayName } from '@/lib/project/getProjectDisplayName'
 import useProjectData, { Project } from '@/lib/project/useProjectData'
 import useSafe from '@/lib/safe/useSafe'
 import queryTable from '@/lib/tableland/queryTable'
@@ -182,6 +183,7 @@ export default function ProjectProfile({
   const body = proposalJSON?.body || ''
   const submittedDate = body.match(/^Date:\s*(.+)$/m)?.[1]?.trim() || null
   const authorName = body.match(/^Author:\s*(.+)$/m)?.[1]?.trim() || null
+  const displayName = getProjectDisplayName(project, proposalJSON)
 
   const totalBudgetDisplay = (() => {
     const match = body.match(/\*{0,2}Total\s+Budget\*{0,2}[:\s|]+(.+?)(?:\s*\||\s*$)/im)
@@ -198,9 +200,9 @@ export default function ProjectProfile({
 
   return (
     <Container>
-      <Head title={project.name} description={project.description} />
+      <Head title={displayName} description={project.description} />
       <ContentLayout
-        header={project.name}
+        header={displayName}
         headerSize="max(20px, 3vw)"
         maxWidth="1050px"
         description={

--- a/ui/pages/projects/index.tsx
+++ b/ui/pages/projects/index.tsx
@@ -6,7 +6,7 @@ import {
   PROPOSALS_TABLE_NAMES,
   PROPOSALS_ADDRESSES,
 } from 'const/config'
-import { BLOCKED_PROJECTS } from 'const/whitelist'
+import { BLOCKED_MDPS, BLOCKED_PROJECTS } from 'const/whitelist'
 import { useRouter } from 'next/router'
 import { getContract, readContract } from 'thirdweb'
 import { PROJECT_ACTIVE, PROJECT_ENDED, PROJECT_PENDING } from '@/lib/nance/types'
@@ -81,7 +81,7 @@ export async function getStaticProps() {
 
     await Promise.all(
       projects.map(async (project: Project, index: number) => {
-        if (!BLOCKED_PROJECTS.has(project.id)) {
+        if (!BLOCKED_PROJECTS.has(project.id) && !BLOCKED_MDPS.has(project.MDP)) {
           const activeStatus = project.active
           if (activeStatus == PROJECT_PENDING
             && project.quarter === submissionQuarter.quarter

--- a/ui/pages/projects/thank-you.tsx
+++ b/ui/pages/projects/thank-you.tsx
@@ -5,7 +5,7 @@ import {
   DISTRIBUTION_TABLE_ADDRESSES,
   PROJECT_TABLE_ADDRESSES,
 } from 'const/config'
-import { BLOCKED_PROJECTS } from 'const/whitelist'
+import { BLOCKED_MDPS, BLOCKED_PROJECTS } from 'const/whitelist'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
@@ -131,7 +131,10 @@ export async function getStaticProps() {
 
     const projectStatement = `SELECT * FROM ${projectTableName} WHERE year = ${year} AND quarter = ${quarter} AND eligible != 0`
     const projects = await queryTable(chain, projectStatement)
-    const filteredProjects = projects.filter((project: any) => !BLOCKED_PROJECTS.has(project?.id))
+    const filteredProjects = projects.filter(
+      (project: any) =>
+        !BLOCKED_PROJECTS.has(project?.id) && !BLOCKED_MDPS.has(project?.MDP)
+    )
 
     const distributionTableContract = getContract({
       client: serverClient,


### PR DESCRIPTION
## Summary

Cleans up the projects page in preparation for this quarter's Senate Vote and the upcoming retroactive rewards cycle. Adds identifying metadata to project cards, filters out projects that shouldn't be on the page, improves fallback handling for missing titles, and introduces a phase timeline graphic so it's visually clear where we are in the project system lifecycle.

## Changes

**Project cards**
- Display the `MDP-###` badge and the author (citizen link + ENS/address fallback) on every project card.
- Extract `AuthorCitizenLink` into a shared component (`ui/components/project/AuthorCitizenLink.tsx`) and reuse it on the project detail page.
- Add `getProjectDisplayName` utility that falls back to the proposal JSON title and, if that is also `# Untitled`, extracts the first meaningful line of the markdown body (skipping boilerplate like `Author:` / `Date:` / `Please read...`).

**Filtering**
- New `BLOCKED_MDPS` list in `ui/const/whitelist.ts` — mainnet-only — used alongside `BLOCKED_PROJECTS` in `/projects`, `/projects/thank-you`, `/governance-proposals`, `/project/[tokenId]`, and the signed-in dashboard.

**Voting cycle**
- Flip `IS_SENATE_VOTE = true` / `IS_MEMBER_VOTE = false` in `ui/const/config.ts` to open the Senate Vote phase.
- Header on `/projects` now reads `Q{current}: {year} Rewards` using the current quarter rather than the retro-vote quarter, to better match what people see on the page.

**Senators roster**
- Update `SENATORS_LIST.arbitrum` to match the current on-chain roster after removing engibob / Eiman / Titan and adding Anastasia back along with Rina. Cypress expectations updated to match.

**Project System intro + phase timeline**
- Add a short intro blurb at the top of `/projects` explaining the project system and linking to `/project-system-docs`.
- Add a 5-step phase timeline graphic (Submit → Senate → Member → Build → Retroactive) with an active "NOW" indicator that reacts to `IS_SENATE_VOTE`, `IS_MEMBER_VOTE`, and `rewardVotingActive`. Retro is gated on `IS_MEMBER_VOTE && rewardVotingActive` so it only lights up once we are actively asking for retro votes.
- Responsive across screen sizes (no horizontal scroll, pulse indicator no longer clips).

## Test plan

- [ ] `/projects` renders MDP number + author on each card.
- [ ] Blocked MDPs (229, 233, 238, 243, 246, 247) do not appear on `/projects`, `/governance-proposals`, or the signed-in dashboard.
- [ ] A project whose body starts with `# Untitled` (e.g. MDP-248) shows a meaningful title from the body.
- [ ] Phase timeline lights up only Senate while `IS_SENATE_VOTE = true`.
- [ ] Flipping to `IS_MEMBER_VOTE = true` lights up Member + Retroactive together.
- [ ] `yarn cypress run --spec "ui/cypress/integration/lib/project/use-proposal-data.cy.tsx"` passes with the updated senator list.
