### PR TITLE
Projects page cleanup: tabbed nav, quarter filters, better titles & budgets

### DIFF
--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -95,6 +95,15 @@ export function ProjectRewards({
   const [edit, setEdit] = useState(false)
   const [distribution, setDistribution] = useState<{ [key: string]: number }>({})
   const [originalDistribution, setOriginalDistribution] = useState<{ [key: string]: number }>({})
+
+  type ProjectTab = 'proposals' | 'active' | 'past'
+  const hasProposals = !!proposals?.length
+  const initialTab: ProjectTab = hasProposals
+    ? 'proposals'
+    : currentProjects?.length
+    ? 'active'
+    : 'past'
+  const [activeTab, setActiveTab] = useState<ProjectTab>(initialTab)
   
   // Separate state for proposal allocations
   const [proposalEdit, setProposalEdit] = useState(false)
@@ -871,10 +880,61 @@ export function ProjectRewards({
               </div>
             </div>
 
-            {proposals && proposals.length > 0 && (
+            {/* Tabs - switch between Project Proposals, Active Projects, Past Projects */}
+            {(() => {
+              const tabs: { id: ProjectTab; label: string; count: number }[] = [
+                { id: 'proposals', label: 'Project Proposals', count: proposals?.length ?? 0 },
+                { id: 'active', label: 'Active Projects', count: currentProjects?.length ?? 0 },
+                { id: 'past', label: 'Past Projects', count: pastProjects?.length ?? 0 },
+              ]
+              return (
+                <div
+                  id="projects-tabs"
+                  role="tablist"
+                  aria-label="Project sections"
+                  className="-mb-3 sm:-mb-4 px-1 sm:px-0 flex items-end gap-1 border-b border-white/10 overflow-x-auto"
+                >
+                  {tabs.map((tab) => {
+                    const isActive = activeTab === tab.id
+                    return (
+                      <button
+                        key={tab.id}
+                        type="button"
+                        role="tab"
+                        aria-selected={isActive}
+                        onClick={() => setActiveTab(tab.id)}
+                        className={`group relative px-3 sm:px-5 py-2.5 sm:py-3 -mb-px text-xs sm:text-sm font-RobotoMono uppercase tracking-wider whitespace-nowrap transition-colors rounded-t-lg border border-b-0 ${
+                          isActive
+                            ? 'bg-black/40 border-white/15 text-white'
+                            : 'bg-transparent border-transparent text-gray-500 hover:text-gray-200'
+                        }`}
+                      >
+                        <span className="flex items-center gap-2">
+                          <span>{tab.label}</span>
+                          <span
+                            className={`inline-flex items-center justify-center min-w-[20px] px-1.5 h-5 rounded-full text-[10px] font-semibold ${
+                              isActive
+                                ? 'bg-blue-500/20 text-blue-200 border border-blue-400/30'
+                                : 'bg-white/5 text-gray-500 border border-white/10 group-hover:bg-white/10 group-hover:text-gray-300'
+                            }`}
+                          >
+                            {tab.count}
+                          </span>
+                        </span>
+                        {isActive && (
+                          <span className="pointer-events-none absolute left-2 right-2 -bottom-px h-0.5 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full" />
+                        )}
+                      </button>
+                    )
+                  })}
+                </div>
+              )
+            })()}
+
+            {activeTab === 'proposals' && proposals && proposals.length > 0 && (
               <div
                 id="proposals-container"
-                className="bg-black/20 rounded-none sm:rounded-xl px-1 py-2 sm:p-6 border-y sm:border border-white/10"
+                className="bg-black/20 rounded-none sm:rounded-b-xl px-1 py-2 sm:p-6 border-y sm:border sm:border-t-0 border-white/10"
               >
                 <h1 className="font-GoodTimes text-white/80 text-base sm:text-xl mb-2 sm:mb-6 px-1 sm:px-0">
                   {IS_SENATE_VOTE ? (
@@ -971,9 +1031,10 @@ export function ProjectRewards({
               </div>
             )}
 
+            {activeTab === 'active' && (
             <div
               id="projects-container"
-              className="bg-black/20 rounded-none sm:rounded-xl px-1 py-2 sm:p-6 border-y sm:border border-white/10"
+              className="bg-black/20 rounded-none sm:rounded-b-xl px-1 py-2 sm:p-6 border-y sm:border sm:border-t-0 border-white/10"
             >
               <h1 className="font-GoodTimes text-white/80 text-base sm:text-xl mb-2 sm:mb-6 px-1 sm:px-0">Active Projects</h1>
 
@@ -1057,9 +1118,12 @@ export function ProjectRewards({
                     ))}
               </div>
             </div>
-            <div className="bg-black/20 rounded-none sm:rounded-xl border-y sm:border border-white/10 overflow-hidden">
+            )}
+            {activeTab === 'past' && (
+            <div className="bg-black/20 rounded-none sm:rounded-b-xl border-y sm:border sm:border-t-0 border-white/10 overflow-hidden">
               <PastProjects projects={pastProjects} />
             </div>
+            )}
           </div>
         </ContentLayout>
       </Container>

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -49,7 +49,7 @@ import SectionCard from '@/components/layout/SectionCard'
 import StandardButtonRight from '@/components/layout/StandardButtonRight'
 import Tooltip from '@/components/layout/Tooltip'
 import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
-import PastProjects from '@/components/project/PastProjects'
+import PastProjects, { hasFinalReport } from '@/components/project/PastProjects'
 import ProjectCard from '@/components/project/ProjectCard'
 import RewardAsset from '@/components/project/RewardAsset'
 
@@ -882,10 +882,11 @@ export function ProjectRewards({
 
             {/* Tabs - switch between Project Proposals, Active Projects, Past Projects */}
             {(() => {
+              const pastProjectsWithReports = pastProjects?.filter(hasFinalReport) ?? []
               const tabs: { id: ProjectTab; label: string; count: number }[] = [
                 { id: 'proposals', label: 'Project Proposals', count: proposals?.length ?? 0 },
                 { id: 'active', label: 'Active Projects', count: currentProjects?.length ?? 0 },
-                { id: 'past', label: 'Past Projects', count: pastProjects?.length ?? 0 },
+                { id: 'past', label: 'Past Projects', count: pastProjectsWithReports.length },
               ]
               return (
                 <div
@@ -1120,7 +1121,7 @@ export function ProjectRewards({
             </div>
             )}
             {activeTab === 'past' && (
-            <div className="bg-black/20 rounded-none sm:rounded-b-xl border-y sm:border sm:border-t-0 border-white/10 overflow-hidden">
+            <div className="bg-black/20 rounded-none sm:rounded-b-xl border-y sm:border sm:border-t-0 border-white/10">
               <PastProjects projects={pastProjects} />
             </div>
             )}

--- a/ui/components/project/PastProjects.tsx
+++ b/ui/components/project/PastProjects.tsx
@@ -1,36 +1,61 @@
 import HatsABI from 'const/abis/Hats.json'
 import ProjectABI from 'const/abis/Project.json'
 import { HATS_ADDRESS, PROJECT_ADDRESSES } from 'const/config'
-import { useRouter } from 'next/router'
-import { useState, useEffect, useCallback, useContext, useMemo } from 'react'
+import { useState, useEffect, useContext, useMemo } from 'react'
 import { Project } from '@/lib/project/useProjectData'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
 import { useChainDefault } from '@/lib/thirdweb/hooks/useChainDefault'
 import useContract from '@/lib/thirdweb/hooks/useContract'
-import { useShallowQueryRoute } from '@/lib/utils/hooks'
-import CardGridContainer from '@/components/layout/CardGridContainer'
-import CardSkeleton from '@/components/layout/CardSkeleton'
-import Frame from '@/components/layout/Frame'
-import PaginationButtons from '@/components/layout/PaginationButtons'
-import Search from '@/components/layout/Search'
 import ProjectCard from '@/components/project/ProjectCard'
 
 type PastProjectProps = {
   projects: Project[]
 }
 
+type QuarterGroup = {
+  key: string
+  year: number
+  quarter: number
+  label: string
+  projects: Project[]
+}
+
+export function hasFinalReport(p: Project): boolean {
+  return Boolean(p.finalReportIPFS || p.finalReportLink)
+}
+
+function groupByQuarter(projects: Project[]): QuarterGroup[] {
+  const groups = new Map<string, QuarterGroup>()
+  for (const project of projects) {
+    const year = Number(project.year) || 0
+    const quarter = Number(project.quarter) || 0
+    const key = `${year}-Q${quarter}`
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        year,
+        quarter,
+        label: `Q${quarter} ${year}`,
+        projects: [],
+      })
+    }
+    groups.get(key)!.projects.push(project)
+  }
+  return Array.from(groups.values()).sort((a, b) => {
+    if (b.year !== a.year) return b.year - a.year
+    return b.quarter - a.quarter
+  })
+}
+
 export default function PastProjects({ projects }: PastProjectProps) {
   const finalReportProjects = useMemo(
-    () => projects.filter((p) => p.finalReportIPFS || p.finalReportLink),
+    () => projects.filter(hasFinalReport),
     [projects]
   )
   const { selectedChain } = useContext(ChainContextV5)
   const chainSlug = getChainSlug(selectedChain)
-  const router = useRouter()
-  const shallowQueryRoute = useShallowQueryRoute()
 
-  //Contracts
   const projectContract = useContract({
     address: PROJECT_ADDRESSES[chainSlug],
     abi: ProjectABI as any,
@@ -44,123 +69,149 @@ export default function PastProjects({ projects }: PastProjectProps) {
   })
 
   const [input, setInput] = useState('')
-  function filterBySearch(projects: Project[]) {
-    return projects.filter((project) => {
-      return project.name
-        ?.toString()
-        .toLowerCase()
-        .includes(input.toLowerCase())
-    })
-  }
 
-  const handlePageChange = useCallback(
-    (newPage: number) => {
-      setPageIdx(newPage)
-      shallowQueryRoute({ page: newPage.toString() })
-    },
-    [shallowQueryRoute]
+  // Group ALL final-report projects (so quarters reflect real data, not the search filter)
+  const groups = useMemo(
+    () => groupByQuarter(finalReportProjects),
+    [finalReportProjects]
   )
 
-  const [maxPage, setMaxPage] = useState(1)
+  const [activeKey, setActiveKey] = useState<string | null>(null)
 
   useEffect(() => {
-    const totalProjects =
-      input != ''
-        ? filterBySearch(finalReportProjects).length
-        : finalReportProjects.length
-
-    setMaxPage(Math.ceil(totalProjects / 9))
-  }, [input, finalReportProjects])
-
-  const [cachedNFTs, setCachedNFTs] = useState<Project[]>([])
-
-  const [pageIdx, setPageIdx] = useState(1)
-
-  useEffect(() => {
-    const { page: urlPage } = router.query
-    if (urlPage && !isNaN(Number(urlPage))) {
-      setPageIdx(Number(urlPage))
+    if (!groups.length) {
+      setActiveKey(null)
+      return
     }
-  }, [router.query])
+    setActiveKey((prev) => {
+      if (prev && groups.some((g) => g.key === prev)) return prev
+      return groups[0].key
+    })
+  }, [groups])
 
-  useEffect(() => {
-    setCachedNFTs(
-      input != '' ? filterBySearch(finalReportProjects) : finalReportProjects
+  const activeGroup = useMemo(
+    () => groups.find((g) => g.key === activeKey) || null,
+    [groups, activeKey]
+  )
+
+  const visibleProjects = useMemo(() => {
+    if (!activeGroup) return []
+    const term = input.trim().toLowerCase()
+    if (!term) return activeGroup.projects
+    return activeGroup.projects.filter((p) =>
+      p.name?.toString().toLowerCase().includes(term)
     )
-  }, [input, finalReportProjects, router.query])
+  }, [activeGroup, input])
 
   useChainDefault()
 
   return (
-    <div className="p-6">
-      <div className="mb-6">
-        <h1 className="font-GoodTimes text-white/80 text-xl mb-4">
-          Past Projects
-        </h1>
-        <div className="bg-black/20 rounded-xl p-4 border border-white/10">
-          <div className="relative">
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <svg
-                className="h-5 w-5 text-gray-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
-            </div>
-            <input
-              className="w-full pl-10 pr-4 py-3 bg-black/30 border border-white/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-all duration-200"
-              onChange={({ target }) => setInput(target.value)}
-              value={input}
-              type="text"
-              name="search"
-              placeholder="Search projects..."
-            />
+    <div className="p-3 sm:p-6 flex flex-col gap-3 sm:gap-5">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-1 sm:px-0">
+        <div className="flex items-baseline gap-3">
+          <h1 className="font-GoodTimes text-white/80 text-base sm:text-xl">
+            Past Projects
+          </h1>
+          <span className="text-[11px] sm:text-xs font-RobotoMono uppercase tracking-wider text-gray-500">
+            {finalReportProjects.length} total
+          </span>
+        </div>
+        <div className="relative w-full sm:max-w-xs">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <svg
+              className="h-4 w-4 text-gray-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
           </div>
+          <input
+            className="w-full pl-9 pr-3 py-2 text-sm bg-black/30 border border-white/15 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-500/40 transition-all"
+            onChange={({ target }) => setInput(target.value)}
+            value={input}
+            type="text"
+            name="search"
+            placeholder={
+              activeGroup
+                ? `Search ${activeGroup.label}...`
+                : 'Search past projects...'
+            }
+          />
         </div>
       </div>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {cachedNFTs?.[0] ? (
-          cachedNFTs
-            ?.slice((pageIdx - 1) * 9, pageIdx * 9)
-            .map((project: any, I: number) => {
-              return (
-                <ProjectCard
-                    key={`project-card-${I}`}
-                    project={project}
-                    projectContract={projectContract}
-                    hatsContract={hatsContract}
-                    isVotingPeriod={false}
-                  />
-              )
-            })
-        ) : (
-          <>
-            {Array.from({ length: 9 }).map((_, i) => (
-              <div
-                key={`card-skeleton-${i}`}
-                className="bg-black/20 rounded-xl border border-white/10 overflow-hidden"
+
+      {groups.length > 0 && (
+        <div
+          role="tablist"
+          aria-label="Past project quarters"
+          className="flex items-end gap-1 border-b border-white/10 overflow-x-auto"
+        >
+          {groups.map((group) => {
+            const isActive = activeKey === group.key
+            return (
+              <button
+                key={group.key}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setActiveKey(group.key)}
+                className={`group relative px-3 sm:px-4 py-2 sm:py-2.5 -mb-px text-xs sm:text-sm font-RobotoMono uppercase tracking-wider whitespace-nowrap transition-colors rounded-t-lg border border-b-0 ${
+                  isActive
+                    ? 'bg-black/40 border-white/15 text-white'
+                    : 'bg-transparent border-transparent text-gray-500 hover:text-gray-200'
+                }`}
               >
-                <CardSkeleton />
-              </div>
-            ))}
-          </>
-        )}
-      </div>
-      <div className="mt-6">
-        <PaginationButtons
-          handlePageChange={handlePageChange}
-          maxPage={maxPage}
-          pageIdx={pageIdx}
-          label="Page"
-        />
-      </div>
+                <span className="flex items-center gap-2">
+                  <span>{group.label}</span>
+                  <span
+                    className={`inline-flex items-center justify-center min-w-[18px] px-1.5 h-[18px] rounded-full text-[9px] sm:text-[10px] font-semibold ${
+                      isActive
+                        ? 'bg-blue-500/20 text-blue-200 border border-blue-400/30'
+                        : 'bg-white/5 text-gray-500 border border-white/10 group-hover:bg-white/10 group-hover:text-gray-300'
+                    }`}
+                  >
+                    {group.projects.length}
+                  </span>
+                </span>
+                {isActive && (
+                  <span className="pointer-events-none absolute left-2 right-2 -bottom-px h-0.5 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full" />
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {groups.length === 0 ? (
+        <div className="bg-black/20 rounded-lg sm:rounded-xl border border-white/10 py-10 text-center text-gray-400">
+          No past projects yet.
+        </div>
+      ) : visibleProjects.length === 0 ? (
+        <div className="bg-black/20 rounded-lg sm:rounded-xl border border-white/10 py-10 text-center text-gray-400">
+          {input
+            ? `No projects in ${activeGroup?.label} match your search.`
+            : 'No projects in this quarter.'}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5 sm:gap-6">
+          {visibleProjects.map((project, i) => (
+            <ProjectCard
+              key={`past-project-${activeKey}-${project.id}-${i}`}
+              project={project}
+              projectContract={projectContract}
+              hatsContract={hatsContract}
+              isVotingPeriod={false}
+            />
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/ui/components/project/PastProjects.tsx
+++ b/ui/components/project/PastProjects.tsx
@@ -13,39 +13,31 @@ type PastProjectProps = {
   projects: Project[]
 }
 
-type QuarterGroup = {
-  key: string
+type QuarterCount = { quarter: number; count: number }
+type YearGroup = {
   year: number
-  quarter: number
-  label: string
-  projects: Project[]
+  total: number
+  quarters: Map<number, Project[]>
 }
 
 export function hasFinalReport(p: Project): boolean {
   return Boolean(p.finalReportIPFS || p.finalReportLink)
 }
 
-function groupByQuarter(projects: Project[]): QuarterGroup[] {
-  const groups = new Map<string, QuarterGroup>()
+function buildYearIndex(projects: Project[]): YearGroup[] {
+  const byYear = new Map<number, YearGroup>()
   for (const project of projects) {
     const year = Number(project.year) || 0
     const quarter = Number(project.quarter) || 0
-    const key = `${year}-Q${quarter}`
-    if (!groups.has(key)) {
-      groups.set(key, {
-        key,
-        year,
-        quarter,
-        label: `Q${quarter} ${year}`,
-        projects: [],
-      })
+    if (!byYear.has(year)) {
+      byYear.set(year, { year, total: 0, quarters: new Map() })
     }
-    groups.get(key)!.projects.push(project)
+    const yg = byYear.get(year)!
+    yg.total += 1
+    if (!yg.quarters.has(quarter)) yg.quarters.set(quarter, [])
+    yg.quarters.get(quarter)!.push(project)
   }
-  return Array.from(groups.values()).sort((a, b) => {
-    if (b.year !== a.year) return b.year - a.year
-    return b.quarter - a.quarter
-  })
+  return Array.from(byYear.values()).sort((a, b) => b.year - a.year)
 }
 
 export default function PastProjects({ projects }: PastProjectProps) {
@@ -70,38 +62,70 @@ export default function PastProjects({ projects }: PastProjectProps) {
 
   const [input, setInput] = useState('')
 
-  // Group ALL final-report projects (so quarters reflect real data, not the search filter)
-  const groups = useMemo(
-    () => groupByQuarter(finalReportProjects),
+  const yearGroups = useMemo(
+    () => buildYearIndex(finalReportProjects),
     [finalReportProjects]
   )
 
-  const [activeKey, setActiveKey] = useState<string | null>(null)
+  const [selectedYear, setSelectedYear] = useState<number | null>(null)
+  const [selectedQuarter, setSelectedQuarter] = useState<number | null>(null)
 
+  // Initialize / heal selection when data changes
   useEffect(() => {
-    if (!groups.length) {
-      setActiveKey(null)
+    if (!yearGroups.length) {
+      setSelectedYear(null)
+      setSelectedQuarter(null)
       return
     }
-    setActiveKey((prev) => {
-      if (prev && groups.some((g) => g.key === prev)) return prev
-      return groups[0].key
+    setSelectedYear((prevYear) => {
+      const stillValid =
+        prevYear != null && yearGroups.some((yg) => yg.year === prevYear)
+      return stillValid ? prevYear : yearGroups[0].year
     })
-  }, [groups])
+  }, [yearGroups])
 
-  const activeGroup = useMemo(
-    () => groups.find((g) => g.key === activeKey) || null,
-    [groups, activeKey]
+  // When year changes, pick the most recent quarter with projects in that year
+  useEffect(() => {
+    if (selectedYear == null) {
+      setSelectedQuarter(null)
+      return
+    }
+    const yg = yearGroups.find((g) => g.year === selectedYear)
+    if (!yg) return
+    setSelectedQuarter((prevQ) => {
+      if (prevQ != null && yg.quarters.has(prevQ)) return prevQ
+      const available = Array.from(yg.quarters.keys()).sort((a, b) => b - a)
+      return available[0] ?? null
+    })
+  }, [selectedYear, yearGroups])
+
+  const activeYearGroup = useMemo(
+    () => yearGroups.find((g) => g.year === selectedYear) ?? null,
+    [yearGroups, selectedYear]
   )
 
+  const quarterCounts: QuarterCount[] = useMemo(() => {
+    if (!activeYearGroup) return []
+    return [1, 2, 3, 4].map((q) => ({
+      quarter: q,
+      count: activeYearGroup.quarters.get(q)?.length ?? 0,
+    }))
+  }, [activeYearGroup])
+
   const visibleProjects = useMemo(() => {
-    if (!activeGroup) return []
+    if (!activeYearGroup || selectedQuarter == null) return []
+    const list = activeYearGroup.quarters.get(selectedQuarter) ?? []
     const term = input.trim().toLowerCase()
-    if (!term) return activeGroup.projects
-    return activeGroup.projects.filter((p) =>
+    if (!term) return list
+    return list.filter((p) =>
       p.name?.toString().toLowerCase().includes(term)
     )
-  }, [activeGroup, input])
+  }, [activeYearGroup, selectedQuarter, input])
+
+  const activeLabel =
+    selectedYear != null && selectedQuarter != null
+      ? `Q${selectedQuarter} ${selectedYear}`
+      : null
 
   useChainDefault()
 
@@ -139,71 +163,119 @@ export default function PastProjects({ projects }: PastProjectProps) {
             type="text"
             name="search"
             placeholder={
-              activeGroup
-                ? `Search ${activeGroup.label}...`
-                : 'Search past projects...'
+              activeLabel ? `Search ${activeLabel}...` : 'Search past projects...'
             }
           />
         </div>
       </div>
 
-      {groups.length > 0 && (
-        <div
-          role="tablist"
-          aria-label="Past project quarters"
-          className="flex items-end gap-1 border-b border-white/10 overflow-x-auto"
-        >
-          {groups.map((group) => {
-            const isActive = activeKey === group.key
-            return (
-              <button
-                key={group.key}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                onClick={() => setActiveKey(group.key)}
-                className={`group relative px-3 sm:px-4 py-2 sm:py-2.5 -mb-px text-xs sm:text-sm font-RobotoMono uppercase tracking-wider whitespace-nowrap transition-colors rounded-t-lg border border-b-0 ${
-                  isActive
-                    ? 'bg-black/40 border-white/15 text-white'
-                    : 'bg-transparent border-transparent text-gray-500 hover:text-gray-200'
-                }`}
-              >
-                <span className="flex items-center gap-2">
-                  <span>{group.label}</span>
+      {yearGroups.length > 0 && (
+        <div className="bg-black/20 rounded-lg sm:rounded-xl border border-white/10 p-2 sm:p-3 flex flex-col gap-2 sm:gap-3">
+          {/* Year tabs */}
+          <div
+            role="tablist"
+            aria-label="Select year"
+            className="flex flex-wrap items-center gap-1.5"
+          >
+            <span className="hidden sm:inline-flex shrink-0 text-[10px] font-RobotoMono uppercase tracking-wider text-gray-500 px-1">
+              Year
+            </span>
+            {yearGroups.map((yg) => {
+              const isActive = selectedYear === yg.year
+              return (
+                <button
+                  key={yg.year}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setSelectedYear(yg.year)}
+                  className={`group inline-flex items-center gap-1.5 px-2.5 sm:px-3 py-1 sm:py-1.5 rounded-md text-xs sm:text-sm font-RobotoMono tracking-wide transition-colors border ${
+                    isActive
+                      ? 'bg-blue-500/15 border-blue-400/40 text-white'
+                      : 'bg-white/5 border-white/10 text-gray-400 hover:bg-white/10 hover:text-white'
+                  }`}
+                >
+                  <span className="font-semibold">{yg.year}</span>
                   <span
-                    className={`inline-flex items-center justify-center min-w-[18px] px-1.5 h-[18px] rounded-full text-[9px] sm:text-[10px] font-semibold ${
-                      isActive
-                        ? 'bg-blue-500/20 text-blue-200 border border-blue-400/30'
-                        : 'bg-white/5 text-gray-500 border border-white/10 group-hover:bg-white/10 group-hover:text-gray-300'
+                    className={`text-[10px] ${
+                      isActive ? 'text-blue-200' : 'text-gray-500 group-hover:text-gray-300'
                     }`}
                   >
-                    {group.projects.length}
+                    {yg.total}
                   </span>
-                </span>
-                {isActive && (
-                  <span className="pointer-events-none absolute left-2 right-2 -bottom-px h-0.5 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full" />
-                )}
-              </button>
-            )
-          })}
+                </button>
+              )
+            })}
+          </div>
+
+          {/* Quarter buttons (always 4, disabled when empty) */}
+          {activeYearGroup && (
+            <div
+              role="tablist"
+              aria-label={`Select quarter in ${selectedYear}`}
+              className="flex items-center gap-1.5"
+            >
+              <span className="hidden sm:inline-flex shrink-0 text-[10px] font-RobotoMono uppercase tracking-wider text-gray-500 px-1">
+                Quarter
+              </span>
+              <div className="grid grid-cols-4 gap-1.5 flex-1 sm:flex-none sm:inline-grid">
+                {quarterCounts.map(({ quarter, count }) => {
+                  const isActive = selectedQuarter === quarter
+                  const isDisabled = count === 0
+                  return (
+                    <button
+                      key={quarter}
+                      type="button"
+                      role="tab"
+                      aria-selected={isActive}
+                      disabled={isDisabled}
+                      onClick={() => setSelectedQuarter(quarter)}
+                      className={`relative px-3 sm:px-4 py-1.5 rounded-md text-xs sm:text-sm font-RobotoMono tracking-wide transition-colors border min-w-[60px] sm:min-w-[72px] ${
+                        isDisabled
+                          ? 'bg-white/[0.02] border-white/5 text-gray-600 cursor-not-allowed'
+                          : isActive
+                          ? 'bg-gradient-to-r from-blue-500/20 to-purple-600/20 border-blue-400/40 text-white shadow-sm'
+                          : 'bg-white/5 border-white/10 text-gray-400 hover:bg-white/10 hover:text-white'
+                      }`}
+                    >
+                      <span className="flex items-center justify-center gap-1.5">
+                        <span className="font-semibold">Q{quarter}</span>
+                        <span
+                          className={`text-[10px] ${
+                            isDisabled
+                              ? 'text-gray-700'
+                              : isActive
+                              ? 'text-blue-200'
+                              : 'text-gray-500'
+                          }`}
+                        >
+                          {count}
+                        </span>
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
         </div>
       )}
 
-      {groups.length === 0 ? (
+      {yearGroups.length === 0 ? (
         <div className="bg-black/20 rounded-lg sm:rounded-xl border border-white/10 py-10 text-center text-gray-400">
           No past projects yet.
         </div>
       ) : visibleProjects.length === 0 ? (
         <div className="bg-black/20 rounded-lg sm:rounded-xl border border-white/10 py-10 text-center text-gray-400">
           {input
-            ? `No projects in ${activeGroup?.label} match your search.`
-            : 'No projects in this quarter.'}
+            ? `No projects in ${activeLabel} match your search.`
+            : `No projects in ${activeLabel}.`}
         </div>
       ) : (
         <div className="flex flex-col gap-1.5 sm:gap-6">
           {visibleProjects.map((project, i) => (
             <ProjectCard
-              key={`past-project-${activeKey}-${project.id}-${i}`}
+              key={`past-project-${selectedYear}-${selectedQuarter}-${project.id}-${i}`}
               project={project}
               projectContract={projectContract}
               hatsContract={hatsContract}

--- a/ui/components/project/ProjectCard.tsx
+++ b/ui/components/project/ProjectCard.tsx
@@ -10,6 +10,7 @@ import {
   PROPOSALS_ADDRESSES,
   IS_SENATE_VOTE,
 } from 'const/config'
+import { getProposalVideoUrl } from 'const/proposalVideos'
 import Link from 'next/link'
 import React, { useContext, memo, useState, useMemo, useEffect } from 'react'
 import { prepareContractCall, sendAndConfirmTransaction, readContract } from 'thirdweb'
@@ -462,23 +463,41 @@ const ProjectCardContent = memo(
                 <SenatorsStatus senatorVotes={senatorVotes} isLoading={senatorVotesLoading} />
               )}
             </div>
-            {(project?.finalReportLink || project?.finalReportIPFS) && (
-              <StandardButton
-                className={`bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 w-fit text-sm px-3 py-2 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 ${
-                  distribute && 'sm:mr-4'
-                }`}
-                link={
-                  project?.finalReportIPFS ? `/project/${project.MDP}` : project?.finalReportLink
-                }
-                onClick={(e: any) => {
-                  e.stopPropagation()
-                }}
-                hoverEffect={false}
-                target={project?.finalReportIPFS ? '_self' : '_blank'}
-              >
-                <p className="text-sm font-medium">📋 Final Report</p>
-              </StandardButton>
-            )}
+            <div className="flex flex-wrap items-center gap-2">
+              {(project?.finalReportLink || project?.finalReportIPFS) && (
+                <StandardButton
+                  className={`bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 w-fit text-sm px-3 py-2 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 ${
+                    distribute && 'sm:mr-4'
+                  }`}
+                  link={
+                    project?.finalReportIPFS ? `/project/${project.MDP}` : project?.finalReportLink
+                  }
+                  onClick={(e: any) => {
+                    e.stopPropagation()
+                  }}
+                  hoverEffect={false}
+                  target={project?.finalReportIPFS ? '_self' : '_blank'}
+                >
+                  <p className="text-sm font-medium">📋 Final Report</p>
+                </StandardButton>
+              )}
+              {(() => {
+                const videoUrl = getProposalVideoUrl(project?.MDP)
+                if (!videoUrl) return null
+                return (
+                  <a
+                    href={videoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="inline-flex items-center gap-1 text-xs text-white/60 hover:text-white underline underline-offset-2 transition-colors"
+                  >
+                    <span aria-hidden>▶</span>
+                    <span>Watch presentation</span>
+                  </a>
+                )
+              })()}
+            </div>
           </div>
           {/* Senate Vote mode: show budget badge and vote buttons together on the right (desktop) or below title (mobile) */}
           {IS_SENATE_VOTE && project?.MDP && project.active === PROJECT_PENDING && (
@@ -529,7 +548,7 @@ const ProjectCardContent = memo(
             ))}
           {!distribute && isVotingPeriod && (
             <div className="flex flex-col items-start sm:items-end flex-shrink-0">
-              <p className="text-gray-400 text-sm">Ineligible</p>
+              <p className="text-gray-400 text-sm">Ongoing</p>
             </div>
           )}
         </div>

--- a/ui/const/proposalVideos.ts
+++ b/ui/const/proposalVideos.ts
@@ -1,0 +1,23 @@
+// Links to each project proposal's video presentation. Keyed by MDP number.
+// Timestamps in the URLs deep-link into the Senate review livestream.
+export const PROPOSAL_VIDEOS: Record<number, string> = {
+  230: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=740s',
+  231: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=1055s',
+  232: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=1477s',
+  233: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=6897s',
+  235: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=1992s',
+  237: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=2585s',
+  238: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=3240s',
+  239: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=3908s',
+  240: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=5656s',
+  241: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=5439s',
+  242: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=5439s',
+  244: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=4635s',
+  245: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=6304s',
+  248: 'https://www.youtube.com/watch?v=bvOK0UFr19M&t=3240s',
+}
+
+export function getProposalVideoUrl(mdp: number | undefined | null): string | null {
+  if (mdp == null) return null
+  return PROPOSAL_VIDEOS[mdp] ?? null
+}

--- a/ui/lib/nance/useProposalJSON.tsx
+++ b/ui/lib/nance/useProposalJSON.tsx
@@ -1,26 +1,128 @@
 import { useEffect, useState } from 'react'
 
-function parseBudgetFromSection(text: string): number {
-  const totalMatch = text.match(
-    /\|\s*(?:#{0,3}\s*)?[Tt]otal\s*:?\s*\|\s*(?:#{0,3}\s*)?\$?([\d,]+(?:\.\d+)?)/
-  )
-  if (totalMatch) {
-    return parseFloat(totalMatch[1].replace(/,/g, '')) || 0
-  }
+// Tokens we'll ignore when looking for USD-denominated amounts. If a value in a
+// table cell is suffixed with one of these (e.g. "1.71 ETH"), we shouldn't
+// treat the bare number as USD.
+const NON_USD_TOKENS = /\b(ETH|MOONEY|BTC|MATIC|ARB|OP|SOL)\b/i
 
-  let sum = 0
-  const rowPattern =
-    /\|\s*[^|]+\|\s*(?:#{0,3}\s*)?\$?([\d,]+(?:\.\d+)?)\s*(?:USDC|USDT|DAI|USD)?\s*\|/g
+function isUsdValue(rawCell: string): boolean {
+  if (NON_USD_TOKENS.test(rawCell)) return false
+  if (/\$/.test(rawCell)) return true
+  return /\b(USDC|USDT|DAI|USD)\b/i.test(rawCell)
+}
+
+// Match `| <description> | <value> |` rows, capturing the description and the
+// raw value cell so callers can decide how to interpret each row.
+const TABLE_ROW_PATTERN =
+  /\|\s*([^|]+?)\s*\|\s*([^|]*?\$?[\d,]+(?:\.\d+)?[^|]*?)\s*\|/g
+
+function parseAmount(cell: string): number {
+  const match = cell.match(/\$?\s*([\d,]+(?:\.\d+)?)/)
+  if (!match) return 0
+  return parseFloat(match[1].replace(/,/g, '')) || 0
+}
+
+function findGrandTotal(text: string): number {
+  TABLE_ROW_PATTERN.lastIndex = 0
   let match
-  while ((match = rowPattern.exec(text)) !== null) {
+  while ((match = TABLE_ROW_PATTERN.exec(text)) !== null) {
     if (/---/.test(match[0])) continue
-    sum += parseFloat(match[1].replace(/,/g, '')) || 0
+    const desc = match[1]
+    const value = match[2]
+    if (/\bgrand\s+total\b/i.test(desc) && isUsdValue(value)) {
+      return parseAmount(value)
+    }
   }
-  return sum
+  return 0
+}
+
+function sumUsdTotals(text: string): number {
+  TABLE_ROW_PATTERN.lastIndex = 0
+  let sum = 0
+  let count = 0
+  let match
+  while ((match = TABLE_ROW_PATTERN.exec(text)) !== null) {
+    if (/---/.test(match[0])) continue
+    const desc = match[1]
+    const value = match[2]
+    if (!/\b[Tt]otal\b/i.test(desc)) continue
+    if (!isUsdValue(value)) continue
+    sum += parseAmount(value)
+    count++
+  }
+  return count > 0 ? sum : 0
+}
+
+// Parse budget sections written as freeform prose rather than a markdown
+// table. Handles lines like:
+//   "Product and Testing 1200"
+//   "Marketing and Content 2000 to 2500"
+//   "Analog Mission Support: $800-$1,000"
+// Ranges use the upper bound so the displayed budget reflects the maximum
+// funding the proposal is requesting.
+function sumFreeformBudgetLines(text: string): number {
+  const lineRe =
+    /^\s*(?:[-*•]\s*)?(?:[A-Za-z][A-Za-z &/()'-]{2,}?)\s*[:\-]?\s*\$?\s*([\d,]+(?:\.\d+)?)(?:\s*(?:-|to|–|—)\s*\$?\s*([\d,]+(?:\.\d+)?))?\s*(?:USD|USDC|USDT|DAI)?\s*$/gim
+  let total = 0
+  let matched = false
+  let m
+  while ((m = lineRe.exec(text)) !== null) {
+    if (NON_USD_TOKENS.test(m[0])) continue
+    const low = parseFloat(m[1].replace(/,/g, '')) || 0
+    const high = m[2] ? parseFloat(m[2].replace(/,/g, '')) || 0 : 0
+    const value = high > low ? high : low
+    if (value <= 0) continue
+    total += value
+    matched = true
+  }
+  return matched ? total : 0
+}
+
+function parseBudgetFromSection(text: string): number {
+  // Prefer an explicit "GRAND TOTAL" row in USD if present.
+  const grand = findGrandTotal(text)
+  if (grand > 0) return grand
+
+  // Otherwise sum every "Total" row that's clearly USD-denominated. This
+  // handles proposals that split a budget into "Total Fixed Costs (USD)" and
+  // "Total Bounties" while ignoring an "ETH" grand total at the bottom.
+  const totals = sumUsdTotals(text)
+  if (totals > 0) return totals
+
+  // Fallback: sum each row's value, skipping rows whose value is not USD.
+  TABLE_ROW_PATTERN.lastIndex = 0
+  let sum = 0
+  let match
+  while ((match = TABLE_ROW_PATTERN.exec(text)) !== null) {
+    if (/---/.test(match[0])) continue
+    const value = match[2]
+    if (!isUsdValue(value)) continue
+    sum += parseAmount(value)
+  }
+  if (sum > 0) return sum
+
+  // Last resort: proposals sometimes list budgets as freeform prose rather
+  // than as a markdown table.
+  return sumFreeformBudgetLines(text)
+}
+
+function parseInlineUsdBudget(body: string): number {
+  const inline = body.match(
+    /(?:estimated|total|project)\s+budget\s*:?\s*\(?\s*\$\s*([\d,]+(?:\.\d+)?)/i
+  )
+  if (inline) return parseFloat(inline[1].replace(/,/g, '')) || 0
+  return 0
 }
 
 function parseUsdBudgetFromBody(body: string): number {
-  const budgetHeading = body.match(/^#{1,3}\s+Budget\s*(?:\(.*?\))?\s*$/im)
+  // 1. Honor an explicit "Estimated Budget: ($X)" / "Total Budget: $X" callout.
+  const inline = parseInlineUsdBudget(body)
+  if (inline > 0) return inline
+
+  // 2. Parse the Budget section if we can find it.
+  const budgetHeading = body.match(
+    /^#{1,3}\s+Budget(?:\s+(?:Allocation|Breakdown|Overview|Summary))?\s*(?:\(.*?\))?\s*$/im
+  )
   if (budgetHeading && budgetHeading.index !== undefined) {
     const sectionStart = budgetHeading.index + budgetHeading[0].length
     const nextHeading = body.slice(sectionStart).search(/^#{1,2}\s+(?!#)/m)
@@ -32,12 +134,11 @@ function parseUsdBudgetFromBody(body: string): number {
     if (result > 0) return result
   }
 
-  const totalMatch = body.match(
-    /\|\s*(?:#{0,3}\s*)?[Tt]otal\s*:?\s*\|\s*(?:#{0,3}\s*)?\$?([\d,]+(?:\.\d+)?)/
-  )
-  if (totalMatch) {
-    return parseFloat(totalMatch[1].replace(/,/g, '')) || 0
-  }
+  // 3. Last-ditch effort: any GRAND TOTAL or USD totals anywhere in the body.
+  const grand = findGrandTotal(body)
+  if (grand > 0) return grand
+  const totals = sumUsdTotals(body)
+  if (totals > 0) return totals
 
   return 0
 }

--- a/ui/lib/project/getProjectDisplayName.ts
+++ b/ui/lib/project/getProjectDisplayName.ts
@@ -17,16 +17,30 @@ function cleanLine(line: string): string {
     .replace(/^\s*\*+\s*/, '')
     .replace(/\*{1,3}/g, '')
     .replace(/^\s*>+\s*/, '')
+    .replace(/!\[(.*?)\]\(.*?\)/g, '$1')
     .replace(/\[(.*?)\]\(.*?\)/g, '$1')
     .trim()
+}
+
+function hasMeaningfulText(line: string): boolean {
+  return /[A-Za-z0-9]/.test(line)
 }
 
 function isTemplateBoilerplate(line: string): boolean {
   if (!line) return true
   if (/^author\s*:/i.test(line)) return true
   if (/^date\s*:/i.test(line)) return true
+  if (/^title\s*:\s*$/i.test(line)) return true
   if (/^please\s+read\b/i.test(line)) return true
-  if (/^moondao\b/i.test(line)) return true
+  if (/^moondao\s+projects?\s+template\b/i.test(line)) return true
+  if (/^moondao\s+project\s+proposal\s*:?\s*$/i.test(line)) return true
+  if (/^make\s+a\s+copy\s+of\s+this\b/i.test(line)) return true
+  if (
+    /^(abstract|problem|solution|benefits?|risks?|objectives?|team|timeline|budget|scope\s+of\s+work)\s*:?\s*$/i.test(
+      line
+    )
+  )
+    return true
   return false
 }
 
@@ -47,10 +61,13 @@ function extractTitleFromBody(body: string | undefined | null): string | null {
 
   const lines = rest.split(/\r?\n/)
   for (const raw of lines) {
-    const line = cleanLine(raw)
+    let line = cleanLine(raw)
     if (!line) continue
+    if (!hasMeaningfulText(line)) continue
     if (isTemplateBoilerplate(line)) continue
     if (isUntitledLike(line)) continue
+    line = line.replace(/^title\s*:\s*/i, '').trim()
+    if (!line || !hasMeaningfulText(line) || isUntitledLike(line)) continue
     if (line.length > 200) return line.slice(0, 200).trim()
     return line
   }


### PR DESCRIPTION
## Summary

Cleans up several rough edges on the `/projects` page and reorganizes it around a tabbed layout.

### Navigation
- Added a tab strip at the top of the page to switch between **Project Proposals**, **Active Projects**, and **Past Projects** instead of stacking all three sections vertically. Tabs are styled as proper folder tabs with an active underline accent and per-tab count badges.
- Past Projects now has its own compact two-level **year + quarter** picker (year chips on top, fixed Q1–Q4 row below). Quarters with no projects in the selected year are disabled, so the layout stays constant and never needs horizontal scrolling. Selecting a quarter filters the list to just that quarter — no scroll-jumping or sticky-nav glitches.
- Past Projects now reuses the same `ProjectCard` component and single-column layout as Active Projects so cards look identical across tabs. Removed the old 2-column grid, pagination, and ad-hoc skeletons.

### Status & labels
- Renamed the "Ineligible" status pill to **Ongoing** for projects that aren't in a voting period.
- Tab count for Past Projects now reflects what's actually rendered (projects with a final report) instead of the raw past-project total, so the header number and the listed cards match.

### Title & budget parsing (`useProposalJSON`, `getProjectDisplayName`)
- Hardened the project title extractor:
  - Strips markdown image syntax (`![]()`) so adjacent images no longer surface as `!!` titles.
  - Skips template boilerplate, common section headers (Abstract, Problem, Budget, etc.), and `Title:` / `Author:` / `Date:` metadata lines without filtering legitimate names that happen to contain "MoonDAO".
  - Strips a leading `Title:` prefix when present.
- Rewrote the budget extractor to be currency-aware:
  - Validates that an amount is actually USD (`$` or `USD/USDC/USDT/DAI`); explicitly rejects ETH/MOONEY/BTC/etc. so an "1.71 ETH" line no longer gets read as "$1".
  - Prefers an explicit `GRAND TOTAL` row, then sums tagged "Total" rows, then individual USD-marked rows, before falling back to a freeform parser that reads prose-style budget lines and ranges (taking the upper bound). Also matches \"Budget Allocation/Breakdown/Overview/Summary\" headings.
  - Fixes Austin's project (MDP-240) showing >$8k from double-counted subtotals and ASTRONYX (MDP-230) reading as \$0 from a freeform-text budget.

### Watch presentation links
- Added a `proposalVideos.ts` map of MDP → YouTube URL and a small \"▶ Watch presentation\" link on each `ProjectCard` when a video is available. Styled as a subtle underlined link rather than a prominent button.

### Whitelist
- Removed MDP-233 from `BLOCKED_MDPS`.

## Test plan
- [ ] Visit `/projects` and confirm the three tabs render with correct counts and switch content correctly.
- [ ] On the Past Projects tab, verify year chips show all years with final reports, and quarter buttons gray out when empty.
- [ ] Switch years/quarters and confirm the project list updates without horizontal scrolling at narrow widths.
- [ ] Spot-check titles/budgets for MDP-230 (ASTRONYX), MDP-240 (Austin), MDP-245, and MDP-237 to ensure they match the proposal text.
- [ ] Verify the \"Watch presentation\" link appears for the MDPs in `proposalVideos.ts` and opens the correct YouTube timestamp.
- [ ] Confirm MDP-233 is visible again now that it's off the blacklist.
- [ ] Confirm Past Projects tab badge count equals the sum of per-quarter counts and equals the rendered card count.