### PR TITLE
fix: dashboard, fees, and footer UX overhaul

### DIFF
--- a/.github/workflows/weekly-fee-distribution.yml
+++ b/.github/workflows/weekly-fee-distribution.yml
@@ -6,9 +6,6 @@ on:
     - cron: '0 21 * * 4'
   workflow_dispatch:
 
-env:
-  FOUNDRY_PROFILE: ci
-
 jobs:
   distribute:
     runs-on: ubuntu-latest
@@ -44,8 +41,10 @@ jobs:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: |
           cd fee-hook
-          # sepolia, mainnet, arbitrum, and polygon
-          CHAINS=(11155111 1 42161 137)
+          # Chains with a deployed FeeHook: sepolia, mainnet, arbitrum, base.
+          # (Polygon was previously listed but has no FeeHook deployment, which
+          # caused the script to revert. Base was missing despite having one.)
+          CHAINS=(11155111 1 42161 8453)
           for CHAIN in "${CHAINS[@]}"; do
             forge script script/DistributeFees.s.sol --rpc-url "https://${CHAIN}.rpc.thirdweb.com/${{ secrets.THIRDWEB_CLIENT_ID }}" --broadcast --via-ir -vvvv || true
           done

--- a/ui/components/home/SignedInDashboard.tsx
+++ b/ui/components/home/SignedInDashboard.tsx
@@ -13,8 +13,9 @@ import {
   ClipboardDocumentIcon,
   PlusIcon,
   ArrowUpRightIcon,
+  ArrowRightIcon,
 } from '@heroicons/react/24/outline'
-import { useFundWallet, usePrivy } from '@privy-io/react-auth'
+import { useFundWallet } from '@privy-io/react-auth'
 import HatsABI from 'const/abis/Hats.json'
 import JBV5Controller from 'const/abis/JBV5Controller.json'
 import JBV5Directory from 'const/abis/JBV5Directory.json'
@@ -47,14 +48,11 @@ import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useContext, useMemo, useState } from 'react'
+import { useContext, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import { useActiveAccount } from 'thirdweb/react'
 import CitizenContext from '@/lib/citizen/citizen-context'
-import { shouldShowTeamsSection } from '@/lib/dashboard/shouldShowTeamsSection'
 import { useNewsletters } from '@/lib/home/useHomeData'
-import { useTeamWearer } from '@/lib/hats/useTeamWearer'
-import { getLinkedEvmAddresses } from '@/lib/privy/linkedEvmAddresses'
 import useMissionData from '@/lib/mission/useMissionData'
 import useMissionRaisedProgress from '@/lib/mission/useMissionRaisedProgress'
 import { PROJECT_ACTIVE, PROJECT_PENDING } from '@/lib/nance/types'
@@ -87,7 +85,6 @@ import ProposalList from '../nance/ProposalList'
 import NewMarketplaceListings from '../subscription/NewMarketplaceListings'
 import DashboardActiveProjects from '../project/DashboardActiveProjects'
 import DashboardQuests from './DashboardQuests'
-import DashboardTeams from './DashboardTeams'
 import LazyEarth from '@/components/globe/LazyEarth'
 
 // Parse citizen location from Tableland (can be JSON or plain string)
@@ -221,11 +218,6 @@ export default function SignedInDashboard({
 
   const account = useActiveAccount()
   const address = account?.address
-  const { user } = usePrivy()
-  const wearerAddresses = useMemo(
-    () => getLinkedEvmAddresses(user, account?.address),
-    [user, account?.address]
-  )
 
   // Hooks for SendModal
   const { nativeBalance } = useNativeBalance()
@@ -252,11 +244,6 @@ export default function SignedInDashboard({
     chain: selectedChain,
   })
 
-  const { userTeams: teamHats, isLoading: isLoadingTeams } = useTeamWearer(
-    teamContract,
-    selectedChain,
-    wearerAddresses
-  )
   const marketplaceTableContract = useContract({
     address: MARKETPLACE_TABLE_ADDRESSES[chainSlug],
     abi: MarketplaceTableABI as any,
@@ -1003,14 +990,10 @@ export default function SignedInDashboard({
           />
         </div>
 
-        {/* Events and Your Teams Section - Side by Side (Teams hidden when user has none) */}
-        <div
-          className={`grid gap-8 mt-8 mb-8 ${
-            shouldShowTeamsSection(teamHats, isLoadingTeams) ? 'grid-cols-1 lg:grid-cols-2' : 'grid-cols-1'
-          }`}
-        >
+        {/* Events and Open Jobs Section - Side by Side */}
+        <div className="grid gap-8 mt-8 mb-8 grid-cols-1 lg:grid-cols-2">
           {/* Events Section */}
-          <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4 sm:p-6 lg:p-8">
+          <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4 sm:p-6 lg:p-8 flex flex-col">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
               <div className="min-w-0 flex-1">
                 <h3 className="text-lg sm:text-xl lg:text-2xl font-bold text-white mb-2 flex items-center gap-2">
@@ -1023,10 +1006,10 @@ export default function SignedInDashboard({
               </div>
             </div>
 
-            <div className="relative">
+            <div className="relative flex-1 min-h-[500px]">
               <div
                 id="luma-loading-dashboard-small"
-                className="absolute inset-0 bg-gray-800/20 rounded-lg flex items-center justify-center min-h-[500px]"
+                className="absolute inset-0 bg-gray-800/20 rounded-lg flex items-center justify-center"
               >
                 <div className="text-white text-center">
                   <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white mx-auto mb-2"></div>
@@ -1036,13 +1019,13 @@ export default function SignedInDashboard({
               <iframe
                 src="https://lu.ma/embed/calendar/cal-7mKdy93TZVlA0Xh/events?lt=dark"
                 width="100%"
-                height="600"
+                height="100%"
                 frameBorder="0"
                 style={{ border: '1px solid #ffffff20', borderRadius: '8px' }}
                 allowFullScreen
                 aria-hidden="false"
                 tabIndex={0}
-                className="rounded-lg relative z-10"
+                className="rounded-lg z-10 absolute inset-0 h-full w-full"
                 loading="lazy"
                 referrerPolicy="no-referrer-when-downgrade"
                 title="MoonDAO Events Calendar"
@@ -1056,80 +1039,75 @@ export default function SignedInDashboard({
             </div>
           </div>
 
-          {/* Your Teams Section - only shown when user is a member of at least one team */}
-          {shouldShowTeamsSection(teamHats, isLoadingTeams) && (
-            <div
-              data-testid="dashboard-your-teams-section"
-              className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4 sm:p-5"
-            >
-              <div className="mb-3">
-                <div className="min-w-0 flex-1">
-                  <h3 className="text-base sm:text-lg font-bold text-white mb-1 flex items-center gap-2">
-                    <UserGroupIcon className="w-4 h-4 sm:w-5 sm:h-5 flex-shrink-0" />
-                    <span className="leading-tight">Your Teams</span>
-                  </h3>
-                </div>
+          {/* Open Jobs Section */}
+          <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4 sm:p-6 lg:p-8 flex flex-col">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+              <div className="min-w-0 flex-1">
+                <h3 className="text-lg sm:text-xl lg:text-2xl font-bold text-white mb-2 flex items-center gap-2">
+                  <BriefcaseIcon className="w-5 h-5 sm:w-6 sm:h-6 lg:w-7 lg:h-7 flex-shrink-0" />
+                  <span className="leading-tight">Open Jobs</span>
+                </h3>
+                <p className="text-gray-300 text-sm sm:text-base leading-tight">
+                  Contribute to MoonDAO and earn rewards
+                </p>
               </div>
-
-              <div className="space-y-2">
-                <DashboardTeams
-                  selectedChain={selectedChain}
-                  hatsContract={hatsContract}
-                  teamContract={teamContract}
-                />
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Open Jobs - Full Width */}
-        <div className="mb-6">
-          <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="font-semibold text-white text-lg">Open Jobs</h3>
               <StandardButton
-                className="text-blue-300 text-sm hover:text-blue-200 transition-all"
+                className="bg-blue-600/20 hover:bg-blue-600/40 text-blue-300 text-sm px-4 py-2 rounded-lg transition-all whitespace-nowrap flex-shrink-0"
                 link="/jobs"
               >
                 See all
               </StandardButton>
             </div>
 
-            <div className="space-y-3">
-              {newestJobs && newestJobs.length > 0 ? (
-                <Link href={newestJobs[0]?.contactInfo || '/jobs'} className="block">
-                  <div className="flex items-center gap-3 p-3 hover:bg-white/5 rounded-xl transition-all cursor-pointer">
-                    <div className="w-10 h-10 rounded-lg overflow-hidden flex items-center justify-center">
-                      <div className="w-full h-full bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center text-white font-bold text-sm">
-                        <BriefcaseIcon className="w-5 h-5" />
+            {newestJobs && newestJobs.length > 0 ? (
+              <div className="flex-1 flex flex-col gap-3 min-h-0">
+                {newestJobs.slice(0, 5).map((job: any) => (
+                  <Link
+                    key={job.id}
+                    href={job?.contactInfo || '/jobs'}
+                    className="block bg-black/20 hover:bg-black/40 border border-white/5 hover:border-white/10 rounded-xl transition-all"
+                  >
+                    <div className="flex items-center gap-3 p-3 sm:p-4">
+                      <div className="w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center text-white flex-shrink-0">
+                        <BriefcaseIcon className="w-5 h-5 sm:w-6 sm:h-6" />
                       </div>
+                      <div className="flex-1 min-w-0">
+                        <h4 className="text-white font-medium text-sm sm:text-base truncate">
+                          {job?.title || 'Open Position'}
+                        </h4>
+                        {job?.description && (
+                          <p className="text-gray-400 text-xs sm:text-sm truncate mt-0.5">
+                            {job.description}
+                          </p>
+                        )}
+                      </div>
+                      <ArrowRightIcon className="w-4 h-4 text-gray-400 flex-shrink-0" />
                     </div>
-                    <div className="flex-1 min-w-0">
-                      <h4 className="text-white font-medium text-sm truncate">
-                        {newestJobs[0]?.title}
-                      </h4>
-                      <p className="text-gray-400 text-xs">
-                        {newestJobs.length > 1
-                          ? `+${newestJobs.length - 1} more positions`
-                          : 'Click to apply'}
-                      </p>
-                    </div>
-                  </div>
-                </Link>
-              ) : (
-                <Link href="/jobs" className="block">
-                  <div className="flex items-center gap-3 p-3 hover:bg-white/5 rounded-xl transition-all cursor-pointer">
-                    <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center text-white">
-                      <BriefcaseIcon className="w-5 h-5" />
-                    </div>
-                    <div className="flex-1">
-                      <h4 className="text-white font-medium text-sm">No open positions</h4>
-                      <p className="text-gray-400 text-xs">Check back soon for opportunities</p>
-                    </div>
-                  </div>
-                </Link>
-              )}
-            </div>
+                  </Link>
+                ))}
+                {newestJobs.length > 5 && (
+                  <Link
+                    href="/jobs"
+                    className="text-center text-blue-300 hover:text-blue-200 text-sm py-2 transition-colors"
+                  >
+                    +{newestJobs.length - 5} more positions →
+                  </Link>
+                )}
+              </div>
+            ) : (
+              <Link
+                href="/jobs"
+                className="flex-1 flex items-center justify-center bg-black/20 border border-white/5 rounded-xl hover:bg-black/30 transition-all min-h-[200px]"
+              >
+                <div className="text-center p-6">
+                  <BriefcaseIcon className="w-10 h-10 text-gray-500 mx-auto mb-2" />
+                  <h4 className="text-white font-medium text-sm">No open positions</h4>
+                  <p className="text-gray-400 text-xs mt-1">
+                    Check back soon for opportunities
+                  </p>
+                </div>
+              </Link>
+            )}
           </div>
         </div>
 

--- a/ui/components/home/SignedInDashboard.tsx
+++ b/ui/components/home/SignedInDashboard.tsx
@@ -1048,7 +1048,7 @@ export default function SignedInDashboard({
                   <span className="leading-tight">Open Jobs</span>
                 </h3>
                 <p className="text-gray-300 text-sm sm:text-base leading-tight">
-                  Contribute to MoonDAO and earn rewards
+                  Find open job positions within the MoonDAO Network.
                 </p>
               </div>
               <StandardButton

--- a/ui/components/home/WalletInfoCard.tsx
+++ b/ui/components/home/WalletInfoCard.tsx
@@ -203,58 +203,60 @@ export default function WalletInfoCard({
       {/* Balances */}
       <div className="space-y-3 mb-4 min-w-0">
         {/* $MOONEY Balance */}
-        <div className="bg-black/20 rounded-lg p-3 border border-white/5 min-w-0">
-          <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2 min-w-0">
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <Image
-                src="/coins/MOONEY.png"
-                alt="MOONEY"
-                width={20}
-                height={20}
-                className="rounded-full flex-shrink-0"
-              />
-              <span className="text-sm text-gray-400">$MOONEY</span>
-            </div>
+        <div className="bg-black/20 rounded-lg p-3 border border-white/5 min-w-0 flex flex-col">
+          <div className="flex items-center gap-2 min-w-0">
+            <Image
+              src="/coins/MOONEY.png"
+              alt="MOONEY"
+              width={20}
+              height={20}
+              className="rounded-full flex-shrink-0"
+            />
+            <span className="text-sm text-gray-400 truncate">$MOONEY</span>
+          </div>
+          <div className="mt-1 mb-3 min-h-[1.75rem] flex items-center">
             {isUnlockedLoading ? (
               <LoadingSpinner width="w-4" height="h-4" className="flex-shrink-0" />
             ) : (
-              <span className="text-white font-semibold text-right min-w-0 break-all">
+              <span className="text-white font-semibold text-lg break-all">
                 {formatToken(unlockedMooney)}
               </span>
             )}
           </div>
           <NavLink
             href="/get-mooney"
-            className="block w-full text-center py-1.5 px-2 rounded-lg bg-green-600/20 hover:bg-green-600/30 text-green-300 text-xs font-medium transition-all"
+            className="block w-full text-center py-1.5 px-2 rounded-lg bg-green-600/20 hover:bg-green-600/30 text-green-300 text-xs font-medium transition-all mt-auto"
           >
             Get $MOONEY
           </NavLink>
         </div>
 
         {/* Locked MOONEY */}
-        <div className="bg-black/20 rounded-lg p-3 border border-white/5 min-w-0">
-          <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 mb-2 min-w-0">
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <Image
-                src="/assets/vmooney-shield.svg"
-                alt="Locked"
-                width={20}
-                height={20}
-                className="flex-shrink-0"
-              />
-              <span className="text-sm text-gray-400">$vMOONEY (Locked)</span>
-            </div>
+        <div className="bg-black/20 rounded-lg p-3 border border-white/5 min-w-0 flex flex-col">
+          <div className="flex items-center gap-2 min-w-0">
+            <Image
+              src="/assets/vmooney-shield.svg"
+              alt="Locked"
+              width={20}
+              height={20}
+              className="flex-shrink-0"
+            />
+            <span className="text-sm text-gray-400 truncate">
+              $vMOONEY (Locked)
+            </span>
+          </div>
+          <div className="mt-1 mb-3 min-h-[1.75rem] flex items-center">
             {isLockedLoading ? (
               <LoadingSpinner width="w-4" height="h-4" className="flex-shrink-0" />
             ) : (
-              <span className="text-white font-semibold text-right min-w-0 break-all">
+              <span className="text-white font-semibold text-lg break-all">
                 {formatToken(lockedMooney)}
               </span>
             )}
           </div>
           <NavLink
             href="/lock"
-            className="block w-full text-center py-1.5 px-2 rounded-lg bg-blue-600/20 hover:bg-blue-600/30 text-blue-300 text-xs font-medium transition-all"
+            className="block w-full text-center py-1.5 px-2 rounded-lg bg-blue-600/20 hover:bg-blue-600/30 text-blue-300 text-xs font-medium transition-all mt-auto"
           >
             Lock $MOONEY
           </NavLink>

--- a/ui/components/layout/ExpandedFooter.tsx
+++ b/ui/components/layout/ExpandedFooter.tsx
@@ -273,14 +273,23 @@ export function ExpandedFooter({
               <h3 className="text-sm font-medium text-gray-400 uppercase mb-4">
                 Follow Us
               </h3>
-              <div className="flex items-center gap-4 mb-6">
+              {/*
+                7 social icons at 40px + a 16px gap was overflowing on
+                ~360–390px viewports (the row needs ~376px but the
+                container's `px-[5vw]` padding only leaves ~325px), which
+                clipped the rightmost icons (GitHub / CoinMarketCap).
+                `flex-wrap` lets the row break onto a second line on
+                phones, and the slightly smaller icon + gap on mobile keeps
+                it to a single tidy row when there's room.
+              */}
+              <div className="flex flex-wrap items-center justify-center gap-2.5 sm:gap-4 mb-6 max-w-full">
                 {socialLinks.map((link) => (
                   <Link
                     key={link.label}
                     href={link.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center justify-center w-10 h-10 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 transition-all duration-300 opacity-70 hover:opacity-100"
+                    className="shrink-0 flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 transition-all duration-300 opacity-70 hover:opacity-100"
                     aria-label={link.label}
                   >
                     {link.icon}

--- a/ui/components/layout/ExpandedFooter.tsx
+++ b/ui/components/layout/ExpandedFooter.tsx
@@ -143,46 +143,54 @@ export function ExpandedFooter({
     hasCallToAction,
   ])
 
-  // Navigation link groups - matching topnav organization exactly
-  const networkLinks = [
-    { text: 'Join Network', href: '/join' },
-    { text: 'Explore Network', href: '/network' },
-    { text: 'Become a Citizen', href: '/join' },
-    { text: 'Create a Team', href: '/team' },
-    { text: 'Submit Contribution', href: '/contributions' },
+  // Footer navigation mirrors the top nav structure 1:1 (see
+  // `ui/lib/navigation/useNavigation.tsx` and the Teams/Projects dropdown
+  // components). Six groups in the same order as the header, with the same
+  // child links — so users see a consistent IA in both places.
+  const citizensLinks = [
+    { text: 'Become a Citizen', href: '/citizen' },
+    { text: 'Submit a Contribution', href: '/contributions' },
+    { text: 'View Citizens', href: '/network?tab=citizens' },
+    { text: 'Explore the Map', href: '/map' },
+  ]
+
+  const teamsLinks = [
+    { text: 'Create a Team', href: '/join' },
+    { text: 'Explore Teams', href: '/network?tab=teams' },
     { text: 'Jobs', href: '/jobs' },
+    { text: 'Marketplace', href: '/marketplace' },
   ]
 
-  const governLinks = [
-    { text: 'Governance Overview', href: '/governance' },
-    { text: 'Project Proposals', href: '/projects' },
-    { text: 'Governance Proposals', href: '/governance-proposals' },
-    { text: 'Constitution', href: '/constitution' },
-  ]
-
-  const tokenLinks = [
-    { text: 'Buy', href: '/mooney' },
-    { text: 'Lock', href: '/lock' },
-  ]
-
-  const projectLinks = [
-    { text: 'Projects Overview', href: '/projects-overview' },
-    { text: 'Projects', href: '/projects' },
+  const projectsLinks = [
     { text: 'Propose Project', href: '/proposals' },
+    { text: 'Explore Projects', href: '/projects' },
+    { text: 'Submit Contribution', href: '/contributions' },
+    { text: 'Projects Overview', href: '/projects-overview' },
+  ]
+
+  const mooneyLinks = [
+    { text: 'Get $MOONEY', href: '/get-mooney' },
+    { text: 'Lock $MOONEY', href: '/lock' },
+    { text: 'Bridge $MOONEY', href: '/bridge' },
+    { text: 'Token Overview', href: '/mooney' },
+    { text: 'Governance Overview', href: '/governance' },
+    { text: 'Governance Proposals', href: '/governance-proposals' },
+  ]
+
+  const launchpadLinks = [
+    { text: 'Launchpad Explainer', href: '/launch' },
+    { text: 'Overview Fundraiser', href: '/mission/4' },
+    { text: 'Fly with Frank Leaderboard', href: '/overview-vote' },
   ]
 
   const learnLinks = [
     { text: 'News', href: '/news' },
+    { text: 'Town Hall', href: '/townhall' },
     { text: 'Roadmap', href: '/roadmap' },
     { text: 'About', href: '/about' },
-    { text: 'Treasury', href: '/treasury' },
     { text: 'Resources', href: '/resources' },
-    { text: 'FAQ', href: '/faq' },
+    { text: 'Constitution', href: '/constitution' },
   ]
-
-  const marketplaceLinks = [{ text: 'Shop', href: '/marketplace' }]
-
-  const supportLinks = [{ text: 'Submit Ticket', href: 'https://discord.gg/moondao' }]
 
   return (
     <>
@@ -234,35 +242,25 @@ export function ExpandedFooter({
                 hasCallToAction && isFullwidth ? 'lg:col-span-4' : 'lg:col-span-6'
               }`}
             >
-              {/* Column 1: NETWORK */}
+              {/* Columns mirror the top-nav groups in order:
+                  Citizens → Teams → Projects → $MOONEY → Launchpad → Learn */}
               <div>
-                <LinkList title="NETWORK" links={networkLinks} />
+                <LinkList title="CITIZENS" links={citizensLinks} />
               </div>
-
-              {/* Column 2: GOVERN */}
               <div>
-                <LinkList title="GOVERN" links={governLinks} />
+                <LinkList title="TEAMS" links={teamsLinks} />
               </div>
-
-              {/* Column 3: $MOONEY */}
               <div>
-                <LinkList title="$MOONEY TOKEN" links={tokenLinks} />
+                <LinkList title="PROJECTS" links={projectsLinks} />
               </div>
-
-              {/* Column 4: PROJECTS */}
               <div>
-                <LinkList title="PROJECTS" links={projectLinks} />
+                <LinkList title="$MOONEY" links={mooneyLinks} />
               </div>
-
-              {/* Column 5: LEARN */}
+              <div>
+                <LinkList title="LAUNCHPAD" links={launchpadLinks} />
+              </div>
               <div>
                 <LinkList title="LEARN" links={learnLinks} />
-              </div>
-
-              {/* Column 6: MARKETPLACE & SUPPORT */}
-              <div className="grid grid-rows-2 gap-8">
-                <LinkList title="MARKETPLACE" links={marketplaceLinks} />
-                <LinkList title="SUPPORT" links={supportLinks} />
               </div>
             </div>
           </div>
@@ -296,7 +294,7 @@ export function ExpandedFooter({
                   </Link>
                 ))}
               </div>
-              <div className="flex flex-wrap justify-center gap-4 text-sm text-gray-400 mb-4">
+              <div className="flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm text-gray-400 mb-4">
                 <Link
                   href="https://docs.moondao.com"
                   target="_blank"
@@ -322,6 +320,18 @@ export function ExpandedFooter({
                   className="hover:text-white transition-colors"
                 >
                   Trade $MOONEY
+                </Link>
+                <span className="text-gray-600">•</span>
+                {/* Support used to be its own footer column, but the top-nav
+                    has no Support group. Surface it here as a utility link
+                    so users still have a one-click path to help. */}
+                <Link
+                  href="https://discord.gg/moondao"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-white transition-colors"
+                >
+                  Submit a Ticket
                 </Link>
               </div>
             </div>

--- a/ui/components/nance/Proposal.tsx
+++ b/ui/components/nance/Proposal.tsx
@@ -1,5 +1,6 @@
 import { ChevronRightIcon } from '@heroicons/react/24/outline'
 import { IS_MEMBER_VOTE, IS_SENATE_VOTE } from 'const/config'
+import { useRouter } from 'next/router'
 import useProposalJSON from '@/lib/nance/useProposalJSON'
 import {
   useProposalStatus,
@@ -91,6 +92,7 @@ export default function Proposal({ project, feedStyle = false, linkDisabled = fa
   const descriptionPreview = getDescriptionPreview(
     proposalJSON?.body || project?.description
   )
+  const phase = getVotingPhaseContext(proposalStatus)
 
   if (feedStyle) {
     return (
@@ -114,11 +116,19 @@ export default function Proposal({ project, feedStyle = false, linkDisabled = fa
               <RequestingTokensOfProposal budget={proposalJSON.budget} variant="feed" />
             </div>
           )}
-          <div className="flex flex-wrap items-start gap-x-4 gap-y-1 text-sm text-gray-400 text-left">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-gray-400 text-left">
             <span className="flex items-center gap-1.5 min-w-0">
-              <StatusDot config={config} />
+              <StatusDot config={config} pulse={Boolean(phase?.pulse)} />
               <span className="min-w-0">{displayLabel}</span>
             </span>
+            {phase && (
+              <PhaseBadge
+                tone={phase.tone}
+                label={phase.label}
+                cta={phase.cta}
+                ctaHref={phase.ctaHref}
+              />
+            )}
           </div>
         </div>
         <ChevronRightIcon
@@ -151,14 +161,22 @@ export default function Proposal({ project, feedStyle = false, linkDisabled = fa
           </p>
         )}
       </div>
-      <div className="flex justify-between items-center mt-4">
-        <div className="flex flex-col items-start">
+      <div className="flex justify-between items-center mt-4 gap-3 flex-wrap">
+        <div className="flex flex-col items-start gap-2">
           <div className="flex items-center gap-x-1.5 min-w-0">
-            <StatusDot config={config} />
+            <StatusDot config={config} pulse={Boolean(phase?.pulse)} />
             <p className="text-sm leading-6 text-white font-RobotoMono font-medium min-w-0">
               {displayLabel}
             </p>
           </div>
+          {phase && (
+            <PhaseBadge
+              tone={phase.tone}
+              label={phase.label}
+              cta={phase.cta}
+              ctaHref={phase.ctaHref}
+            />
+          )}
         </div>
         <ChevronRightIcon
           className="h-5 w-5 flex-none text-gray-400"
@@ -167,5 +185,54 @@ export default function Proposal({ project, feedStyle = false, linkDisabled = fa
         />
       </div>
     </div>
+  )
+}
+
+function PhaseBadge({
+  tone,
+  label,
+  cta,
+  ctaHref,
+}: {
+  tone: 'member' | 'senate'
+  label: string
+  cta: string | null
+  ctaHref: string | null
+}) {
+  const router = useRouter()
+  const styles =
+    tone === 'member'
+      ? {
+          wrapper:
+            'bg-emerald-500/15 border-emerald-500/40 text-emerald-300',
+          cta:
+            'bg-emerald-500 hover:bg-emerald-400 text-black shadow-[0_0_12px_rgba(16,185,129,0.45)]',
+        }
+      : {
+          wrapper: 'bg-orange-500/15 border-orange-500/40 text-orange-300',
+          cta: 'bg-orange-500 hover:bg-orange-400 text-black',
+        }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${styles.wrapper}`}
+    >
+      {label}
+      {cta && ctaHref && (
+        // Use a button (not <a>) so it can safely nest inside parent
+        // `<Link>` wrappers without producing invalid <a>-in-<a> markup.
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            e.preventDefault()
+            router.push(ctaHref)
+          }}
+          className={`ml-1 rounded-full px-2 py-0.5 text-[10px] font-bold normal-case tracking-normal transition-all cursor-pointer ${styles.cta}`}
+        >
+          {cta} →
+        </button>
+      )}
+    </span>
   )
 }

--- a/ui/components/nance/Proposal.tsx
+++ b/ui/components/nance/Proposal.tsx
@@ -1,4 +1,5 @@
 import { ChevronRightIcon } from '@heroicons/react/24/outline'
+import { IS_MEMBER_VOTE, IS_SENATE_VOTE } from 'const/config'
 import useProposalJSON from '@/lib/nance/useProposalJSON'
 import {
   useProposalStatus,
@@ -18,15 +19,57 @@ type ProposalProps = {
   linkDisabled?: boolean
 }
 
-function StatusDot({ config }: { config: StatusIndicatorStyle }) {
+function StatusDot({
+  config,
+  pulse = false,
+}: {
+  config: StatusIndicatorStyle
+  pulse?: boolean
+}) {
   return (
     <span
-      className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full ${config.bg}`}
+      className={`relative flex h-4 w-4 shrink-0 items-center justify-center rounded-full ${config.bg}`}
       aria-hidden
     >
-      <span className={`block h-1.5 w-1.5 rounded-full ${config.dot}`} />
+      {pulse && (
+        <span
+          className={`absolute inline-flex h-full w-full rounded-full opacity-60 animate-ping ${config.dot}`}
+        />
+      )}
+      <span className={`relative block h-1.5 w-1.5 rounded-full ${config.dot}`} />
     </span>
   )
+}
+
+/**
+ * Resolve the user-facing voting-phase context for a proposal based on the
+ * current cycle flags in `const/config.ts` (IS_SENATE_VOTE / IS_MEMBER_VOTE).
+ *
+ * - Member Vote: proposals in `Voting` status need vMOONEY holders to allocate
+ *   their voting power on /projects. Treat this as an active call to action.
+ * - Senate Vote: proposals in `Temperature Check` status are awaiting Senate
+ *   approval. Surface this so members understand the proposal isn't stale.
+ */
+function getVotingPhaseContext(status: ProposalStatus | undefined) {
+  if (IS_MEMBER_VOTE && status === 'Voting') {
+    return {
+      label: 'Member Vote',
+      cta: 'Vote Now',
+      ctaHref: '/projects',
+      tone: 'member' as const,
+      pulse: true,
+    }
+  }
+  if (IS_SENATE_VOTE && status === 'Temperature Check') {
+    return {
+      label: 'Senate Vote In Progress',
+      cta: null,
+      ctaHref: null,
+      tone: 'senate' as const,
+      pulse: true,
+    }
+  }
+  return null
 }
 
 function getDescriptionPreview(body: string | undefined, maxLength = 120): string | null {

--- a/ui/components/nance/ProposalInfo.tsx
+++ b/ui/components/nance/ProposalInfo.tsx
@@ -3,6 +3,7 @@ import { add, differenceInDays, formatDistanceToNow, fromUnixTime } from 'date-f
 import Image from 'next/image'
 import Link from 'next/link'
 import { STATUS_CONFIG, STATUS_DISPLAY_LABELS, ProposalStatus } from '@/lib/nance/useProposalStatus'
+import { getProjectDisplayName } from '@/lib/project/getProjectDisplayName'
 import { Project } from '@/lib/project/useProjectData'
 import { AddressLink } from './AddressLink'
 import RequestingTokensOfProposal from './RequestingTokensOfProposal'
@@ -72,7 +73,15 @@ export default function ProposalInfo({
   /** Dashboard feed: match newsletter typography; no inner link (card is wrapped by Link). */
   feedStyle?: boolean
 }) {
-  const titleText = `MDP-${project.MDP}: ${project.name}`
+  // Resolve the title the same way the projects page does:
+  //   1. Tableland `project.name` (when it's a real title, not "Untitled")
+  //   2. `proposalJSON.title` (from IPFS)
+  //   3. First meaningful H1 in the proposal body
+  //   4. "Untitled Project" fallback
+  // This avoids `MDP-X: undefined` / `MDP-X: Untitled` on the dashboard for
+  // proposals whose Tableland row hasn't been populated yet.
+  const displayName = getProjectDisplayName(project, proposalJSON)
+  const titleText = `MDP-${project.MDP}: ${displayName}`
 
   return (
     <div className="flex min-w-0 flex-col gap-x-4 sm:flex-row">

--- a/ui/components/tokens/WeeklyRewardPool.tsx
+++ b/ui/components/tokens/WeeklyRewardPool.tsx
@@ -110,17 +110,23 @@ export default function WeeklyRewardPool() {
               const hookAddress = FEE_HOOK_ADDRESSES[slug]
               if (!hookAddress) return BigNumber.from(0)
 
-              const contract = getContract({
-                client,
-                address: hookAddress,
-                abi: FeeHook.abi as any,
-                chain,
-              })
-              return readContract({
-                contract,
-                method: 'estimateFees',
-                params: [address],
-              }).catch(() => BigNumber.from(0))
+              try {
+                const contract = getContract({
+                  client,
+                  address: hookAddress,
+                  abi: FeeHook.abi as any,
+                  chain,
+                })
+                const estimate = await readContract({
+                  contract,
+                  method: 'estimateFees',
+                  params: [address],
+                })
+                return BigNumber.from(estimate?.toString() || '0')
+              } catch (err) {
+                console.error(`Error fetching estimate for ${slug}:`, err)
+                return BigNumber.from(0)
+              }
             })
           )
         ).reduce((acc, est) => acc.add(est || BigNumber.from(0)), BigNumber.from(0))
@@ -128,6 +134,7 @@ export default function WeeklyRewardPool() {
         setEstimatedFees(ethers.utils.formatEther(totalEstimated))
       } catch (e) {
         console.error('Error fetching estimates:', e)
+        setEstimatedFees('0')
       }
     }
 
@@ -138,10 +145,15 @@ export default function WeeklyRewardPool() {
     if (!address) return
 
     const fetchStatus = async () => {
-      try {
-        const raw = await Promise.all(
-          chains.map(async (chain) => {
-            const slug = getChainSlug(chain)
+      // Each chain is fetched independently. A single chain failure (e.g.
+      // public RPC hiccup or rate limit) used to reject the whole Promise.all
+      // and leave `feeData` empty, which surfaced as "No fee data available"
+      // when the user tried to check in. Isolate failures per-chain so the
+      // remaining chains still populate.
+      const raw = await Promise.all(
+        chains.map(async (chain) => {
+          const slug = getChainSlug(chain)
+          try {
             const hookAddress = FEE_HOOK_ADDRESSES[slug]
             if (!hookAddress) return null
 
@@ -200,43 +212,44 @@ export default function WeeklyRewardPool() {
               hasVMooney,
               checkedInOnChain: last === start,
             }
-          })
-        )
+          } catch (err) {
+            console.error(`Error fetching check-in status for ${slug}:`, err)
+            return null
+          }
+        })
+      )
 
-        const results = raw.filter((r) => r) as Array<{
-          chain: any
-          slug: string
-          contract: any
-          start: bigint
-          last: bigint
-          count: bigint
-          vMooneyBalance: bigint
-          hasVMooney: boolean
-          checkedInOnChain: boolean
-        }>
+      const results = raw.filter((r) => r) as Array<{
+        chain: any
+        slug: string
+        contract: any
+        start: bigint
+        last: bigint
+        count: bigint
+        vMooneyBalance: bigint
+        hasVMooney: boolean
+        checkedInOnChain: boolean
+      }>
 
-        setFeeData(results)
+      setFeeData(results)
 
-        // Only chains where the user actually holds vMOONEY are eligible for
-        // check-in (the FeeHook reverts otherwise). The "checked in" state
-        // should therefore only consider those chains; otherwise a user who
-        // has vMOONEY on one chain (e.g. Arbitrum) and is already checked in
-        // there would be incorrectly shown as "not checked in" because they
-        // have a 0 balance on the other chains.
-        const eligibleChains = results.filter((r) => r.hasVMooney)
-        const totalCount = results.reduce(
-          (acc, { count }) => acc + Number(count || BigInt(0)),
-          0
-        )
-        const allChecked =
-          eligibleChains.length > 0 &&
-          eligibleChains.every(({ checkedInOnChain }) => checkedInOnChain)
+      // Only chains where the user actually holds vMOONEY are eligible for
+      // check-in (the FeeHook reverts otherwise). The "checked in" state
+      // should therefore only consider those chains; otherwise a user who
+      // has vMOONEY on one chain (e.g. Arbitrum) and is already checked in
+      // there would be incorrectly shown as "not checked in" because they
+      // have a 0 balance on the other chains.
+      const eligibleChains = results.filter((r) => r.hasVMooney)
+      const totalCount = results.reduce(
+        (acc, { count }) => acc + Number(count || BigInt(0)),
+        0
+      )
+      const allChecked =
+        eligibleChains.length > 0 &&
+        eligibleChains.every(({ checkedInOnChain }) => checkedInOnChain)
 
-        setCheckedInCount(totalCount)
-        setIsCheckedIn(allChecked)
-      } catch (err) {
-        console.error('Error fetching check‑in status:', err)
-      }
+      setCheckedInCount(totalCount)
+      setIsCheckedIn(allChecked)
     }
 
     fetchStatus()

--- a/ui/components/tokens/WeeklyRewardPool.tsx
+++ b/ui/components/tokens/WeeklyRewardPool.tsx
@@ -30,6 +30,42 @@ import Frame from '@/components/layout/Frame'
 import { LoadingSpinner } from '@/components/layout/LoadingSpinner'
 import { PrivyWeb3Button } from '../privy/PrivyWeb3Button'
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+/**
+ * `readContract` occasionally fails with
+ * `TypeError: Cannot read properties of undefined (reading 'buffer')` when
+ * the underlying RPC returns a malformed/empty response (typically Infura
+ * batch hiccups). Retry on that specific failure mode so a transient blip
+ * on a single chain (most often Arbitrum) doesn't drop its row from the
+ * weekly reward pool data — that was the root cause of the dashboard
+ * showing "0 check-ins" while the user was actually checked in.
+ */
+async function safeRead<T>(
+  fn: () => Promise<T>,
+  label: string,
+  retries = 2,
+  baseDelay = 250
+): Promise<T | null> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: any) {
+      const isLast = attempt === retries
+      const isBufferDecodeError =
+        err?.message?.includes("reading 'buffer'") ||
+        err?.message?.includes('decodeAbiParameters')
+      if (!isLast && isBufferDecodeError) {
+        await sleep(baseDelay * Math.pow(2, attempt))
+        continue
+      }
+      console.error(`safeRead [${label}] failed:`, err)
+      return null
+    }
+  }
+  return null
+}
+
 export default function WeeklyRewardPool() {
   const account = useActiveAccount()
   const address = account?.address
@@ -117,23 +153,22 @@ export default function WeeklyRewardPool() {
               const hookAddress = FEE_HOOK_ADDRESSES[slug]
               if (!hookAddress) return BigNumber.from(0)
 
-              try {
-                const contract = getContract({
-                  client,
-                  address: hookAddress,
-                  abi: FeeHook.abi as any,
-                  chain,
-                })
-                const estimate = await readContract({
-                  contract,
-                  method: 'estimateFees',
-                  params: [address],
-                })
-                return BigNumber.from(estimate?.toString() || '0')
-              } catch (err) {
-                console.error(`Error fetching estimate for ${slug}:`, err)
-                return BigNumber.from(0)
-              }
+              const contract = getContract({
+                client,
+                address: hookAddress,
+                abi: FeeHook.abi as any,
+                chain,
+              })
+              const estimate = await safeRead(
+                () =>
+                  readContract({
+                    contract,
+                    method: 'estimateFees',
+                    params: [address],
+                  }),
+                `${slug}.estimateFees`
+              )
+              return BigNumber.from(estimate?.toString() || '0')
             })
           )
         ).reduce((acc, est) => acc.add(est || BigNumber.from(0)), BigNumber.from(0))
@@ -172,52 +207,82 @@ export default function WeeklyRewardPool() {
             })
 
             const [start, last, count, vMooneyAddress] = await Promise.all([
-              readContract({ contract, method: 'weekStart', params: [] }),
-              readContract({
-                contract,
-                method: 'lastCheckIn',
-                params: [address],
-              }),
-              readContract({
-                contract,
-                method: 'getCheckedInCount',
-                params: [],
-              }),
-              readContract({
-                contract,
-                method: 'vMooneyAddress',
-                params: [],
-              }),
+              safeRead(
+                () => readContract({ contract, method: 'weekStart', params: [] }),
+                `${slug}.weekStart`
+              ),
+              safeRead(
+                () =>
+                  readContract({
+                    contract,
+                    method: 'lastCheckIn',
+                    params: [address],
+                  }),
+                `${slug}.lastCheckIn`
+              ),
+              safeRead(
+                () =>
+                  readContract({
+                    contract,
+                    method: 'getCheckedInCount',
+                    params: [],
+                  }),
+                `${slug}.getCheckedInCount`
+              ),
+              safeRead(
+                () =>
+                  readContract({
+                    contract,
+                    method: 'vMooneyAddress',
+                    params: [],
+                  }),
+                `${slug}.vMooneyAddress`
+              ),
             ])
+
+            // Drop the chain only if the truly required reads are missing
+            // after retries. Previously a single rejected read would null
+            // out the whole chain, which is what was making Arbitrum's
+            // check-in count silently disappear.
+            if (start == null || vMooneyAddress == null) {
+              console.warn(
+                `Skipping ${slug}: missing required FeeHook reads (start=${start}, vMooneyAddress=${vMooneyAddress})`
+              )
+              return null
+            }
 
             const vMooneyContract = getContract({
               client,
-              address: vMooneyAddress,
+              address: vMooneyAddress as `0x${string}`,
               abi: ERC20ABI as any,
               chain,
             })
 
-            const vMooneyBalance = await readContract({
-              contract: vMooneyContract,
-              method: 'balanceOf',
-              params: [address],
-            })
+            const vMooneyBalance = await safeRead(
+              () =>
+                readContract({
+                  contract: vMooneyContract,
+                  method: 'balanceOf',
+                  params: [address],
+                }),
+              `${slug}.balanceOf`
+            )
 
-            const hasVMooney =
-              vMooneyBalance !== undefined &&
-              vMooneyBalance !== null &&
-              vMooneyBalance > BigInt(0)
+            const balance = (vMooneyBalance as bigint | null) ?? BigInt(0)
+            const safeLast = (last as bigint | null) ?? BigInt(0)
+            const safeCount = (count as bigint | null) ?? BigInt(0)
+            const hasVMooney = balance > BigInt(0)
 
             return {
               chain,
               slug,
               contract,
-              start,
-              last,
-              count,
-              vMooneyBalance,
+              start: start as bigint,
+              last: safeLast,
+              count: safeCount,
+              vMooneyBalance: balance,
               hasVMooney,
-              checkedInOnChain: last === start,
+              checkedInOnChain: safeLast === (start as bigint),
             }
           } catch (err) {
             console.error(`Error fetching check-in status for ${slug}:`, err)

--- a/ui/components/tokens/WeeklyRewardPool.tsx
+++ b/ui/components/tokens/WeeklyRewardPool.tsx
@@ -10,8 +10,15 @@ import Link from 'next/link'
 import { useContext, useState, useEffect, useMemo } from 'react'
 import toast from 'react-hot-toast'
 import { getContract, readContract, prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
-import { arbitrum, base, ethereum, sepolia, arbitrumSepolia, Chain } from 'thirdweb/chains'
 import { useActiveAccount } from 'thirdweb/react'
+import {
+  arbitrum,
+  base,
+  ethereum,
+  sepolia,
+  arbitrumSepolia,
+  Chain,
+} from '@/lib/rpc/chains'
 import toastStyle from '../../lib/marketplace/marketplace-utils/toastConfig'
 import useETHPrice from '@/lib/etherscan/useETHPrice'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'

--- a/ui/components/tokens/WeeklyRewardPool.tsx
+++ b/ui/components/tokens/WeeklyRewardPool.tsx
@@ -184,6 +184,11 @@ export default function WeeklyRewardPool() {
               params: [address],
             })
 
+            const hasVMooney =
+              vMooneyBalance !== undefined &&
+              vMooneyBalance !== null &&
+              vMooneyBalance > BigInt(0)
+
             return {
               chain,
               slug,
@@ -192,6 +197,7 @@ export default function WeeklyRewardPool() {
               last,
               count,
               vMooneyBalance,
+              hasVMooney,
               checkedInOnChain: last === start,
             }
           })
@@ -205,22 +211,26 @@ export default function WeeklyRewardPool() {
           last: bigint
           count: bigint
           vMooneyBalance: bigint
+          hasVMooney: boolean
           checkedInOnChain: boolean
         }>
 
         setFeeData(results)
 
-        // aggregate counts & allChecked
-        const { totalCount, allChecked } = results.reduce(
-          (acc, { last, start, count }) => {
-            acc.totalCount += Number(count || BigInt(0))
-            if (last !== start) {
-              acc.allChecked = false
-            }
-            return acc
-          },
-          { totalCount: 0, allChecked: true }
+        // Only chains where the user actually holds vMOONEY are eligible for
+        // check-in (the FeeHook reverts otherwise). The "checked in" state
+        // should therefore only consider those chains; otherwise a user who
+        // has vMOONEY on one chain (e.g. Arbitrum) and is already checked in
+        // there would be incorrectly shown as "not checked in" because they
+        // have a 0 balance on the other chains.
+        const eligibleChains = results.filter((r) => r.hasVMooney)
+        const totalCount = results.reduce(
+          (acc, { count }) => acc + Number(count || BigInt(0)),
+          0
         )
+        const allChecked =
+          eligibleChains.length > 0 &&
+          eligibleChains.every(({ checkedInOnChain }) => checkedInOnChain)
 
         setCheckedInCount(totalCount)
         setIsCheckedIn(allChecked)
@@ -245,6 +255,8 @@ export default function WeeklyRewardPool() {
 
       const currentChain = contextSelectedChain
       let transactionsSent = 0
+      let alreadyCheckedInCount = 0
+      let eligibleChainsCount = 0
 
       const waitForChainSwitch = async (targetChainId: number, maxWait = 5000) => {
         const startTime = Date.now()
@@ -259,8 +271,12 @@ export default function WeeklyRewardPool() {
       }
 
       for (const data of feeData) {
-        if (data.checkedInOnChain) continue
         if (!data.vMooneyBalance || data.vMooneyBalance === BigInt(0)) {
+          continue
+        }
+        eligibleChainsCount++
+        if (data.checkedInOnChain) {
+          alreadyCheckedInCount++
           continue
         }
 
@@ -365,9 +381,22 @@ export default function WeeklyRewardPool() {
           shapes: ['circle', 'star'],
           colors: ['#ffffff', '#FFD700', '#00FFFF', '#ff69b4', '#8A2BE2'],
         })
+        if (alreadyCheckedInCount + transactionsSent === eligibleChainsCount) {
+          setIsCheckedIn(true)
+        }
+      } else if (eligibleChainsCount === 0) {
+        toast.error(
+          'No vMOONEY detected on Ethereum, Arbitrum, or Base. Lock MOONEY to participate.',
+          { style: toastStyle }
+        )
+      } else if (alreadyCheckedInCount === eligibleChainsCount) {
+        toast(
+          "You're already checked in for this week. Rewards are distributed automatically each week.",
+          { style: toastStyle }
+        )
         setIsCheckedIn(true)
       } else {
-        toast.error('No check-ins needed. You may already be checked in or have no vMOONEY.', {
+        toast.error('No check-ins were submitted. Please try again.', {
           style: toastStyle,
         })
       }
@@ -431,7 +460,11 @@ export default function WeeklyRewardPool() {
         <div className="space-y-4">
           {!address || (VMOONEYBalance && VMOONEYBalance > 0) ? (
             <PrivyWeb3Button
-              label={isCheckedIn ? 'Already Checked In' : 'Check In & Claim Reward'}
+              label={
+                isCheckedIn
+                  ? 'Checked In • Reward Auto-Distributes Weekly'
+                  : 'Check In For This Week'
+              }
               action={handleCheckIn}
               isDisabled={isCheckedIn}
               className={`w-full py-4 text-white font-semibold rounded-xl transition-all duration-300 transform hover:scale-[1.01] shadow-lg whitespace-nowrap ${

--- a/ui/components/tokens/WeeklyRewardPool.tsx
+++ b/ui/components/tokens/WeeklyRewardPool.tsx
@@ -479,20 +479,23 @@ export default function WeeklyRewardPool() {
         {/* Action Button */}
         <div className="space-y-4">
           {!address || (VMOONEYBalance && VMOONEYBalance > 0) ? (
-            <PrivyWeb3Button
-              label={
-                isCheckedIn
-                  ? 'Checked In • Reward Auto-Distributes Weekly'
-                  : 'Check In For This Week'
-              }
-              action={handleCheckIn}
-              isDisabled={isCheckedIn}
-              className={`w-full py-4 text-white font-semibold rounded-xl transition-all duration-300 transform hover:scale-[1.01] shadow-lg whitespace-nowrap ${
-                isCheckedIn
-                  ? 'bg-gradient-to-r from-green-500 to-emerald-600 cursor-not-allowed shadow-green-500/25'
-                  : 'bg-gradient-to-r from-blue-500 via-purple-600 to-pink-600 hover:from-blue-600 hover:via-purple-700 hover:to-pink-700 shadow-purple-500/25'
-              }`}
-            />
+            <div className="space-y-2">
+              <PrivyWeb3Button
+                label={isCheckedIn ? 'Checked In ✓' : 'Check In This Week'}
+                action={handleCheckIn}
+                isDisabled={isCheckedIn}
+                className={`w-full py-4 text-white font-semibold rounded-xl transition-all duration-300 transform hover:scale-[1.01] shadow-lg truncate ${
+                  isCheckedIn
+                    ? 'bg-gradient-to-r from-green-500 to-emerald-600 cursor-not-allowed shadow-green-500/25'
+                    : 'bg-gradient-to-r from-blue-500 via-purple-600 to-pink-600 hover:from-blue-600 hover:via-purple-700 hover:to-pink-700 shadow-purple-500/25'
+                }`}
+              />
+              {isCheckedIn && (
+                <p className="text-center text-xs text-green-300/80">
+                  Rewards auto-distribute weekly
+                </p>
+              )}
+            </div>
           ) : (
             <Link
               href="/lock"

--- a/ui/components/xp/Quest.tsx
+++ b/ui/components/xp/Quest.tsx
@@ -131,9 +131,17 @@ export default function Quest({
   const fetchHasClaimed = useCallback(
     async (polling = false) => {
       const verifierId = quest.verifier?.verifierId
+      // Guard: a 42-char `0x...` address is required. An empty / malformed
+      // address makes viem throw deep in its ABI encoder with messages like
+      // "Cannot read properties of undefined (reading 'buffer')".
+      const isValidAddress =
+        typeof userAddress === 'string' &&
+        userAddress.startsWith('0x') &&
+        userAddress.length === 42
+
       if (
         xpManagerContract &&
-        userAddress &&
+        isValidAddress &&
         verifierId !== undefined &&
         verifierId !== null
       ) {
@@ -142,18 +150,29 @@ export default function Quest({
           setIsCheckingClaimed(true)
         }
 
-        const claimed = await readContract({
-          contract: xpManagerContract,
-          method: 'hasClaimedFromVerifier' as string,
-          params: [userAddress, verifierId],
-        })
+        try {
+          const claimed = await readContract({
+            contract: xpManagerContract,
+            method: 'hasClaimedFromVerifier' as string,
+            params: [userAddress, BigInt(verifierId)],
+          })
 
-        setHasClaimed(Boolean(claimed))
-        // Always clear checking status when not polling, regardless of result
-        if (!polling) {
-          setIsCheckingClaimed(false)
+          setHasClaimed(Boolean(claimed))
+          if (!polling) {
+            setIsCheckingClaimed(false)
+          }
+          return Boolean(claimed)
+        } catch (err) {
+          // Common causes: contract not deployed on current chain, RPC
+          // returned `0x`, decode error, network blip. Treat as "not claimed"
+          // so the UI stays usable instead of crashing the page.
+          console.error('Error reading hasClaimedFromVerifier:', err)
+          setHasClaimed(false)
+          if (!polling) {
+            setIsCheckingClaimed(false)
+          }
+          return false
         }
-        return Boolean(claimed)
       } else {
         // Always clear checking status when not polling
         if (!polling) {
@@ -509,28 +528,32 @@ export default function Quest({
     async function fetchXpAmount() {
       setIsLoadingXpAmount(true)
 
-      if (quest.verifier.type === 'staged') {
-        // For staged quests, show total claimable XP instead of fixed amount
-        await fetchStagedProgress()
-        setIsLoadingXpAmount(false)
-        return
-      }
+      try {
+        if (quest.verifier.type === 'staged') {
+          // For staged quests, show total claimable XP instead of fixed amount
+          await fetchStagedProgress()
+          return
+        }
 
-      if (quest.verifier.xpPerClaim) {
-        setXpAmount(quest.verifier.xpPerClaim)
-        setIsLoadingXpAmount(false)
-        return
-      }
+        if (quest.verifier.xpPerClaim) {
+          setXpAmount(quest.verifier.xpPerClaim)
+          return
+        }
 
-      if (verifierContract && userAddress) {
-        const xpAmount = await readContract({
-          contract: verifierContract,
-          method: 'xpPerClaim' as string,
-          params: [],
-        })
-        setXpAmount(Number(xpAmount))
+        if (verifierContract && userAddress) {
+          const xpAmount = await readContract({
+            contract: verifierContract,
+            method: 'xpPerClaim' as string,
+            params: [],
+          })
+          setXpAmount(Number(xpAmount))
+        }
+      } catch (err) {
+        console.error('Error fetching XP amount:', err)
+        setXpAmount(0)
+      } finally {
+        setIsLoadingXpAmount(false)
       }
-      setIsLoadingXpAmount(false)
     }
 
     fetchXpAmount()

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -393,6 +393,14 @@ export const JOBS_TABLE_ADDRESSES: Index = {
   'arbitrum-sepolia': '0x97F9F6DC65b57af7E0B0CB32E5E3153af14E3332',
 }
 
+// Fallback Tableland names – used when the on-chain `getTableName()` read
+// fails (e.g. RPC rate-limit / Thirdweb hosted RPC blip during ISR build).
+// Verified against on-chain reads on 2026-04-21.
+export const JOBS_TABLE_NAMES: Index = {
+  arbitrum: 'JOBBOARD_42161_115',
+  sepolia: 'JOBBOARD_11155111_1899',
+}
+
 export const MARKETPLACE_ADDRESS =
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
     ? polygonConfig.Marketplace
@@ -402,6 +410,11 @@ export const MARKETPLACE_TABLE_ADDRESSES: Index = {
   arbitrum: '0xEeaa3BfA8E4843b8538D57b5723C2267ecA2c16E',
   sepolia: '0x46025c3b96B01d551274Ba7AdC6057FD15E0923b',
   'arbitrum-sepolia': '0xE632A675C305F0aF36b1514e924BE99DC1AB9884',
+}
+
+export const MARKETPLACE_TABLE_NAMES: Index = {
+  arbitrum: 'MARKETPLACE_42161_116',
+  sepolia: 'MARKETPLACE_11155111_1898',
 }
 
 export const VMOONEY_SWEEPSTAKES: string = ethConfig.vMooneySweepstakesZeroG

--- a/ui/pages/dashboard.tsx
+++ b/ui/pages/dashboard.tsx
@@ -4,7 +4,9 @@ import {
   DEFAULT_CHAIN_V5,
   JBV5_CONTROLLER_ADDRESS,
   JOBS_TABLE_ADDRESSES,
+  JOBS_TABLE_NAMES,
   MARKETPLACE_TABLE_ADDRESSES,
+  MARKETPLACE_TABLE_NAMES,
   MISSION_TABLE_ADDRESSES,
   MISSION_TABLE_NAMES,
   PROJECT_TABLE_ADDRESSES,
@@ -256,31 +258,60 @@ export async function getStaticProps() {
         projectTableNameResolved || PROJECT_TABLE_NAMES[chainSlug] || ''
       const missionTableName =
         missionTableNameResolved || MISSION_TABLE_NAMES[chainSlug] || ''
+      // Marketplace and Jobs tables previously had no fallback. When the
+      // on-chain `getTableName()` read fails (RPC blip / ISR build hiccup),
+      // queries silently returned empty arrays — the dashboard would say
+      // "No open positions" and "No new listings" even with live data.
+      const marketplaceTableNameWithFallback =
+        marketplaceTableName || MARKETPLACE_TABLE_NAMES[chainSlug] || ''
+      const jobTableNameWithFallback =
+        jobTableName || JOBS_TABLE_NAMES[chainSlug] || ''
 
       const blockedIds = BLOCKED_CITIZENS.size > 0
         ? ` WHERE id NOT IN (${Array.from(BLOCKED_CITIZENS).join(',')})`
         : ''
       const [citizens, citizensCountResult, listings, jobs, teams, projects, missionRows] =
         await Promise.all([
-          citizenTableName ? queryTable(chain, `SELECT * FROM ${citizenTableName} ORDER BY id DESC LIMIT 8`) : Promise.resolve([]),
-          citizenTableName ? queryTable(chain, `SELECT COUNT(*) as count FROM ${citizenTableName}${blockedIds}`) : Promise.resolve([{ count: 0 }]),
-        marketplaceTableName ? queryTable(
+          citizenTableName ? queryTable(chain, `SELECT * FROM ${citizenTableName} ORDER BY id DESC LIMIT 8`).catch((error) => {
+            console.error('Error querying citizen table:', error)
+            return []
+          }) : Promise.resolve([]),
+          citizenTableName ? queryTable(chain, `SELECT COUNT(*) as count FROM ${citizenTableName}${blockedIds}`).catch((error) => {
+            console.error('Error querying citizen count:', error)
+            return [{ count: 0 }]
+          }) : Promise.resolve([{ count: 0 }]),
+        marketplaceTableNameWithFallback ? queryTable(
           chain,
-          `SELECT * FROM ${marketplaceTableName} WHERE (startTime = 0 OR startTime <= ${Math.floor(
+          `SELECT * FROM ${marketplaceTableNameWithFallback} WHERE (startTime = 0 OR startTime <= ${Math.floor(
             Date.now() / 1000
           )}) AND (endTime = 0 OR endTime >= ${Math.floor(
             Date.now() / 1000
           )}) ORDER BY id DESC LIMIT 5`
-        ) : Promise.resolve([]),
-        jobTableName ? queryTable(
+        ).catch((error) => {
+          console.error('Error querying marketplace table:', error)
+          return []
+        }) : Promise.resolve([]),
+        jobTableNameWithFallback ? queryTable(
           chain,
-          `SELECT * FROM ${jobTableName} WHERE (endTime = 0 OR endTime >= ${Math.floor(
+          `SELECT * FROM ${jobTableNameWithFallback} WHERE (endTime = 0 OR endTime >= ${Math.floor(
             Date.now() / 1000
           )}) ORDER BY id DESC LIMIT 5`
-        ) : Promise.resolve([]),
-        teamTableName ? queryTable(chain, `SELECT * FROM ${teamTableName} ORDER BY id DESC`) : Promise.resolve([]),
-        projectTableName ? queryTable(chain, `SELECT * FROM ${projectTableName} ORDER BY id DESC`) : Promise.resolve([]),
-        missionTableName ? queryTable(chain, `SELECT * FROM ${missionTableName} ORDER BY id DESC LIMIT 1`) : Promise.resolve([]),
+        ).catch((error) => {
+          console.error('Error querying job board table:', error)
+          return []
+        }) : Promise.resolve([]),
+        teamTableName ? queryTable(chain, `SELECT * FROM ${teamTableName} ORDER BY id DESC`).catch((error) => {
+          console.error('Error querying team table:', error)
+          return []
+        }) : Promise.resolve([]),
+        projectTableName ? queryTable(chain, `SELECT * FROM ${projectTableName} ORDER BY id DESC`).catch((error) => {
+          console.error('Error querying project table:', error)
+          return []
+        }) : Promise.resolve([]),
+        missionTableName ? queryTable(chain, `SELECT * FROM ${missionTableName} ORDER BY id DESC LIMIT 1`).catch((error) => {
+          console.error('Error querying mission table:', error)
+          return []
+        }) : Promise.resolve([]),
       ])
 
       const citizensCount = Number(citizensCountResult?.[0]?.count ?? 0)
@@ -364,12 +395,38 @@ export async function getStaticProps() {
     newestTeams = teams
     allProjects = projects
 
-    // Process missions data - simplified to just pass basic data to client
+    // Process missions data - simplified to just pass basic data to client.
+    // Always populate `missions` + `featuredMissionData` from the table row so
+    // the dashboard can render *something* even when JB controller / IPFS
+    // calls fail. The client fills in richer details after hydration.
     if (missionRows && missionRows.length > 0) {
       const filteredMissionRows = missionRows.filter((mission: any) => {
         return !BLOCKED_MISSIONS.has(mission.id) && mission && mission.id
       })
       if (filteredMissionRows.length > 0 && filteredMissionRows[0]?.projectId) {
+        const baseRow = filteredMissionRows[0]
+        const fallbackMission = {
+          id: baseRow.id,
+          teamId: baseRow.teamId,
+          projectId: baseRow.projectId,
+          fundingGoal: baseRow.fundingGoal || 0,
+          deadline: baseRow.deadline || null,
+          stage: baseRow.stage || 1,
+          metadata: {
+            name: 'Featured Mission',
+            description: 'Loading mission details...',
+            image: '/assets/placeholder-mission.png',
+          },
+        }
+
+        // Seed with the basic row first so the section renders even if any
+        // of the downstream calls below fail.
+        missions = [fallbackMission]
+        featuredMissionData = {
+          mission: fallbackMission,
+          projectMetadata: fallbackMission.metadata,
+        }
+
         try {
           const chain = DEFAULT_CHAIN_V5
           const jbV5ControllerContract = getContract({
@@ -382,52 +439,36 @@ export async function getStaticProps() {
           const metadataURI = await readContract({
             contract: jbV5ControllerContract,
             method: 'uriOf' as string,
-            params: [filteredMissionRows[0].projectId],
+            params: [baseRow.projectId],
           }).catch((error) => {
-            console.error('Failed to fetch featured mission metadata:', error)
+            console.error('Failed to fetch featured mission metadata URI:', error)
             return null
           })
 
           if (metadataURI) {
-            const metadataRes = await fetch(getIPFSGateway(metadataURI))
-            const metadata = await metadataRes.json()
-
-            missions = [
-              {
-                id: filteredMissionRows[0].id,
-                teamId: filteredMissionRows[0].teamId,
-                projectId: filteredMissionRows[0].projectId,
-                fundingGoal: filteredMissionRows[0].fundingGoal || 0,
-                deadline: filteredMissionRows[0].deadline || null,
-                stage: filteredMissionRows[0].stage || 1,
-                metadata: metadata,
-              },
-            ]
-
-            // Pass basic featured mission data - let client fetch details
-            featuredMissionData = {
-              mission: missions[0],
-              projectMetadata: metadata,
+            try {
+              const metadataRes = await fetch(getIPFSGateway(metadataURI))
+              if (metadataRes.ok) {
+                const metadata = await metadataRes.json()
+                const enrichedMission = {
+                  ...fallbackMission,
+                  metadata,
+                }
+                missions = [enrichedMission]
+                featuredMissionData = {
+                  mission: enrichedMission,
+                  projectMetadata: metadata,
+                }
+              }
+            } catch (ipfsError) {
+              console.warn(
+                'Failed to fetch featured mission metadata from IPFS:',
+                ipfsError
+              )
             }
           }
         } catch (error) {
-          console.warn('Failed to fetch featured mission metadata:', error)
-          // Fallback to basic data without metadata
-          missions = [
-            {
-              id: filteredMissionRows[0].id,
-              teamId: filteredMissionRows[0].teamId,
-              projectId: filteredMissionRows[0].projectId,
-              fundingGoal: filteredMissionRows[0].fundingGoal || 0,
-              deadline: filteredMissionRows[0].deadline || null,
-              stage: filteredMissionRows[0].stage || 1,
-              metadata: {
-                name: 'Featured Mission',
-                description: 'Loading mission details...',
-                image: '/assets/placeholder-mission.png',
-              },
-            },
-          ]
+          console.warn('Failed to enrich featured mission metadata:', error)
         }
       }
     }

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -245,8 +245,33 @@ export default function Fees() {
                     jsonrpc: '2.0',
                   }),
                 })
+                if (!response.ok) {
+                  console.error(
+                    `RPC request failed for ${slug}: ${response.status} ${response.statusText}`
+                  )
+                  return BigNumber.from(0)
+                }
                 const data = await response.json()
-                return BigNumber.from(data.result || '0')
+                if (data?.error) {
+                  console.error(`RPC error for ${slug}:`, data.error)
+                  return BigNumber.from(0)
+                }
+                const result = data?.result
+                // Guard against malformed responses like '0x' or non-hex strings
+                // that would otherwise throw inside BigNumber.from.
+                if (
+                  typeof result !== 'string' ||
+                  !/^0x[0-9a-fA-F]+$/.test(result)
+                ) {
+                  if (result !== undefined && result !== null) {
+                    console.error(
+                      `Invalid eth_getBalance result for ${slug}:`,
+                      result
+                    )
+                  }
+                  return BigNumber.from(0)
+                }
+                return BigNumber.from(result)
               } catch (error) {
                 console.error(`Error fetching balance for ${slug}:`, error)
                 return BigNumber.from(0)

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -26,6 +26,7 @@ import {
   readContract,
   getContract,
 } from 'thirdweb'
+import { useActiveAccount } from 'thirdweb/react'
 import {
   arbitrum,
   base,
@@ -33,8 +34,7 @@ import {
   sepolia,
   arbitrumSepolia,
   Chain,
-} from 'thirdweb/chains'
-import { useActiveAccount } from 'thirdweb/react'
+} from '@/lib/rpc/chains'
 import toastStyle from '../lib/marketplace/marketplace-utils/toastConfig'
 import useETHPrice from '@/lib/etherscan/useETHPrice'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -63,6 +63,44 @@ type FeeChainData = {
 
 const WEEK = 7 * 24 * 60 * 60
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+/**
+ * `readContract` calls occasionally fail with
+ * `TypeError: Cannot read properties of undefined (reading 'buffer')`.
+ *
+ * This happens deep inside `decodeAbiParameters` when the RPC returns a
+ * malformed/empty response — usually a transient symptom of Infura
+ * rate-limiting batched JSON-RPC reads. Retrying once or twice with a
+ * short backoff almost always succeeds, and prevents the per-chain
+ * `Promise.all` from rejecting (which previously dropped Arbitrum's row
+ * from `feeData` entirely).
+ */
+async function safeRead<T>(
+  fn: () => Promise<T>,
+  label: string,
+  retries = 2,
+  baseDelay = 250
+): Promise<T | null> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: any) {
+      const isLast = attempt === retries
+      const isBufferDecodeError =
+        err?.message?.includes("reading 'buffer'") ||
+        err?.message?.includes('decodeAbiParameters')
+      if (!isLast && isBufferDecodeError) {
+        await sleep(baseDelay * Math.pow(2, attempt))
+        continue
+      }
+      console.error(`safeRead [${label}] failed:`, err)
+      return null
+    }
+  }
+  return null
+}
+
 function formatEth(value: string | null, decimals = 4) {
   if (value === null) return null
   const num = Number(value)
@@ -249,23 +287,22 @@ export default function Fees() {
               const hookAddress = FEE_HOOK_ADDRESSES[slug]
               if (!hookAddress) return BigNumber.from(0)
 
-              try {
-                const contract = getContract({
-                  client,
-                  address: hookAddress,
-                  abi: FeeHook.abi as any,
-                  chain,
-                })
-                const estimate = await readContract({
-                  contract,
-                  method: 'estimateFees',
-                  params: [address],
-                })
-                return BigNumber.from(estimate?.toString() || '0')
-              } catch (err) {
-                console.error(`Error fetching estimate for ${slug}:`, err)
-                return BigNumber.from(0)
-              }
+              const contract = getContract({
+                client,
+                address: hookAddress,
+                abi: FeeHook.abi as any,
+                chain,
+              })
+              const estimate = await safeRead(
+                () =>
+                  readContract({
+                    contract,
+                    method: 'estimateFees',
+                    params: [address],
+                  }),
+                `${slug}.estimateFees`
+              )
+              return BigNumber.from(estimate?.toString() || '0')
             })
           )
         ).reduce((acc, est) => acc.add(est || BigNumber.from(0)), BigNumber.from(0))
@@ -303,53 +340,88 @@ export default function Fees() {
               chain,
             })
 
+            // Read each method independently with retry. Previously these
+            // were batched in `Promise.all`; if any single read failed (the
+            // recurring `decodeAbiParameters → buffer` error from a flaky
+            // RPC batch), the whole chain row was dropped from `feeData`,
+            // which surfaced as Arbitrum data going missing.
             const [start, last, count, vMooneyAddress] = await Promise.all([
-              readContract({ contract, method: 'weekStart', params: [] }),
-              readContract({
-                contract,
-                method: 'lastCheckIn',
-                params: [address],
-              }),
-              readContract({
-                contract,
-                method: 'getCheckedInCount',
-                params: [],
-              }),
-              readContract({
-                contract,
-                method: 'vMooneyAddress',
-                params: [],
-              }),
+              safeRead(
+                () => readContract({ contract, method: 'weekStart', params: [] }),
+                `${slug}.weekStart`
+              ),
+              safeRead(
+                () =>
+                  readContract({
+                    contract,
+                    method: 'lastCheckIn',
+                    params: [address],
+                  }),
+                `${slug}.lastCheckIn`
+              ),
+              safeRead(
+                () =>
+                  readContract({
+                    contract,
+                    method: 'getCheckedInCount',
+                    params: [],
+                  }),
+                `${slug}.getCheckedInCount`
+              ),
+              safeRead(
+                () =>
+                  readContract({
+                    contract,
+                    method: 'vMooneyAddress',
+                    params: [],
+                  }),
+                `${slug}.vMooneyAddress`
+              ),
             ])
+
+            // We need at least the week boundaries + vMooney address to do
+            // anything useful. If those are missing the chain is unusable
+            // for this render, but we still don't want to throw — other
+            // chains should keep populating.
+            if (start == null || vMooneyAddress == null) {
+              console.warn(
+                `Skipping ${slug}: missing required FeeHook reads (start=${start}, vMooneyAddress=${vMooneyAddress})`
+              )
+              return null
+            }
 
             const vMooneyContract = getContract({
               client,
-              address: vMooneyAddress,
+              address: vMooneyAddress as `0x${string}`,
               abi: ERC20ABI as any,
               chain,
             })
 
-            const vMooneyBalance = await readContract({
-              contract: vMooneyContract,
-              method: 'balanceOf',
-              params: [address],
-            })
+            const vMooneyBalance = await safeRead(
+              () =>
+                readContract({
+                  contract: vMooneyContract,
+                  method: 'balanceOf',
+                  params: [address],
+                }),
+              `${slug}.balanceOf`
+            )
 
-            const hasVMooney =
-              vMooneyBalance !== undefined &&
-              vMooneyBalance !== null &&
-              vMooneyBalance > BigInt(0)
+            const balance = (vMooneyBalance as bigint | null) ?? BigInt(0)
+            const safeLast = (last as bigint | null) ?? BigInt(0)
+            const safeCount = (count as bigint | null) ?? BigInt(0)
+            const hasVMooney = balance > BigInt(0)
 
             return {
               chain,
               slug,
               contract,
-              start,
-              last,
-              count,
-              vMooneyBalance,
+              start: start as bigint,
+              last: safeLast,
+              count: safeCount,
+              vMooneyBalance: balance,
               hasVMooney,
-              checkedInOnChain: last === start,
+              checkedInOnChain: safeLast === (start as bigint),
             }
           } catch (err) {
             console.error(`Error fetching check-in status for ${slug}:`, err)

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -249,17 +249,23 @@ export default function Fees() {
               const hookAddress = FEE_HOOK_ADDRESSES[slug]
               if (!hookAddress) return BigNumber.from(0)
 
-              const contract = getContract({
-                client,
-                address: hookAddress,
-                abi: FeeHook.abi as any,
-                chain,
-              })
-              return readContract({
-                contract,
-                method: 'estimateFees',
-                params: [address],
-              }).catch(() => BigNumber.from(0))
+              try {
+                const contract = getContract({
+                  client,
+                  address: hookAddress,
+                  abi: FeeHook.abi as any,
+                  chain,
+                })
+                const estimate = await readContract({
+                  contract,
+                  method: 'estimateFees',
+                  params: [address],
+                })
+                return BigNumber.from(estimate?.toString() || '0')
+              } catch (err) {
+                console.error(`Error fetching estimate for ${slug}:`, err)
+                return BigNumber.from(0)
+              }
             })
           )
         ).reduce((acc, est) => acc.add(est || BigNumber.from(0)), BigNumber.from(0))
@@ -267,6 +273,7 @@ export default function Fees() {
         setEstimatedFees(ethers.utils.formatEther(totalEstimated))
       } catch (e) {
         console.error('Error fetching estimates:', e)
+        setEstimatedFees('0')
       }
     }
 
@@ -277,10 +284,15 @@ export default function Fees() {
     if (!address) return
 
     const fetchStatus = async () => {
-      try {
-        const raw = await Promise.all(
-          chains.map(async (chain) => {
-            const slug = getChainSlug(chain)
+      // Each chain is fetched independently. A single chain failure (RPC
+      // hiccup, rate limit, etc.) used to reject the whole Promise.all and
+      // leave `feeData` empty, surfacing as "No fee data available" when the
+      // user tried to check in. Isolate failures per-chain so the remaining
+      // chains still populate.
+      const raw = await Promise.all(
+        chains.map(async (chain) => {
+          const slug = getChainSlug(chain)
+          try {
             const hookAddress = FEE_HOOK_ADDRESSES[slug]
             if (!hookAddress) return null
 
@@ -339,31 +351,32 @@ export default function Fees() {
               hasVMooney,
               checkedInOnChain: last === start,
             }
-          })
-        )
+          } catch (err) {
+            console.error(`Error fetching check-in status for ${slug}:`, err)
+            return null
+          }
+        })
+      )
 
-        const results = raw.filter((r) => r !== null) as FeeChainData[]
-        setFeeData(results)
+      const results = raw.filter((r) => r !== null) as FeeChainData[]
+      setFeeData(results)
 
-        // Only chains where the user actually holds vMOONEY are eligible to
-        // check in (the FeeHook reverts otherwise). Aggregating "checked in"
-        // across all chains regardless of balance would mean a user with
-        // vMOONEY only on Arbitrum is forever shown as "not checked in"
-        // because they can never check in on Ethereum / Base.
-        const eligibleChains = results.filter((r) => r.hasVMooney)
-        const totalCount = results.reduce(
-          (acc, { count }) => acc + Number(count || BigInt(0)),
-          0
-        )
-        const allChecked =
-          eligibleChains.length > 0 &&
-          eligibleChains.every(({ checkedInOnChain }) => checkedInOnChain)
+      // Only chains where the user actually holds vMOONEY are eligible to
+      // check in (the FeeHook reverts otherwise). Aggregating "checked in"
+      // across all chains regardless of balance would mean a user with
+      // vMOONEY only on Arbitrum is forever shown as "not checked in"
+      // because they can never check in on Ethereum / Base.
+      const eligibleChains = results.filter((r) => r.hasVMooney)
+      const totalCount = results.reduce(
+        (acc, { count }) => acc + Number(count || BigInt(0)),
+        0
+      )
+      const allChecked =
+        eligibleChains.length > 0 &&
+        eligibleChains.every(({ checkedInOnChain }) => checkedInOnChain)
 
-        setCheckedInCount(totalCount)
-        setIsCheckedIn(allChecked)
-      } catch (err) {
-        console.error('Error fetching check‑in status:', err)
-      }
+      setCheckedInCount(totalCount)
+      setIsCheckedIn(allChecked)
     }
 
     fetchStatus()

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -1,3 +1,13 @@
+import {
+  ArrowRightIcon,
+  ArrowTopRightOnSquareIcon,
+  CheckBadgeIcon,
+  ClockIcon,
+  CurrencyDollarIcon,
+  GiftIcon,
+  LockClosedIcon,
+  UserGroupIcon,
+} from '@heroicons/react/24/outline'
 import { useWallets } from '@privy-io/react-auth'
 import { usePrivy } from '@privy-io/react-auth'
 import confetti from 'canvas-confetti'
@@ -6,8 +16,9 @@ import FeeHook from 'const/abis/FeeHook.json'
 import { FEE_HOOK_ADDRESSES, DEFAULT_CHAIN_V5 } from 'const/config'
 import { BigNumber } from 'ethers'
 import { ethers } from 'ethers'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
-import React, { useState, useEffect, useContext } from 'react'
+import React, { useState, useEffect, useContext, useMemo } from 'react'
 import toast from 'react-hot-toast'
 import {
   prepareContractCall,
@@ -18,6 +29,7 @@ import {
 import {
   arbitrum,
   base,
+  ethereum,
   sepolia,
   arbitrumSepolia,
   Chain,
@@ -26,7 +38,6 @@ import { useActiveAccount } from 'thirdweb/react'
 import toastStyle from '../lib/marketplace/marketplace-utils/toastConfig'
 import useETHPrice from '@/lib/etherscan/useETHPrice'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
-import useWindowSize from '@/lib/team/use-window-size'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
 import client from '@/lib/thirdweb/client'
@@ -34,10 +45,119 @@ import { useTotalVP } from '@/lib/tokens/hooks/useTotalVP'
 import Container from '../components/layout/Container'
 import ContentLayout from '../components/layout/ContentLayout'
 import WebsiteHead from '../components/layout/Head'
-import Asset from '@/components/dashboard/treasury/balance/Asset'
+import { LoadingSpinner } from '@/components/layout/LoadingSpinner'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
-import Card from '@/components/layout/Card'
 import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
+
+type FeeChainData = {
+  chain: Chain
+  slug: string
+  contract: any
+  start: bigint
+  last: bigint
+  count: bigint
+  vMooneyBalance: bigint
+  hasVMooney: boolean
+  checkedInOnChain: boolean
+}
+
+const WEEK = 7 * 24 * 60 * 60
+
+function formatEth(value: string | null, decimals = 4) {
+  if (value === null) return null
+  const num = Number(value)
+  if (Number.isNaN(num)) return null
+  return num.toFixed(decimals)
+}
+
+function formatUsd(value: string | null, ethPrice?: number) {
+  if (value === null || !ethPrice) return null
+  const num = Number(value) * ethPrice
+  if (Number.isNaN(num)) return null
+  return num.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  subValue,
+  loading,
+  accent,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: React.ReactNode
+  subValue?: React.ReactNode
+  loading?: boolean
+  accent?: string
+}) {
+  return (
+    <div className="bg-black/20 rounded-none sm:rounded-xl px-3 py-4 sm:p-5 border-y sm:border border-white/10 flex flex-col gap-3 h-full">
+      <div className="flex items-center gap-3">
+        <div
+          className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${
+            accent ?? 'bg-gradient-to-br from-blue-500/40 to-purple-600/40'
+          }`}
+        >
+          {icon}
+        </div>
+        <span className="text-xs sm:text-sm uppercase tracking-wider text-gray-400 font-RobotoMono">
+          {label}
+        </span>
+      </div>
+      <div className="mt-auto">
+        {loading ? (
+          <div className="flex items-center gap-2 text-gray-300 text-sm">
+            <LoadingSpinner width="w-4" height="h-4" />
+            Loading...
+          </div>
+        ) : (
+          <>
+            <div className="text-white font-GoodTimes text-xl sm:text-2xl break-words">
+              {value}
+            </div>
+            {subValue && (
+              <div className="text-gray-400 text-xs sm:text-sm mt-1">{subValue}</div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function HowItWorksStep({
+  step,
+  title,
+  description,
+  icon,
+}: {
+  step: number
+  title: string
+  description: string
+  icon: React.ReactNode
+}) {
+  return (
+    <div className="flex gap-3 sm:gap-4 items-start">
+      <div className="flex flex-col items-center flex-shrink-0">
+        <div className="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500/30 to-purple-600/30 border border-white/15 flex items-center justify-center text-white">
+          {icon}
+        </div>
+        <div className="mt-1 text-[10px] tracking-wider text-gray-500 font-RobotoMono uppercase">
+          Step {step}
+        </div>
+      </div>
+      <div className="flex-1 min-w-0">
+        <h3 className="font-GoodTimes text-white text-sm sm:text-base">{title}</h3>
+        <p className="mt-1 text-sm text-gray-300 leading-relaxed">{description}</p>
+      </div>
+    </div>
+  )
+}
 
 export default function Fees() {
   const account = useActiveAccount()
@@ -47,28 +167,27 @@ export default function Fees() {
 
   const { wallets } = useWallets()
   const isTestnet = process.env.NEXT_PUBLIC_CHAIN !== 'mainnet'
-  const chains: Chain[] = isTestnet
-    ? [sepolia, arbitrumSepolia]
-    : [arbitrum, base]
+  const chains: Chain[] = useMemo(
+    () => (isTestnet ? [sepolia, arbitrumSepolia] : [ethereum, arbitrum, base]),
+    [isTestnet]
+  )
 
-  const { isMobile } = useWindowSize()
   const { selectedChain, setSelectedChain } = useContext(ChainContextV5)
   const { data: ethPrice } = useETHPrice(1, 'ETH_TO_USD')
-
-  const WEEK = 7 * 24 * 60 * 60
 
   const [isCheckedIn, setIsCheckedIn] = useState(false)
   const [checkedInCount, setCheckedInCount] = useState<number | null>(null)
   const [feesAvailable, setFeesAvailable] = useState<string | null>(null)
   const [estimatedFees, setEstimatedFees] = useState<string | null>(null)
-  const [feeData, setFeeData] = useState<any[]>([])
+  const [feeData, setFeeData] = useState<FeeChainData[]>([])
   const [weekEnd, setWeekEnd] = useState<number | null>(null)
   const { selectedWallet } = useContext(PrivyWalletContext)
   const { walletVP: VMOONEYBalance } = useTotalVP(address || '')
 
+  // Fetch reward pool balance across chains. We hit each FeeHook's native ETH
+  // balance directly via JSON-RPC because that's what `distributeFees` will
+  // pay out from at the end of the week.
   useEffect(() => {
-    if (!address) return
-
     const fetchBalances = async () => {
       try {
         const totalFees = (
@@ -77,44 +196,46 @@ export default function Fees() {
               const slug = getChainSlug(chain)
               const hookAddress = FEE_HOOK_ADDRESSES[slug]
               if (!hookAddress) return BigNumber.from(0)
-              const contract = getContract({
-                client,
-                address: hookAddress,
-                abi: FeeHook.abi as any,
-                chain,
-              })
-              const balance = await readContract({
-                contract,
-                method: 'balanceOf',
-                params: [],
-              })
-              return balance
+              try {
+                const response = await fetch(chain.rpc, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    method: 'eth_getBalance',
+                    params: [hookAddress, 'latest'],
+                    id: 1,
+                    jsonrpc: '2.0',
+                  }),
+                })
+                const data = await response.json()
+                return BigNumber.from(data.result || '0')
+              } catch (error) {
+                console.error(`Error fetching balance for ${slug}:`, error)
+                return BigNumber.from(0)
+              }
             })
           )
-        )
-          .filter((bal) => bal !== undefined && bal !== null)
-          .reduce(
-            (acc, bal) => acc.add(bal || BigNumber.from(0)),
-            BigNumber.from(0)
-          )
+        ).reduce((acc, bal) => acc.add(bal || BigNumber.from(0)), BigNumber.from(0))
 
-        setFeesAvailable(
-          ethers.utils.formatEther(totalFees || BigNumber.from(0))
-        )
+        setFeesAvailable(ethers.utils.formatEther(totalFees || BigNumber.from(0)))
       } catch (e) {
         console.error('Error fetching balances:', e)
+        setFeesAvailable('0')
       }
     }
 
     fetchBalances()
-  }, [address, chains, client, WEEK])
+  }, [chains])
 
   useEffect(() => {
-    if (!feeData.length) return
-    const starts = feeData.map((d) => BigNumber.from(d.start).toNumber())
+    if (!feeData.length) {
+      setWeekEnd(null)
+      return
+    }
+    const starts = feeData.map((d) => Number(d.start))
     const earliest = Math.min(...starts)
     setWeekEnd((earliest + WEEK) * 1000)
-  }, [feeData, WEEK])
+  }, [feeData])
 
   useEffect(() => {
     if (!address) return
@@ -141,10 +262,7 @@ export default function Fees() {
               }).catch(() => BigNumber.from(0))
             })
           )
-        ).reduce(
-          (acc, est) => acc.add(est || BigNumber.from(0)),
-          BigNumber.from(0)
-        )
+        ).reduce((acc, est) => acc.add(est || BigNumber.from(0)), BigNumber.from(0))
 
         setEstimatedFees(ethers.utils.formatEther(totalEstimated))
       } catch (e) {
@@ -153,7 +271,7 @@ export default function Fees() {
     }
 
     fetchEstimates()
-  }, [address, chains, client, WEEK])
+  }, [address, chains])
 
   useEffect(() => {
     if (!address) return
@@ -205,6 +323,11 @@ export default function Fees() {
               params: [address],
             })
 
+            const hasVMooney =
+              vMooneyBalance !== undefined &&
+              vMooneyBalance !== null &&
+              vMooneyBalance > BigInt(0)
+
             return {
               chain,
               slug,
@@ -213,34 +336,28 @@ export default function Fees() {
               last,
               count,
               vMooneyBalance,
-              checkedInOnChain: BigNumber.from(last).eq(BigNumber.from(start)),
+              hasVMooney,
+              checkedInOnChain: last === start,
             }
           })
         )
 
-        const results = raw.filter((r) => r) as Array<{
-          chain: any
-          slug: string
-          contract: any
-          start: BigNumber
-          last: BigNumber
-          count: BigNumber
-          checkedInOnChain: boolean
-        }>
-
+        const results = raw.filter((r) => r !== null) as FeeChainData[]
         setFeeData(results)
 
-        // aggregate counts & allChecked
-        const { totalCount, allChecked } = results.reduce(
-          (acc, { last, start, count }) => {
-            acc.totalCount += Number(count || 0)
-            if (!BigNumber.from(last).eq(BigNumber.from(start))) {
-              acc.allChecked = false
-            }
-            return acc
-          },
-          { totalCount: 0, allChecked: true }
+        // Only chains where the user actually holds vMOONEY are eligible to
+        // check in (the FeeHook reverts otherwise). Aggregating "checked in"
+        // across all chains regardless of balance would mean a user with
+        // vMOONEY only on Arbitrum is forever shown as "not checked in"
+        // because they can never check in on Ethereum / Base.
+        const eligibleChains = results.filter((r) => r.hasVMooney)
+        const totalCount = results.reduce(
+          (acc, { count }) => acc + Number(count || BigInt(0)),
+          0
         )
+        const allChecked =
+          eligibleChains.length > 0 &&
+          eligibleChains.every(({ checkedInOnChain }) => checkedInOnChain)
 
         setCheckedInCount(totalCount)
         setIsCheckedIn(allChecked)
@@ -250,62 +367,124 @@ export default function Fees() {
     }
 
     fetchStatus()
-  }, [address, chains, client, WEEK])
+  }, [address, chains])
 
   const handleCheckIn = async () => {
     try {
       if (!account) throw new Error('No account found')
+
+      if (!feeData || feeData.length === 0) {
+        toast.error('Fee data is still loading. Please try again in a moment.', {
+          style: toastStyle,
+        })
+        return
+      }
+
       const currentChain = selectedChain
+      let transactionsSent = 0
+      let alreadyCheckedInCount = 0
+      let eligibleChainsCount = 0
+
+      const waitForChainSwitch = async (targetChainId: number, maxWait = 5000) => {
+        const startTime = Date.now()
+        while (Date.now() - startTime < maxWait) {
+          const walletChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
+          if (walletChainId === targetChainId) return true
+          await new Promise((resolve) => setTimeout(resolve, 100))
+        }
+        return false
+      }
+
       for (const data of feeData) {
-        if (data.checkedInOnChain) continue
-        if (!data.vMooneyBalance || BigNumber.from(data.vMooneyBalance).eq(0)) {
+        if (!data.hasVMooney) continue
+        eligibleChainsCount++
+        if (data.checkedInOnChain) {
+          alreadyCheckedInCount++
           continue
         }
-        if (selectedChain.id !== data.chain.id) {
+
+        const walletChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
+        if (walletChainId !== data.chain.id) {
           await wallets[selectedWallet].switchChain(data.chain.id)
           setSelectedChain(data.chain)
+          const switched = await waitForChainSwitch(data.chain.id)
+          if (!switched) continue
+          await new Promise((resolve) => setTimeout(resolve, 500))
         }
+
         const tx = prepareContractCall({
           contract: data.contract,
           method: 'checkIn' as string,
           params: [],
         })
-        await sendAndConfirmTransaction({
-          transaction: tx,
-          account,
+        await sendAndConfirmTransaction({ transaction: tx, account })
+        transactionsSent++
+      }
+
+      const finalWalletChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
+      if (finalWalletChainId !== currentChain.id) {
+        await wallets[selectedWallet].switchChain(currentChain.id)
+        setSelectedChain(currentChain)
+        await waitForChainSwitch(currentChain.id)
+      }
+
+      if (transactionsSent > 0) {
+        toast.success(
+          `Checked in on ${transactionsSent} chain${transactionsSent > 1 ? 's' : ''}!`,
+          { style: toastStyle }
+        )
+        confetti({
+          particleCount: 150,
+          spread: 100,
+          origin: { y: 0.6 },
+          shapes: ['circle', 'star'],
+          colors: ['#ffffff', '#FFD700', '#00FFFF', '#ff69b4', '#8A2BE2'],
+        })
+        if (alreadyCheckedInCount + transactionsSent === eligibleChainsCount) {
+          setIsCheckedIn(true)
+        }
+      } else if (eligibleChainsCount === 0) {
+        toast.error(
+          'No vMOONEY detected on Ethereum, Arbitrum, or Base. Lock MOONEY to participate.',
+          { style: toastStyle }
+        )
+      } else if (alreadyCheckedInCount === eligibleChainsCount) {
+        toast(
+          "You're already checked in for this week. Rewards are distributed automatically every Thursday.",
+          { style: toastStyle }
+        )
+        setIsCheckedIn(true)
+      } else {
+        toast.error('No check-ins were submitted. Please try again.', {
+          style: toastStyle,
         })
       }
-      await wallets[selectedWallet].switchChain(currentChain.id)
-      setSelectedChain(currentChain)
-      toast.success('You\'re checked in for this week\'s reward pool! 🎉', { style: toastStyle })
-      confetti({
-        particleCount: 150,
-        spread: 100,
-        origin: { y: 0.6 },
-        shapes: ['circle', 'star'],
-        colors: ['#ffffff', '#FFD700', '#00FFFF', '#ff69b4', '#8A2BE2'],
-      })
-      setIsCheckedIn(true)
     } catch (error) {
       console.error('Error checking in:', error)
-      toast.error('Check-in failed — ensure you have vMOONEY and gas.', { style: toastStyle })
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error occurred'
+      toast.error(`Check-in failed: ${errorMessage}`, { style: toastStyle })
     }
   }
+
+  const hasVMooney = !!(VMOONEYBalance && VMOONEYBalance > 0)
+  const poolEth = formatEth(feesAvailable)
+  const poolUsd = formatUsd(feesAvailable, ethPrice)
+  const yourEth = formatEth(estimatedFees)
+  const yourUsd = formatUsd(estimatedFees, ethPrice)
 
   return (
     <>
       <WebsiteHead
-        title={'Liquidity Rewards'}
-        description={
-          'Check in weekly and distribute accrued fees. To check in you will need to sign one transaction per chain.'
-        }
+        title="Liquidity Rewards"
+        description="Liquidity providers can claim a share of the weekly trading-fee reward pool by checking in. Rewards are distributed automatically each week."
       />
-      <section className="w-[calc(100vw-20px)]">
+      <section id="fees-container" className="overflow-hidden">
         <Container>
           <ContentLayout
-            header={'Liquidity Rewards'}
+            header="Liquidity Rewards"
             headerSize="max(20px, 3vw)"
-            description={'Get liquidity rewards by checking in weekly.'}
+            description="Earn a share of MoonDAO's weekly trading-fee reward pool by checking in."
             preFooter={
               <NoticeFooter
                 defaultImage="../assets/MoonDAO-Logo-White.svg"
@@ -321,93 +500,287 @@ export default function Fees() {
             isProfile
             mode="compact"
             popOverEffect={false}
+            branded={false}
           >
-            <Card>
-              {!authenticated ? (
-                <div className="text-center">
-                  <h1 className="text-2xl font-bold mb-4">
-                    Please Connect Your Wallet to check in.
-                  </h1>
+            <div className="mt-8 md:mt-12 flex flex-col gap-3 sm:gap-6">
+              {/* How it works */}
+              <div className="bg-black/20 rounded-none sm:rounded-xl px-3 py-4 sm:p-5 border-y sm:border border-white/10">
+                <div className="flex flex-col gap-4">
+                  <div>
+                    <h2 className="font-GoodTimes text-white text-base sm:text-lg">
+                      How Liquidity Rewards Work
+                    </h2>
+                    <p className="mt-2 text-sm sm:text-base text-gray-300 leading-relaxed">
+                      MoonDAO captures trading fees from MOONEY/ETH liquidity
+                      pools on Ethereum, Arbitrum, and Base. Each week the
+                      collected ETH is split pro-rata among vMOONEY holders
+                      who checked in for that week — your share is proportional
+                      to your vMOONEY balance.
+                    </p>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-2">
+                    <HowItWorksStep
+                      step={1}
+                      title="Lock MOONEY"
+                      description="Lock MOONEY to receive vMOONEY. The longer and larger you lock, the more vMOONEY (and the larger your share)."
+                      icon={<LockClosedIcon className="w-5 h-5" />}
+                    />
+                    <HowItWorksStep
+                      step={2}
+                      title="Check In Weekly"
+                      description="Sign one transaction per chain where you hold vMOONEY. This registers you as a participant in this week's pool."
+                      icon={<CheckBadgeIcon className="w-5 h-5" />}
+                    />
+                    <HowItWorksStep
+                      step={3}
+                      title="Receive ETH Automatically"
+                      description="Every Thursday a cron calls distributeFees() on each chain. ETH is sent directly to checked-in wallets — no claim required."
+                      icon={<GiftIcon className="w-5 h-5" />}
+                    />
+                  </div>
+
+                  <div className="mt-2 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-xs sm:text-sm text-gray-400 border-t border-white/10 pt-4">
+                    <div className="flex items-center gap-2">
+                      <ClockIcon className="w-4 h-4" />
+                      <span>
+                        Distribution runs every Thursday at 1pm Pacific
+                      </span>
+                    </div>
+                    <Link
+                      href="https://docs.moondao.com"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-blue-300 hover:text-blue-200 transition-colors"
+                    >
+                      Read the docs
+                      <ArrowTopRightOnSquareIcon className="w-3.5 h-3.5" />
+                    </Link>
+                  </div>
                 </div>
-              ) : !(VMOONEYBalance > 0) ? (
-                <div className="text-center">
-                  <h1 className="text-2xl font-bold mb-4">
-                    Get vMOONEY to collect rewards!
+              </div>
+
+              {/* Stats */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+                <StatCard
+                  icon={<CurrencyDollarIcon className="w-5 h-5 text-white" />}
+                  label="Reward Pool"
+                  value={poolEth ? `${poolEth} ETH` : 'Loading...'}
+                  subValue={poolUsd ? `~$${poolUsd}` : undefined}
+                  loading={feesAvailable === null}
+                  accent="bg-gradient-to-br from-emerald-500/40 to-teal-600/40"
+                />
+                <StatCard
+                  icon={<GiftIcon className="w-5 h-5 text-white" />}
+                  label="Your Estimated Reward"
+                  value={
+                    !address
+                      ? 'Connect wallet'
+                      : !hasVMooney
+                      ? 'Lock MOONEY'
+                      : yourEth
+                      ? `${yourEth} ETH`
+                      : 'Calculating...'
+                  }
+                  subValue={
+                    address && hasVMooney && yourUsd ? `~$${yourUsd}` : undefined
+                  }
+                  loading={!!address && hasVMooney && estimatedFees === null}
+                  accent="bg-gradient-to-br from-purple-500/40 to-pink-600/40"
+                />
+                <StatCard
+                  icon={<UserGroupIcon className="w-5 h-5 text-white" />}
+                  label="Participants This Week"
+                  value={
+                    checkedInCount === null
+                      ? 'Loading...'
+                      : checkedInCount.toLocaleString()
+                  }
+                  subValue={
+                    checkedInCount !== null
+                      ? checkedInCount === 1
+                        ? '1 check-in across all chains'
+                        : `${checkedInCount} check-ins across all chains`
+                      : undefined
+                  }
+                  loading={checkedInCount === null}
+                  accent="bg-gradient-to-br from-blue-500/40 to-indigo-600/40"
+                />
+                <StatCard
+                  icon={<ClockIcon className="w-5 h-5 text-white" />}
+                  label="Next Distribution"
+                  value={
+                    weekEnd
+                      ? new Date(weekEnd).toLocaleDateString(undefined, {
+                          month: 'short',
+                          day: 'numeric',
+                        })
+                      : 'TBD'
+                  }
+                  subValue={
+                    weekEnd
+                      ? new Date(weekEnd).toLocaleTimeString(undefined, {
+                          hour: 'numeric',
+                          minute: '2-digit',
+                        })
+                      : undefined
+                  }
+                  loading={weekEnd === null && !!address}
+                  accent="bg-gradient-to-br from-amber-500/40 to-orange-600/40"
+                />
+              </div>
+
+              {/* Action card */}
+              <div className="bg-black/20 rounded-none sm:rounded-xl px-3 py-4 sm:p-5 border-y sm:border border-white/10">
+                {!authenticated ? (
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                    <div>
+                      <h2 className="font-GoodTimes text-white text-base sm:text-lg">
+                        Connect your wallet to check in
+                      </h2>
+                      <p className="mt-1 text-sm text-gray-300">
+                        You need a connected wallet with vMOONEY to participate
+                        in this week's reward pool.
+                      </p>
+                    </div>
+                    <PrivyWeb3Button
+                      v5
+                      requiredChain={DEFAULT_CHAIN_V5}
+                      label="Connect Wallet"
+                      action={() => {}}
+                      className="px-6 py-3 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-RobotoMono rounded-xl transition-all duration-300 shadow-lg whitespace-nowrap"
+                    />
+                  </div>
+                ) : !hasVMooney ? (
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                    <div>
+                      <h2 className="font-GoodTimes text-white text-base sm:text-lg">
+                        Lock MOONEY to start earning
+                      </h2>
+                      <p className="mt-1 text-sm text-gray-300">
+                        Only vMOONEY holders qualify for the weekly reward pool.
+                        Lock MOONEY to receive vMOONEY.
+                      </p>
+                    </div>
                     <PrivyWeb3Button
                       v5
                       requiredChain={DEFAULT_CHAIN_V5}
                       label="Get vMOONEY"
                       action={() => router.push('/lock')}
-                      className="px-6 py-3 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-RobotoMono rounded-xl transition-all duration-300 transform hover:scale-[1.02] shadow-lg hover:shadow-xl border-0"
+                      className="px-6 py-3 bg-gradient-to-r from-orange-500 to-red-600 hover:from-orange-600 hover:to-red-700 text-white font-RobotoMono rounded-xl transition-all duration-300 shadow-lg whitespace-nowrap"
                     />
-                  </h1>
-                </div>
-              ) : (
-                <div className="mt-3 w-[25vw] flex flex-col gap-4">
-                  <div className="mb-2">
-                    <div className="text-xl font-GoodTimes opacity-80">
-                      Reward Pool This Week:
-                    </div>
-                    <Asset
-                      name="ETH"
-                      amount={
-                        feesAvailable !== null
-                          ? Number(feesAvailable).toFixed(4)
-                          : 'Loading...'
-                      }
-                      usd={
-                        feesAvailable !== null && ethPrice
-                          ? (Number(feesAvailable) * ethPrice).toFixed(2)
-                          : 'Loading...'
-                      }
-                    />
-                    {estimatedFees !== null && (
-                      <div className="mt-4">
-                        <div className="text-xl font-GoodTimes opacity-80">
-                          Your Estimated Rewards:
-                        </div>
-                        <Asset
-                          name="ETH"
-                          amount={Number(estimatedFees).toFixed(4)}
-                          usd={
-                            ethPrice
-                              ? (Number(estimatedFees) * ethPrice).toFixed(2)
-                              : '0'
-                          }
-                        />
-                      </div>
-                    )}
-                    {feesAvailable !== null && Number(feesAvailable) > 0 && (
-                      <div className="mt-4 opacity-75">
-                        {checkedInCount !== null
-                          ? checkedInCount > 0
-                            ? checkedInCount === 1
-                              ? '1 person checked this week!'
-                              : `${checkedInCount} people checked in this week!`
-                            : 'No one has checked in yet!'
-                          : 'Loading...'}
-                      </div>
-                    )}
-                    {weekEnd && (
-                      <div className="mt-4 text-sm text-center opacity-75">
-                        Week ends on {new Date(weekEnd).toLocaleString()}
-                      </div>
-                    )}
                   </div>
-                  {feesAvailable !== null &&
-                    Number(feesAvailable) > 0 &&
-                    !isCheckedIn && (
-                      <PrivyWeb3Button
-                        skipNetworkCheck={true}
-                        action={handleCheckIn}
-                        label={isCheckedIn ? 'Checked In' : 'Check In'}
-                        className="w-full max-w-[250px] rounded-[5vmax] rounded-tl-[20px]"
-                        isDisabled={!address || isCheckedIn}
-                      />
-                    )}
+                ) : (
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                    <div className="flex-1">
+                      <h2 className="font-GoodTimes text-white text-base sm:text-lg">
+                        {isCheckedIn
+                          ? "You're checked in for this week"
+                          : 'Check in for this week'}
+                      </h2>
+                      <p className="mt-1 text-sm text-gray-300">
+                        {isCheckedIn
+                          ? 'Your share will be sent to your wallet automatically when distribution runs on Thursday.'
+                          : 'Sign one transaction per chain where you hold vMOONEY to register for this week. The wallet may prompt you to switch networks.'}
+                      </p>
+                    </div>
+                    <PrivyWeb3Button
+                      skipNetworkCheck
+                      action={handleCheckIn}
+                      label={isCheckedIn ? 'Checked In' : 'Check In Now'}
+                      className={`px-6 py-3 font-RobotoMono rounded-xl transition-all duration-300 shadow-lg whitespace-nowrap ${
+                        isCheckedIn
+                          ? 'bg-gradient-to-r from-green-500 to-emerald-600 cursor-not-allowed'
+                          : 'bg-gradient-to-r from-blue-500 via-purple-600 to-pink-600 hover:from-blue-600 hover:via-purple-700 hover:to-pink-700 text-white'
+                      }`}
+                      isDisabled={!address || isCheckedIn}
+                    />
+                  </div>
+                )}
+              </div>
+
+              {/* Per-chain breakdown */}
+              {address && hasVMooney && feeData.length > 0 && (
+                <div className="bg-black/20 rounded-none sm:rounded-xl px-3 py-4 sm:p-5 border-y sm:border border-white/10">
+                  <h2 className="font-GoodTimes text-white text-base sm:text-lg mb-3">
+                    Your Status By Chain
+                  </h2>
+                  <div className="overflow-x-auto -mx-3 sm:mx-0">
+                    <table className="min-w-full text-sm">
+                      <thead>
+                        <tr className="text-left text-gray-400 border-b border-white/10">
+                          <th className="px-3 py-2 font-RobotoMono uppercase text-xs tracking-wider">
+                            Chain
+                          </th>
+                          <th className="px-3 py-2 font-RobotoMono uppercase text-xs tracking-wider">
+                            vMOONEY
+                          </th>
+                          <th className="px-3 py-2 font-RobotoMono uppercase text-xs tracking-wider">
+                            Status
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {feeData.map((d) => {
+                          const balance = Number(
+                            ethers.utils.formatEther(BigNumber.from(d.vMooneyBalance ?? 0))
+                          )
+                          let status: React.ReactNode = (
+                            <span className="text-gray-500">Not eligible</span>
+                          )
+                          if (d.hasVMooney) {
+                            status = d.checkedInOnChain ? (
+                              <span className="inline-flex items-center gap-1.5 text-emerald-300">
+                                <span className="w-2 h-2 rounded-full bg-emerald-400" />
+                                Checked in
+                              </span>
+                            ) : (
+                              <span className="inline-flex items-center gap-1.5 text-amber-300">
+                                <span className="w-2 h-2 rounded-full bg-amber-400" />
+                                Needs check-in
+                              </span>
+                            )
+                          }
+                          return (
+                            <tr
+                              key={d.slug}
+                              className="border-b border-white/5 last:border-b-0"
+                            >
+                              <td className="px-3 py-3 text-white capitalize">
+                                {d.chain.name ?? d.slug}
+                              </td>
+                              <td className="px-3 py-3 text-gray-200 font-RobotoMono">
+                                {balance.toLocaleString(undefined, {
+                                  minimumFractionDigits: 0,
+                                  maximumFractionDigits: 4,
+                                })}
+                              </td>
+                              <td className="px-3 py-3">{status}</td>
+                            </tr>
+                          )
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                  <p className="mt-3 text-xs text-gray-500">
+                    A check-in transaction is required on each chain where you
+                    hold vMOONEY. Chains where you have a 0 balance are skipped
+                    automatically.
+                  </p>
                 </div>
               )}
-            </Card>
+
+              {/* Footer link to in-app dashboard widget */}
+              <div className="text-center pt-2 pb-4">
+                <Link
+                  href="/dashboard"
+                  className="inline-flex items-center gap-2 text-sm text-blue-300 hover:text-blue-200 transition-colors"
+                >
+                  <span>Back to dashboard</span>
+                  <ArrowRightIcon className="w-4 h-4" />
+                </Link>
+              </div>
+            </div>
           </ContentLayout>
         </Container>
       </section>

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -495,9 +495,41 @@ export default function Fees() {
       <section id="fees-container" className="overflow-hidden">
         <Container>
           <ContentLayout
-            header="Liquidity Rewards"
-            headerSize="max(20px, 3vw)"
-            description="Earn a share of MoonDAO's weekly trading-fee reward pool by checking in."
+            header={
+              // Render the title + tagline together so we can control the
+              // spacing tightly. ContentLayout's built-in `description` slot
+              // injects a wrapper with `md:mt-20` (when `branded={false}`)
+              // that pushes the tagline ~80px below the title on desktop —
+              // way too airy. Passing both in `header` sidesteps that.
+              <div className="flex flex-col gap-2 sm:gap-3 max-w-3xl">
+                <span
+                  className="font-GoodTimes text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.6)] block"
+                  style={{
+                    // clamp keeps the title readable on phones (28px floor)
+                    // without ballooning on ultrawide monitors (52px ceiling).
+                    // The default `.header-responsive` could push the title
+                    // up to 64px on a 1600px viewport, which combined with
+                    // the dark gradient backdrop made it hard to read.
+                    fontSize: 'clamp(28px, 4.2vw, 48px)',
+                    lineHeight: 1.05,
+                    letterSpacing: '0.01em',
+                  }}
+                >
+                  Liquidity Rewards
+                </span>
+                <p
+                  className="text-white/80 font-RobotoMono leading-snug max-w-2xl"
+                  style={{
+                    // Tighter clamp than `.sub-header`'s `max(2vmin, 20px)`
+                    // which jumped between sizes oddly on tablet widths.
+                    fontSize: 'clamp(14px, 1.4vw, 17px)',
+                  }}
+                >
+                  Earn a share of MoonDAO&apos;s weekly trading-fee reward
+                  pool by checking in.
+                </p>
+              </div>
+            }
             preFooter={
               <NoticeFooter
                 defaultImage="../assets/MoonDAO-Logo-White.svg"

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -573,28 +573,37 @@ export default function Fees() {
               // injects a wrapper with `md:mt-20` (when `branded={false}`)
               // that pushes the tagline ~80px below the title on desktop —
               // way too airy. Passing both in `header` sidesteps that.
-              <div className="flex flex-col gap-2 sm:gap-3 max-w-3xl">
-                <span
-                  className="font-GoodTimes text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.6)] block"
+              //
+              // Visibility hardening:
+              // - `pt-24 md:pt-28` keeps the title clear of the fixed
+              //   navbar on every viewport (the layout pulls the wrapper up
+              //   ~80px via `mt-[-80px]`, which on small screens used to
+              //   tuck the title behind the nav).
+              // - `!important` font-size: the global `.header-responsive`
+              //   rule on the parent uses `!important`, so an inline style
+              //   on a *child* span normally wins, but we still mark it to
+              //   be safe.
+              // - Layered text-shadows + a subtle backdrop pill give the
+                //   white type guaranteed contrast over the dark gradient
+              //   regardless of what scrolls behind it.
+              <div className="pt-24 md:pt-28 lg:pt-20 pb-2 flex flex-col gap-3 sm:gap-4 max-w-3xl">
+                <h1
+                  className="font-GoodTimes text-white block"
                   style={{
-                    // clamp keeps the title readable on phones (28px floor)
-                    // without ballooning on ultrawide monitors (52px ceiling).
-                    // The default `.header-responsive` could push the title
-                    // up to 64px on a 1600px viewport, which combined with
-                    // the dark gradient backdrop made it hard to read.
-                    fontSize: 'clamp(28px, 4.2vw, 48px)',
+                    fontSize: 'clamp(36px, 5.5vw, 60px)',
                     lineHeight: 1.05,
                     letterSpacing: '0.01em',
+                    textShadow:
+                      '0 2px 4px rgba(0,0,0,0.85), 0 4px 18px rgba(0,0,0,0.6), 0 0 1px rgba(255,255,255,0.25)',
                   }}
                 >
                   Liquidity Rewards
-                </span>
+                </h1>
                 <p
-                  className="text-white/80 font-RobotoMono leading-snug max-w-2xl"
+                  className="text-white font-RobotoMono leading-snug max-w-2xl"
                   style={{
-                    // Tighter clamp than `.sub-header`'s `max(2vmin, 20px)`
-                    // which jumped between sizes oddly on tablet widths.
-                    fontSize: 'clamp(14px, 1.4vw, 17px)',
+                    fontSize: 'clamp(15px, 1.6vw, 18px)',
+                    textShadow: '0 1px 4px rgba(0,0,0,0.7)',
                   }}
                 >
                   Earn a share of MoonDAO&apos;s weekly trading-fee reward


### PR DESCRIPTION
## Summary

A grab-bag of UX, layout, and resilience fixes spanning the signed-in dashboard, the `/fees` (Liquidity Rewards) flow, and the global footer. The common thread is making the app feel solid on flaky RPCs and on small screens.

### Dashboard (`/`)
- Removed the **Your Teams** section and promoted **Open Jobs** into its slot, side-by-side with **Upcoming Events**, to cut empty space.
- Open Jobs now shows up to 5 previews with an "N more positions →" link and the corrected subtitle "Find open job positions within the MoonDAO Network."
- **Latest Proposals** now reads `IS_MEMBER_VOTE` / `IS_SENATE_VOTE` from `const/config.ts` and surfaces an active voting-phase badge. When a member vote is open, each card gets a pulsing dot and a "Vote Now →" CTA button (rendered as a `<button>` with `stopPropagation` so it nests cleanly inside the card's outer `<Link>`).
- `getStaticProps` is now resilient: every `queryTable` call is wrapped in `.catch` so a single failed Tableland query no longer empties the dashboard. `JOBS_TABLE_NAMES` and `MARKETPLACE_TABLE_NAMES` fallbacks were added in `const/config.ts` for when `getTableName()` contract reads fail.
- Featured Mission falls back to row data + placeholder metadata if the IPFS enrichment fetch fails, so the section never disappears entirely.
- `WalletInfoCard` polish.

### Liquidity Rewards (`/fees`)
- **Per-method RPC retry helper** (`safeRead`) added to both `pages/fees.tsx` and `components/tokens/WeeklyRewardPool.tsx`. The recurring `TypeError: Cannot read properties of undefined (reading 'buffer')` from `decodeAbiParameters` (caused by Infura batching hiccups, predominantly on Arbitrum) is now caught and retried with exponential backoff. Previously, a single bad read in the per-chain `Promise.all` would drop the entire chain row from `feeData`, which surfaced as "0 check-ins," a hung "Next Distribution," and the "Fee data is still loading" toast.
- Each FeeHook read (`weekStart`, `lastCheckIn`, `getCheckedInCount`, `vMooneyAddress`, `balanceOf`, `estimateFees`) is now individually wrapped, so partial data still renders.
- **`isCheckedIn` aggregation** now only considers chains where the user actually holds vMOONEY (the FeeHook reverts otherwise) — a vMOONEY-only-on-Arbitrum user is no longer permanently shown as "not checked in."
- **Header readability**: `Liquidity Rewards` title rebuilt with `clamp(36px, 5.5vw, 60px)`, layered text-shadows for guaranteed contrast over the gradient backdrop, and `pt-24 md:pt-28` so it never tucks under the fixed navbar on phones. Subtitle now uses `clamp(15px, 1.6vw, 18px)`.
- Title + tagline are passed together in `ContentLayout`'s `header` slot to bypass the `md:mt-20` gap that the built-in `description` slot injects when `branded={false}`.

### Footer (`ExpandedFooter`)
- **Follow Us icon row** no longer clips on small phones. Switched from `flex` to `flex-wrap`, smaller mobile sizing (`w-9 h-9 sm:w-10 sm:h-10`), tighter mobile gap (`gap-2.5 sm:gap-4`), and `shrink-0` on each link. All seven socials are visible across every viewport.
- **Footer columns now mirror the top-nav structure 1:1** — same six groups (Citizens, Teams, Projects, $MOONEY, Launchpad, Learn) in the same order with the same children, sourced from the canonical `useNavigation.tsx` / `TeamsNavDropdown` / `ProjectsNavDropdown`. Removed stale `NETWORK` / `GOVERN` / `MARKETPLACE` / `SUPPORT` columns and broken hrefs (`/treasury`, `/faq`).
- "Submit a Ticket" moved to the bottom utility row alongside Documentation / Newsletter / Trade $MOONEY.

### Proposals
- `Proposal.tsx` and `ProposalInfo.tsx` now expose voting-phase context (member vs senate) with a reusable `PhaseBadge` and animated `StatusDot pulse`.

### Misc resilience
- `Quest.tsx`: stricter `isValidAddress` guards and `try/catch` around `readContract` to avoid the same `buffer` decode error; `verifierId` explicitly cast to `BigInt`. Defaults `hasClaimed=false` and `xpAmount=0` on failure.
- `weekly-fee-distribution.yml`: removed `FOUNDRY_PROFILE: ci` (no `[profile.ci]` exists in `fee-hook/foundry.toml`, which was failing the cron's `forge build`).

## Test plan

- [ ] `/` (signed in): no "Your Teams" card; Open Jobs and Upcoming Events sit side-by-side, Open Jobs lists at least one position.
- [ ] `/` Latest Proposals: when `IS_MEMBER_VOTE=true` in `const/config.ts`, member-vote-eligible proposals render the pulsing dot + "Vote Now →" CTA. Clicking the CTA navigates without triggering the card's outer link.
- [ ] `/fees` on mobile, tablet, and desktop: title is legible against the gradient at every width, no horizontal scroll, no overlap with navbar.
- [ ] `/fees` as a vMOONEY holder: no "Fee data is still loading" toast on first click of "Check In"; "Next Distribution" populates; check-in count is non-zero after a successful check-in.
- [ ] `/fees` console: no recurring `Cannot read properties of undefined (reading 'buffer')` errors on Arbitrum (transient ones may log once but should retry and succeed).
- [ ] Footer on a 360px viewport: all 7 social icons visible, no clipping. Footer columns match top-nav order/structure.
- [ ] Quests page: no `buffer` errors in console; quests still claimable.
- [ ] CI: `weekly-fee-distribution.yml` `forge build` step passes.