### PR TITLE
Contribution flow polish + Overview vote / leaderboard fixes

### DIFF
--- a/ui/components/coinbase/CBOnramp.tsx
+++ b/ui/components/coinbase/CBOnramp.tsx
@@ -720,6 +720,40 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
             <LargeAmountExchangeOnrampNotice walletAddress={address} />
           )}
 
+        {/* Payment-method recommendation — shown right before the Buy button so
+            users see it at the moment they're about to choose how to pay. */}
+        <div
+          data-testid="cbonramp-debit-card-tip"
+          className="bg-emerald-500/10 border border-emerald-400/30 rounded-lg p-4"
+        >
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0 w-6 h-6 bg-emerald-500/20 rounded-full flex items-center justify-center mt-0.5">
+              <svg
+                className="w-3.5 h-3.5 text-emerald-300"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2.5}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <div className="flex-1">
+              <p className="text-emerald-200 font-semibold text-sm mb-1">
+                Tip: Use a debit card for the best results
+              </p>
+              <p className="text-emerald-100/80 text-xs leading-relaxed">
+                In our experience, bank-issued debit cards have the highest success rate.
+                Credit cards, prepaid cards, and virtual cards are not supported by Coinbase.
+              </p>
+            </div>
+          </div>
+        </div>
+
         {/* Purchase button */}
         <PrivyWeb3Button
           label={
@@ -761,12 +795,6 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
           <p className="text-gray-300 text-xs text-center leading-relaxed">
             You'll be redirected to Coinbase to complete your purchase securely.
           </p>
-          <div className="border-t border-white/5">
-            <p className="text-gray-400 text-xs text-center leading-relaxed italic">
-              Coinbase only accepts bank-issued debit cards and does not accept credit cards,
-              prepaid cards, or virtual cards at this time.
-            </p>
-          </div>
         </div>
       </div>
     </div>

--- a/ui/components/home/FeaturedMissionSection.tsx
+++ b/ui/components/home/FeaturedMissionSection.tsx
@@ -325,13 +325,31 @@ export default function FeaturedMissionSection({ missions, featuredMissionData }
 
               {/* CTA Buttons */}
               <div className="flex flex-row gap-2 md:gap-4 pt-4">
-                <StandardButton
-                  className="bg-gradient-to-r from-[#6C407D] to-[#5F4BA2] text-white font-semibold text-xs md:text-sm px-3 md:px-4 lg:px-6 py-2 md:py-3 rounded-lg md:rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-xl hover:shadow-purple-500/30 border border-white/20 text-center w-full flex items-center justify-center"
-                  link={`/mission/${featuredMission?.id}`}
-                  hoverEffect={false}
-                >
-                  <span className="ml-1 md:ml-2">Contribute</span>
-                </StandardButton>
+                <div className="relative group w-full">
+                  <div className="absolute -inset-1 bg-gradient-to-r from-[#6C407D] via-[#5F4BA2] to-[#4660E7] rounded-xl blur-lg opacity-75 group-hover:opacity-100 transition-opacity duration-300"></div>
+                  <StandardButton
+                    className="relative bg-gradient-to-r from-[#6C407D] via-[#5F4BA2] to-[#4660E7] text-white font-bold text-base md:text-xl lg:text-2xl uppercase tracking-wide px-6 md:px-8 lg:px-10 py-4 md:py-5 lg:py-6 rounded-xl hover:scale-[1.03] transition-all duration-300 hover:shadow-2xl hover:shadow-purple-500/40 border border-white/20 text-center w-full flex items-center justify-center"
+                    link={`/mission/${featuredMission?.id}`}
+                    hoverEffect={false}
+                  >
+                    <div className="flex items-center justify-center w-full text-center">
+                      <span className="relative">Contribute</span>
+                      <svg
+                        className="w-4 h-4 md:w-5 md:h-5 lg:w-6 lg:h-6 group-hover:translate-x-1 transition-transform duration-300 ml-2 md:ml-3"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M13 7l5 5m0 0l-5 5m5-5H6"
+                        />
+                      </svg>
+                    </div>
+                  </StandardButton>
+                </div>
               </div>
             </div>
           </div>

--- a/ui/components/layout/Tooltip.tsx
+++ b/ui/components/layout/Tooltip.tsx
@@ -237,7 +237,11 @@ export default function Tooltip({
               bottom: position.bottom,
               left: position.left,
               opacity: 1,
-              zIndex: 1000,
+              // Must sit above modal overlays (which use z-[9999] across
+              // the codebase) so tooltips spawned inside a modal — like
+              // the network help on the contribute modal — actually render
+              // on top of the dimming layer instead of behind it.
+              zIndex: 10000,
               transform: 'translateX(-50%)',
               transformOrigin: 'bottom center',
             }}

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1814,19 +1814,7 @@ export default function MissionContributeModal({
                 <label className="text-gray-300 font-medium text-sm uppercase tracking-wider">
                   Network
                 </label>
-                <div className="flex items-center gap-3">
-                  {/* Help text aimed at first-time contributors who aren't
-                      sure which network to pick. Sits to the LEFT of the
-                      dropdown so the question mark reads as "ask before
-                      picking" rather than as a label decoration. The default
-                      24px Tooltip trigger is used (no size override) so the
-                      "?" is comfortably tappable on touch devices. */}
-                  <Tooltip
-                    text="Not sure what network? Choose whichever chain you have ETH on. If you don't have ETH then choose Arbitrum."
-                    compact
-                  >
-                    ?
-                  </Tooltip>
+                <div className="flex items-center gap-2">
                   <div className="flex-1 min-w-0">
                     <NetworkSelector
                       chains={chains}
@@ -1843,6 +1831,18 @@ export default function MissionContributeModal({
                       }
                     />
                   </div>
+                  {/* Help text aimed at first-time contributors who aren't
+                      sure which network to pick. Sits to the RIGHT of the
+                      dropdown as a follow-up "?" affordance. Uses the
+                      default 24px Tooltip trigger (no size override) so it
+                      reads as a clearly-tappable help button, larger than
+                      the small inline `?`s elsewhere on the mission card. */}
+                  <Tooltip
+                    text="Not sure what network? Choose whichever chain you have ETH on. If you don't have ETH then choose Arbitrum."
+                    compact
+                  >
+                    ?
+                  </Tooltip>
                 </div>
               </div>
 

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1062,20 +1062,26 @@ export default function MissionContributeModal({
     }
 
     const emailTrim = contributorEmail.trim()
+    // Each entry is a full verb phrase so we can drop them into a single
+    // `Please {a} and {b}.` template without ending up with ungrammatical
+    // toasts like "Please a valid email address." when only one field is
+    // missing.
     const missingRequired: string[] = []
     if (!isValidContributorEmail(emailTrim)) {
-      missingRequired.push('a valid email address')
+      missingRequired.push('enter a valid email address')
     }
     if (!agreedToCondition) {
       missingRequired.push('agree to the Terms and Conditions')
     }
     if (missingRequired.length > 0) {
-      toast.error(
+      const joined =
         missingRequired.length === 1
-          ? `Please ${missingRequired[0]}.`
-          : `Please enter ${missingRequired[0]} and ${missingRequired[1]}.`,
-        { style: toastStyle, duration: 6000 }
-      )
+          ? missingRequired[0]
+          : `${missingRequired.slice(0, -1).join(', ')} and ${missingRequired[missingRequired.length - 1]}`
+      toast.error(`Please ${joined}.`, {
+        style: toastStyle,
+        duration: 6000,
+      })
       return
     }
 

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1049,10 +1049,22 @@ export default function MissionContributeModal({
       console.error('Primary terminal contract not initialized')
       return
     }
+
+    const emailTrim = contributorEmail.trim()
+    const missingRequired: string[] = []
+    if (!isValidContributorEmail(emailTrim)) {
+      missingRequired.push('a valid email address')
+    }
     if (!agreedToCondition) {
-      toast.error('Please agree to the terms.', {
-        style: toastStyle,
-      })
+      missingRequired.push('agree to the Terms and Conditions')
+    }
+    if (missingRequired.length > 0) {
+      toast.error(
+        missingRequired.length === 1
+          ? `Please ${missingRequired[0]}.`
+          : `Please enter ${missingRequired[0]} and ${missingRequired[1]}.`,
+        { style: toastStyle, duration: 6000 }
+      )
       return
     }
 
@@ -1082,14 +1094,6 @@ export default function MissionContributeModal({
       return toast.error('Mission tokens are not supported on this network.', {
         style: toastStyle,
       })
-    }
-
-    const emailTrim = contributorEmail.trim()
-    if (!isValidContributorEmail(emailTrim)) {
-      toast.error('Please enter a valid email address.', {
-        style: toastStyle,
-      })
-      return
     }
 
     // Reset rejection state when attempting a new transaction
@@ -1874,6 +1878,23 @@ export default function MissionContributeModal({
                           ? '…'
                           : '—'}
                       </span>
+                      {fundingBalanceResolved &&
+                        fundingBalanceWei != null &&
+                        fundingBalanceWei > BigInt(0) &&
+                        ethUsdPrice != null &&
+                        ethUsdPrice > 0 && (
+                          <span className="text-gray-400 tabular-nums ml-1">
+                            (~$
+                            {(
+                              parseFloat(formatUnits(fundingBalanceWei.toString(), 18)) *
+                              ethUsdPrice
+                            ).toLocaleString('en-US', {
+                              maximumFractionDigits: 2,
+                              minimumFractionDigits: 2,
+                            })}
+                            )
+                          </span>
+                        )}
                       <span className="text-gray-500 text-[11px] sm:text-xs ml-1">
                         on {(payChain.name ?? 'network').replace(' One', '')}
                         {!walletOnPayChain && fundingBalanceResolved ? (
@@ -2033,7 +2054,10 @@ export default function MissionContributeModal({
                         htmlFor="contribution-contributor-email-direct"
                         className="text-gray-300 font-medium text-sm uppercase tracking-wider"
                       >
-                        Email
+                        Email{' '}
+                        <span className="text-red-400 normal-case font-semibold">
+                          (required)
+                        </span>
                       </label>
                       <p className="text-sm text-gray-300 leading-relaxed mt-2">
                         We will use this email to send you relevant updates about the mission and
@@ -2068,7 +2092,10 @@ export default function MissionContributeModal({
                   <div className="bg-gradient-to-r from-slate-800/30 to-slate-900/40 backdrop-blur-sm rounded-xl p-3 sm:p-5 border border-white/10 flex flex-col gap-3">
                     <div>
                       <p className="text-gray-300 font-medium text-sm uppercase tracking-wider">
-                        Terms and Conditions
+                        Terms and Conditions{' '}
+                        <span className="text-red-400 normal-case font-semibold">
+                          (required)
+                        </span>
                       </p>
                     </div>
                     <MissionTokenNotice />
@@ -2134,8 +2161,6 @@ export default function MissionContributeModal({
                       className="flex-1 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 disabled:from-gray-700 disabled:to-gray-600 text-white py-4 px-6 rounded-xl font-semibold transition-all duration-300 transform hover:scale-[1.02] disabled:hover:scale-100 shadow-xl shadow-purple-500/20 hover:shadow-purple-500/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none"
                       action={buyMissionToken}
                       isDisabled={
-                        !agreedToCondition ||
-                        !isValidContributorEmail(contributorEmail.trim()) ||
                         !usdInput ||
                         parseFloat((usdInput as string).replace(/,/g, '')) <= 0 ||
                         !chainSlugs.includes(chainSlug) ||
@@ -2202,7 +2227,10 @@ export default function MissionContributeModal({
                         htmlFor="contribution-contributor-email-onramp"
                         className="text-gray-300 font-medium text-sm uppercase tracking-wider"
                       >
-                        Email
+                        Email{' '}
+                        <span className="text-red-400 normal-case font-semibold">
+                          (required)
+                        </span>
                       </label>
                       <p className="text-sm text-gray-300 leading-relaxed mt-2">
                         We will use this email to send you relevant updates about the mission and
@@ -2237,7 +2265,10 @@ export default function MissionContributeModal({
                   <div className="bg-gradient-to-r from-slate-800/30 to-slate-900/40 backdrop-blur-sm rounded-xl p-3 sm:p-5 border border-white/10 flex flex-col gap-3">
                     <div>
                       <p className="text-gray-300 font-medium text-sm uppercase tracking-wider">
-                        Terms and Conditions
+                        Terms and Conditions{' '}
+                        <span className="text-red-400 normal-case font-semibold">
+                          (required)
+                        </span>
                       </p>
                     </div>
                     <MissionTokenNotice />

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1825,48 +1825,87 @@ export default function MissionContributeModal({
               </div>
 
               {/* Contribution amount — primary input */}
-              <div className="space-y-3">
+              <div className="space-y-2">
                 <label
                   htmlFor="payment-input"
-                  className="text-white font-semibold text-sm uppercase tracking-wider"
+                  className="flex items-center gap-2 text-white font-semibold text-sm uppercase tracking-wider"
                 >
-                  You contribute
+                  <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-cyan-500/25 text-cyan-200 text-[11px] font-bold ring-1 ring-cyan-400/40">
+                    1
+                  </span>
+                  Enter contribution amount
                 </label>
-                <div className="bg-slate-950/90 border border-cyan-500/25 ring-1 ring-cyan-500/10 shadow-lg shadow-black/30 rounded-xl p-3 sm:p-4">
-                  <div className="flex items-center justify-between gap-2 sm:gap-4">
-                    <div className="flex items-center space-x-2 sm:space-x-4 min-w-0 shrink">
-                      <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-slate-800 flex items-center justify-center border border-white/15 shrink-0">
-                        <Image
-                          src="/coins/ETH.svg"
-                          alt="ETH"
-                          width={24}
-                          height={24}
-                          className="w-5 h-5 sm:w-6 sm:h-6"
-                        />
-                      </div>
-                      <div className="min-w-0">
-                        <p className="font-semibold text-white text-base sm:text-lg truncate">
-                          {calculateEthAmount()}
-                        </p>
-                        <p className="text-gray-500 text-xs">ETH (estimated)</p>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1.5 sm:gap-2 rounded-xl px-2 sm:px-3 py-2 border border-white/15 bg-black/50 shadow-inner shrink-0">
-                      <span className="text-cyan-200/80 text-base sm:text-lg font-bold shrink-0">$</span>
+                <p className="text-gray-400 text-xs sm:text-sm">
+                  Type the amount of USD you want to contribute. We&apos;ll convert it to ETH for
+                  you.
+                </p>
+                <div className="bg-slate-950/90 border-2 border-cyan-500/40 ring-2 ring-cyan-500/15 shadow-lg shadow-cyan-500/10 rounded-xl p-4 sm:p-6 transition-all focus-within:border-cyan-400/70 focus-within:ring-cyan-400/30 focus-within:shadow-cyan-500/25">
+                  <label
+                    htmlFor="payment-input"
+                    className="block cursor-text"
+                  >
+                    <div className="flex items-baseline justify-center gap-1 sm:gap-2 min-w-0">
+                      <span className="text-cyan-200/80 text-3xl sm:text-5xl font-bold shrink-0 select-none">
+                        $
+                      </span>
                       <input
                         id="payment-input"
                         type="text"
                         inputMode="decimal"
-                        className="min-w-0 w-16 sm:w-28 bg-transparent border-none outline-none text-white text-right text-base sm:text-lg font-bold placeholder-gray-600 focus:placeholder-gray-500 focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        autoFocus
+                        autoComplete="off"
+                        aria-label="Contribution amount in USD"
+                        className="min-w-0 flex-1 max-w-[14ch] bg-transparent border-none outline-none text-white text-center text-4xl sm:text-6xl font-bold tracking-tight placeholder-gray-600 focus:placeholder-gray-500 focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                         value={usdInput}
                         onChange={handleUsdInputChange}
                         placeholder="0"
                         maxLength={15}
                       />
-                      <span className="text-gray-300 text-base sm:text-lg font-bold shrink-0">USD</span>
+                      <span className="text-gray-300 text-xl sm:text-2xl font-bold shrink-0 select-none">
+                        USD
+                      </span>
                     </div>
+                    <div className="mt-2 flex items-center justify-center gap-1.5">
+                      <Image
+                        src="/coins/ETH.svg"
+                        alt=""
+                        width={14}
+                        height={14}
+                        className="w-3.5 h-3.5 opacity-60"
+                      />
+                      <p className="text-gray-400 text-xs sm:text-sm tabular-nums">
+                        ≈ {calculateEthAmount()} ETH
+                      </p>
+                    </div>
+                  </label>
+
+                  {/* Quick amount presets */}
+                  <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+                    {[10, 25, 50, 100, 500].map((preset) => {
+                      const isActive =
+                        parseFloat((usdInput || '').replace(/,/g, '')) === preset
+                      return (
+                        <button
+                          key={preset}
+                          type="button"
+                          onClick={() => {
+                            handleUsdInputChange({
+                              target: { value: String(preset) },
+                            } as React.ChangeEvent<HTMLInputElement>)
+                          }}
+                          className={`px-3 py-1.5 rounded-lg text-sm font-semibold transition-colors border ${
+                            isActive
+                              ? 'bg-cyan-500/25 border-cyan-400/60 text-cyan-100'
+                              : 'bg-white/5 hover:bg-white/15 border-white/15 text-white'
+                          }`}
+                        >
+                          ${preset}
+                        </button>
+                      )
+                    })}
                   </div>
-                  <div className="mt-3 pt-3 border-t border-white/10 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+
+                  <div className="mt-4 pt-3 border-t border-white/10 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                     <p className="text-gray-400 text-xs sm:text-sm">
                       <span className="text-gray-500 uppercase tracking-wide mr-1">Balance</span>
                       <span className="text-white font-medium tabular-nums">

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -862,6 +862,13 @@ export default function MissionContributeModal({
       if (!stale()) {
         commitEstimate()
         setEstimatedGas(applyGasBuffer(BigInt(isCrossChain ? 300000 : 180000), isCrossChain))
+        // Reset the LayerZero quote on any failure (e.g. RPC timeout on
+        // Ethereum, ABI mismatch, etc.) so a stale value from a previous
+        // estimate doesn't linger and so the UI can exit its loading state
+        // once `isLoadingGasEstimate` flips false. PaymentBreakdown will
+        // render a "—" placeholder for the cross-chain fee in that case
+        // rather than spinning forever.
+        if (isCrossChain) setCrossChainQuote(BigInt(0))
         setIsLoadingGasEstimate(false)
       }
     }

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1896,9 +1896,11 @@ export default function MissionContributeModal({
                     </div>
                   </label>
 
-                  {/* Quick amount presets */}
+                  {/* Quick amount presets — power-of-ten ladder so users can
+                      jump from a small "try it" contribution to a serious
+                      one in a single tap. */}
                   <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
-                    {[10, 25, 50, 100, 500].map((preset) => {
+                    {[10, 100, 1000, 10000].map((preset) => {
                       const isActive =
                         parseFloat((usdInput || '').replace(/,/g, '')) === preset
                       return (
@@ -1916,7 +1918,7 @@ export default function MissionContributeModal({
                               : 'bg-white/5 hover:bg-white/15 border-white/15 text-white'
                           }`}
                         >
-                          ${preset}
+                          ${preset.toLocaleString('en-US')}
                         </button>
                       )
                     })}

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1444,6 +1444,28 @@ export default function MissionContributeModal({
     }
   }, [paymentEthAmount, getQuote, ruleset])
 
+  /**
+   * Distinguish "we don't yet have the data needed to compute the quote"
+   * from "your contribution genuinely rounds to 0 tokens". Without this,
+   * a transient ETH/USD price failure (Etherscan rate-limit, etc.) would
+   * leave `ethUsdPrice = 0`, gate `paymentEthAmount` to 0, and the
+   * "You receive" line would silently show "0 $OVERVIEW" with no signal
+   * to the user that anything is loading.
+   */
+  const cleanUsdInputForQuote =
+    typeof usdInput === 'string' ? usdInput.replace(/,/g, '') : ''
+  const numericUsdInputForQuote = parseFloat(cleanUsdInputForQuote)
+  const userTypedUsdAmount =
+    Number.isFinite(numericUsdInputForQuote) && numericUsdInputForQuote > 0
+  const rulesetReadyForQuote = !!(ruleset && ruleset[0] && ruleset[1])
+  const isQuoteLoading =
+    userTypedUsdAmount &&
+    output === 0 &&
+    (isLoadingEthUsdPrice ||
+      !ethUsdPrice ||
+      !rulesetReadyForQuote ||
+      paymentEthAmount <= 0)
+
   // Update ETH input when USD changes
   useEffect(() => {
     if (usdInput && ethUsdPrice) {
@@ -2021,11 +2043,22 @@ export default function MissionContributeModal({
                       className="text-left sm:text-right border-t sm:border-t-0 border-white/[0.08] pt-3 sm:pt-0 sm:border-l sm:pl-4 sm:min-w-[10rem]"
                       role="status"
                       aria-live="polite"
-                      aria-label={`${token?.tokenSymbol || 'Tokens'}: ${formatContributionOutput(output)}`}
+                      aria-label={
+                        isQuoteLoading
+                          ? `Calculating ${token?.tokenSymbol || 'token'} quote`
+                          : `${token?.tokenSymbol || 'Tokens'}: ${formatContributionOutput(output)}`
+                      }
                     >
-                      <p className="font-bold text-emerald-200/95 text-xl sm:text-2xl tabular-nums tracking-tight sm:text-right">
-                        {formatContributionOutput(output)}
-                      </p>
+                      {isQuoteLoading ? (
+                        <div className="flex items-center gap-2 sm:justify-end">
+                          <LoadingSpinner className="scale-50" />
+                          <p className="text-white/60 text-sm">Calculating…</p>
+                        </div>
+                      ) : (
+                        <p className="font-bold text-emerald-200/95 text-xl sm:text-2xl tabular-nums tracking-tight sm:text-right">
+                          {formatContributionOutput(output)}
+                        </p>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -53,7 +53,7 @@ import { formatEthFiveSigFigs } from '@/lib/mission/formatEthFiveSigFigs'
 import type { FundingChainBalanceEntry } from '@/lib/mission/useMissionDefaultFundingChain'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
 import type { Chain } from '@/lib/rpc/chains'
-import { arbitrum, base, ethereum, sepolia, optimismSepolia } from '@/lib/rpc/chains'
+import { arbitrum, ethereum, sepolia, optimismSepolia } from '@/lib/rpc/chains'
 import { useGasPrice } from '@/lib/rpc/useGasPrice'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import { addNetworkToWallet } from '@/lib/thirdweb/addNetworkToWallet'
@@ -63,6 +63,7 @@ import useContract from '@/lib/thirdweb/hooks/useContract'
 import { useNativeBalance } from '@/lib/thirdweb/hooks/useNativeBalance'
 import StandardButton from '@/components/layout/StandardButton'
 import Modal from '@/components/layout/Modal'
+import Tooltip from '@/components/layout/Tooltip'
 import NetworkSelector from '@/components/thirdweb/NetworkSelector'
 import { CBOnramp } from '../coinbase/CBOnramp'
 import ConditionCheckbox from '../layout/ConditionCheckbox'
@@ -126,8 +127,11 @@ export default function MissionContributeModal({
   const isCitizen = useCitizen(DEFAULT_CHAIN_V5)
   const router = useRouter()
   const isTestnet = process.env.NEXT_PUBLIC_CHAIN !== 'mainnet'
+  // Base was previously offered here but caused confusion / abandonment for
+  // contributors who didn't have ETH on Base. Arbitrum + Ethereum are the
+  // supported funding chains; users on Base will be prompted to switch.
   const chains = useMemo(
-    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum, base, ethereum]),
+    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum, ethereum]),
     [isTestnet]
   )
   const chainSlugs = chains.map((chain) => getChainSlug(chain))
@@ -1807,9 +1811,22 @@ export default function MissionContributeModal({
                 )}
 
               <div className="space-y-3">
-                <label className="text-gray-300 font-medium text-sm uppercase tracking-wider">
-                  Network
-                </label>
+                <div className="flex items-center gap-1.5">
+                  <label className="text-gray-300 font-medium text-sm uppercase tracking-wider">
+                    Network
+                  </label>
+                  {/* Help text aimed at first-time contributors who aren't sure
+                      which network to pick — Arbitrum is our default for cheap
+                      gas, so we surface it as the safe fallback. */}
+                  <Tooltip
+                    text="Not sure what network? Choose whichever chain you have ETH on. If you don't have ETH then choose Arbitrum."
+                    compact
+                    wrap
+                    buttonClassName="!h-3.5 !w-3.5 !text-[8px] !pl-0 -ml-0.5"
+                  >
+                    ?
+                  </Tooltip>
+                </div>
                 <NetworkSelector
                   chains={chains}
                   align="left"

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1811,34 +1811,39 @@ export default function MissionContributeModal({
                 )}
 
               <div className="space-y-3">
-                <div className="flex items-center gap-1.5">
-                  <label className="text-gray-300 font-medium text-sm uppercase tracking-wider">
-                    Network
-                  </label>
-                  {/* Help text aimed at first-time contributors who aren't sure
-                      which network to pick — Arbitrum is our default for cheap
-                      gas, so we surface it as the safe fallback. */}
+                <label className="text-gray-300 font-medium text-sm uppercase tracking-wider">
+                  Network
+                </label>
+                <div className="flex items-center gap-3">
+                  {/* Help text aimed at first-time contributors who aren't
+                      sure which network to pick. Sits to the LEFT of the
+                      dropdown so the question mark reads as "ask before
+                      picking" rather than as a label decoration. The default
+                      24px Tooltip trigger is used (no size override) so the
+                      "?" is comfortably tappable on touch devices. */}
                   <Tooltip
                     text="Not sure what network? Choose whichever chain you have ETH on. If you don't have ETH then choose Arbitrum."
                     compact
-                    wrap
-                    buttonClassName="!h-3.5 !w-3.5 !text-[8px] !pl-0 -ml-0.5"
                   >
                     ?
                   </Tooltip>
+                  <div className="flex-1 min-w-0">
+                    <NetworkSelector
+                      chains={chains}
+                      align="left"
+                      displayChain={
+                        !userChosePayChainInModal &&
+                        fundingDisplayChain != null &&
+                        selectedChain.id !== fundingDisplayChain.id
+                          ? fundingDisplayChain
+                          : undefined
+                      }
+                      onUserSelectChain={() =>
+                        setUserChosePayChainInModal(true)
+                      }
+                    />
+                  </div>
                 </div>
-                <NetworkSelector
-                  chains={chains}
-                  align="left"
-                  displayChain={
-                    !userChosePayChainInModal &&
-                    fundingDisplayChain != null &&
-                    selectedChain.id !== fundingDisplayChain.id
-                      ? fundingDisplayChain
-                      : undefined
-                  }
-                  onUserSelectChain={() => setUserChosePayChainInModal(true)}
-                />
               </div>
 
               {/* Contribution amount — primary input */}

--- a/ui/components/mission/MissionInfo.tsx
+++ b/ui/components/mission/MissionInfo.tsx
@@ -1,14 +1,30 @@
 import Image from 'next/image'
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import type { LeaderboardEntry } from '@/lib/overview-delegate/leaderboard'
 import { useShallowQueryRoute } from '@/lib/utils/hooks'
 import MissionActivityList from './MissionActivityList'
 import MissionPayRedeem from './MissionPayRedeem'
 import MissionSocialLinks from './MissionSocialLinks'
 import MissionTimelineChart from './MissionTimelineChart'
 import MissionTokenInfo from './MissionTokenInfo'
+import OverviewLeaderboardPreview from './OverviewLeaderboardPreview'
 
-export type MissionInfoTabType = 'activity' | 'about' | 'tokenomics'
+export type MissionInfoTabType =
+  | 'activity'
+  | 'about'
+  | 'tokenomics'
+  | 'leaderboard'
+
+/** Human-readable label for each tab. We map explicitly so we can use a
+ *  multi-word label (e.g. "Fly with Frank") for the leaderboard tab without
+ *  losing the title-cased fallback for the other tabs. */
+const TAB_LABELS: Record<MissionInfoTabType, string> = {
+  about: 'About',
+  leaderboard: 'Fly with Frank',
+  activity: 'Activity',
+  tokenomics: 'Tokenomics',
+}
 
 function MissionInfoTab({
   tab,
@@ -22,14 +38,14 @@ function MissionInfoTab({
   const isActive = currentTab === tab
   return (
     <button
-      className={`relative px-5 py-3 text-base md:text-lg font-semibold tracking-wide transition-all duration-200 ${
+      className={`relative px-5 py-3 text-base md:text-lg font-semibold tracking-wide whitespace-nowrap transition-all duration-200 ${
         isActive
           ? 'text-white'
           : 'text-gray-500 hover:text-gray-300'
       }`}
       onClick={() => setTab(tab)}
     >
-      {tab.charAt(0).toUpperCase() + tab.slice(1)}
+      {TAB_LABELS[tab]}
       {isActive && (
         <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-3/4 h-[2px] bg-indigo-400 rounded-full" />
       )}
@@ -74,19 +90,53 @@ export default function MissionInfo({
   recommendedChain = null,
   fundingChainBalances = null,
   fundingCompareEnabled = false,
+  /** Pre-fetched $OVERVIEW leaderboard for the Overview Mission (id 4).
+   *  When provided we surface a dedicated Leaderboard tab; for every other
+   *  mission this is `undefined` and the tab is hidden. */
+  _overviewLeaderboard,
 }: any) {
   const router = useRouter()
   const shallowQueryRoute = useShallowQueryRoute()
 
+  const showLeaderboardTab = Array.isArray(_overviewLeaderboard)
+
+  /** Tabs in the order they should appear in the bar. The leaderboard slot
+   *  sits right after "about" so the most actionable content for mission 4
+   *  shows up early — but it's omitted entirely for missions that don't
+   *  ship leaderboard data. */
+  const visibleTabs = useMemo<MissionInfoTabType[]>(
+    () =>
+      showLeaderboardTab
+        ? ['about', 'leaderboard', 'activity', 'tokenomics']
+        : ['about', 'activity', 'tokenomics'],
+    [showLeaderboardTab]
+  )
+
+  /** Resolve the initial tab from `?tab=`, falling back to "about" if the
+   *  URL specifies a tab that isn't valid for this mission (e.g. someone
+   *  shares a `?tab=leaderboard` link to a non-mission-4 page). */
+  const resolveTab = (raw: unknown): MissionInfoTabType => {
+    if (
+      typeof raw === 'string' &&
+      (visibleTabs as string[]).includes(raw)
+    ) {
+      return raw as MissionInfoTabType
+    }
+    return 'about'
+  }
+
   const [tab, setTab] = useState<MissionInfoTabType>(
-    (router.query.tab as MissionInfoTabType) || 'about'
+    resolveTab(router.query.tab)
   )
 
   useEffect(() => {
     if (router.query.tab) {
-      setTab(router.query.tab as MissionInfoTabType)
+      setTab(resolveTab(router.query.tab))
     }
-  }, [router])
+    // resolveTab depends on visibleTabs; including the latter triggers a
+    // re-resolve if the leaderboard data arrives after first paint.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router, visibleTabs])
 
   useEffect(() => {
     if (!router.isReady || !mission?.id) return
@@ -122,12 +172,19 @@ export default function MissionInfo({
         />
       </div>
 
-      {/* Tab Navigation */}
+      {/* Tab Navigation — overflow-x-auto so the bar stays single-row on
+          phones when the optional Leaderboard tab makes it wider than the
+          viewport. */}
       <div className="w-full flex flex-col md:flex-row items-start md:items-center justify-between gap-4 mb-8">
-        <div className="flex items-center gap-1 border-b border-white/[0.08]">
-          <MissionInfoTab tab="about" currentTab={tab} setTab={setTab} />
-          <MissionInfoTab tab="activity" currentTab={tab} setTab={setTab} />
-          <MissionInfoTab tab="tokenomics" currentTab={tab} setTab={setTab} />
+        <div className="flex items-center gap-1 border-b border-white/[0.08] overflow-x-auto max-w-full -mx-1 px-1">
+          {visibleTabs.map((t) => (
+            <MissionInfoTab
+              key={t}
+              tab={t}
+              currentTab={tab}
+              setTab={setTab}
+            />
+          ))}
         </div>
         <div className="hidden md:flex items-center gap-2">
           <MissionSocialLinks
@@ -201,6 +258,20 @@ export default function MissionInfo({
                   />
                 </div>
               )}
+            </div>
+          )}
+          {tab === 'leaderboard' && showLeaderboardTab && (
+            <div className="w-full mb-8">
+              <MissionInfoHeader
+                title="Fly with Frank Leaderboard"
+                icon="/assets/icon-star-blue.svg"
+              />
+              <OverviewLeaderboardPreview
+                leaderboard={
+                  (_overviewLeaderboard as LeaderboardEntry[]) ?? []
+                }
+                missionId={mission?.id ?? 4}
+              />
             </div>
           )}
           {tab === 'activity' && (

--- a/ui/components/mission/MissionPayRedeem.tsx
+++ b/ui/components/mission/MissionPayRedeem.tsx
@@ -288,7 +288,6 @@ function MissionPayRedeemContent({
                     >
                       Max
                     </button>
-                  </div>
                 </div>
               </div>
             </div>

--- a/ui/components/mission/MissionPayRedeem.tsx
+++ b/ui/components/mission/MissionPayRedeem.tsx
@@ -190,8 +190,13 @@ function MissionPayRedeemContent({
                       </div>
                     </div>
 
-                    <div className="flex min-w-0 w-full md:flex-1 items-center gap-2 rounded-lg px-3 py-2.5 border border-white/15 bg-black/50 shadow-inner">
-                      <span className="text-cyan-200/80 text-lg font-bold shrink-0">$</span>
+                    <label
+                      htmlFor="usd-contribution-input"
+                      className="flex min-w-0 w-full md:flex-1 items-center gap-2 rounded-lg px-3 py-2.5 border border-white/15 bg-black/50 shadow-inner cursor-text focus-within:border-cyan-400/50 focus-within:ring-1 focus-within:ring-cyan-400/30 transition-colors"
+                    >
+                      <span className="text-cyan-200/80 text-lg font-bold shrink-0 select-none pointer-events-none">
+                        $
+                      </span>
                       <input
                         id="usd-contribution-input"
                         type="text"
@@ -202,8 +207,10 @@ function MissionPayRedeemContent({
                         placeholder="0"
                         maxLength={15}
                       />
-                      <span className="text-gray-300 text-lg font-bold shrink-0">USD</span>
-                    </div>
+                      <span className="text-gray-300 text-lg font-bold shrink-0 select-none pointer-events-none">
+                        USD
+                      </span>
+                    </label>
                   </div>
 
                   <div className="pt-3 border-t border-white/[0.08] min-w-0 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -216,6 +223,23 @@ function MissionPayRedeemContent({
                           ? `${formatEthFiveSigFigs(Number(contributionBalanceEth))} ETH`
                           : '—'}
                       </span>
+                      {contributionBalanceEth != null &&
+                        Number.isFinite(contributionBalanceEth) &&
+                        contributionBalanceEth > 0 &&
+                        ethUsdPrice != null &&
+                        ethUsdPrice > 0 && (
+                          <span className="text-gray-400 tabular-nums ml-1">
+                            (~$
+                            {(Number(contributionBalanceEth) * ethUsdPrice).toLocaleString(
+                              'en-US',
+                              {
+                                maximumFractionDigits: 2,
+                                minimumFractionDigits: 2,
+                              }
+                            )}
+                            )
+                          </span>
+                        )}
                       <span className="text-gray-500 text-[11px] sm:text-xs ml-1">
                         on{' '}
                         {contributionBalanceChain?.name?.replace(' One', '') ?? 'network'}

--- a/ui/components/mission/MissionPayRedeem.tsx
+++ b/ui/components/mission/MissionPayRedeem.tsx
@@ -215,9 +215,11 @@ function MissionPayRedeemContent({
                   </div>
                 </label>
 
-                {/* Quick amount presets */}
+                {/* Quick amount presets — power-of-ten ladder so users can
+                    jump from a small "try it" contribution to a serious one
+                    in a single tap. Keep in sync with MissionContributeModal. */}
                 <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
-                  {[10, 25, 50, 100, 500].map((preset) => {
+                  {[10, 100, 1000, 10000].map((preset) => {
                     const isActive =
                       parseFloat((usdInput || '').replace(/,/g, '')) === preset
                     return (
@@ -235,7 +237,7 @@ function MissionPayRedeemContent({
                             : 'bg-white/5 hover:bg-white/15 border-white/15 text-white'
                         }`}
                       >
-                        ${preset}
+                        ${preset.toLocaleString('en-US')}
                       </button>
                     )
                   })}

--- a/ui/components/mission/MissionPayRedeem.tsx
+++ b/ui/components/mission/MissionPayRedeem.tsx
@@ -165,55 +165,83 @@ function MissionPayRedeemContent({
             <div className="space-y-2">
               <label
                 htmlFor="usd-contribution-input"
-                className="text-white font-semibold text-xs uppercase tracking-wider"
+                className="flex items-center gap-2 text-white font-semibold text-xs uppercase tracking-wider"
               >
-                You contribute
+                <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-cyan-500/25 text-cyan-200 text-[11px] font-bold ring-1 ring-cyan-400/40">
+                  1
+                </span>
+                Enter contribution amount
               </label>
-              <div className="bg-slate-950/90 border border-cyan-500/25 ring-1 ring-cyan-500/10 shadow-lg shadow-black/40 rounded-xl p-3 sm:p-4 min-w-0">
-                <div className="flex flex-col gap-4 min-w-0">
-                  {/* ETH ↔ USD: side-by-side from md up, stacked on small screens */}
-                  <div className="flex flex-col md:flex-row md:items-center gap-4 min-w-0">
-                    <div className="flex items-center gap-3 min-w-0 md:flex-1">
-                      <div className="w-9 h-9 shrink-0 bg-slate-800 rounded-full flex items-center justify-center ring-1 ring-white/15">
-                        <Image
-                          src="/coins/ETH.svg"
-                          alt="ETH"
-                          width={18}
-                          height={18}
-                        />
-                      </div>
-                      <div className="min-w-0">
-                        <p className="font-bold text-white text-lg leading-tight break-all sm:break-normal">
-                          {calculateEthAmount()}
-                        </p>
-                        <p className="text-gray-500 text-xs">ETH (estimated)</p>
-                      </div>
-                    </div>
-
-                    <label
-                      htmlFor="usd-contribution-input"
-                      className="flex min-w-0 w-full md:flex-1 items-center gap-2 rounded-lg px-3 py-2.5 border border-white/15 bg-black/50 shadow-inner cursor-text focus-within:border-cyan-400/50 focus-within:ring-1 focus-within:ring-cyan-400/30 transition-colors"
-                    >
-                      <span className="text-cyan-200/80 text-lg font-bold shrink-0 select-none pointer-events-none">
-                        $
-                      </span>
-                      <input
-                        id="usd-contribution-input"
-                        type="text"
-                        inputMode="decimal"
-                        className="min-w-0 flex-1 bg-transparent border-none outline-none text-lg font-bold text-white text-right placeholder-gray-600 focus:placeholder-gray-500 focus:ring-0 ring-0 transition-colors duration-200 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                        value={usdInput}
-                        onChange={handleUsdInputChange}
-                        placeholder="0"
-                        maxLength={15}
-                      />
-                      <span className="text-gray-300 text-lg font-bold shrink-0 select-none pointer-events-none">
-                        USD
-                      </span>
-                    </label>
+              <p className="text-gray-400 text-xs">
+                Type the amount of USD you want to contribute. We&apos;ll convert it to ETH for
+                you.
+              </p>
+              <div className="bg-slate-950/90 border-2 border-cyan-500/40 ring-2 ring-cyan-500/15 shadow-lg shadow-cyan-500/10 rounded-xl p-4 sm:p-5 min-w-0 transition-all focus-within:border-cyan-400/70 focus-within:ring-cyan-400/30 focus-within:shadow-cyan-500/25">
+                <label
+                  htmlFor="usd-contribution-input"
+                  className="block cursor-text"
+                >
+                  <div className="flex items-baseline justify-center gap-1 sm:gap-2 min-w-0">
+                    <span className="text-cyan-200/80 text-3xl sm:text-5xl font-bold shrink-0 select-none">
+                      $
+                    </span>
+                    <input
+                      id="usd-contribution-input"
+                      type="text"
+                      inputMode="decimal"
+                      autoComplete="off"
+                      aria-label="Contribution amount in USD"
+                      className="min-w-0 flex-1 max-w-[14ch] bg-transparent border-none outline-none text-white text-center text-4xl sm:text-6xl font-bold tracking-tight placeholder-gray-600 focus:placeholder-gray-500 focus:ring-0 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                      value={usdInput}
+                      onChange={handleUsdInputChange}
+                      placeholder="0"
+                      maxLength={15}
+                    />
+                    <span className="text-gray-300 text-xl sm:text-2xl font-bold shrink-0 select-none">
+                      USD
+                    </span>
                   </div>
+                  <div className="mt-2 flex items-center justify-center gap-1.5">
+                    <Image
+                      src="/coins/ETH.svg"
+                      alt=""
+                      width={14}
+                      height={14}
+                      className="w-3.5 h-3.5 opacity-60"
+                    />
+                    <p className="text-gray-400 text-xs sm:text-sm tabular-nums">
+                      ≈ {calculateEthAmount()} ETH
+                    </p>
+                  </div>
+                </label>
 
-                  <div className="pt-3 border-t border-white/[0.08] min-w-0 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                {/* Quick amount presets */}
+                <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+                  {[10, 25, 50, 100, 500].map((preset) => {
+                    const isActive =
+                      parseFloat((usdInput || '').replace(/,/g, '')) === preset
+                    return (
+                      <button
+                        key={preset}
+                        type="button"
+                        onClick={() => {
+                          handleUsdInputChange({
+                            target: { value: String(preset) },
+                          } as React.ChangeEvent<HTMLInputElement>)
+                        }}
+                        className={`px-3 py-1.5 rounded-lg text-sm font-semibold transition-colors border ${
+                          isActive
+                            ? 'bg-cyan-500/25 border-cyan-400/60 text-cyan-100'
+                            : 'bg-white/5 hover:bg-white/15 border-white/15 text-white'
+                        }`}
+                      >
+                        ${preset}
+                      </button>
+                    )
+                  })}
+                </div>
+
+                <div className="mt-4 pt-3 border-t border-white/[0.08] min-w-0 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <p className="text-gray-400 text-xs sm:text-sm leading-relaxed break-words min-w-0">
                       <span className="text-gray-500 uppercase tracking-wide mr-1">Balance</span>
                       <span className="text-white font-medium tabular-nums">

--- a/ui/components/mission/MissionPayRedeem.tsx
+++ b/ui/components/mission/MissionPayRedeem.tsx
@@ -292,7 +292,7 @@ function MissionPayRedeemContent({
                     : 'Contribute'
                 }
                 id="open-contribute-modal"
-                className="rounded-xl gradient-2 w-full py-2.5 font-medium"
+                className="rounded-xl gradient-2 w-full py-4 sm:py-5 text-xl sm:text-2xl font-bold tracking-wide uppercase shadow-lg shadow-blue-500/30 ring-1 ring-white/10 hover:shadow-xl hover:shadow-blue-500/50 hover:brightness-110 hover:scale-[1.02] active:scale-[0.99] transition-all duration-200"
                 action={() => onOpenModal?.(usdInput)}
                 isDisabled={isLoadingEthUsdPrice && usdInput && parseFloat(usdInput) > 0}
               />
@@ -1008,7 +1008,7 @@ function MissionPayRedeemComponent({
                       : 'Contribute'
                   }
                   id="open-contribute-modal"
-                  className={`rounded-full gradient-2 rounded-full w-[80vw] py-1 ${buttonClassName}`}
+                  className={`rounded-full gradient-2 w-[85vw] py-3.5 text-lg font-bold uppercase tracking-wide shadow-xl shadow-blue-500/40 ring-1 ring-white/15 hover:brightness-110 hover:shadow-blue-500/60 active:scale-[0.99] transition-all duration-200 ${buttonClassName}`}
                   action={() => requestOpenContributeModal(usdInput)}
                   isDisabled={isLoadingEthUsdPrice && parseFloat(usdInput) > 0}
                   showSignInLabel={false}

--- a/ui/components/mission/MissionPayRedeem.tsx
+++ b/ui/components/mission/MissionPayRedeem.tsx
@@ -111,6 +111,7 @@ function MissionPayRedeemContent({
   hideRecentContributions = false,
   contributionBalanceEth,
   contributionBalanceChain,
+  isQuoteLoading = false,
 }: any) {
   const resolvedSymbol = getMissionTokenSymbol(mission?.id, token?.tokenSymbol)
   const isRefundable = Number(stage) === 3
@@ -314,17 +315,37 @@ function MissionPayRedeemContent({
                       className="flex items-baseline gap-1.5 flex-wrap"
                       role="status"
                       aria-live="polite"
-                      aria-label={`${resolvedSymbol || 'tokens'}: ${formatContributionOutput(output)}`}
+                      aria-label={
+                        isQuoteLoading
+                          ? `Calculating ${resolvedSymbol || 'tokens'} quote`
+                          : `${resolvedSymbol || 'tokens'}: ${formatContributionOutput(output)}`
+                      }
                     >
-                      <p
-                        id="token-output"
-                        className="text-lg sm:text-xl font-bold text-emerald-200/95 tabular-nums tracking-tight"
-                      >
-                        {formatContributionOutput(output)}
-                      </p>
-                      <p className="font-bold text-white/70 text-sm leading-tight">
-                        {resolvedSymbol ? `$${resolvedSymbol}` : 'tokens'}
-                      </p>
+                      {isQuoteLoading ? (
+                        // Distinguish "we don't have the price/ruleset yet" from
+                        // "your contribution legitimately rounds to 0 tokens".
+                        // Without this users would see "0 $OVERVIEW" during
+                        // a transient ETH-price hiccup and assume the calc is
+                        // broken (it's just the upstream price API being slow).
+                        <div className="flex items-center gap-2">
+                          <LoadingSpinner className="scale-50" />
+                          <p className="text-white/60 text-sm">
+                            Calculating {resolvedSymbol ? `$${resolvedSymbol}` : 'tokens'}…
+                          </p>
+                        </div>
+                      ) : (
+                        <>
+                          <p
+                            id="token-output"
+                            className="text-lg sm:text-xl font-bold text-emerald-200/95 tabular-nums tracking-tight"
+                          >
+                            {formatContributionOutput(output)}
+                          </p>
+                          <p className="font-bold text-white/70 text-sm leading-tight">
+                            {resolvedSymbol ? `$${resolvedSymbol}` : 'tokens'}
+                          </p>
+                        </>
+                      )}
                     </div>
                     {(() => {
                       const sym = (resolvedSymbol || '').trim()
@@ -1026,6 +1047,28 @@ function MissionPayRedeemComponent({
     }
   }, [usdInput, ethUsdPrice])
 
+  /**
+   * Whether the "You receive" quote is genuinely waiting on something the
+   * user can't influence (ETH/USD price still loading, ruleset not loaded
+   * yet, or USD typed but ETH input not yet derived). When true we render
+   * a spinner instead of "0" so users understand the calc isn't broken —
+   * historically a transient Etherscan failure would leave `ethUsdPrice`
+   * at 0, the input gating would skip, and the user would just see "0
+   * $OVERVIEW" with no signal that anything was wrong.
+   */
+  const cleanUsdInput =
+    typeof usdInput === 'string' ? usdInput.replace(/,/g, '') : ''
+  const numericUsdInput = parseFloat(cleanUsdInput)
+  const userTypedAmount = Number.isFinite(numericUsdInput) && numericUsdInput > 0
+  const ruleSetReady = !!(ruleset && ruleset[0] && ruleset[1])
+  const isQuoteLoading =
+    userTypedAmount &&
+    output === 0 &&
+    (isLoadingEthUsdPrice ||
+      !ethUsdPrice ||
+      !ruleSetReady ||
+      parseFloat(input) <= 0)
+
   useEffect(() => {
     if (
       Number(stage) === 3 &&
@@ -1120,6 +1163,7 @@ function MissionPayRedeemComponent({
                 hideRecentContributions={hideRecentContributions}
                 contributionBalanceEth={contributionBalance.eth}
                 contributionBalanceChain={contributionBalance.chain}
+                isQuoteLoading={isQuoteLoading}
               />
             </div>
           )}

--- a/ui/components/mission/MissionProfile.tsx
+++ b/ui/components/mission/MissionProfile.tsx
@@ -447,7 +447,11 @@ export default function MissionProfile({
               recommendedFundingChain={recommendedChain}
               onlyButton
               visibleButton={windowWidth > 0 && windowWidth > 768}
-              buttonClassName="max-h-1/2 w-full  rounded-full text-sm flex justify-center items-center"
+              buttonClassName={
+                mission?.id === 4 || String(mission?.id) === '4'
+                  ? 'w-full sm:min-w-[280px] rounded-full gradient-2 px-8 sm:px-10 py-3.5 sm:py-4 text-base sm:text-xl font-bold uppercase tracking-wide shadow-lg shadow-blue-500/30 ring-1 ring-white/15 hover:brightness-110 hover:shadow-xl hover:shadow-blue-500/50 hover:scale-[1.02] active:scale-[0.99] transition-all duration-200 flex justify-center items-center'
+                  : 'max-h-1/2 w-full  rounded-full text-sm flex justify-center items-center'
+              }
             />
           )
         }

--- a/ui/components/mission/MissionProfile.tsx
+++ b/ui/components/mission/MissionProfile.tsx
@@ -41,6 +41,7 @@ import { useMissionDefaultFundingChain } from '@/lib/mission/useMissionDefaultFu
 import { useManagerActions } from '@/lib/mission/useManagerActions'
 import useMissionData from '@/lib/mission/useMissionData'
 import { useOnrampFlow } from '@/lib/mission/useOnrampFlow'
+import type { LeaderboardEntry } from '@/lib/overview-delegate/leaderboard'
 import {
   type Chain,
   arbitrum,
@@ -71,6 +72,7 @@ import MissionMobileContributeButton from '@/components/mission/MissionMobileCon
 import MissionPayRedeem from '@/components/mission/MissionPayRedeem'
 import MissionProfileHeader from '@/components/mission/MissionProfileHeader'
 import MissionTeamSection from '@/components/mission/MissionTeamSection'
+import OverviewLeaderboardPreview from '@/components/mission/OverviewLeaderboardPreview'
 import TeamMembers from '@/components/subscription/TeamMembers'
 import { TwitterIcon } from '@/components/assets'
 
@@ -102,6 +104,9 @@ type MissionProfileProps = {
   _teamHats?: any[]
   _fundingGoal: number
   _ruleset: any[]
+  /** Pre-fetched top entries of the $OVERVIEW leaderboard. Only provided
+   *  for the Overview Flight mission (id 4); undefined for other missions. */
+  _overviewLeaderboard?: LeaderboardEntry[]
 }
 
 export default function MissionProfile({
@@ -115,6 +120,7 @@ export default function MissionProfile({
   _teamHats,
   _fundingGoal,
   _ruleset,
+  _overviewLeaderboard,
 }: MissionProfileProps) {
   const account = useActiveAccount()
   const router = useRouter()
@@ -449,7 +455,10 @@ export default function MissionProfile({
               visibleButton={windowWidth > 0 && windowWidth > 768}
               buttonClassName={
                 mission?.id === 4 || String(mission?.id) === '4'
-                  ? 'w-full sm:min-w-[280px] rounded-full gradient-2 px-8 sm:px-10 py-3.5 sm:py-4 text-base sm:text-xl font-bold uppercase tracking-wide shadow-lg shadow-blue-500/30 ring-1 ring-white/15 hover:brightness-110 hover:shadow-xl hover:shadow-blue-500/50 hover:scale-[1.02] active:scale-[0.99] transition-all duration-200 flex justify-center items-center'
+                  ? // Overview Mission CTA: prominent but sized to avoid colliding
+                    // with the amount-raised text on sm/md or the manager-actions
+                    // row below. No hover-scale (keeps the button inside its slot).
+                    'w-full sm:w-auto sm:min-w-[200px] sm:max-w-[260px] rounded-full gradient-2 px-5 sm:px-7 py-2.5 sm:py-3 text-sm sm:text-base font-bold uppercase tracking-wide shadow-lg shadow-blue-500/30 ring-1 ring-white/15 hover:brightness-110 hover:shadow-blue-500/50 active:scale-[0.99] transition-all duration-200 flex justify-center items-center'
                   : 'max-h-1/2 w-full  rounded-full text-sm flex justify-center items-center'
               }
             />
@@ -630,32 +639,15 @@ export default function MissionProfile({
                 </div>
               </div>
             </div>
-            {/* Support Candidates Card - only for mission 4 (Overview flight on Arbitrum) */}
+            {/* Fly with Frank Leaderboard preview — only for mission 4
+                (Overview Flight on Arbitrum). Surfaces the top candidates by
+                $OVERVIEW backed and links to the full voting page. */}
             {(mission?.id === 4 || String(mission?.id) === '4') && (
               <div className="w-full px-5 md:px-8 lg:px-12 mt-4 md:mt-6 flex justify-center">
-                <Link
-                  href={`/overview-vote?from=mission&missionId=${mission?.id ?? ''}`}
-                  className="w-full max-w-[1200px] block bg-gradient-to-r from-indigo-900/30 via-purple-900/20 to-blue-900/20 border border-indigo-500/20 hover:border-indigo-500/40 rounded-2xl p-4 sm:p-6 transition-all duration-300 group"
-                >
-                  <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-                    <div className="flex items-center gap-3">
-                      <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-indigo-500/20 to-purple-500/20 flex items-center justify-center border border-indigo-500/30 group-hover:scale-105 transition-transform">
-                        <span className="text-2xl">🗳️</span>
-                      </div>
-                      <div>
-                        <h3 className="text-lg font-semibold text-white group-hover:text-indigo-200 transition-colors">
-                          Support candidates
-                        </h3>
-                        <p className="text-gray-400 text-sm">
-                          After contributing, back a candidate on the leaderboard to amplify your impact.
-                        </p>
-                      </div>
-                    </div>
-                    <span className="text-indigo-400 font-medium text-sm sm:text-base group-hover:text-indigo-300 whitespace-nowrap">
-                      Back a candidate →
-                    </span>
-                  </div>
-                </Link>
+                <OverviewLeaderboardPreview
+                  leaderboard={_overviewLeaderboard ?? []}
+                  missionId={mission?.id ?? 4}
+                />
               </div>
             )}
             <MissionJuiceboxFooter

--- a/ui/components/mission/MissionProfile.tsx
+++ b/ui/components/mission/MissionProfile.tsx
@@ -72,7 +72,6 @@ import MissionMobileContributeButton from '@/components/mission/MissionMobileCon
 import MissionPayRedeem from '@/components/mission/MissionPayRedeem'
 import MissionProfileHeader from '@/components/mission/MissionProfileHeader'
 import MissionTeamSection from '@/components/mission/MissionTeamSection'
-import OverviewLeaderboardPreview from '@/components/mission/OverviewLeaderboardPreview'
 import TeamMembers from '@/components/subscription/TeamMembers'
 import { TwitterIcon } from '@/components/assets'
 
@@ -580,6 +579,15 @@ export default function MissionProfile({
                   recommendedChain={recommendedChain}
                   fundingChainBalances={fundingChainBalances}
                   fundingCompareEnabled={fundingChainCompareEnabled}
+                  // Only thread the leaderboard through for missions that
+                  // actually have one (today: just mission 4). MissionInfo
+                  // uses the presence of this array to decide whether to
+                  // render the dedicated "Fly with Frank" tab.
+                  _overviewLeaderboard={
+                    mission?.id === 4 || String(mission?.id) === '4'
+                      ? _overviewLeaderboard ?? []
+                      : undefined
+                  }
                 />
               </div>
             </div>
@@ -639,17 +647,10 @@ export default function MissionProfile({
                 </div>
               </div>
             </div>
-            {/* Fly with Frank Leaderboard preview — only for mission 4
-                (Overview Flight on Arbitrum). Surfaces the top candidates by
-                $OVERVIEW backed and links to the full voting page. */}
-            {(mission?.id === 4 || String(mission?.id) === '4') && (
-              <div className="w-full px-5 md:px-8 lg:px-12 mt-4 md:mt-6 flex justify-center">
-                <OverviewLeaderboardPreview
-                  leaderboard={_overviewLeaderboard ?? []}
-                  missionId={mission?.id ?? 4}
-                />
-              </div>
-            )}
+            {/* The Fly with Frank Leaderboard now lives inside MissionInfo
+                as a dedicated tab so it surfaces above the fold instead of
+                being hidden at the bottom of the page. See MissionInfo's
+                `_overviewLeaderboard` prop wiring above. */}
             <MissionJuiceboxFooter
               projectId={mission?.projectId ?? 0}
               isManager={isManager}

--- a/ui/components/mission/MissionProfile.tsx
+++ b/ui/components/mission/MissionProfile.tsx
@@ -45,7 +45,6 @@ import type { LeaderboardEntry } from '@/lib/overview-delegate/leaderboard'
 import {
   type Chain,
   arbitrum,
-  base,
   ethereum,
   optimismSepolia,
   sepolia,
@@ -148,8 +147,12 @@ export default function MissionProfile({
   const [deployTokenModalEnabled, setDeployTokenModalEnabled] = useState(false)
 
   const isTestnet = process.env.NEXT_PUBLIC_CHAIN !== 'mainnet'
+  // Keep this list in sync with MissionContributeModal — Base was removed
+  // from the supported funding chains (users without ETH on Base were
+  // bouncing). Mission funding-chain detection / "switch to richest chain"
+  // banners therefore won't suggest Base anymore.
   const chains = useMemo(
-    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum, base, ethereum]),
+    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum, ethereum]),
     [isTestnet]
   )
   const chainSlugs = chains.map((chain) => getChainSlug(chain))

--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -141,105 +141,166 @@ const MissionProfileHeader = React.memo(
       offChainCommittedUsd,
     ])
 
+    /** Mission 4 (Frank's Overview Flight) gets a special header layout where
+     *  the title + tagline span the full content width, with the image and
+     *  funding card sitting side-by-side underneath. Other missions keep the
+     *  original side-by-side title/image arrangement. */
+    const isOverviewMission =
+      mission?.id === 4 || String(mission?.id) === '4'
+
+    const titleBlock = (
+      <div className="space-y-2">
+        <div className="flex items-start gap-2">
+          {mission?.metadata?.name && (
+            <MissionSingleLineTitle
+              text={mission.metadata.name}
+              minPx={22}
+              // Allow the title to scale up when it has the full content
+              // width to itself (Overview Mission layout); cap at the
+              // standard size otherwise.
+              maxPx={isOverviewMission ? 64 : 42}
+              data-testid="mission-profile-title"
+            />
+          )}
+          {isManager && setMissionMetadataModalEnabled && (
+            <button
+              className="shrink-0 mt-1 p-2 bg-white/5 hover:bg-white/10 backdrop-blur-sm rounded-xl transition-all duration-200 border border-white/10 hover:border-white/20"
+              onClick={() => setMissionMetadataModalEnabled(true)}
+              title="Edit Mission"
+            >
+              <PencilIcon width={16} height={16} className="text-white/70 hover:text-white" />
+            </button>
+          )}
+        </div>
+        {mission?.metadata?.tagline && (
+          <p
+            className={
+              isOverviewMission
+                ? 'text-base sm:text-lg md:text-xl text-gray-300 leading-relaxed max-w-3xl'
+                : 'text-base sm:text-lg text-gray-400 leading-relaxed max-w-2xl'
+            }
+          >
+            {mission.metadata.tagline}
+          </p>
+        )}
+        {/* Team Attribution sits with the title in the Overview layout so it
+            reads as part of the full-width header block. */}
+        {isOverviewMission && ruleset && teamNFT?.metadata?.name && (
+          <div className="flex flex-wrap items-center gap-1.5 text-sm text-gray-500 pt-1">
+            <span>
+              Launched{' '}
+              {new Date(ruleset?.[0]?.start * 1000).toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              })}
+            </span>
+            <span>·</span>
+            <Link
+              href={`/team/${generatePrettyLink(teamNFT?.metadata?.name)}`}
+              className="text-indigo-400 hover:text-indigo-300 transition-colors duration-200"
+            >
+              {teamNFT?.metadata?.name}
+            </Link>
+          </div>
+        )}
+      </div>
+    )
+
+    const imageBlock = (
+      <div className="w-full min-w-0 lg:h-full lg:min-h-0 flex flex-col">
+        <div className="relative group w-full flex-1 min-h-0">
+          {mission?.metadata?.logoUri ? (
+            <div className="relative aspect-square lg:aspect-auto lg:h-full lg:min-h-[260px] w-full rounded-2xl shadow-2xl border border-white/10 overflow-hidden">
+              <IPFSRenderer
+                src={mission?.metadata?.logoUri}
+                fillContainer
+                className="object-cover transition-transform duration-500 group-hover:scale-[1.02]"
+                height={640}
+                width={640}
+                alt="Mission Image"
+                sizes="(max-width: 1024px) 100vw, 560px"
+              />
+              {teamNFT?.metadata?.image && (
+                <div className="absolute bottom-3 right-3 sm:bottom-4 sm:right-4">
+                  <IPFSRenderer
+                    src={teamNFT?.metadata?.image}
+                    className="w-16 h-16 sm:w-[4.5rem] sm:h-[4.5rem] rounded-full border-2 border-[#090d21] shadow-lg ring-2 ring-white/10"
+                    height={72}
+                    width={72}
+                    alt="Team Image"
+                  />
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="aspect-square lg:aspect-auto lg:h-full lg:min-h-[260px] w-full rounded-2xl border border-white/10 bg-gradient-to-br from-slate-800 to-slate-900 flex items-center justify-center shadow-2xl">
+              <div className="text-center px-4">
+                <div className="w-12 h-12 mx-auto mb-3 bg-indigo-500/20 rounded-xl flex items-center justify-center">
+                  <Image src="/assets/icon-star-blue.svg" alt="Mission" width={24} height={24} />
+                </div>
+                <p className="text-gray-500 text-sm">Mission Image</p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    )
+
     return (
       <div className="w-full bg-[#090d21] relative">
         {/* Background */}
         <div className="absolute inset-0 bg-gradient-to-b from-indigo-950/20 via-transparent to-transparent pointer-events-none" />
 
         <div className="relative z-10 w-full px-5 md:px-8 lg:px-12 pt-6 pb-4 lg:pt-8 lg:pb-6">
-          <div className="w-full grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8 lg:gap-10 items-start lg:items-stretch max-w-[1200px] mx-auto">
-            {/* Mission image — square on mobile; on lg stretches to match copy column height (object-cover) */}
-            <div className="w-full min-w-0 lg:h-full lg:min-h-0 flex flex-col">
-              <div className="relative group w-full flex-1 min-h-0">
-                {mission?.metadata?.logoUri ? (
-                  <div className="relative aspect-square lg:aspect-auto lg:h-full lg:min-h-[260px] w-full rounded-2xl shadow-2xl border border-white/10 overflow-hidden">
-                    <IPFSRenderer
-                      src={mission?.metadata?.logoUri}
-                      fillContainer
-                      className="object-cover transition-transform duration-500 group-hover:scale-[1.02]"
-                      height={640}
-                      width={640}
-                      alt="Mission Image"
-                      sizes="(max-width: 1024px) 100vw, 560px"
-                    />
-                    {teamNFT?.metadata?.image && (
-                      <div className="absolute bottom-3 right-3 sm:bottom-4 sm:right-4">
-                        <IPFSRenderer
-                          src={teamNFT?.metadata?.image}
-                          className="w-16 h-16 sm:w-[4.5rem] sm:h-[4.5rem] rounded-full border-2 border-[#090d21] shadow-lg ring-2 ring-white/10"
-                          height={72}
-                          width={72}
-                          alt="Team Image"
-                        />
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <div className="aspect-square lg:aspect-auto lg:h-full lg:min-h-[260px] w-full rounded-2xl border border-white/10 bg-gradient-to-br from-slate-800 to-slate-900 flex items-center justify-center shadow-2xl">
-                    <div className="text-center px-4">
-                      <div className="w-12 h-12 mx-auto mb-3 bg-indigo-500/20 rounded-xl flex items-center justify-center">
-                        <Image src="/assets/icon-star-blue.svg" alt="Mission" width={24} height={24} />
-                      </div>
-                      <p className="text-gray-500 text-sm">Mission Image</p>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
+          <div
+            className={`w-full max-w-[1200px] mx-auto ${
+              isOverviewMission
+                ? // Overview Mission layout: title spans full width up top,
+                //   then image + funding card side-by-side below.
+                  'flex flex-col gap-6 lg:gap-8'
+                : ''
+            }`}
+          >
+            {isOverviewMission && titleBlock}
+            <div
+              className={`w-full grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8 lg:gap-10 items-start lg:items-stretch ${
+                isOverviewMission ? '' : 'max-w-[1200px] mx-auto'
+              }`}
+            >
+              {/* Mission image — square on mobile; on lg stretches to match copy column height (object-cover) */}
+              {imageBlock}
 
-            {/* Mission copy + funding (same column width as image on lg) */}
-            <div className="flex flex-col justify-center lg:justify-start min-w-0 mt-1 lg:mt-0 lg:h-full lg:min-h-0 space-y-4">
-              {/* Title & Tagline */}
-              <div className="space-y-2">
-                <div className="flex items-start gap-2">
-                  {mission?.metadata?.name && (
-                    <MissionSingleLineTitle
-                      text={mission.metadata.name}
-                      minPx={22}
-                      maxPx={42}
-                      data-testid="mission-profile-title"
-                    />
-                  )}
-                  {isManager && setMissionMetadataModalEnabled && (
-                    <button
-                      className="shrink-0 mt-1 p-2 bg-white/5 hover:bg-white/10 backdrop-blur-sm rounded-xl transition-all duration-200 border border-white/10 hover:border-white/20"
-                      onClick={() => setMissionMetadataModalEnabled(true)}
-                      title="Edit Mission"
+              {/* Mission copy + funding (same column width as image on lg) */}
+              <div className="flex flex-col justify-center lg:justify-start min-w-0 mt-1 lg:mt-0 lg:h-full lg:min-h-0 space-y-4">
+                {/* Title & Tagline (only in the default layout — the Overview
+                    layout renders these full-width above this grid). */}
+                {!isOverviewMission && titleBlock}
+
+                {/* Team Attribution (only in the default layout — Overview puts
+                    this with the title block). */}
+                {!isOverviewMission && ruleset && teamNFT?.metadata?.name && (
+                  <div className="flex flex-wrap items-center gap-1.5 text-sm text-gray-500">
+                    <span>
+                      Launched{' '}
+                      {new Date(ruleset?.[0]?.start * 1000).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}
+                    </span>
+                    <span>·</span>
+                    <Link
+                      href={`/team/${generatePrettyLink(teamNFT?.metadata?.name)}`}
+                      className="text-indigo-400 hover:text-indigo-300 transition-colors duration-200"
                     >
-                      <PencilIcon width={16} height={16} className="text-white/70 hover:text-white" />
-                    </button>
-                  )}
-                </div>
-                {mission?.metadata?.tagline && (
-                  <p className="text-base sm:text-lg text-gray-400 leading-relaxed max-w-2xl">
-                    {mission.metadata.tagline}
-                  </p>
+                      {teamNFT?.metadata?.name}
+                    </Link>
+                  </div>
                 )}
-              </div>
 
-              {/* Team Attribution */}
-              {ruleset && teamNFT?.metadata?.name && (
-                <div className="flex flex-wrap items-center gap-1.5 text-sm text-gray-500">
-                  <span>
-                    Launched{' '}
-                    {new Date(ruleset?.[0]?.start * 1000).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })}
-                  </span>
-                  <span>·</span>
-                  <Link
-                    href={`/team/${generatePrettyLink(teamNFT?.metadata?.name)}`}
-                    className="text-indigo-400 hover:text-indigo-300 transition-colors duration-200"
-                  >
-                    {teamNFT?.metadata?.name}
-                  </Link>
-                </div>
-              )}
-
-              {/* Funding Card */}
-              <div className="bg-white/[0.03] backdrop-blur-sm rounded-2xl p-3 sm:p-5 border border-white/[0.06] w-full">
+                {/* Funding Card */}
+                <div className="bg-white/[0.03] backdrop-blur-sm rounded-2xl p-3 sm:p-5 border border-white/[0.06] w-full">
                 {/* Amount Raised + CTA Row */}
                 <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-4">
                   <div className="min-w-0 w-full sm:w-auto">
@@ -444,6 +505,7 @@ const MissionProfileHeader = React.memo(
                       {paymentsCount || 0}
                     </p>
                   </div>
+                </div>
                 </div>
               </div>
             </div>

--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -244,7 +244,7 @@ const MissionProfileHeader = React.memo(
                 height={640}
                 width={640}
                 alt="Mission Image"
-                sizes="(max-width: 1024px) 100vw, 580px"
+                sizes="(max-width: 1024px) 100vw, 480px"
               />
               {teamNFT?.metadata?.image && (
                 <div className="absolute bottom-3 right-3 sm:bottom-4 sm:right-4">
@@ -293,10 +293,12 @@ const MissionProfileHeader = React.memo(
             <div
               className={`w-full grid grid-cols-1 gap-8 lg:gap-10 items-start lg:items-stretch ${
                 isOverviewMission
-                  ? // 1:1 split lets the funding card claim the full half of
-                    // the row so it reads as a true "co-equal" panel with
-                    // the artwork instead of a narrow side rail.
-                    'lg:grid-cols-2'
+                  ? // 2:3 split: shrinks the (square) artwork column so the
+                    //   image height — which drives the row height — is
+                    //   smaller, while the funding card claims more
+                    //   horizontal real-estate. Net effect: less empty
+                    //   vertical space inside the contribute card.
+                    'lg:grid-cols-[2fr_3fr]'
                   : 'lg:grid-cols-[3fr_2fr] max-w-[1200px] mx-auto'
               }`}
             >

--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -207,19 +207,45 @@ const MissionProfileHeader = React.memo(
       </div>
     )
 
+    /** The Overview Mission's artwork is essentially square, so stretching it
+     *  to fill the funding card's height on `lg+` (the default behaviour) was
+     *  cropping the top and bottom via `object-cover`. For mission 4 we lock
+     *  the image to `aspect-square` at every breakpoint and bound it with a
+     *  `max-w` so it stays roughly the same height as the funding card on
+     *  wide screens (instead of becoming a giant 720px square). We also
+     *  switch to `object-contain` so any minor source-aspect mismatch shows
+     *  thin matching-color letterboxing instead of cropping subject matter.
+     *
+     *  Other missions keep the existing fill-to-match behaviour so wider
+     *  mission images can still match the copy column. */
+    const imageAspectClass = isOverviewMission
+      ? // square at every breakpoint; bounded so it doesn't dwarf the
+        // funding card on lg+. mx-auto centers within the wider 3fr column.
+        'aspect-square w-full max-w-[520px] mx-auto'
+      : 'aspect-square lg:aspect-auto lg:h-full lg:min-h-[260px] w-full'
+    const imageWrapperClass = isOverviewMission
+      ? 'w-full min-w-0 flex flex-col self-start'
+      : 'w-full min-w-0 lg:h-full lg:min-h-0 flex flex-col'
+    const imageObjectFitClass = isOverviewMission
+      ? // matches the page bg so any letterbox bars look intentional, not boxed
+        'object-contain bg-[#090d21]'
+      : 'object-cover'
+
     const imageBlock = (
-      <div className="w-full min-w-0 lg:h-full lg:min-h-0 flex flex-col">
+      <div className={imageWrapperClass}>
         <div className="relative group w-full flex-1 min-h-0">
           {mission?.metadata?.logoUri ? (
-            <div className="relative aspect-square lg:aspect-auto lg:h-full lg:min-h-[260px] w-full rounded-2xl shadow-2xl border border-white/10 overflow-hidden">
+            <div
+              className={`relative ${imageAspectClass} rounded-2xl shadow-2xl border border-white/10 overflow-hidden`}
+            >
               <IPFSRenderer
                 src={mission?.metadata?.logoUri}
                 fillContainer
-                className="object-cover transition-transform duration-500 group-hover:scale-[1.02]"
+                className={`${imageObjectFitClass} transition-transform duration-500 group-hover:scale-[1.02]`}
                 height={640}
                 width={640}
                 alt="Mission Image"
-                sizes="(max-width: 1024px) 100vw, 560px"
+                sizes="(max-width: 1024px) 100vw, 520px"
               />
               {teamNFT?.metadata?.image && (
                 <div className="absolute bottom-3 right-3 sm:bottom-4 sm:right-4">
@@ -234,7 +260,9 @@ const MissionProfileHeader = React.memo(
               )}
             </div>
           ) : (
-            <div className="aspect-square lg:aspect-auto lg:h-full lg:min-h-[260px] w-full rounded-2xl border border-white/10 bg-gradient-to-br from-slate-800 to-slate-900 flex items-center justify-center shadow-2xl">
+            <div
+              className={`${imageAspectClass} rounded-2xl border border-white/10 bg-gradient-to-br from-slate-800 to-slate-900 flex items-center justify-center shadow-2xl`}
+            >
               <div className="text-center px-4">
                 <div className="w-12 h-12 mx-auto mb-3 bg-indigo-500/20 rounded-xl flex items-center justify-center">
                   <Image src="/assets/icon-star-blue.svg" alt="Mission" width={24} height={24} />

--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -210,21 +210,20 @@ const MissionProfileHeader = React.memo(
     /** The Overview Mission's artwork is essentially square, so stretching it
      *  to fill the funding card's height on `lg+` (the default behaviour) was
      *  cropping the top and bottom via `object-cover`. For mission 4 we lock
-     *  the image to `aspect-square` at every breakpoint and bound it with a
-     *  `max-w` so it stays roughly the same height as the funding card on
-     *  wide screens (instead of becoming a giant 720px square). We also
-     *  switch to `object-contain` so any minor source-aspect mismatch shows
-     *  thin matching-color letterboxing instead of cropping subject matter.
+     *  the image to `aspect-square` at every breakpoint and let it fill its
+     *  column (the grid below splits 1:1 for Overview, so the column width
+     *  ≈580px on a 1200px layout — the resulting square is balanced against
+     *  the funding card height-wise). We use `object-contain` so any minor
+     *  source-aspect mismatch shows thin matching-color letterboxing instead
+     *  of cropping subject matter.
      *
      *  Other missions keep the existing fill-to-match behaviour so wider
      *  mission images can still match the copy column. */
     const imageAspectClass = isOverviewMission
-      ? // square at every breakpoint; bounded so it doesn't dwarf the
-        // funding card on lg+. mx-auto centers within the wider 3fr column.
-        'aspect-square w-full max-w-[520px] mx-auto'
+      ? 'aspect-square w-full'
       : 'aspect-square lg:aspect-auto lg:h-full lg:min-h-[260px] w-full'
     const imageWrapperClass = isOverviewMission
-      ? 'w-full min-w-0 flex flex-col self-start'
+      ? 'w-full min-w-0 flex flex-col'
       : 'w-full min-w-0 lg:h-full lg:min-h-0 flex flex-col'
     const imageObjectFitClass = isOverviewMission
       ? // matches the page bg so any letterbox bars look intentional, not boxed
@@ -245,7 +244,7 @@ const MissionProfileHeader = React.memo(
                 height={640}
                 width={640}
                 alt="Mission Image"
-                sizes="(max-width: 1024px) 100vw, 520px"
+                sizes="(max-width: 1024px) 100vw, 580px"
               />
               {teamNFT?.metadata?.image && (
                 <div className="absolute bottom-3 right-3 sm:bottom-4 sm:right-4">
@@ -292,8 +291,13 @@ const MissionProfileHeader = React.memo(
           >
             {isOverviewMission && titleBlock}
             <div
-              className={`w-full grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8 lg:gap-10 items-start lg:items-stretch ${
-                isOverviewMission ? '' : 'max-w-[1200px] mx-auto'
+              className={`w-full grid grid-cols-1 gap-8 lg:gap-10 items-start lg:items-stretch ${
+                isOverviewMission
+                  ? // 1:1 split lets the funding card claim the full half of
+                    // the row so it reads as a true "co-equal" panel with
+                    // the artwork instead of a narrow side rail.
+                    'lg:grid-cols-2'
+                  : 'lg:grid-cols-[3fr_2fr] max-w-[1200px] mx-auto'
               }`}
             >
               {/* Mission image — square on mobile; on lg stretches to match copy column height (object-cover) */}
@@ -327,8 +331,19 @@ const MissionProfileHeader = React.memo(
                   </div>
                 )}
 
-                {/* Funding Card */}
-                <div className="bg-white/[0.03] backdrop-blur-sm rounded-2xl p-3 sm:p-5 border border-white/[0.06] w-full">
+                {/* Funding Card. For the Overview Mission we stretch this
+                    card to fill the full height of the row so its bottom
+                    edge aligns with the square hero image. The content
+                    inside stays top-aligned and the bottom (Stats Row) is
+                    pushed to the card's bottom via mt-auto, which gives a
+                    balanced look without big midsection gaps. */}
+                <div
+                  className={`bg-white/[0.03] backdrop-blur-sm rounded-2xl p-3 sm:p-5 border border-white/[0.06] w-full ${
+                    isOverviewMission
+                      ? 'lg:flex-1 lg:min-h-0 lg:flex lg:flex-col'
+                      : ''
+                  }`}
+                >
                 {/* Amount Raised + CTA Row */}
                 <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-4">
                   <div className="min-w-0 w-full sm:w-auto">
@@ -442,8 +457,16 @@ const MissionProfileHeader = React.memo(
                   ) : null}
                 </div>
 
-                {/* Stats Row */}
-                <div className="grid grid-cols-3 gap-2 sm:gap-3">
+                {/* Stats Row. On the Overview layout the funding card is
+                    stretched to match the hero image; mt-auto pushes this
+                    row to the card's bottom so the extra height shows up
+                    as breathing room above the stats rather than a gap
+                    below them. */}
+                <div
+                  className={`grid grid-cols-3 gap-2 sm:gap-3 ${
+                    isOverviewMission ? 'lg:mt-auto' : ''
+                  }`}
+                >
                   {/* Goal */}
                   <div className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0">
                     <div className="flex items-center gap-1 sm:gap-1.5 mb-1.5 min-w-0">

--- a/ui/components/mission/OverviewLeaderboardPreview.tsx
+++ b/ui/components/mission/OverviewLeaderboardPreview.tsx
@@ -1,0 +1,165 @@
+import Link from 'next/link'
+import type { LeaderboardEntry } from '@/lib/overview-delegate/leaderboard'
+import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
+import IPFSRenderer from '@/components/layout/IPFSRenderer'
+
+type OverviewLeaderboardPreviewProps = {
+  /** Top N entries (already sorted, highest first). */
+  leaderboard: LeaderboardEntry[]
+  /** Mission ID to thread through the leaderboard CTA so the destination page
+   *  can render its "back to mission" affordance. */
+  missionId?: string | number
+}
+
+const RANK_BADGE_STYLES = [
+  // 1st — gold
+  'bg-gradient-to-br from-amber-300/40 to-amber-500/30 text-amber-100 ring-1 ring-amber-300/40',
+  // 2nd — silver
+  'bg-gradient-to-br from-slate-200/30 to-slate-400/20 text-slate-100 ring-1 ring-slate-300/40',
+  // 3rd — bronze
+  'bg-gradient-to-br from-orange-400/30 to-orange-600/20 text-orange-100 ring-1 ring-orange-300/40',
+]
+
+const DEFAULT_RANK_STYLE =
+  'bg-white/5 text-gray-300 ring-1 ring-white/10'
+
+function formatTotal(amount: number): string {
+  return amount.toLocaleString(undefined, { maximumFractionDigits: 0 })
+}
+
+/**
+ * Compact $OVERVIEW leaderboard preview surfaced on the mission/4 page.
+ *
+ * Shows the top entries with rank, avatar, name, and totals. Always renders
+ * a CTA to the full leaderboard so users can vote in one click — even when
+ * the list is empty (early in the campaign).
+ */
+export default function OverviewLeaderboardPreview({
+  leaderboard,
+  missionId,
+}: OverviewLeaderboardPreviewProps) {
+  const fullLeaderboardHref = `/overview-vote${
+    missionId != null ? `?from=mission&missionId=${missionId}` : ''
+  }`
+
+  const hasEntries = leaderboard.length > 0
+
+  return (
+    <section
+      data-testid="mission-overview-leaderboard-preview"
+      className="w-full max-w-[1200px] bg-gradient-to-br from-indigo-950/40 via-purple-950/30 to-slate-900/60 border border-indigo-500/20 rounded-2xl overflow-hidden"
+    >
+      <div className="px-6 md:px-8 pt-6 pb-2 flex items-start sm:items-center justify-between gap-4 flex-col sm:flex-row">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-indigo-500/30 to-purple-500/30 flex items-center justify-center border border-indigo-500/30 shrink-0">
+            <span className="text-xl">🚀</span>
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-xl md:text-2xl font-GoodTimes text-white truncate">
+              Fly with Frank Leaderboard
+            </h2>
+            <p className="text-indigo-200/80 text-xs sm:text-sm">
+              Top citizens backed by $OVERVIEW holders
+            </p>
+          </div>
+        </div>
+        <Link
+          href={fullLeaderboardHref}
+          className="shrink-0 text-indigo-200 hover:text-white text-xs sm:text-sm font-medium transition-colors whitespace-nowrap"
+        >
+          View full leaderboard →
+        </Link>
+      </div>
+
+      <div className="px-6 md:px-8 pb-6 pt-3">
+        {hasEntries ? (
+          <ol className="flex flex-col gap-2 sm:gap-3">
+            {leaderboard.map((entry, index) => {
+              const rankStyle =
+                index < RANK_BADGE_STYLES.length
+                  ? RANK_BADGE_STYLES[index]
+                  : DEFAULT_RANK_STYLE
+              const citizenHref = entry.citizenName
+                ? `/citizen/${generatePrettyLinkWithId(
+                    entry.citizenName,
+                    entry.citizenId
+                  )}`
+                : `/citizen/${entry.citizenId}`
+              const displayName =
+                entry.citizenName || `Citizen #${entry.citizenId}`
+              return (
+                <li
+                  key={entry.delegateeAddress}
+                  className="flex items-center gap-3 sm:gap-4 p-3 sm:p-4 rounded-xl bg-black/20 border border-white/[0.08] hover:border-indigo-400/30 transition-colors"
+                >
+                  <div
+                    className={`flex-shrink-0 w-8 h-8 sm:w-9 sm:h-9 flex items-center justify-center rounded-full font-bold text-sm ${rankStyle}`}
+                  >
+                    {index + 1}
+                  </div>
+                  <div className="w-9 h-9 sm:w-10 sm:h-10 rounded-full overflow-hidden flex-shrink-0">
+                    {entry.citizenImage ? (
+                      <IPFSRenderer
+                        src={entry.citizenImage}
+                        alt={displayName}
+                        width={40}
+                        height={40}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div className="w-full h-full bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center text-white font-bold text-xs sm:text-sm">
+                        {displayName[0]?.toUpperCase() || 'C'}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <Link
+                      href={citizenHref}
+                      className="text-white text-sm sm:text-base font-medium hover:underline truncate block"
+                    >
+                      {displayName}
+                    </Link>
+                    <p className="text-gray-400 text-xs sm:text-sm">
+                      {entry.delegatorCount} backer
+                      {entry.delegatorCount !== 1 ? 's' : ''}
+                    </p>
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    <p className="text-white text-sm sm:text-base font-semibold tabular-nums">
+                      {formatTotal(entry.totalDelegated)}
+                    </p>
+                    <p className="text-gray-400 text-[11px] sm:text-xs uppercase tracking-wide">
+                      $OVERVIEW
+                    </p>
+                  </div>
+                </li>
+              )
+            })}
+          </ol>
+        ) : (
+          <div className="rounded-xl bg-black/20 border border-white/[0.08] p-6 text-center">
+            <p className="text-gray-300 text-sm sm:text-base font-medium">
+              No backers yet — be the first to back a candidate.
+            </p>
+            <p className="text-gray-500 text-xs sm:text-sm mt-1">
+              Contribute to earn $OVERVIEW, then pledge it to the citizen you
+              want to fly with Frank.
+            </p>
+          </div>
+        )}
+
+        <div className="mt-4 sm:mt-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <p className="text-gray-400 text-xs sm:text-sm">
+            The 25 citizens with the most $OVERVIEW support advance to Round 2.
+          </p>
+          <Link
+            href={fullLeaderboardHref}
+            className="shrink-0 inline-flex items-center justify-center px-4 py-2 rounded-lg bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-400 hover:to-purple-500 text-white text-xs sm:text-sm font-semibold transition-all duration-200 shadow-lg shadow-indigo-500/20"
+          >
+            Back a candidate →
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/ui/components/mission/PaymentBreakdown.tsx
+++ b/ui/components/mission/PaymentBreakdown.tsx
@@ -135,26 +135,39 @@ export function PaymentBreakdown({
           <p className={rowValueClass}>${usdInput} USD</p>
         </div>
 
-        {/* Cross-Chain Fee */}
+        {/* Cross-Chain Fee. Spinner is gated on `isLoadingGasEstimate`
+            ONLY — previously it also required a non-zero fee value, which
+            meant any time the LayerZero quote failed/timed out (e.g. slow
+            Ethereum RPC) the value stayed at "0.00" forever and the
+            spinner spun indefinitely even though loading was done. After
+            loading finishes we render whatever value we have, falling back
+            to a "—" placeholder when no quote was retrieved so users see
+            the breakdown progress instead of an apparent hang. */}
         {chainSlug !== defaultChainSlug && !layerZeroLimitExceeded && (
           <div className="flex items-center justify-between gap-3">
             <p className={rowLabelClass}>Cross-chain fee</p>
-            {!isLoadingGasEstimate && layerZeroFeeDisplay.usd !== '0.00' ? (
+            {isLoadingGasEstimate ? (
+              <LoadingSpinner className="scale-50" />
+            ) : layerZeroFeeDisplay.usd !== '0.00' ? (
               <p className={rowValueClass}>~${layerZeroFeeDisplay.usd} USD</p>
             ) : (
-              <LoadingSpinner className="scale-50" />
+              <p className={`${rowValueClass} text-gray-500`}>—</p>
             )}
           </div>
         )}
 
-        {/* Gas Fee */}
+        {/* Gas Fee. Same spinner-gate rationale as the cross-chain row
+            above — only spin while we're actively loading, then show the
+            value (or a "—" placeholder if the estimator returned nothing). */}
         {showEstimatedGas && (
           <div className="flex items-center justify-between gap-3">
             <p className={rowLabelClass}>Gas fee</p>
-            {!isLoadingGasEstimate && gasCostDisplay.eth !== '0.0000' ? (
+            {isLoadingGasEstimate ? (
+              <LoadingSpinner className="scale-50" />
+            ) : gasCostDisplay.eth !== '0.0000' ? (
               <p className={rowValueClass}>~${gasCostDisplay.usd} USD</p>
             ) : (
-              <LoadingSpinner className="scale-50" />
+              <p className={`${rowValueClass} text-gray-500`}>—</p>
             )}
           </div>
         )}

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -39,6 +39,7 @@ import { useCitizens } from '@/lib/citizen/useCitizen'
 import { useAssets } from '@/lib/dashboard/hooks'
 import { useTablelandQuery } from '@/lib/swr/useTablelandQuery'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import { sendOnchainNotification } from '@/lib/notifications/sendOnchainNotification'
 import { Project } from '@/lib/project/useProjectData'
 import { ethereum } from '@/lib/rpc/chains'
 import useWindowSize from '@/lib/team/use-window-size'
@@ -895,6 +896,25 @@ export function ProjectRewards({
           shapes: ['circle', 'star'],
           colors: ['#ffffff', '#FFD700', '#00FFFF', '#ff69b4', '#8A2BE2'],
         })
+
+        // Fire-and-forget Discord notification. We pass the count of
+        // projects the user actually allocated to (entries with a non-zero
+        // weight) so the message has more signal than just "submitted".
+        const allocatedProjectCount = Object.values(scopedDistribution).filter(
+          (v) => v > 0
+        ).length
+        void sendOnchainNotification(
+          '/api/distribution/distribution-notification',
+          {
+            txHash: receipt?.transactionHash,
+            quarter,
+            year,
+            projectCount: allocatedProjectCount,
+            isEdit,
+          },
+          { label: 'retro-distribution-notification' }
+        )
+
         setTimeout(
           () =>
             router.push(
@@ -1027,6 +1047,27 @@ export function ProjectRewards({
           shapes: ['circle', 'star'],
           colors: ['#ffffff', '#FFD700', '#00FFFF', '#ff69b4', '#8A2BE2'],
         })
+
+        // Fire-and-forget Discord notification. The proposal count reflects
+        // proposals the user *actually* allocated to (post author-exclusion
+        // / normalization) — that's the most accurate signal of how many
+        // proposals they weighed in on.
+        const proposalCount = Object.values(normalizedDistribution).filter(
+          (v) => v > 0
+        ).length
+        void sendOnchainNotification(
+          '/api/proposals/vote-notification',
+          {
+            txHash: receipt?.transactionHash,
+            kind: 'member',
+            quarter: submissionQuarter,
+            year: submissionYear,
+            proposalCount,
+            isEdit,
+          },
+          { label: 'member-vote-notification' }
+        )
+
         setTimeout(
           () =>
             router.push(

--- a/ui/components/nance/VotingModal.tsx
+++ b/ui/components/nance/VotingModal.tsx
@@ -9,6 +9,7 @@ import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import { formatNumberUSStyle } from '@/lib/nance'
+import { sendOnchainNotification } from '@/lib/notifications/sendOnchainNotification'
 import { Project } from '@/lib/project/useProjectData'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
@@ -106,6 +107,22 @@ export default function VotingModal({
         })
         toast.success('Vote submitted!')
       }
+
+      // Post a Discord notification about this Senate vote. Fire-and-forget:
+      // never block the UI on it. The helper handles auth, retries, and logs
+      // failures to the console so we can spot regressions.
+      void sendOnchainNotification(
+        '/api/proposals/vote-notification',
+        {
+          txHash: receipt?.transactionHash,
+          kind: 'senate',
+          proposalName: project?.name,
+          proposalMDP: project?.MDP,
+          isEdit: edit,
+        },
+        { label: 'senate-vote-notification' }
+      )
+
       setSubmitting(false)
     } catch (error) {
       console.error('Error submitting distribution:', error)

--- a/ui/lib/etherscan/useETHPrice.tsx
+++ b/ui/lib/etherscan/useETHPrice.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import useSWR from 'swr'
 import fetcher from '@/lib/swr/fetcher'
 

--- a/ui/lib/etherscan/useETHPrice.tsx
+++ b/ui/lib/etherscan/useETHPrice.tsx
@@ -69,10 +69,6 @@ export default function useETHPrice(
     shouldRetryOnError: true,
   })
 
-  // Hold on to the last successfully-fetched price across renders so a
-  // transient SWR error doesn't drop us back to null mid-typing.
-  const lastGoodPriceRef = useRef<number | null>(null)
-
   const fetchedPrice = useMemo<number | null>(() => {
     const raw = ethPriceData?.result?.ethusd
     if (raw == null) return null
@@ -81,23 +77,28 @@ export default function useETHPrice(
     return price
   }, [ethPriceData])
 
-  // On first mount, hydrate the ref from localStorage so contributions are
-  // computable immediately on a slow network. (Initialized lazily here
-  // rather than via useState so we don't ship a stale price as the source
-  // of truth — `fetchedPrice` always wins once SWR resolves.)
-  if (lastGoodPriceRef.current == null && fetchedPrice == null) {
+  // Hold on to the last successfully-fetched price across renders so a
+  // transient SWR error doesn't drop us back to null mid-typing.
+  //
+  // Initialized lazily from localStorage (≤24h old) so the very first
+  // render on a slow network can already quote a contribution against the
+  // cached value rather than briefly showing 0. The lazy initializer runs
+  // exactly once per mount and keeps the render itself pure (no
+  // localStorage reads or ref mutations during render — that pattern
+  // misbehaves under React strict-mode double-invocation).
+  const [lastGoodPrice, setLastGoodPrice] = useState<number | null>(() => {
     const cached = readCachedPrice()
-    if (cached) lastGoodPriceRef.current = cached.price
-  }
+    return cached ? cached.price : null
+  })
 
   useEffect(() => {
-    if (fetchedPrice != null) {
-      lastGoodPriceRef.current = fetchedPrice
+    if (fetchedPrice != null && fetchedPrice !== lastGoodPrice) {
+      setLastGoodPrice(fetchedPrice)
       writeCachedPrice(fetchedPrice)
     }
-  }, [fetchedPrice])
+  }, [fetchedPrice, lastGoodPrice])
 
-  const ethPrice = fetchedPrice ?? lastGoodPriceRef.current ?? null
+  const ethPrice = fetchedPrice ?? lastGoodPrice ?? null
 
   const convertedAmount = useMemo(() => {
     if (!ethPrice || !amount) return 0

--- a/ui/lib/etherscan/useETHPrice.tsx
+++ b/ui/lib/etherscan/useETHPrice.tsx
@@ -1,9 +1,56 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import useSWR from 'swr'
 import fetcher from '@/lib/swr/fetcher'
 
 type QuoteDirection = 'ETH_TO_USD' | 'USD_TO_ETH'
 
+const LOCAL_STORAGE_KEY = 'moondao:eth-usd-price'
+const LOCAL_STORAGE_TTL_MS = 1000 * 60 * 60 * 24 // 24h — only as a *last* resort
+
+type CachedPrice = { price: number; ts: number }
+
+function readCachedPrice(): CachedPrice | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(LOCAL_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    const price = Number(parsed?.price)
+    const ts = Number(parsed?.ts)
+    if (!Number.isFinite(price) || price <= 0 || !Number.isFinite(ts)) {
+      return null
+    }
+    if (Date.now() - ts > LOCAL_STORAGE_TTL_MS) return null
+    return { price, ts }
+  } catch {
+    return null
+  }
+}
+
+function writeCachedPrice(price: number) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify({ price, ts: Date.now() })
+    )
+  } catch {
+    // Quota / private mode — ignore, this is just a cache.
+  }
+}
+
+/**
+ * `useETHPrice` resolves the current ETH/USD price.
+ *
+ * Resilience matters here: the contribution UI (MissionPayRedeem,
+ * MissionContributeModal) divides USD by this price to figure out the ETH
+ * amount and the resulting token quote. If this hook ever returns a falsy
+ * price, the user sees "You receive 0" with no explanation. To avoid that
+ * we (a) hit a backend endpoint that already races multiple price sources
+ * (etherscan / coingecko / cryptocompare), (b) keep the previous good
+ * value when SWR transitions to an error state, and (c) fall back to a
+ * localStorage-cached price (≤24h old) before giving up.
+ */
 export default function useETHPrice(
   amount: number,
   direction: QuoteDirection = 'ETH_TO_USD'
@@ -17,18 +64,40 @@ export default function useETHPrice(
     revalidateOnFocus: false,
     keepPreviousData: true,
     dedupingInterval: 30000,
+    errorRetryCount: 3,
+    errorRetryInterval: 2000,
+    shouldRetryOnError: true,
   })
 
-  const ethPrice = useMemo(() => {
-    if (ethPriceData?.result?.ethusd) {
-      const price = parseFloat(ethPriceData.result.ethusd)
-      // Validate
-      if (!isNaN(price) && price > 0) {
-        return price
-      }
-    }
-    return null
+  // Hold on to the last successfully-fetched price across renders so a
+  // transient SWR error doesn't drop us back to null mid-typing.
+  const lastGoodPriceRef = useRef<number | null>(null)
+
+  const fetchedPrice = useMemo<number | null>(() => {
+    const raw = ethPriceData?.result?.ethusd
+    if (raw == null) return null
+    const price = typeof raw === 'string' ? parseFloat(raw) : Number(raw)
+    if (!Number.isFinite(price) || price <= 0) return null
+    return price
   }, [ethPriceData])
+
+  // On first mount, hydrate the ref from localStorage so contributions are
+  // computable immediately on a slow network. (Initialized lazily here
+  // rather than via useState so we don't ship a stale price as the source
+  // of truth — `fetchedPrice` always wins once SWR resolves.)
+  if (lastGoodPriceRef.current == null && fetchedPrice == null) {
+    const cached = readCachedPrice()
+    if (cached) lastGoodPriceRef.current = cached.price
+  }
+
+  useEffect(() => {
+    if (fetchedPrice != null) {
+      lastGoodPriceRef.current = fetchedPrice
+      writeCachedPrice(fetchedPrice)
+    }
+  }, [fetchedPrice])
+
+  const ethPrice = fetchedPrice ?? lastGoodPriceRef.current ?? null
 
   const convertedAmount = useMemo(() => {
     if (!ethPrice || !amount) return 0
@@ -40,7 +109,11 @@ export default function useETHPrice(
     }
   }, [ethPrice, amount, direction])
 
-  const isLoading = isLoadingPrice && !ethPriceData
+  // Only report "loading" if we have *no* price at all to work with.
+  // Once we have any usable number (fresh or cached) the contribution UI
+  // can quote against it, and SWR will silently revalidate in the
+  // background.
+  const isLoading = isLoadingPrice && ethPrice == null
 
   return { data: convertedAmount, isLoading, error, ethPrice }
 }

--- a/ui/lib/navigation/useNavigation.tsx
+++ b/ui/lib/navigation/useNavigation.tsx
@@ -69,13 +69,13 @@ export default function useNavigation(citizen: any) {
         ],
       },
       {
-        name: 'Launchpad',
+        name: 'Send Frank to Space',
         icon: RocketLaunchIcon,
         href: '/launch',
         children: [
-          { name: 'Launchpad Explainer', href: '/launch' },
-          { name: 'Overview Fundraiser', href: '/mission/4' },
+          { name: 'Fundraiser', href: '/mission/4' },
           { name: 'Fly with Frank Leaderboard', href: '/overview-vote' },
+          { name: 'Launchpad Explainer', href: '/launch' },
         ],
       },
       {

--- a/ui/lib/notifications/sendOnchainNotification.ts
+++ b/ui/lib/notifications/sendOnchainNotification.ts
@@ -1,0 +1,94 @@
+import { getAccessToken } from '@privy-io/react-auth'
+
+/**
+ * POSTs a fire-and-forget Discord notification for an on-chain action.
+ *
+ * Use this for any client-side call to one of our `*-notification` API routes
+ * (leaderboard delegation, proposal vote, retroactive distribution, …).
+ *
+ * Why a shared helper:
+ *
+ *  1. Every notification route is wrapped in `authMiddleware`, which short-
+ *     circuits with 401 unless the request includes either a valid NextAuth
+ *     session cookie OR an `Authorization: Bearer ${accessToken}` header.
+ *     The NextAuth cookie isn't always present for Privy-only flows (race
+ *     after sign-in, expired session, blocked third-party cookies), so we
+ *     always send the Bearer header — otherwise the message silently never
+ *     gets posted.
+ *
+ *  2. Discord and our own routes occasionally blip on 5xx / network. A small
+ *     bounded retry loop with backoff prevents single transient failures
+ *     from dropping notifications without spamming on permanent errors.
+ *
+ *  3. Surfacing failures via `console.warn` (instead of swallowing with
+ *     `.catch(() => {})`) makes regressions visible in the browser console
+ *     so we don't end up debugging "sometimes it doesn't fire" again.
+ *
+ * The call is fire-and-forget from the caller's perspective; we never throw
+ * and never block the UI flow. Returns `true` when Discord acked, `false`
+ * otherwise.
+ */
+export async function sendOnchainNotification(
+  /** API route path, e.g. `/api/proposals/vote-notification`. */
+  path: string,
+  /** Body fields specific to this notification (txHash + anything the route
+   *  expects). The helper will inject `accessToken` automatically. */
+  body: Record<string, unknown>,
+  options: {
+    /** Tag used in console logs to identify this notification kind. */
+    label?: string
+    /** Total attempts including the first try. Defaults to 3. */
+    maxAttempts?: number
+    /** Base linear backoff between retries in ms. Defaults to 1500ms. */
+    backoffMs?: number
+  } = {}
+): Promise<boolean> {
+  const label = options.label ?? path
+  const maxAttempts = options.maxAttempts ?? 3
+  const backoffMs = options.backoffMs ?? 1500
+
+  try {
+    const accessToken = await getAccessToken()
+    if (!accessToken) {
+      console.warn(`[${label}] skipped: missing accessToken`)
+      return false
+    }
+    if (!body.txHash) {
+      console.warn(`[${label}] skipped: missing txHash`)
+      return false
+    }
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const resp = await fetch(path, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({ ...body, accessToken }),
+        })
+        if (resp.ok) return true
+
+        // 4xx (other than 408 / 429) means the server rejected the request
+        // for a permanent reason — retrying won't help. Log and bail.
+        if (
+          resp.status >= 400 &&
+          resp.status < 500 &&
+          resp.status !== 408 &&
+          resp.status !== 429
+        ) {
+          const errBody = await resp.text().catch(() => '')
+          console.warn(`[${label}] failed (${resp.status}): ${errBody}`)
+          return false
+        }
+      } catch (fetchErr) {
+        if (attempt === maxAttempts - 1) throw fetchErr
+      }
+      await new Promise((r) => setTimeout(r, backoffMs * (attempt + 1)))
+    }
+  } catch (err) {
+    console.warn(`[${label}] error:`, err)
+  }
+  return false
+}

--- a/ui/lib/overview-delegate/fetchLeaderboard.ts
+++ b/ui/lib/overview-delegate/fetchLeaderboard.ts
@@ -128,7 +128,7 @@ export async function fetchOverviewLeaderboard(
       }
     }
 
-    return buildLeaderboard(aggregated, citizenMap as any, limit)
+    return buildLeaderboard(aggregated, citizenMap, limit)
   } catch (error) {
     console.error('[fetchOverviewLeaderboard] fatal error:', error)
     return []

--- a/ui/lib/overview-delegate/fetchLeaderboard.ts
+++ b/ui/lib/overview-delegate/fetchLeaderboard.ts
@@ -1,0 +1,136 @@
+import {
+  CITIZEN_TABLE_NAMES,
+  OVERVIEW_BLOCKED_CITIZEN_IDS,
+  OVERVIEW_DELEGATION_VOTE_ID,
+  OVERVIEW_TOKEN_ADDRESS,
+  OVERVIEW_TOKEN_DECIMALS,
+  VOTES_TABLE_NAMES,
+} from 'const/config'
+import { formatUnits } from 'ethers'
+import { arbitrum } from '@/lib/rpc/chains'
+import queryTable from '@/lib/tableland/queryTable'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import { engineBatchRead } from '@/lib/thirdweb/engine'
+import {
+  aggregateDelegations,
+  buildLeaderboard,
+  isValidEthAddress,
+  parseDelegations,
+} from './leaderboard'
+import type { LeaderboardEntry } from './leaderboard'
+
+const ERC20_BALANCE_OF_ABI = [
+  {
+    inputs: [{ name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
+/**
+ * Fetches the Overview Flight ($OVERVIEW) delegation leaderboard server-side.
+ *
+ * Centralizes the Tableland → balance-batch → citizen-resolve pipeline that
+ * previously lived in `pages/overview-vote.tsx` and the leaderboard-notification
+ * API route, so additional surfaces (e.g. the mission/4 page) can render
+ * trustworthy leaderboard data without re-implementing it.
+ *
+ * @param limit Optional max rows to return. Omit for the full leaderboard.
+ * @returns A sorted (highest-delegated first) list of citizens with totals.
+ */
+export async function fetchOverviewLeaderboard(
+  limit?: number
+): Promise<LeaderboardEntry[]> {
+  try {
+    const chain = arbitrum
+    const chainSlug = getChainSlug(chain)
+
+    const votesTableName = VOTES_TABLE_NAMES[chainSlug]
+    if (!votesTableName) return []
+
+    const statement = `SELECT * FROM ${votesTableName} WHERE voteId = ${OVERVIEW_DELEGATION_VOTE_ID}`
+    const rows = await queryTable(chain, statement)
+    if (!rows || rows.length === 0) return []
+
+    const delegations = parseDelegations(rows)
+    if (delegations.length === 0) return []
+
+    const uniqueDelegators = [
+      ...new Set(delegations.map((d) => d.delegatorAddress)),
+    ]
+
+    const balanceMap: Record<string, number> = {}
+    try {
+      const balances = await engineBatchRead<string>(
+        OVERVIEW_TOKEN_ADDRESS,
+        'balanceOf',
+        uniqueDelegators.map((addr) => [addr]),
+        ERC20_BALANCE_OF_ABI,
+        chain.id
+      )
+      for (let i = 0; i < uniqueDelegators.length; i++) {
+        const raw = balances[i]
+        const wei = BigInt(raw || '0')
+        const normalized = parseFloat(
+          formatUnits(wei, OVERVIEW_TOKEN_DECIMALS)
+        )
+        balanceMap[uniqueDelegators[i].toLowerCase()] = normalized
+      }
+    } catch (error) {
+      // If the on-chain balance read fails, fall back to stored delegation
+      // amounts so we never show an empty leaderboard purely due to RPC flake.
+      console.error(
+        '[fetchOverviewLeaderboard] balance read failed, using stored amounts:',
+        error
+      )
+      for (const addr of uniqueDelegators) {
+        balanceMap[addr.toLowerCase()] = Infinity
+      }
+    }
+
+    const aggregated = aggregateDelegations(delegations, balanceMap)
+    if (aggregated.length === 0) return []
+
+    const safeAddresses = aggregated
+      .map((e) => e.delegateeAddress)
+      .filter(isValidEthAddress)
+
+    const citizenMap: Record<
+      string,
+      { id: number | string; name: string; image?: string }
+    > = {}
+
+    if (safeAddresses.length > 0) {
+      try {
+        const citizenTableName = CITIZEN_TABLE_NAMES[chainSlug]
+        if (citizenTableName) {
+          const inClause = safeAddresses.map((a) => `'${a}'`).join(',')
+          const citizenStatement = `SELECT id, name, owner, image FROM ${citizenTableName} WHERE LOWER(owner) IN (${inClause})`
+          const citizenRows = await queryTable(chain, citizenStatement)
+          if (citizenRows) {
+            for (const c of citizenRows) {
+              if (OVERVIEW_BLOCKED_CITIZEN_IDS.includes(c.id)) continue
+              citizenMap[c.owner.toLowerCase()] = {
+                id: c.id,
+                name: c.name,
+                image: c.image,
+              }
+            }
+          }
+        }
+      } catch (error) {
+        console.error(
+          '[fetchOverviewLeaderboard] citizen lookup failed:',
+          error
+        )
+      }
+    }
+
+    return buildLeaderboard(aggregated, citizenMap as any, limit)
+  } catch (error) {
+    console.error('[fetchOverviewLeaderboard] fatal error:', error)
+    return []
+  }
+}

--- a/ui/lib/overview-delegate/leaderboard.ts
+++ b/ui/lib/overview-delegate/leaderboard.ts
@@ -76,7 +76,14 @@ export function aggregateDelegations(
 
 export function buildLeaderboard(
   aggregated: AggregatedEntry[],
-  citizenMap: Record<string, { id: number; name: string; image?: string }>,
+  // `id` is widened to `number | string` to match `LeaderboardEntry.citizenId`
+  // and the actual shape coming back from Tableland (which can return numeric
+  // columns as strings depending on the gateway). Callers no longer need an
+  // `as any` cast here.
+  citizenMap: Record<
+    string,
+    { id: number | string; name: string; image?: string }
+  >,
   limit?: number
 ): LeaderboardEntry[] {
   const leaderboard: LeaderboardEntry[] = []

--- a/ui/pages/api/distribution/distribution-notification.ts
+++ b/ui/pages/api/distribution/distribution-notification.ts
@@ -1,0 +1,217 @@
+/**
+ * Discord notification for retroactive-rewards distribution submissions.
+ *
+ * Fires when a citizen submits (or updates) their distribution row on the
+ * Distribution Tableland contract. The route validates that the transaction
+ * was sent by an authenticated wallet, that it actually targets the
+ * Distribution contract, and that it's recent — then posts a message to
+ * Discord summarizing what was submitted (quarter / year / project count).
+ *
+ * Mirrors the auth + validation pattern of `vote-notification.ts` and
+ * `leaderboard-notification.ts`. The client must send the Privy access token
+ * both in the `Authorization: Bearer ...` header (so `authMiddleware` lets
+ * the request through) and in the body (so we can re-verify and look up the
+ * user's wallets).
+ */
+import {
+  CITIZEN_TABLE_NAMES,
+  DEFAULT_CHAIN_V5,
+  DISTRIBUTION_TABLE_ADDRESSES,
+  GENERAL_CHANNEL_ID,
+  TEST_CHANNEL_ID,
+  DEPLOYED_ORIGIN,
+} from 'const/config'
+import { authMiddleware } from 'middleware/authMiddleware'
+import withMiddleware from 'middleware/withMiddleware'
+import { waitForReceipt } from 'thirdweb'
+import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
+import { getPrivyUserData } from '@/lib/privy'
+import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
+import queryTable from '@/lib/tableland/queryTable'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import { serverClient } from '@/lib/thirdweb/client'
+import { getBlocksInTimeframe } from '@/lib/utils/blocks'
+
+const chain = DEFAULT_CHAIN_V5
+const chainSlug = getChainSlug(chain)
+
+const NOTIFICATION_CHANNEL_ID =
+  process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
+    ? GENERAL_CHANNEL_ID
+    : TEST_CHANNEL_ID
+
+const usedTransactions = new Set<string>()
+setInterval(() => {
+  usedTransactions.clear()
+}, 60 * 60 * 1000)
+
+function shortAddress(address: string): string {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`
+}
+
+async function handler(req: any, res: any) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  try {
+    const data = typeof req.body === 'string' ? JSON.parse(req.body) : req.body
+    if (!data) {
+      return res.status(400).json({ message: 'Bad request' })
+    }
+
+    const { txHash, accessToken } = data
+    if (!txHash || !accessToken) {
+      return res.status(400).json({ message: 'Missing required fields' })
+    }
+
+    const privyUserData = await getPrivyUserData(accessToken)
+    if (!privyUserData) {
+      return res.status(400).json({ message: 'Invalid access token' })
+    }
+
+    const { walletAddresses } = privyUserData
+    if (walletAddresses.length === 0) {
+      return res.status(400).json({ message: 'No wallet addresses found' })
+    }
+
+    if (usedTransactions.has(txHash)) {
+      return res.status(400).json({
+        message: 'This transaction has already been processed',
+      })
+    }
+
+    const txReceipt = await waitForReceipt({
+      client: serverClient,
+      chain,
+      transactionHash: txHash,
+    })
+
+    if (!txReceipt) {
+      return res.status(400).json({ message: 'Transaction not found' })
+    }
+
+    const txFrom = txReceipt.from?.toLowerCase()
+    const normalizedWalletAddresses = walletAddresses.map((addr: string) =>
+      addr?.toLowerCase()
+    )
+
+    if (!txFrom || !normalizedWalletAddresses.includes(txFrom)) {
+      return res.status(403).json({
+        message: 'Transaction sender does not match authenticated user',
+      })
+    }
+
+    const distributionAddress = DISTRIBUTION_TABLE_ADDRESSES[chainSlug]
+    if (
+      !distributionAddress ||
+      txReceipt.to?.toLowerCase() !== distributionAddress.toLowerCase()
+    ) {
+      return res.status(400).json({
+        message: 'Transaction is not to the Distribution contract',
+      })
+    }
+
+    const txBlockNumber = parseInt(
+      typeof txReceipt.blockNumber === 'object' &&
+        txReceipt.blockNumber &&
+        'toString' in txReceipt.blockNumber
+        ? (txReceipt.blockNumber as any).toString()
+        : String(txReceipt.blockNumber)
+    )
+    const provider = ethers5Adapter.provider.toEthers({
+      client: serverClient,
+      chain,
+    })
+    const currBlockNumber = await provider.getBlockNumber()
+    const maxBlocksAge = getBlocksInTimeframe(chain, 10)
+    const blockAge = currBlockNumber - txBlockNumber
+
+    if (blockAge > maxBlocksAge) {
+      return res.status(400).json({
+        message: 'Transaction is too old',
+      })
+    }
+
+    usedTransactions.add(txHash)
+
+    const voterAddress = txReceipt.from.toLowerCase()
+    const citizenTableName = CITIZEN_TABLE_NAMES[chainSlug]
+
+    let voterCitizen: any = null
+    if (citizenTableName) {
+      try {
+        const voterRows: any = await queryTable(
+          chain,
+          `SELECT name, id, image, owner FROM ${citizenTableName} WHERE LOWER(owner) = '${voterAddress}'`
+        )
+        if (voterRows?.length > 0) {
+          voterCitizen = voterRows[0]
+        }
+      } catch {}
+    }
+
+    const voterDisplay = voterCitizen?.name
+      ? `[${voterCitizen.name}](${DEPLOYED_ORIGIN}/citizen/${generatePrettyLinkWithId(voterCitizen.name, voterCitizen.id)})`
+      : shortAddress(voterAddress)
+
+    const quarter = Number(data.quarter)
+    const year = Number(data.year)
+    const projectCountRaw = data.projectCount
+    const projectCount =
+      typeof projectCountRaw === 'number' && Number.isFinite(projectCountRaw)
+        ? projectCountRaw
+        : null
+
+    const quarterLabel =
+      Number.isInteger(quarter) && Number.isInteger(year)
+        ? ` for **Q${quarter} ${year}**`
+        : ''
+    const acrossLabel =
+      projectCount != null && projectCount > 0
+        ? ` across **${projectCount} project${projectCount === 1 ? '' : 's'}**`
+        : ''
+    const verb = data.isEdit
+      ? 'updated their retroactive rewards distribution'
+      : 'submitted a retroactive rewards distribution'
+
+    let content = `## 🎯 **${voterDisplay}** ${verb}${quarterLabel}${acrossLabel}`
+    content += `\n\n[View projects →](${DEPLOYED_ORIGIN}/projects)`
+
+    const messageData: any = {
+      embeds: [{ description: content }],
+    }
+
+    if (voterCitizen?.image) {
+      messageData.embeds[0].thumbnail = {
+        url: `https://ipfs.io/ipfs/${voterCitizen.image.replace('ipfs://', '')}`,
+      }
+    }
+
+    const response = await fetch(
+      `https://discord.com/api/v10/channels/${NOTIFICATION_CHANNEL_ID}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN}`,
+        },
+        body: JSON.stringify(messageData),
+      }
+    )
+
+    if (!response.ok) {
+      usedTransactions.delete(txHash)
+      throw new Error('Failed to send message to Discord')
+    }
+
+    return res.status(200).json({ success: true })
+  } catch (err: any) {
+    console.error('Distribution notification error:', err)
+    return res.status(400).json({
+      message: err.message || 'Failed to send distribution notification',
+    })
+  }
+}
+
+export default withMiddleware(handler, authMiddleware)

--- a/ui/pages/api/etherscan/eth-price.ts
+++ b/ui/pages/api/etherscan/eth-price.ts
@@ -3,38 +3,111 @@ import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
 import { NextApiRequest, NextApiResponse } from 'next'
 
+/**
+ * Try Etherscan first (so the response shape stays the same as before for
+ * any callers that read `result.ethusd`), then fall back to CoinGecko and
+ * finally CryptoCompare. We *only* return 5xx if every source fails — a
+ * single rate-limit on Etherscan used to zero out the contribution UI
+ * because it derives the ETH input from `usd / ethUsdPrice`.
+ *
+ * Each fallback path normalizes back into the Etherscan-shaped envelope
+ * `{ message: 'OK', result: { ethusd: '<price>', source } }` so the client
+ * doesn't need to care which source actually served the price.
+ */
+
+const PRICE_TTL_SECONDS = 60
+
+type PriceResult = { price: number; source: string }
+
+async function fetchEtherscan(): Promise<PriceResult | null> {
+  const apiKey = process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY
+  if (!apiKey) return null
+  try {
+    const res = await fetch(
+      `https://api.etherscan.io/v2/api?module=stats&action=ethprice&chainid=1&apikey=${apiKey}`,
+      { signal: AbortSignal.timeout(4000) }
+    )
+    if (!res.ok) return null
+    const data = await res.json()
+    const raw = data?.result?.ethusd
+    const price = typeof raw === 'string' ? parseFloat(raw) : Number(raw)
+    if (data?.message !== 'OK' || !Number.isFinite(price) || price <= 0) {
+      return null
+    }
+    return { price, source: 'etherscan' }
+  } catch (err) {
+    console.warn('[eth-price] etherscan fetch failed:', err)
+    return null
+  }
+}
+
+async function fetchCoinGecko(): Promise<PriceResult | null> {
+  try {
+    const res = await fetch(
+      'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
+      { signal: AbortSignal.timeout(4000) }
+    )
+    if (!res.ok) return null
+    const data = await res.json()
+    const price = Number(data?.ethereum?.usd)
+    if (!Number.isFinite(price) || price <= 0) return null
+    return { price, source: 'coingecko' }
+  } catch (err) {
+    console.warn('[eth-price] coingecko fetch failed:', err)
+    return null
+  }
+}
+
+async function fetchCryptoCompare(): Promise<PriceResult | null> {
+  try {
+    const res = await fetch(
+      'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD',
+      { signal: AbortSignal.timeout(4000) }
+    )
+    if (!res.ok) return null
+    const data = await res.json()
+    const price = Number(data?.USD)
+    if (!Number.isFinite(price) || price <= 0) return null
+    return { price, source: 'cryptocompare' }
+  } catch (err) {
+    console.warn('[eth-price] cryptocompare fetch failed:', err)
+    return null
+  }
+}
+
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  try {
-    setCDNCacheHeaders(res, 60, 60, 'Accept-Encoding')
+  // Race etherscan + coingecko in parallel so a slow primary source doesn't
+  // gate the response on its full timeout. Whichever returns a valid number
+  // first wins; cryptocompare is only used if both of those fail.
+  const [etherscan, coingecko] = await Promise.all([
+    fetchEtherscan(),
+    fetchCoinGecko(),
+  ])
 
-    const ethPrice = await fetch(
-      `https://api.etherscan.io/v2/api?module=stats&action=ethprice&chainid=1&apikey=${process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY}`
-    )
-
-    if (!ethPrice.ok) {
-      throw new Error(`Etherscan API returned ${ethPrice.status}`)
-    }
-
-    const ethPriceData = await ethPrice.json()
-
-    // Validate response structure
-    if (
-      !ethPriceData ||
-      ethPriceData.message !== 'OK' ||
-      !ethPriceData.result?.ethusd
-    ) {
-      throw new Error('Invalid response structure from Etherscan API')
-    }
-
-    res.status(200).json(ethPriceData)
-  } catch (error) {
-    console.error('Etherscan API error:', error)
-    res.status(500).json({ error: 'Failed to fetch current ETH price' })
+  let result = etherscan ?? coingecko
+  if (!result) {
+    result = await fetchCryptoCompare()
   }
+
+  if (!result) {
+    console.error('[eth-price] all price sources failed')
+    return res.status(502).json({ error: 'Failed to fetch current ETH price' })
+  }
+
+  setCDNCacheHeaders(res, PRICE_TTL_SECONDS, PRICE_TTL_SECONDS, 'Accept-Encoding')
+
+  return res.status(200).json({
+    status: '1',
+    message: 'OK',
+    result: {
+      ethusd: result.price.toString(),
+      source: result.source,
+    },
+  })
 }
 
 export default withMiddleware(handler, rateLimit)

--- a/ui/pages/api/etherscan/eth-price.ts
+++ b/ui/pages/api/etherscan/eth-price.ts
@@ -75,20 +75,58 @@ async function fetchCryptoCompare(): Promise<PriceResult | null> {
   }
 }
 
+/**
+ * Resolves with the first promise that settles with a non-null value.
+ *
+ * Differs from `Promise.any` in two important ways for our use:
+ *  1. Our fetchers return `null` on failure rather than throwing, so a
+ *     `null` resolution should be treated like a rejection (keep waiting
+ *     for the other source).
+ *  2. We deliberately *don't* abort the slower request — we just stop
+ *     waiting for it. The slow source's `AbortSignal.timeout` already
+ *     bounds the work, and letting it finish in the background is fine
+ *     because the serverless invocation will be torn down anyway.
+ *
+ * Returns `null` only if every input resolves null / rejects.
+ */
+function raceFirstValid<T>(promises: Promise<T | null>[]): Promise<T | null> {
+  if (promises.length === 0) return Promise.resolve(null)
+  return new Promise((resolve) => {
+    let pending = promises.length
+    let settled = false
+    const finish = (value: T | null) => {
+      if (settled) return
+      settled = true
+      resolve(value)
+    }
+    for (const p of promises) {
+      p.then(
+        (value) => {
+          if (value != null) {
+            finish(value)
+          } else if (--pending === 0) {
+            finish(null)
+          }
+        },
+        () => {
+          if (--pending === 0) finish(null)
+        }
+      )
+    }
+  })
+}
+
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  // Race etherscan + coingecko in parallel so a slow primary source doesn't
-  // gate the response on its full timeout. Whichever returns a valid number
-  // first wins; cryptocompare is only used if both of those fail.
-  const [etherscan, coingecko] = await Promise.all([
-    fetchEtherscan(),
-    fetchCoinGecko(),
-  ])
-
-  let result = etherscan ?? coingecko
+  // Truly race etherscan + coingecko: whichever returns a valid price
+  // *first* resolves the response. We don't wait for the slower source to
+  // also finish (each has its own 4s timeout, and `Promise.all` would
+  // serialize us behind the slowest). Cryptocompare is only consulted if
+  // both of the primaries failed/returned null.
+  let result = await raceFirstValid([fetchEtherscan(), fetchCoinGecko()])
   if (!result) {
     result = await fetchCryptoCompare()
   }

--- a/ui/pages/api/overview/leaderboard-notification.ts
+++ b/ui/pages/api/overview/leaderboard-notification.ts
@@ -1,46 +1,26 @@
 import {
   CITIZEN_TABLE_NAMES,
   GENERAL_CHANNEL_ID,
-  OVERVIEW_BLOCKED_CITIZEN_IDS,
-  OVERVIEW_DELEGATION_VOTE_ID,
-  OVERVIEW_TOKEN_ADDRESS,
-  OVERVIEW_TOKEN_DECIMALS,
   TEST_CHANNEL_ID,
   VOTES_TABLE_ADDRESSES,
-  VOTES_TABLE_NAMES,
   DEPLOYED_ORIGIN,
 } from 'const/config'
-import { formatUnits } from 'ethers'
 import { authMiddleware } from 'middleware/authMiddleware'
 import withMiddleware from 'middleware/withMiddleware'
 import { waitForReceipt } from 'thirdweb'
 import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
+import { fetchOverviewLeaderboard } from '@/lib/overview-delegate/fetchLeaderboard'
 import {
-  parseDelegations,
-  aggregateDelegations,
-  buildLeaderboard,
-  isValidEthAddress,
   formatLeaderboardStandings,
+  isValidEthAddress,
 } from '@/lib/overview-delegate/leaderboard'
-import type { LeaderboardEntry } from '@/lib/overview-delegate/leaderboard'
 import { getPrivyUserData } from '@/lib/privy'
 import { arbitrum } from '@/lib/rpc/chains'
 import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import { serverClient } from '@/lib/thirdweb/client'
-import { engineBatchRead } from '@/lib/thirdweb/engine'
 import { getBlocksInTimeframe } from '@/lib/utils/blocks'
-
-const ERC20_BALANCE_OF_ABI = [
-  {
-    inputs: [{ name: 'account', type: 'address' }],
-    name: 'balanceOf',
-    outputs: [{ name: '', type: 'uint256' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-]
 
 const chain = arbitrum
 const chainSlug = getChainSlug(chain)
@@ -54,76 +34,6 @@ const usedTransactions = new Set<string>()
 setInterval(() => {
   usedTransactions.clear()
 }, 60 * 60 * 1000)
-
-async function buildCurrentLeaderboard(): Promise<LeaderboardEntry[]> {
-  const votesTableName = VOTES_TABLE_NAMES[chainSlug]
-  if (!votesTableName) return []
-
-  const statement = `SELECT * FROM ${votesTableName} WHERE voteId = ${OVERVIEW_DELEGATION_VOTE_ID}`
-  const rows = await queryTable(chain, statement)
-  if (!rows || rows.length === 0) return []
-
-  const delegations = parseDelegations(rows)
-  if (delegations.length === 0) return []
-
-  const uniqueDelegators = [
-    ...new Set(delegations.map((d) => d.delegatorAddress)),
-  ]
-
-  let balanceMap: Record<string, number> = {}
-  try {
-    const balances = await engineBatchRead<string>(
-      OVERVIEW_TOKEN_ADDRESS,
-      'balanceOf',
-      uniqueDelegators.map((addr) => [addr]),
-      ERC20_BALANCE_OF_ABI,
-      chain.id
-    )
-    for (let i = 0; i < uniqueDelegators.length; i++) {
-      const raw = balances[i]
-      const wei = BigInt(raw || '0')
-      const normalized = parseFloat(formatUnits(wei, OVERVIEW_TOKEN_DECIMALS))
-      balanceMap[uniqueDelegators[i].toLowerCase()] = normalized
-    }
-  } catch {
-    for (const addr of uniqueDelegators) {
-      balanceMap[addr.toLowerCase()] = Infinity
-    }
-  }
-
-  const aggregated = aggregateDelegations(delegations, balanceMap)
-  if (aggregated.length === 0) return []
-
-  const safeAddresses = aggregated
-    .map((e) => e.delegateeAddress)
-    .filter(isValidEthAddress)
-
-  let citizenMap: Record<
-    string,
-    { id: number; name: string; image?: string }
-  > = {}
-
-  if (safeAddresses.length > 0) {
-    const citizenTableName = CITIZEN_TABLE_NAMES[chainSlug]
-    if (citizenTableName) {
-      const inClause = safeAddresses.map((a) => `'${a}'`).join(',')
-      const citizenStatement = `SELECT id, name, owner, image FROM ${citizenTableName} WHERE LOWER(owner) IN (${inClause})`
-      const citizenRows = await queryTable(chain, citizenStatement)
-      if (citizenRows) {
-        for (const c of citizenRows) {
-          if (OVERVIEW_BLOCKED_CITIZEN_IDS.includes(c.id)) continue
-          citizenMap[c.owner.toLowerCase()] = {
-            id: c.id,
-            name: c.name,
-            image: c.image,
-          }
-        }
-      }
-    }
-  }
-
-  return buildLeaderboard(aggregated, citizenMap, 25)
-}
 
 async function handler(req: any, res: any) {
   if (req.method !== 'POST') {
@@ -244,10 +154,7 @@ async function handler(req: any, res: any) {
       } catch {}
     }
 
-    let leaderboard: LeaderboardEntry[] = []
-    try {
-      leaderboard = await buildCurrentLeaderboard()
-    } catch {}
+    const leaderboard = await fetchOverviewLeaderboard(25)
 
     const voterDisplay = voterCitizen?.name
       ? `[${voterCitizen.name}](${DEPLOYED_ORIGIN}/citizen/${generatePrettyLinkWithId(voterCitizen.name, voterCitizen.id)})`

--- a/ui/pages/api/proposals/vote-notification.ts
+++ b/ui/pages/api/proposals/vote-notification.ts
@@ -1,0 +1,277 @@
+/**
+ * Discord notification for proposal votes.
+ *
+ * Two flavors, distinguished by the `kind` field in the request body:
+ *   - 'senate': a single-proposal Senate vote (NonProjectProposal contract).
+ *               Includes the proposal name + MDP + distribution payload.
+ *   - 'member': a quarterly Member Vote across many proposals (Proposals
+ *               contract). Includes quarter / year and a count of proposals
+ *               the voter allocated to.
+ *
+ * The route validates that:
+ *   - The caller has a valid Privy token (via the Bearer header — populated by
+ *     the new `Authorization: Bearer ${accessToken}` convention also used by
+ *     leaderboard-notification — and re-checked against the body for defense
+ *     in depth).
+ *   - The transaction was sent by one of the authenticated user's wallets.
+ *   - The transaction's `to` matches the expected contract for `kind`.
+ *   - The transaction is recent (within ~10 minutes of blocks).
+ *   - We haven't already processed this `txHash` in this Node process.
+ */
+import {
+  CITIZEN_TABLE_NAMES,
+  DEFAULT_CHAIN_V5,
+  GENERAL_CHANNEL_ID,
+  NON_PROJECT_PROPOSAL_ADDRESSES,
+  PROPOSALS_ADDRESSES,
+  TEST_CHANNEL_ID,
+  DEPLOYED_ORIGIN,
+} from 'const/config'
+import { authMiddleware } from 'middleware/authMiddleware'
+import withMiddleware from 'middleware/withMiddleware'
+import { waitForReceipt } from 'thirdweb'
+import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
+import { getPrivyUserData } from '@/lib/privy'
+import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
+import queryTable from '@/lib/tableland/queryTable'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import { serverClient } from '@/lib/thirdweb/client'
+import { getBlocksInTimeframe } from '@/lib/utils/blocks'
+
+const chain = DEFAULT_CHAIN_V5
+const chainSlug = getChainSlug(chain)
+
+const NOTIFICATION_CHANNEL_ID =
+  process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
+    ? GENERAL_CHANNEL_ID
+    : TEST_CHANNEL_ID
+
+// In-process dedup: if the same tx is posted twice by the client (retry, etc.)
+// we don't want two Discord messages. This isn't multi-instance-safe on
+// serverless, but it covers the common case of a client-side retry.
+const usedTransactions = new Set<string>()
+setInterval(() => {
+  usedTransactions.clear()
+}, 60 * 60 * 1000)
+
+type VoteKind = 'senate' | 'member'
+
+function isVoteKind(value: unknown): value is VoteKind {
+  return value === 'senate' || value === 'member'
+}
+
+function shortAddress(address: string): string {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`
+}
+
+async function handler(req: any, res: any) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  try {
+    const data = typeof req.body === 'string' ? JSON.parse(req.body) : req.body
+    if (!data) {
+      return res.status(400).json({ message: 'Bad request' })
+    }
+
+    const { txHash, accessToken, kind } = data
+    if (!txHash || !accessToken) {
+      return res.status(400).json({ message: 'Missing required fields' })
+    }
+    if (!isVoteKind(kind)) {
+      return res
+        .status(400)
+        .json({ message: "Invalid 'kind' (expected 'senate' or 'member')" })
+    }
+
+    const privyUserData = await getPrivyUserData(accessToken)
+    if (!privyUserData) {
+      return res.status(400).json({ message: 'Invalid access token' })
+    }
+
+    const { walletAddresses } = privyUserData
+    if (walletAddresses.length === 0) {
+      return res.status(400).json({ message: 'No wallet addresses found' })
+    }
+
+    if (usedTransactions.has(txHash)) {
+      return res.status(400).json({
+        message: 'This transaction has already been processed',
+      })
+    }
+
+    const txReceipt = await waitForReceipt({
+      client: serverClient,
+      chain,
+      transactionHash: txHash,
+    })
+
+    if (!txReceipt) {
+      return res.status(400).json({ message: 'Transaction not found' })
+    }
+
+    const txFrom = txReceipt.from?.toLowerCase()
+    const normalizedWalletAddresses = walletAddresses.map((addr: string) =>
+      addr?.toLowerCase()
+    )
+
+    if (!txFrom || !normalizedWalletAddresses.includes(txFrom)) {
+      return res.status(403).json({
+        message: 'Transaction sender does not match authenticated user',
+      })
+    }
+
+    // Each `kind` has exactly one valid destination contract.
+    const expectedContract =
+      kind === 'senate'
+        ? NON_PROJECT_PROPOSAL_ADDRESSES[chainSlug]
+        : PROPOSALS_ADDRESSES[chainSlug]
+
+    if (
+      !expectedContract ||
+      txReceipt.to?.toLowerCase() !== expectedContract.toLowerCase()
+    ) {
+      return res.status(400).json({
+        message: 'Transaction is not to the expected contract for this vote',
+      })
+    }
+
+    const txBlockNumber = parseInt(
+      typeof txReceipt.blockNumber === 'object' &&
+        txReceipt.blockNumber &&
+        'toString' in txReceipt.blockNumber
+        ? (txReceipt.blockNumber as any).toString()
+        : String(txReceipt.blockNumber)
+    )
+    const provider = ethers5Adapter.provider.toEthers({
+      client: serverClient,
+      chain,
+    })
+    const currBlockNumber = await provider.getBlockNumber()
+    const maxBlocksAge = getBlocksInTimeframe(chain, 10)
+    const blockAge = currBlockNumber - txBlockNumber
+
+    if (blockAge > maxBlocksAge) {
+      return res.status(400).json({
+        message: 'Transaction is too old',
+      })
+    }
+
+    usedTransactions.add(txHash)
+
+    const voterAddress = txReceipt.from.toLowerCase()
+    const citizenTableName = CITIZEN_TABLE_NAMES[chainSlug]
+
+    let voterCitizen: any = null
+    if (citizenTableName) {
+      try {
+        const voterRows: any = await queryTable(
+          chain,
+          `SELECT name, id, image, owner FROM ${citizenTableName} WHERE LOWER(owner) = '${voterAddress}'`
+        )
+        if (voterRows?.length > 0) {
+          voterCitizen = voterRows[0]
+        }
+      } catch {}
+    }
+
+    const voterDisplay = voterCitizen?.name
+      ? `[${voterCitizen.name}](${DEPLOYED_ORIGIN}/citizen/${generatePrettyLinkWithId(voterCitizen.name, voterCitizen.id)})`
+      : shortAddress(voterAddress)
+
+    let content = ''
+    let linkUrl = ''
+
+    if (kind === 'senate') {
+      // Senate vote payload: { proposalName, proposalMDP, isEdit }
+      const proposalNameRaw =
+        typeof data.proposalName === 'string' ? data.proposalName.trim() : ''
+      const proposalMDPRaw = data.proposalMDP
+      const proposalMDP =
+        typeof proposalMDPRaw === 'number'
+          ? proposalMDPRaw
+          : typeof proposalMDPRaw === 'string' && proposalMDPRaw.trim() !== ''
+            ? Number(proposalMDPRaw)
+            : null
+
+      const proposalLabel = proposalNameRaw
+        ? proposalMDP != null && Number.isFinite(proposalMDP)
+          ? `MDP-${proposalMDP}: ${proposalNameRaw}`
+          : proposalNameRaw
+        : proposalMDP != null && Number.isFinite(proposalMDP)
+          ? `MDP-${proposalMDP}`
+          : 'a proposal'
+
+      const verb = data.isEdit ? 'updated their vote on' : 'voted on'
+      content = `## 🗳️ **${voterDisplay}** ${verb} **${proposalLabel}**`
+
+      if (proposalMDP != null && Number.isFinite(proposalMDP)) {
+        linkUrl = `${DEPLOYED_ORIGIN}/proposal/${proposalMDP}`
+        content += `\n\n[View proposal →](${linkUrl})`
+      }
+    } else {
+      // Member vote payload: { quarter, year, proposalCount, isEdit }
+      const quarter = Number(data.quarter)
+      const year = Number(data.year)
+      const proposalCountRaw = data.proposalCount
+      const proposalCount =
+        typeof proposalCountRaw === 'number' && Number.isFinite(proposalCountRaw)
+          ? proposalCountRaw
+          : null
+
+      const quarterLabel =
+        Number.isInteger(quarter) && Number.isInteger(year)
+          ? ` for **Q${quarter} ${year}**`
+          : ''
+      const acrossLabel =
+        proposalCount != null && proposalCount > 0
+          ? ` across **${proposalCount} proposal${proposalCount === 1 ? '' : 's'}**`
+          : ''
+      const verb = data.isEdit
+        ? 'updated their member vote'
+        : 'submitted a member vote'
+
+      content = `## 🗳️ **${voterDisplay}** ${verb}${quarterLabel}${acrossLabel}`
+      linkUrl = `${DEPLOYED_ORIGIN}/projects`
+      content += `\n\n[View proposals →](${linkUrl})`
+    }
+
+    const messageData: any = {
+      embeds: [{ description: content }],
+    }
+
+    if (voterCitizen?.image) {
+      messageData.embeds[0].thumbnail = {
+        url: `https://ipfs.io/ipfs/${voterCitizen.image.replace('ipfs://', '')}`,
+      }
+    }
+
+    const response = await fetch(
+      `https://discord.com/api/v10/channels/${NOTIFICATION_CHANNEL_ID}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN}`,
+        },
+        body: JSON.stringify(messageData),
+      }
+    )
+
+    if (!response.ok) {
+      // Allow a retry from the client if Discord rejected us.
+      usedTransactions.delete(txHash)
+      throw new Error('Failed to send message to Discord')
+    }
+
+    return res.status(200).json({ success: true })
+  } catch (err: any) {
+    console.error('Vote notification error:', err)
+    return res.status(400).json({
+      message: err.message || 'Failed to send vote notification',
+    })
+  }
+}
+
+export default withMiddleware(handler, authMiddleware)

--- a/ui/pages/mission/[tokenId].tsx
+++ b/ui/pages/mission/[tokenId].tsx
@@ -5,6 +5,8 @@ import dynamic from 'next/dynamic'
 import { fetchFromIPFSWithFallback, getIPFSGateway } from '@/lib/ipfs/gateway'
 import { getMissionServerData } from '@/lib/mission/fetchMissionServerData'
 import { fetchTokenMetadata } from '@/lib/mission/fetchTokenServerData'
+import { fetchOverviewLeaderboard } from '@/lib/overview-delegate/fetchLeaderboard'
+import type { LeaderboardEntry } from '@/lib/overview-delegate/leaderboard'
 import { fetchTeamNFTAndHats } from '@/lib/team/fetchTeamServerData'
 import Head from '@/components/layout/Head'
 import { Mission } from '@/components/mission/MissionCard'
@@ -32,7 +34,12 @@ type ProjectProfileProps = {
   _teamHats?: any[]
   _fundingGoal: number
   _ruleset: any[]
+  _overviewLeaderboard?: LeaderboardEntry[]
 }
+
+/** Mission ID for the Overview Flight fundraiser; used to opportunistically
+ *  hydrate the $OVERVIEW leaderboard preview rendered on its mission page. */
+const OVERVIEW_MISSION_ID = 4
 
 export default function MissionProfilePage({
   mission,
@@ -45,6 +52,7 @@ export default function MissionProfilePage({
   _teamHats,
   _fundingGoal,
   _ruleset,
+  _overviewLeaderboard,
 }: ProjectProfileProps) {
   const selectedChain = DEFAULT_CHAIN_V5
 
@@ -67,6 +75,7 @@ export default function MissionProfilePage({
           _teamHats={_teamHats}
           _fundingGoal={_fundingGoal}
           _ruleset={_ruleset}
+          _overviewLeaderboard={_overviewLeaderboard}
         />
       </JuiceProviders>
     </>
@@ -154,6 +163,20 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query, re
         ? contractData.metadataURI.replace('ipfs://', '')
         : contractData.metadataURI
 
+      // Kick off the (mission-4-only) Overview leaderboard fetch in parallel
+      // with the IPFS metadata + token metadata round-trips so it doesn't
+      // serially extend page TTFB.
+      const isOverviewMission = Number(tokenId) === OVERVIEW_MISSION_ID
+      const overviewLeaderboardPromise = isOverviewMission
+        ? fetchOverviewLeaderboard(5).catch((error) => {
+            console.warn(
+              '[mission/4] overview leaderboard fetch failed:',
+              error
+            )
+            return [] as LeaderboardEntry[]
+          })
+        : Promise.resolve(undefined)
+
       const metadata = await fetchFromIPFSWithFallback(ipfsHash).catch((error: any) => {
         console.warn('All IPFS gateways failed:', error)
         return {
@@ -181,6 +204,8 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query, re
           ]
         : [{ weight: 0 }, { reservedPercent: 0 }]
 
+      const _overviewLeaderboard = await overviewLeaderboardPromise
+
       return {
         props: {
           mission,
@@ -193,6 +218,9 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query, re
           _teamHats: teamHats,
           _fundingGoal: missionRow.fundingGoal,
           _ruleset,
+          ...(_overviewLeaderboard !== undefined
+            ? { _overviewLeaderboard }
+            : {}),
         },
       }
     } catch (error) {

--- a/ui/pages/overview-vote.tsx
+++ b/ui/pages/overview-vote.tsx
@@ -86,6 +86,12 @@ export default function OverviewDelegate({
   // user had when they first backed someone. Users who have since earned
   // more $OVERVIEW therefore see their delegated total stuck at the old
   // value until they successfully re-submit.
+  //
+  // We only adjust the entry if the server total looks *stale* relative to
+  // the user's live balance. If the server already knows about the larger
+  // balance (entry total >= live balance), we leave it alone to avoid the
+  // double-count case where server had fresh data and we'd add the delta on
+  // top of an already-correct number.
   const visibleLeaderboard = useMemo(() => {
     if (
       !userAddress ||
@@ -99,16 +105,24 @@ export default function OverviewDelegate({
     const targetAddr = previousDelegation.delegatee.toLowerCase()
     const liveAmount = Math.floor(userBalance)
     const storedAmount = previousDelegation.amount
-    const delta = liveAmount - storedAmount
-    if (delta === 0) return displayLeaderboard
     let touched = false
     const overlaid = displayLeaderboard.map((entry) => {
       if (entry.delegateeAddress.toLowerCase() !== targetAddr) return entry
+      // Server total already reflects (at least) the user's current balance —
+      // assume it's fresh and leave it alone. This avoids inflating the
+      // number when ISR happened to revalidate after the user's balance bump.
+      if (entry.totalDelegated >= liveAmount) return entry
+      // Server total < live balance => server is stale (likely fell back to
+      // stored amount). Swap the user's stored portion for the live balance.
+      const userServerContribution = Math.min(
+        entry.totalDelegated,
+        storedAmount
+      )
+      const adjusted =
+        entry.totalDelegated - userServerContribution + liveAmount
+      if (adjusted === entry.totalDelegated) return entry
       touched = true
-      return {
-        ...entry,
-        totalDelegated: Math.max(0, entry.totalDelegated + delta),
-      }
+      return { ...entry, totalDelegated: Math.max(0, adjusted) }
     })
     if (!touched) return displayLeaderboard
     return [...overlaid].sort((a, b) => b.totalDelegated - a.totalDelegated)
@@ -455,11 +469,45 @@ export default function OverviewDelegate({
         setIsRefreshing(false)
       }
       pollForUpdate()
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error submitting delegation:', error)
-      toast.error('Failed to submit delegation. Please try again.', {
-        style: toastStyle,
-      })
+      // Pull a useful message out of whatever shape the error happens to be
+      // in (thirdweb v5 errors, viem-style errors, plain Error, etc.) so the
+      // toast actually tells the user *why* the submit failed instead of
+      // hiding everything behind a generic retry message.
+      const rawMessage: string =
+        error?.shortMessage ||
+        error?.cause?.shortMessage ||
+        error?.cause?.message ||
+        error?.message ||
+        ''
+      const lower = rawMessage.toLowerCase()
+
+      let toastMessage = 'Failed to submit delegation. Please try again.'
+      if (
+        lower.includes('user rejected') ||
+        lower.includes('user denied') ||
+        lower.includes('rejected the request') ||
+        lower.includes('action_rejected')
+      ) {
+        toastMessage = 'Transaction cancelled in your wallet.'
+      } else if (
+        lower.includes('insufficient funds') ||
+        lower.includes('insufficient balance')
+      ) {
+        toastMessage =
+          'Not enough ETH on Arbitrum to cover gas. Add a small amount of ETH to your wallet on Arbitrum and try again.'
+      } else if (
+        lower.includes('chain') &&
+        (lower.includes('mismatch') || lower.includes('switch'))
+      ) {
+        toastMessage =
+          'Wallet is on the wrong network. Please switch to Arbitrum and try again.'
+      } else if (rawMessage) {
+        toastMessage = `Failed to submit delegation: ${rawMessage.slice(0, 160)}`
+      }
+
+      toast.error(toastMessage, { style: toastStyle, duration: 8000 })
     } finally {
       setIsSubmitting(false)
     }

--- a/ui/pages/overview-vote.tsx
+++ b/ui/pages/overview-vote.tsx
@@ -10,7 +10,7 @@ import {
 } from 'const/config'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
 import { getAccessToken } from '@privy-io/react-auth'
 import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
@@ -78,6 +78,42 @@ export default function OverviewDelegate({
     setDisplayLeaderboard(leaderboard)
   }, [leaderboard])
 
+  // Overlay the connected user's *live* $OVERVIEW balance onto the leaderboard
+  // entry of the citizen they've delegated to. Without this, when the
+  // server-side balance fetch in `fetchOverviewLeaderboard` either fails or
+  // is served from a stale `getStaticProps` cache (revalidate: 60), we fall
+  // back to the originally-stored delegation amount — which is whatever the
+  // user had when they first backed someone. Users who have since earned
+  // more $OVERVIEW therefore see their delegated total stuck at the old
+  // value until they successfully re-submit.
+  const visibleLeaderboard = useMemo(() => {
+    if (
+      !userAddress ||
+      !previousDelegation ||
+      userBalance == null ||
+      !Number.isFinite(userBalance) ||
+      userBalance <= 0
+    ) {
+      return displayLeaderboard
+    }
+    const targetAddr = previousDelegation.delegatee.toLowerCase()
+    const liveAmount = Math.floor(userBalance)
+    const storedAmount = previousDelegation.amount
+    const delta = liveAmount - storedAmount
+    if (delta === 0) return displayLeaderboard
+    let touched = false
+    const overlaid = displayLeaderboard.map((entry) => {
+      if (entry.delegateeAddress.toLowerCase() !== targetAddr) return entry
+      touched = true
+      return {
+        ...entry,
+        totalDelegated: Math.max(0, entry.totalDelegated + delta),
+      }
+    })
+    if (!touched) return displayLeaderboard
+    return [...overlaid].sort((a, b) => b.totalDelegated - a.totalDelegated)
+  }, [displayLeaderboard, previousDelegation, userBalance, userAddress])
+
   const votesContract = useContract({
     address: VOTES_TABLE_ADDRESSES[overviewChainSlug],
     chain: overviewChain,
@@ -91,8 +127,14 @@ export default function OverviewDelegate({
     const checkExisting = async () => {
       try {
         const stmt = `SELECT * FROM ${votesTableName} WHERE voteId = ${OVERVIEW_DELEGATION_VOTE_ID} AND address = '${userAddress.toLowerCase()}'`
+        // Use the env-aware Tableland endpoint (testnets vs mainnet). The
+        // hardcoded `tableland.network` URL silently 404s the row on testnet,
+        // which falsely sets `hasExistingDelegation = false` and routes the
+        // submit to `insertIntoTable` — that then reverts due to the
+        // `unique(address, voteId)` constraint and the user gets the generic
+        // "Failed to submit delegation" toast on every re-back.
         const res = await fetch(
-          `https://tableland.network/api/v1/query?statement=${encodeURIComponent(stmt)}`
+          `${TABLELAND_ENDPOINT}?statement=${encodeURIComponent(stmt)}`
         )
         if (res.ok) {
           const data = await res.json()
@@ -258,7 +300,31 @@ export default function OverviewDelegate({
     const vote = JSON.stringify({ [selectedCitizen.owner]: delegateAmount })
 
     try {
-      const method = hasExistingDelegation ? 'updateTableCol' : 'insertIntoTable'
+      // Re-check existence right before submitting. The initial check from
+      // mount can be stale (race after a previous vote landed, or the user
+      // hopped wallets). Picking the wrong method causes the Tableland mutate
+      // to fail server-side: insertIntoTable on an existing (address,voteId)
+      // pair violates the unique constraint, and updateTableCol when no row
+      // exists silently no-ops. Either way the user sees the generic
+      // "Failed to submit delegation" error.
+      let existsNow = hasExistingDelegation
+      try {
+        const stmt = `SELECT id FROM ${votesTableName} WHERE voteId = ${OVERVIEW_DELEGATION_VOTE_ID} AND address = '${userAddress!.toLowerCase()}'`
+        const res = await fetch(
+          `${TABLELAND_ENDPOINT}?statement=${encodeURIComponent(stmt)}`
+        )
+        if (res.ok) {
+          const data = await res.json()
+          existsNow = Array.isArray(data) && data.length > 0
+        }
+      } catch (lookupErr) {
+        console.warn(
+          '[overview-vote] pre-submit existence check failed; falling back to cached value',
+          lookupErr
+        )
+      }
+
+      const method = existsNow ? 'updateTableCol' : 'insertIntoTable'
       const tx = prepareContractCall({
         contract: votesContract,
         method: method as string,
@@ -646,13 +712,13 @@ export default function OverviewDelegate({
                 The 25 citizens with the most $OVERVIEW support advance to Round 2.
               </p>
 
-              {displayLeaderboard.length === 0 ? (
+              {visibleLeaderboard.length === 0 ? (
                 <p className="text-gray-400 text-center py-6 sm:py-8 text-sm">
                   No delegations yet. Be the first to back a candidate!
                 </p>
               ) : (
                 <div className="space-y-2 sm:space-y-3">
-                  {displayLeaderboard.map((entry, index) => {
+                  {visibleLeaderboard.map((entry, index) => {
                     const citizenLink = entry.citizenName
                       ? `/citizen/${generatePrettyLinkWithId(entry.citizenName, entry.citizenId)}`
                       : `/citizen/${entry.citizenId}`

--- a/ui/pages/overview-vote.tsx
+++ b/ui/pages/overview-vote.tsx
@@ -12,10 +12,10 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
-import { getAccessToken } from '@privy-io/react-auth'
 import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import { sendOnchainNotification } from '@/lib/notifications/sendOnchainNotification'
 import { fetchOverviewLeaderboard } from '@/lib/overview-delegate/fetchLeaderboard'
 import { applyOptimisticUpdate } from '@/lib/overview-delegate/leaderboard'
 import type { LeaderboardEntry } from '@/lib/overview-delegate/leaderboard'
@@ -347,70 +347,18 @@ export default function OverviewDelegate({
       const receipt: any = await sendAndConfirmTransaction({ transaction: tx, account })
       setHasExistingDelegation(true)
 
-      // Send Discord notification (fire-and-forget). The notification API is
-      // wrapped in `authMiddleware`, which requires either a valid NextAuth
-      // session cookie OR an `Authorization: Bearer <privy-token>` header. We
-      // can't rely solely on the NextAuth cookie because it isn't always
-      // present for Privy-authenticated users (race after sign-in, expired
-      // session, blocked third-party cookies, etc.) — so we always send the
-      // Bearer token explicitly. Without this the middleware silently 401s
-      // and the Discord message never gets posted.
-      ;(async () => {
-        try {
-          const accessToken = await getAccessToken()
-          const txHash = receipt?.transactionHash
-          if (!accessToken || !txHash) {
-            console.warn(
-              '[leaderboard-notification] skipped: missing',
-              !accessToken ? 'accessToken' : 'txHash'
-            )
-            return
-          }
-
-          // Tiny retry loop for transient network / 5xx failures so a single
-          // blip doesn't drop the notification entirely.
-          const maxAttempts = 3
-          for (let attempt = 0; attempt < maxAttempts; attempt++) {
-            try {
-              const resp = await fetch(
-                '/api/overview/leaderboard-notification',
-                {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${accessToken}`,
-                  },
-                  body: JSON.stringify({
-                    txHash,
-                    accessToken,
-                    delegateeAddress: selectedCitizen.owner,
-                  }),
-                }
-              )
-              if (resp.ok) return
-              // 4xx responses (other than 408/429) indicate a problem that
-              // retrying won't fix — log and stop.
-              if (
-                resp.status >= 400 &&
-                resp.status < 500 &&
-                resp.status !== 408 &&
-                resp.status !== 429
-              ) {
-                const body = await resp.text().catch(() => '')
-                console.warn(
-                  `[leaderboard-notification] failed (${resp.status}): ${body}`
-                )
-                return
-              }
-            } catch (fetchErr) {
-              if (attempt === maxAttempts - 1) throw fetchErr
-            }
-            await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)))
-          }
-        } catch (err) {
-          console.warn('[leaderboard-notification] error:', err)
-        }
-      })()
+      // Fire-and-forget Discord notification via the shared helper, which
+      // handles the Privy Bearer header (the notification API's
+      // `authMiddleware` 401s without it for Privy-only sessions) and the
+      // bounded retry loop for transient network / 5xx blips.
+      void sendOnchainNotification(
+        '/api/overview/leaderboard-notification',
+        {
+          txHash: receipt?.transactionHash,
+          delegateeAddress: selectedCitizen.owner,
+        },
+        { label: 'leaderboard-notification' }
+      )
 
       confetti({
         particleCount: 150,

--- a/ui/pages/overview-vote.tsx
+++ b/ui/pages/overview-vote.tsx
@@ -267,18 +267,70 @@ export default function OverviewDelegate({
       const receipt: any = await sendAndConfirmTransaction({ transaction: tx, account })
       setHasExistingDelegation(true)
 
-      // Send Discord notification (fire-and-forget)
-      getAccessToken().then((accessToken) => {
-        fetch('/api/overview/leaderboard-notification', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            txHash: receipt.transactionHash,
-            accessToken,
-            delegateeAddress: selectedCitizen.owner,
-          }),
-        }).catch(() => {})
-      }).catch(() => {})
+      // Send Discord notification (fire-and-forget). The notification API is
+      // wrapped in `authMiddleware`, which requires either a valid NextAuth
+      // session cookie OR an `Authorization: Bearer <privy-token>` header. We
+      // can't rely solely on the NextAuth cookie because it isn't always
+      // present for Privy-authenticated users (race after sign-in, expired
+      // session, blocked third-party cookies, etc.) — so we always send the
+      // Bearer token explicitly. Without this the middleware silently 401s
+      // and the Discord message never gets posted.
+      ;(async () => {
+        try {
+          const accessToken = await getAccessToken()
+          const txHash = receipt?.transactionHash
+          if (!accessToken || !txHash) {
+            console.warn(
+              '[leaderboard-notification] skipped: missing',
+              !accessToken ? 'accessToken' : 'txHash'
+            )
+            return
+          }
+
+          // Tiny retry loop for transient network / 5xx failures so a single
+          // blip doesn't drop the notification entirely.
+          const maxAttempts = 3
+          for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+              const resp = await fetch(
+                '/api/overview/leaderboard-notification',
+                {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${accessToken}`,
+                  },
+                  body: JSON.stringify({
+                    txHash,
+                    accessToken,
+                    delegateeAddress: selectedCitizen.owner,
+                  }),
+                }
+              )
+              if (resp.ok) return
+              // 4xx responses (other than 408/429) indicate a problem that
+              // retrying won't fix — log and stop.
+              if (
+                resp.status >= 400 &&
+                resp.status < 500 &&
+                resp.status !== 408 &&
+                resp.status !== 429
+              ) {
+                const body = await resp.text().catch(() => '')
+                console.warn(
+                  `[leaderboard-notification] failed (${resp.status}): ${body}`
+                )
+                return
+              }
+            } catch (fetchErr) {
+              if (attempt === maxAttempts - 1) throw fetchErr
+            }
+            await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)))
+          }
+        } catch (err) {
+          console.warn('[leaderboard-notification] error:', err)
+        }
+      })()
 
       confetti({
         particleCount: 150,

--- a/ui/pages/overview-vote.tsx
+++ b/ui/pages/overview-vote.tsx
@@ -2,10 +2,8 @@ import confetti from 'canvas-confetti'
 import VotesTableABI from 'const/abis/Votes.json'
 import {
   CITIZEN_TABLE_NAMES,
-  OVERVIEW_BLOCKED_CITIZEN_IDS,
   OVERVIEW_DELEGATION_VOTE_ID,
   OVERVIEW_TOKEN_ADDRESS,
-  OVERVIEW_TOKEN_DECIMALS,
   TABLELAND_ENDPOINT,
   VOTES_TABLE_ADDRESSES,
   VOTES_TABLE_NAMES,
@@ -18,36 +16,19 @@ import { getAccessToken } from '@privy-io/react-auth'
 import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
-import {
-  applyOptimisticUpdate,
-  isValidEthAddress,
-  parseDelegations,
-  aggregateDelegations,
-  buildLeaderboard,
-} from '@/lib/overview-delegate/leaderboard'
+import { fetchOverviewLeaderboard } from '@/lib/overview-delegate/fetchLeaderboard'
+import { applyOptimisticUpdate } from '@/lib/overview-delegate/leaderboard'
 import type { LeaderboardEntry } from '@/lib/overview-delegate/leaderboard'
 import { arbitrum } from '@/lib/rpc/chains'
 import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
-import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
-import { engineBatchRead } from '@/lib/thirdweb/engine'
 import useWatchTokenBalance from '@/lib/tokens/hooks/useWatchTokenBalance'
 import Container from '@/components/layout/Container'
 import Head from '@/components/layout/Head'
 import IPFSRenderer from '@/components/layout/IPFSRenderer'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
-
-const ERC20_BALANCE_OF_ABI = [
-  {
-    inputs: [{ name: 'account', type: 'address' }],
-    name: 'balanceOf',
-    outputs: [{ name: '', type: 'uint256' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-]
 
 type Citizen = {
   id: string
@@ -754,122 +735,9 @@ export default function OverviewDelegate({
 }
 
 export async function getStaticProps() {
-  try {
-    const chain = arbitrum
-    const chainSlug = getChainSlug(chain)
-    const tokenAddress = OVERVIEW_TOKEN_ADDRESS
-
-    // 1. Query delegations from Tableland
-    const votesTableName = VOTES_TABLE_NAMES[chainSlug]
-    if (!votesTableName) {
-      return {
-        props: { leaderboard: [], tokenAddress },
-        revalidate: 60,
-      }
-    }
-
-    const statement = `SELECT * FROM ${votesTableName} WHERE voteId = ${OVERVIEW_DELEGATION_VOTE_ID}`
-    const rows = await queryTable(chain, statement)
-
-    if (!rows || rows.length === 0) {
-      return {
-        props: { leaderboard: [], tokenAddress },
-        revalidate: 60,
-      }
-    }
-
-    const delegations = parseDelegations(rows)
-
-    if (delegations.length === 0) {
-      return {
-        props: { leaderboard: [], tokenAddress },
-        revalidate: 60,
-      }
-    }
-
-    // 2. Batch-fetch current balances (anti-gaming)
-    const uniqueDelegators = [...new Set(delegations.map((d) => d.delegatorAddress))]
-
-    let balanceMap: Record<string, number> = {}
-    try {
-      const balances = await engineBatchRead<string>(
-        tokenAddress,
-        'balanceOf',
-        uniqueDelegators.map((addr) => [addr]),
-        ERC20_BALANCE_OF_ABI,
-        chain.id
-      )
-      const divisor = 10n ** BigInt(OVERVIEW_TOKEN_DECIMALS)
-      for (let i = 0; i < uniqueDelegators.length; i++) {
-        const raw = balances[i]
-        const wei = BigInt(raw || '0')
-        const whole = wei / divisor
-        const remainder = wei % divisor
-        const normalized = Number(whole) + Number(remainder) / Number(divisor)
-        balanceMap[uniqueDelegators[i].toLowerCase()] = normalized
-      }
-    } catch (error) {
-      console.error('Error fetching balances, using stored amounts:', error)
-      for (const addr of uniqueDelegators) {
-        balanceMap[addr.toLowerCase()] = Infinity
-      }
-    }
-
-    const aggregated = aggregateDelegations(delegations, balanceMap)
-
-    if (aggregated.length === 0) {
-      return {
-        props: { leaderboard: [], tokenAddress },
-        revalidate: 60,
-      }
-    }
-
-    const safeAddresses = aggregated
-      .map((e) => e.delegateeAddress)
-      .filter(isValidEthAddress)
-
-    let citizenMap: Record<
-      string,
-      { id: number | string; name: string; image?: string }
-    > = {}
-
-    if (safeAddresses.length > 0) {
-      try {
-        const citizenTableName = CITIZEN_TABLE_NAMES[chainSlug]
-        if (citizenTableName) {
-          const inClause = safeAddresses
-            .map((a) => `'${a}'`)
-            .join(',')
-          const citizenStatement = `SELECT id, name, owner, image FROM ${citizenTableName} WHERE LOWER(owner) IN (${inClause})`
-          const citizenRows = await queryTable(chain, citizenStatement)
-
-          if (citizenRows) {
-            for (const c of citizenRows) {
-              if (OVERVIEW_BLOCKED_CITIZEN_IDS.includes(c.id)) continue
-              citizenMap[c.owner.toLowerCase()] = {
-                id: c.id,
-                name: c.name,
-                image: c.image,
-              }
-            }
-          }
-        }
-      } catch (error) {
-        console.error('Error fetching citizen data:', error)
-      }
-    }
-
-    const leaderboardResult = buildLeaderboard(aggregated, citizenMap)
-
-    return {
-      props: { leaderboard: leaderboardResult, tokenAddress },
-      revalidate: 60,
-    }
-  } catch (error) {
-    console.error('Error in getStaticProps:', error)
-    return {
-      props: { leaderboard: [], tokenAddress: OVERVIEW_TOKEN_ADDRESS },
-      revalidate: 60,
-    }
+  const leaderboard = await fetchOverviewLeaderboard()
+  return {
+    props: { leaderboard, tokenAddress: OVERVIEW_TOKEN_ADDRESS },
+    revalidate: 60,
   }
 }


### PR DESCRIPTION
## Summary
24 commits on top of `main`; broadly three themes:

### Contribution flow (mission page + Contribute modal)
- Make the USD input the primary, focus-first contribution control: bigger / clickable input area, USD estimate, $10 / $100 / $1k / $10k presets, clearer "Sign In · Fund · Contribute" caption and a more prominent Contribute CTA.
- Better validation + error handling on the input (decimal-safe formatting, max-length, Max button against live native balance).
- Nudge users with low ETH toward debit-card on-ramp via `AcceptedPaymentMethods` / `CBOnramp`.
- Fix cross-chain gas estimate getting stuck on a stale LayerZero quote when the estimate fails (now resets so `PaymentBreakdown` can render a "—" placeholder instead of spinning forever).
- Make the "You receive … $TOKEN" quote resilient to a flaky ETH/USD price source:
  - `/api/etherscan/eth-price` now races Etherscan + CoinGecko in parallel and falls back to CryptoCompare; only 502s if all three fail.
  - `useETHPrice` retries on error, keeps the last good price across renders, and persists it to `localStorage` (24h) so a transient hiccup no longer drops `ethUsdPrice` to 0 mid-typing.
  - When the price/ruleset isn't ready yet, "You receive" renders a loading spinner instead of "0", so users can tell the calc is loading vs. genuinely zero.

### Overview vote / leaderboard ($OVERVIEW)
- New leaderboard tab on the fundraising page + leaderboard preview on the mission page.
- Fix delegation submit failures: pre-submit existence check picks the right `insertIntoTable` vs `updateTableCol` even after wallet-switch / race conditions, and the existence query now uses the env-aware `TABLELAND_ENDPOINT` instead of a hardcoded mainnet URL.
- Fix stale leaderboard balances: overlay the connected user's live $OVERVIEW balance onto their leaderboard entry so an older delegated amount no longer shows when the server-side fetch falls back to stored amounts.
- Surface the real submit error in the toast (user-rejected, insufficient ETH for gas, wrong network, etc.) instead of a generic retry message.
- Vote notifications: new `/api/proposals/vote-notification` and improvements to `/api/overview/leaderboard-notification` + `sendOnchainNotification`.

### Header / navigation polish
- Iterative header tweaks (4 parts) + navigation improvements (`useNavigation`).
- Network selector tooltip + tooltip component fixes.
- Featured mission section & MissionProfileHeader copy/layout pass.

## Test plan
- [ ] Type a USD amount on a mission page (mission 4) — "You receive $OVERVIEW" updates as you type and shows a spinner (not "0") if the ETH/USD price is briefly unavailable.
- [ ] Force the Etherscan endpoint to fail (e.g., empty `NEXT_PUBLIC_ETHERSCAN_API_KEY`) and confirm CoinGecko / CryptoCompare fallback keeps the quote live.
- [ ] Open the Contribute modal on Arbitrum and on a cross-chain source (Ethereum / Base): gas estimate + LayerZero quote populate; if the estimate fails the breakdown shows "—" instead of an infinite spinner.
- [ ] On `/overview-vote` with an existing delegation, increase your $OVERVIEW balance and re-back the same citizen — submit succeeds (no "Failed to submit delegation"), leaderboard reflects your live balance.
- [ ] On the same page with no prior delegation, back a citizen — succeeds, leaderboard updates.
- [ ] Trigger common wallet errors (cancel in wallet, wrong network, insufficient ETH for gas) and confirm the toast names the actual reason.
- [ ] Mission page leaderboard preview + fundraising-page leaderboard tab render and link to `/overview-vote`.
- [ ] Header / navigation: open