### PR TITLE
Mission page polish: live deadline countdown, Fly with Frank explainer, and Discord notification reliability

### DIFF
--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -46,6 +46,7 @@ import { calculateTokensFromPayment } from '@/lib/juicebox/tokenCalculations'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import { isValidContributorEmail } from '@/lib/contribution/validateContributorEmail'
 import { formatContributionOutput } from '@/lib/mission'
+import { sendContributionNotification } from '@/lib/mission/sendContributionNotification'
 import { waitForCrossChainPayReceipt } from '@/lib/mission/waitForCrossChainPayReceipt'
 import { fetchNativeBalanceWei } from '@/lib/mission/contributeModalDefaultChain'
 import { computeContributionMaxUsd } from '@/lib/mission/computeContributionMaxUsd'
@@ -1166,42 +1167,12 @@ export default function MissionContributeModal({
         flushSync(() => setContributeButtonPhase('confirm'))
         const originReceipt: any = await waitForReceipt(submittedOrigin)
 
-        // Send notification while the user is still in the modal
-        try {
-          const accessTokenCross = await getAccessToken()
-          const notificationBodyCross = {
-            txHash: originReceipt.transactionHash,
-            accessToken: accessTokenCross,
-            txChainSlug: chainSlug,
-            projectId: mission?.projectId,
-            contributorEmail: emailTrim,
-            newsletterOptIn,
-            isCrossChain: true,
-            memo: message,
-          }
-          const maxAttempts = 5
-          for (let attempt = 0; attempt < maxAttempts; attempt++) {
-            const resp = await fetch('/api/mission/contribution-notification', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(notificationBodyCross),
-            })
-            if (resp.ok) break
-            const body: any = await resp.json().catch(() => ({}))
-            const msg = body?.message || ''
-            const retryable =
-              msg.includes('CrossChainPayInitiated') || msg.includes('Transaction not found')
-            if (retryable && attempt < maxAttempts - 1) {
-              await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)))
-              continue
-            }
-            break
-          }
-        } catch (notifyErr) {
-          console.error('Cross-chain contribution notification error:', notifyErr)
-        }
-
-        // Notification sent -- now show success and allow the user to leave
+        // Show success UI immediately. Previously we awaited the notification
+        // POST (and up to ~20s of retries) before showing confetti/closing the
+        // modal, which on Ethereum could keep the user staring at a spinner
+        // for 30-90s. Many users would close the tab during that window,
+        // which cancelled the notification fetch and meant the Discord ping
+        // was lost forever.
         confetti({
           particleCount: 150,
           spread: 100,
@@ -1233,6 +1204,49 @@ export default function MissionContributeModal({
             { shallow: true }
           )
         }
+
+        // Fire the notification in the background with `keepalive: true` so
+        // the first attempt survives a tab close. Retries (5xx, network
+        // errors, transient RPC races) still happen if the page stays open.
+        void (async () => {
+          try {
+            const accessTokenCross = await getAccessToken()
+            const result = await sendContributionNotification(
+              {
+                txHash: originReceipt.transactionHash,
+                accessToken: accessTokenCross,
+                txChainSlug: chainSlug,
+                projectId: mission?.projectId,
+                contributorEmail: emailTrim,
+                newsletterOptIn,
+                isCrossChain: true,
+                memo: message,
+              },
+              {
+                keepalive: true,
+                onAttemptError: ({ attempt, status, message: m, willRetry }) => {
+                  console.warn(
+                    `Cross-chain contribution notification attempt ${attempt} failed (status ${status}): ${m}${
+                      willRetry ? ' — retrying' : ''
+                    }`
+                  )
+                },
+              }
+            )
+            if (!result.ok) {
+              console.error(
+                'Cross-chain contribution notification failed after retries:',
+                result.status,
+                result.message
+              )
+            }
+          } catch (notifyErr) {
+            console.error(
+              'Cross-chain contribution notification error:',
+              notifyErr
+            )
+          }
+        })()
 
         // Settlement polling continues in the background (notification already sent)
         void (async () => {
@@ -1305,41 +1319,32 @@ export default function MissionContributeModal({
 
       // Same-chain and cross-chain both settle with a Juicebox Pay on `DEFAULT_CHAIN_V5`; we always
       // notify using that destination tx hash and `defaultChainSlug` (not the LayerZero source tx).
-      const notificationBody = {
-        txHash: receipt.transactionHash,
-        accessToken: accessToken,
-        txChainSlug: defaultChainSlug,
-        projectId: mission?.projectId,
-        contributorEmail: emailTrim,
-        newsletterOptIn,
-      }
-
-      let contributionNotificationData: { message?: string; success?: boolean } = {}
-      const maxNotificationAttempts = 5
-      for (let attempt = 0; attempt < maxNotificationAttempts; attempt++) {
-        const contributionNotification = await fetch('/api/mission/contribution-notification', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(notificationBody),
-        })
-        contributionNotificationData = await contributionNotification.json()
-
-        if (contributionNotification.ok) {
-          break
+      const notificationResult = await sendContributionNotification(
+        {
+          txHash: receipt.transactionHash,
+          accessToken,
+          txChainSlug: defaultChainSlug,
+          projectId: mission?.projectId,
+          contributorEmail: emailTrim,
+          newsletterOptIn,
+        },
+        {
+          onAttemptError: ({ attempt, status, message: m, willRetry }) => {
+            console.warn(
+              `Contribution notification attempt ${attempt} failed (status ${status}): ${m}${
+                willRetry ? ' — retrying' : ''
+              }`
+            )
+          },
         }
+      )
 
-        const msg = contributionNotificationData?.message || ''
-        const retryable =
-          msg.includes('No Pay event found') || msg.includes('Transaction not found')
-        if (retryable && attempt < maxNotificationAttempts - 1) {
-          await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)))
-          continue
-        }
-        break
-      }
-
-      if (!contributionNotificationData?.success && contributionNotificationData?.message) {
-        console.warn('Contribution notification:', contributionNotificationData.message)
+      if (!notificationResult.ok && notificationResult.message) {
+        console.warn(
+          'Contribution notification:',
+          notificationResult.status,
+          notificationResult.message
+        )
       }
 
       setInput('0')

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1315,38 +1315,12 @@ export default function MissionContributeModal({
         receipt = await waitForReceipt(submittedPay)
       }
 
-      const accessToken = await getAccessToken()
-
-      // Same-chain and cross-chain both settle with a Juicebox Pay on `DEFAULT_CHAIN_V5`; we always
-      // notify using that destination tx hash and `defaultChainSlug` (not the LayerZero source tx).
-      const notificationResult = await sendContributionNotification(
-        {
-          txHash: receipt.transactionHash,
-          accessToken,
-          txChainSlug: defaultChainSlug,
-          projectId: mission?.projectId,
-          contributorEmail: emailTrim,
-          newsletterOptIn,
-        },
-        {
-          onAttemptError: ({ attempt, status, message: m, willRetry }) => {
-            console.warn(
-              `Contribution notification attempt ${attempt} failed (status ${status}): ${m}${
-                willRetry ? ' — retrying' : ''
-              }`
-            )
-          },
-        }
-      )
-
-      if (!notificationResult.ok && notificationResult.message) {
-        console.warn(
-          'Contribution notification:',
-          notificationResult.status,
-          notificationResult.message
-        )
-      }
-
+      // Show success UI immediately on tx confirmation. Same-chain and
+      // cross-chain both settle with a Juicebox Pay on `DEFAULT_CHAIN_V5`,
+      // so the notification fetch is fired into the background (with
+      // `keepalive: true`) using the destination tx hash + `defaultChainSlug`
+      // — never blocking the modal close, confetti, or free-mint flow on
+      // the notification API's retry window.
       setInput('0')
       setUsdInput('0')
 
@@ -1377,6 +1351,47 @@ export default function MissionContributeModal({
         shapes: ['circle', 'star'],
         colors: ['#ffffff', '#FFD700', '#00FFFF', '#ff69b4', '#8A2BE2'],
       })
+
+      // Fire the Discord/newsletter notification in the background. Mirrors
+      // the cross-chain branch's pattern: `keepalive: true` lets the first
+      // attempt survive the user closing the tab, and any retries happen
+      // out-of-band so the success UI is never gated on them.
+      const sameChainTxHash = receipt.transactionHash
+      const sameChainProjectId = mission?.projectId
+      void (async () => {
+        try {
+          const accessToken = await getAccessToken()
+          const result = await sendContributionNotification(
+            {
+              txHash: sameChainTxHash,
+              accessToken,
+              txChainSlug: defaultChainSlug,
+              projectId: sameChainProjectId,
+              contributorEmail: emailTrim,
+              newsletterOptIn,
+            },
+            {
+              keepalive: true,
+              onAttemptError: ({ attempt, status, message: m, willRetry }) => {
+                console.warn(
+                  `Contribution notification attempt ${attempt} failed (status ${status}): ${m}${
+                    willRetry ? ' — retrying' : ''
+                  }`
+                )
+              },
+            }
+          )
+          if (!result.ok) {
+            console.error(
+              'Contribution notification failed after retries:',
+              result.status,
+              result.message
+            )
+          }
+        } catch (notifyErr) {
+          console.error('Contribution notification error:', notifyErr)
+        }
+      })()
 
       if (!isCitizen) {
         // Check free mint eligibility via the API (uses Bendystraw participants data)

--- a/ui/components/mission/MissionDeadlineCountdown.tsx
+++ b/ui/components/mission/MissionDeadlineCountdown.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Live countdown to a mission deadline, with millisecond precision.
+ *
+ * Render goal: drop into the existing "Deadline" stat card in
+ * `MissionProfileHeader` in place of the static `duration` string and look
+ * native to the surrounding GoodTimes typography. The unit letters (`d` /
+ * `h` / `m` / `s`) are rendered in a muted gray so the digits read first;
+ * `tabular-nums` keeps the digits from jittering as they tick.
+ *
+ * Layout stability: the previous implementation used `flex-wrap`, which
+ * meant that at borderline card widths the seconds chunk would oscillate
+ * between fitting on the same line and wrapping to a new one as digits
+ * ticked, causing the card to grow and shrink vertically. We now lock the
+ * layout instead — `flex-col` on small screens (always two fixed rows) and
+ * `flex-row` with `whitespace-nowrap` on `sm:` and up (always one fixed
+ * row). The breakpoint matches the rest of the deadline card, which already
+ * scales typography at `sm:`.
+ */
+interface MissionDeadlineCountdownProps {
+  deadline: number
+  className?: string
+}
+
+function pad(value: number, length = 2) {
+  return value.toString().padStart(length, '0')
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const HOUR_MS = 60 * 60 * 1000
+const MINUTE_MS = 60 * 1000
+const SECOND_MS = 1000
+
+export default function MissionDeadlineCountdown({
+  deadline,
+  className = '',
+}: MissionDeadlineCountdownProps) {
+  const [now, setNow] = useState(() => Date.now())
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const tick = () => {
+      if (cancelled) return
+      setNow(Date.now())
+      rafRef.current =
+        typeof window !== 'undefined' && window.requestAnimationFrame
+          ? window.requestAnimationFrame(tick)
+          : (setTimeout(tick, 50) as unknown as number)
+    }
+
+    tick()
+
+    return () => {
+      cancelled = true
+      if (rafRef.current != null) {
+        if (typeof window !== 'undefined' && window.cancelAnimationFrame) {
+          window.cancelAnimationFrame(rafRef.current)
+        } else {
+          clearTimeout(rafRef.current as unknown as ReturnType<typeof setTimeout>)
+        }
+      }
+    }
+  }, [])
+
+  const remaining = Math.max(0, deadline - now)
+  const days = Math.floor(remaining / DAY_MS)
+  const hours = Math.floor((remaining % DAY_MS) / HOUR_MS)
+  const minutes = Math.floor((remaining % HOUR_MS) / MINUTE_MS)
+  const seconds = Math.floor((remaining % MINUTE_MS) / SECOND_MS)
+  const millis = Math.floor(remaining % SECOND_MS)
+
+  return (
+    <div
+      className={`text-white font-GoodTimes leading-tight tabular-nums text-[10px] sm:text-sm flex flex-col sm:flex-row sm:items-baseline sm:flex-nowrap sm:gap-1 ${className}`}
+      role="timer"
+      aria-label={`Time remaining: ${days} days, ${hours} hours, ${minutes} minutes, ${seconds}.${pad(
+        millis,
+        3
+      )} seconds`}
+    >
+      <span className="whitespace-nowrap">
+        {days > 0 ? (
+          <>
+            {pad(days)}
+            <span className="text-gray-400">d</span>{' '}
+          </>
+        ) : null}
+        {pad(hours)}
+        <span className="text-gray-400">h</span>{' '}
+        {pad(minutes)}
+        <span className="text-gray-400">m</span>
+      </span>
+      <span className="whitespace-nowrap">
+        {pad(seconds)}
+        <span className="text-white/70">.{pad(millis, 3)}</span>
+        <span className="text-gray-400">s</span>
+      </span>
+    </div>
+  )
+}

--- a/ui/components/mission/MissionFlyWithFrankExplainer.tsx
+++ b/ui/components/mission/MissionFlyWithFrankExplainer.tsx
@@ -1,0 +1,185 @@
+import Link from 'next/link'
+
+type MissionFlyWithFrankExplainerProps = {
+  /** Total $OVERVIEW backing the candidate currently sitting in 25th place
+   *  on the leaderboard. `null` (or `<= 0`) means there are fewer than 25
+   *  ranked candidates yet, so any positive backing qualifies. */
+  top25Threshold: number | null
+  /** Total citizens currently on the leaderboard. Drives accurate empty-
+   *  state copy when the top 25 isn't filled yet — without it we can't
+   *  distinguish "genuinely <25 ranked" from "fetch came back partial",
+   *  so we'd risk falsely claiming "fewer than 25 citizens are ranked". */
+  rankedCount?: number
+  /** Mission ID used to thread "from" context into the leaderboard CTA so
+   *  the destination page can render its "back to mission" affordance. */
+  missionId?: string | number
+}
+
+const STEPS: {
+  title: string
+  description: string
+  href?: string
+  cta?: string
+}[] = [
+  {
+    title: 'Contribute to the campaign',
+    description:
+      'Every contribution earns $OVERVIEW — your voting power for who flies with Frank.',
+  },
+  {
+    title: 'Become a citizen',
+    description:
+      'Mint your Citizen NFT to be eligible to fly. Without it, you can\u2019t be backed.',
+    href: '/join',
+    cta: 'Become a citizen \u2192',
+  },
+  {
+    title: 'Back a citizen\u2019s candidacy',
+    description:
+      'Pledge your $OVERVIEW to the citizen you want to send to space.',
+  },
+]
+
+function formatThreshold(amount: number): string {
+  return amount.toLocaleString('en-US', { maximumFractionDigits: 0 })
+}
+
+/**
+ * Compact 3-step explainer surfaced on the Overview Mission page directly
+ * under the support tiers. Walks contributors through what it takes to put
+ * a citizen on the "Fly with Frank" leaderboard, and shows the live
+ * minimum $OVERVIEW backing required to crack the top 25.
+ */
+export default function MissionFlyWithFrankExplainer({
+  top25Threshold,
+  rankedCount,
+  missionId,
+}: MissionFlyWithFrankExplainerProps) {
+  const leaderboardHref = `/overview-vote${
+    missionId != null ? `?from=mission&missionId=${missionId}` : ''
+  }`
+
+  const hasThreshold =
+    top25Threshold != null && Number.isFinite(top25Threshold) && top25Threshold > 0
+  // Three "no threshold" cases we need to distinguish so we never lie:
+  //   1. Genuinely <25 ranked AND we know it (rankedCount provided & <25)
+  //   2. Fetch returned 0/undefined entries (we can't claim anything)
+  //   3. Top 25 IS filled but threshold is 0 (effectively the same as #1
+  //      from the contributor's POV: any backing qualifies)
+  // A `rankedCount` of 0 almost always means the leaderboard fetch failed
+  // for the Overview Mission (it has had real backers from launch), so we
+  // don't trust it as a "genuinely empty leaderboard" signal — fall through
+  // to the neutral "Live" copy in that case.
+  const knowsCount = typeof rankedCount === 'number' && rankedCount > 0
+  const top25Full = knowsCount && (rankedCount as number) >= 25
+
+  // Step 3 routes to the leaderboard so users can pledge immediately. We
+  // can't bake this into the static STEPS array because it depends on the
+  // mission ID prop.
+  const steps = STEPS.map((step, index) =>
+    index === 2
+      ? { ...step, href: leaderboardHref, cta: 'Back a candidate \u2192' }
+      : step
+  )
+
+  return (
+    <section
+      data-testid="mission-fly-with-frank-explainer"
+      className="mt-4 pt-4 border-t border-white/[0.08] space-y-4"
+      aria-label="How to fly with Frank"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-gray-400 font-medium text-xs uppercase tracking-wider">
+          How to fly with Frank
+        </h3>
+        <span className="text-[10px] uppercase tracking-wider text-indigo-300/80">
+          3 steps
+        </span>
+      </div>
+
+      <ol className="flex flex-col gap-2.5 list-none m-0 p-0">
+        {steps.map((step, index) => (
+          <li
+            key={step.title}
+            className="relative w-full rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-2.5 flex items-start gap-3"
+          >
+            <div className="flex-shrink-0 w-6 h-6 rounded-full bg-gradient-to-br from-indigo-500/30 to-purple-500/30 ring-1 ring-indigo-300/30 flex items-center justify-center text-indigo-100 text-[11px] font-bold leading-none">
+              {index + 1}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-white font-medium text-xs sm:text-sm leading-snug">
+                {step.title}
+              </p>
+              <p className="text-gray-500 text-[11px] sm:text-xs leading-relaxed mt-0.5">
+                {step.description}
+              </p>
+              {step.href && step.cta ? (
+                <Link
+                  href={step.href}
+                  className="inline-block mt-1.5 text-[11px] sm:text-xs font-semibold text-indigo-300 hover:text-indigo-200 transition-colors"
+                >
+                  {step.cta}
+                </Link>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <div className="rounded-lg border border-indigo-400/20 bg-gradient-to-br from-indigo-500/10 via-purple-500/5 to-transparent px-3 py-2.5">
+        <p className="text-[10px] uppercase tracking-wider text-indigo-200/80 font-semibold">
+          Top 25 threshold
+        </p>
+        {hasThreshold ? (
+          <>
+            <p className="mt-1 text-white font-GoodTimes text-base sm:text-lg tabular-nums leading-tight">
+              {formatThreshold(top25Threshold as number)}
+              <span className="ml-1.5 text-[11px] sm:text-xs uppercase tracking-wide text-indigo-200/80">
+                $OVERVIEW
+              </span>
+            </p>
+            <p className="text-gray-500 text-[11px] sm:text-xs leading-relaxed mt-1">
+              {knowsCount
+                ? `${rankedCount} citizens ranked. Your candidate needs more than this to crack the top 25 and advance to Round 2.`
+                : 'Your candidate needs more than this to crack the top 25 and advance to Round 2.'}
+            </p>
+          </>
+        ) : top25Full ? (
+          // We know the top 25 is filled but couldn't compute a numeric
+          // threshold (e.g. RPC hiccup). Be neutral instead of claiming
+          // "Open" which would be misleading.
+          <>
+            <p className="mt-1 text-white font-GoodTimes text-base sm:text-lg leading-tight">
+              {rankedCount} ranked
+            </p>
+            <p className="text-gray-500 text-[11px] sm:text-xs leading-relaxed mt-1">
+              Top 25 is contested. Check the leaderboard for the live minimum
+              backing required to crack it.
+            </p>
+          </>
+        ) : knowsCount ? (
+          // Genuinely fewer than 25 ranked candidates.
+          <>
+            <p className="mt-1 text-white font-GoodTimes text-base sm:text-lg leading-tight">
+              Open
+            </p>
+            <p className="text-gray-500 text-[11px] sm:text-xs leading-relaxed mt-1">
+              {`${rankedCount} of 25 slots filled — any $OVERVIEW backing currently puts your candidate in the top 25.`}
+            </p>
+          </>
+        ) : (
+          // We don't know the count at all. Stay neutral.
+          <>
+            <p className="mt-1 text-white font-GoodTimes text-base sm:text-lg leading-tight">
+              Live
+            </p>
+            <p className="text-gray-500 text-[11px] sm:text-xs leading-relaxed mt-1">
+              Check the leaderboard for the current top 25 and the minimum
+              backing required to break in.
+            </p>
+          </>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/ui/components/mission/MissionInfo.tsx
+++ b/ui/components/mission/MissionInfo.tsx
@@ -94,6 +94,14 @@ export default function MissionInfo({
    *  When provided we surface a dedicated Leaderboard tab; for every other
    *  mission this is `undefined` and the tab is hidden. */
   _overviewLeaderboard,
+  /** Live "minimum $OVERVIEW to enter the top 25" value for the Overview
+   *  Mission. Forwarded to MissionPayRedeem so the explainer card under the
+   *  support tiers can render the threshold callout. */
+  _overviewTop25Threshold,
+  /** Total ranked candidates on the leaderboard. Forwarded to the explainer
+   *  card so the empty-state copy can stay accurate when the top 25 isn't
+   *  filled yet. */
+  _overviewRankedCount,
 }: any) {
   const router = useRouter()
   const shallowQueryRoute = useShallowQueryRoute()
@@ -326,6 +334,8 @@ export default function MissionInfo({
             fundingPickReady={fundingPickReady}
             fundingChainBalances={fundingChainBalances}
             recommendedFundingChain={recommendedChain}
+            overviewTop25Threshold={_overviewTop25Threshold}
+            overviewRankedCount={_overviewRankedCount}
           />
         </div>
       </div>

--- a/ui/components/mission/MissionPayRedeem.tsx
+++ b/ui/components/mission/MissionPayRedeem.tsx
@@ -33,6 +33,7 @@ import AcceptedPaymentMethods from '../privy/AcceptedPaymentMethods'
 import { PrivyWeb3Button } from '../privy/PrivyWeb3Button'
 import MissionActivityList from './MissionActivityList'
 import MissionContributorTiersPanel from './MissionContributorTiersPanel'
+import MissionFlyWithFrankExplainer from './MissionFlyWithFrankExplainer'
 import MissionTokenExchangeRates from './MissionTokenExchangeRates'
 
 /**
@@ -112,6 +113,8 @@ function MissionPayRedeemContent({
   contributionBalanceEth,
   contributionBalanceChain,
   isQuoteLoading = false,
+  overviewTop25Threshold,
+  overviewRankedCount,
 }: any) {
   const resolvedSymbol = getMissionTokenSymbol(mission?.id, token?.tokenSymbol)
   const isRefundable = Number(stage) === 3
@@ -377,6 +380,14 @@ function MissionPayRedeemContent({
             </div>
 
             <MissionContributorTiersPanel missionId={mission?.id} />
+            {overviewTop25Threshold !== undefined &&
+              (mission?.id === 4 || String(mission?.id) === '4') && (
+                <MissionFlyWithFrankExplainer
+                  top25Threshold={overviewTop25Threshold}
+                  rankedCount={overviewRankedCount}
+                  missionId={mission?.id}
+                />
+              )}
             {resolvedSymbol && +tokenCredit?.toString() > 0 && (
               <PrivyWeb3Button
                 requiredChain={DEFAULT_CHAIN_V5}
@@ -562,6 +573,16 @@ export type MissionPayRedeemProps = {
   fundingPickReady?: boolean
   fundingChainBalances?: FundingChainBalanceEntry[] | null
   recommendedFundingChain?: Chain | null
+  /** Live minimum $OVERVIEW required to crack the top 25 on the Fly with
+   *  Frank leaderboard. `null` means fewer than 25 ranked candidates exist
+   *  yet; `undefined` means we're not on the Overview Mission and the
+   *  explainer card should not render at all. */
+  overviewTop25Threshold?: number | null
+  /** Total ranked candidates on the $OVERVIEW leaderboard. Lets the
+   *  explainer's empty-state copy reflect reality (e.g. "X of 25 slots
+   *  filled") instead of falsely claiming "fewer than 25" when a fetch
+   *  hiccup truncates results. */
+  overviewRankedCount?: number
 }
 
 function MissionPayRedeemComponent({
@@ -589,6 +610,8 @@ function MissionPayRedeemComponent({
   fundingPickReady = false,
   fundingChainBalances = null,
   recommendedFundingChain = null,
+  overviewTop25Threshold,
+  overviewRankedCount,
 }: MissionPayRedeemProps) {
   const { selectedChain } = useContext(ChainContextV5)
   const defaultChainSlug = getChainSlug(DEFAULT_CHAIN_V5)
@@ -1164,6 +1187,8 @@ function MissionPayRedeemComponent({
                 contributionBalanceEth={contributionBalance.eth}
                 contributionBalanceChain={contributionBalance.chain}
                 isQuoteLoading={isQuoteLoading}
+                overviewTop25Threshold={overviewTop25Threshold}
+                overviewRankedCount={overviewRankedCount}
               />
             </div>
           )}

--- a/ui/components/mission/MissionProfile.tsx
+++ b/ui/components/mission/MissionProfile.tsx
@@ -105,6 +105,15 @@ type MissionProfileProps = {
   /** Pre-fetched top entries of the $OVERVIEW leaderboard. Only provided
    *  for the Overview Flight mission (id 4); undefined for other missions. */
   _overviewLeaderboard?: LeaderboardEntry[]
+  /** $OVERVIEW total backing the candidate currently sitting at rank 25 on
+   *  the leaderboard. `null` when fewer than 25 candidates exist. Only
+   *  provided for the Overview Flight mission. Powers the "minimum to enter
+   *  the top 25" callout in the Fly with Frank explainer card. */
+  _overviewTop25Threshold?: number | null
+  /** Total ranked candidates on the $OVERVIEW leaderboard. Used by the Fly
+   *  with Frank explainer to show honest empty-state copy when the top 25
+   *  isn't filled yet (vs. just claiming "fewer than 25"). */
+  _overviewRankedCount?: number
 }
 
 export default function MissionProfile({
@@ -119,6 +128,8 @@ export default function MissionProfile({
   _fundingGoal,
   _ruleset,
   _overviewLeaderboard,
+  _overviewTop25Threshold,
+  _overviewRankedCount,
 }: MissionProfileProps) {
   const account = useActiveAccount()
   const router = useRouter()
@@ -543,6 +554,16 @@ export default function MissionProfile({
                     fundingPickReady={fundingPickReady}
                     fundingChainBalances={fundingChainBalances}
                     recommendedFundingChain={recommendedChain}
+                    overviewTop25Threshold={
+                      mission?.id === 4 || String(mission?.id) === '4'
+                        ? _overviewTop25Threshold ?? null
+                        : undefined
+                    }
+                    overviewRankedCount={
+                      mission?.id === 4 || String(mission?.id) === '4'
+                        ? _overviewRankedCount
+                        : undefined
+                    }
                     hideRecentContributions
                   />
                 </div>
@@ -589,6 +610,16 @@ export default function MissionProfile({
                   _overviewLeaderboard={
                     mission?.id === 4 || String(mission?.id) === '4'
                       ? _overviewLeaderboard ?? []
+                      : undefined
+                  }
+                  _overviewTop25Threshold={
+                    mission?.id === 4 || String(mission?.id) === '4'
+                      ? _overviewTop25Threshold ?? null
+                      : undefined
+                  }
+                  _overviewRankedCount={
+                    mission?.id === 4 || String(mission?.id) === '4'
+                      ? _overviewRankedCount
                       : undefined
                   }
                 />

--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -22,6 +22,7 @@ import {
   jbSubgraphVolumeToBigIntWei,
   weiBigintToEthNumber,
 } from '@/lib/mission/useMissionRaisedProgress'
+import MissionDeadlineCountdown from './MissionDeadlineCountdown'
 import MissionFundingMilestonesList from './MissionFundingMilestonesList'
 import MissionFundingProgressBar from './MissionFundingProgressBar'
 import MissionSingleLineTitle from './MissionSingleLineTitle'
@@ -531,19 +532,27 @@ const MissionProfileHeader = React.memo(
                         </span>
                       ) : null}
                     </div>
-                    <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
-                      {refundPeriodPassed || deadlinePassed
-                        ? deadlinePassed
+                    {refundPeriodPassed || deadlinePassed ? (
+                      <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
+                        {deadlinePassed
                           ? `${new Date(deadline || 0).toLocaleDateString('en-US', {
                               month: 'short',
                               day: 'numeric',
                               year: 'numeric',
                             })}`
-                          : 'REFUNDED'
-                        : Number(stage) === 3
-                        ? 'REFUND'
-                        : duration}
-                    </p>
+                          : 'REFUNDED'}
+                      </p>
+                    ) : Number(stage) === 3 ? (
+                      <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
+                        REFUND
+                      </p>
+                    ) : deadline != null && deadline > 0 ? (
+                      <MissionDeadlineCountdown deadline={deadline} />
+                    ) : (
+                      <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
+                        {duration}
+                      </p>
+                    )}
                   </div>
 
                   {/* Contributions */}

--- a/ui/lib/mission/sendContributionNotification.ts
+++ b/ui/lib/mission/sendContributionNotification.ts
@@ -1,0 +1,160 @@
+/**
+ * Posts to `/api/mission/contribution-notification` with retry/backoff.
+ *
+ * Why this exists: the same-chain (Arbitrum) and cross-chain (Ethereum) flows
+ * in `MissionContributeModal` previously had near-duplicate retry loops that
+ * each only matched a couple of very specific server-generated 400 messages.
+ * In practice that meant any 5xx, network error, or message we didn't think to
+ * list was a fatal one-and-done — which on Ethereum surfaced as missing
+ * Discord notifications.
+ *
+ * Behavior:
+ * - Retries on network errors and any 5xx response (transient backend or
+ *   platform timeouts).
+ * - Retries on a small allowlist of known-transient 4xx messages (RPC race
+ *   between the wallet's node and the server's node, Etherscan blip, Discord
+ *   API blip, etc).
+ * - Treats explicit validation/auth/replay messages as fatal — there's no
+ *   point hammering them.
+ * - Uses `keepalive: true` so the request can complete even if the user
+ *   closes the tab right after submitting the on-chain transaction. This is
+ *   especially important for cross-chain contributions where the success UI
+ *   is shown immediately and the notification is fired in the background.
+ */
+
+export interface ContributionNotificationBody {
+  txHash: string
+  // Privy's `getAccessToken()` is typed `string | null`; we forward whatever
+  // we got and let the server's auth check reject if it's missing.
+  accessToken: string | null
+  txChainSlug: string
+  projectId: any
+  contributorEmail: string
+  newsletterOptIn: boolean
+  isCrossChain?: boolean
+  memo?: string
+}
+
+export interface ContributionNotificationResult {
+  ok: boolean
+  status: number
+  message: string
+  attempts: number
+}
+
+const RETRYABLE_MESSAGE_FRAGMENTS = [
+  // Server-side `waitForReceipt` lost the race against the wallet's RPC.
+  'Transaction not found',
+  // Cross-chain log scan ran before the server's node indexed the receipt.
+  'No CrossChainPayInitiated event found',
+  // Same-chain Pay log scan ran before the server's node indexed the receipt.
+  'No Pay event found',
+  // Etherscan blip on price lookup.
+  'Failed to get ETH price',
+  // Discord API rate-limit / transient 5xx — bubbled up as 400 by the handler.
+  'Failed to send message to Discord',
+]
+
+function isRetryable(status: number, message: string): boolean {
+  // Network error or any server-side failure / platform timeout.
+  if (status === 0 || status >= 500) return true
+  return RETRYABLE_MESSAGE_FRAGMENTS.some((fragment) =>
+    message.includes(fragment)
+  )
+}
+
+export async function sendContributionNotification(
+  body: ContributionNotificationBody,
+  options: {
+    maxAttempts?: number
+    /**
+     * When true, the underlying fetch uses `keepalive: true` so the first
+     * attempt survives a tab close. Note that JS callbacks (and therefore
+     * retries) cannot run after the page is unloaded, so keepalive only
+     * affects the in-flight request — it does not magically schedule retries.
+     */
+    keepalive?: boolean
+    /** Hook for logging in callers without coupling to console. */
+    onAttemptError?: (info: {
+      attempt: number
+      status: number
+      message: string
+      willRetry: boolean
+    }) => void
+  } = {}
+): Promise<ContributionNotificationResult> {
+  const { maxAttempts = 5, keepalive = false, onAttemptError } = options
+  const serializedBody = JSON.stringify(body)
+
+  let lastStatus = 0
+  let lastMessage = ''
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const resp = await fetch('/api/mission/contribution-notification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: serializedBody,
+        keepalive,
+      })
+
+      lastStatus = resp.status
+      const data: any = await resp.json().catch(() => ({}))
+      lastMessage = data?.message || ''
+
+      if (resp.ok) {
+        return {
+          ok: true,
+          status: resp.status,
+          message: lastMessage,
+          attempts: attempt + 1,
+        }
+      }
+
+      const willRetry =
+        isRetryable(resp.status, lastMessage) && attempt < maxAttempts - 1
+      onAttemptError?.({
+        attempt: attempt + 1,
+        status: resp.status,
+        message: lastMessage,
+        willRetry,
+      })
+
+      if (!willRetry) {
+        return {
+          ok: false,
+          status: resp.status,
+          message: lastMessage,
+          attempts: attempt + 1,
+        }
+      }
+    } catch (err: any) {
+      lastStatus = 0
+      lastMessage = err?.message || 'Network error'
+      const willRetry = attempt < maxAttempts - 1
+      onAttemptError?.({
+        attempt: attempt + 1,
+        status: 0,
+        message: lastMessage,
+        willRetry,
+      })
+      if (!willRetry) {
+        return {
+          ok: false,
+          status: 0,
+          message: lastMessage,
+          attempts: attempt + 1,
+        }
+      }
+    }
+
+    await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)))
+  }
+
+  return {
+    ok: false,
+    status: lastStatus,
+    message: lastMessage,
+    attempts: maxAttempts,
+  }
+}

--- a/ui/lib/overview-delegate/fetchLeaderboard.ts
+++ b/ui/lib/overview-delegate/fetchLeaderboard.ts
@@ -6,7 +6,13 @@ import {
   OVERVIEW_TOKEN_DECIMALS,
   VOTES_TABLE_NAMES,
 } from 'const/config'
-import { formatUnits } from 'ethers'
+// `formatUnits` lives on `ethers/lib/utils` in ethers v5 (the version this
+// project ships). Importing the named export from `'ethers'` directly works
+// at type-check time but blows up at runtime under Next's Webpack barrel
+// optimizer ("(0 , formatUnits) is not a function"), which silently kicks
+// the leaderboard onto its stored-amount fallback path. Pulling from the
+// utils sub-path avoids the optimizer foot-gun.
+import { formatUnits } from 'ethers/lib/utils'
 import { arbitrum } from '@/lib/rpc/chains'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'

--- a/ui/pages/api/mission/contribution-notification.ts
+++ b/ui/pages/api/mission/contribution-notification.ts
@@ -46,6 +46,14 @@ import { formatNumberWithCommasAndDecimals } from '@/lib/utils/numbers'
 
 const chainSlug = getChainSlug(DEFAULT_CHAIN_V5)
 
+// Allow this handler to run longer than the Vercel default (10s on Hobby /
+// 15s on Pro). Cross-chain (Ethereum) notifications routinely need more time
+// for `waitForReceipt`, Tableland reads, IPFS metadata, Etherscan ETH price,
+// Discord, and the awaited thank-you email.
+export const config = {
+  maxDuration: 60,
+}
+
 const NOTIFICATION_CHANNEL_ID =
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
     ? GENERAL_CHANNEL_ID
@@ -72,11 +80,32 @@ const missionCreatorContract = getContract({
   abi: MissionCreator.abi as any,
 })
 
-// In-memory storage for used transaction hashes to prevent replay attacks
-const usedTransactions = new Set<string>()
+// In-memory storage for used transaction hashes to prevent replay attacks.
+//
+// Stored as `txHash -> insertion timestamp (ms)`. We treat any entry older
+// than `USED_TX_TTL_MS` as stale and let the request through, so a previous
+// invocation that was killed mid-flight by the platform (timeout, OOM, lambda
+// recycle) doesn't permanently lock the txHash on a warm instance — the
+// client's retry would otherwise keep getting "This transaction has already
+// been processed" with no way to recover.
+const USED_TX_TTL_MS = 90 * 1000
+const usedTransactions = new Map<string, number>()
+
+function isUsedTransaction(txHash: string): boolean {
+  const insertedAt = usedTransactions.get(txHash)
+  if (insertedAt === undefined) return false
+  if (Date.now() - insertedAt > USED_TX_TTL_MS) {
+    usedTransactions.delete(txHash)
+    return false
+  }
+  return true
+}
 
 setInterval(() => {
-  usedTransactions.clear()
+  const now = Date.now()
+  for (const [txHash, insertedAt] of usedTransactions) {
+    if (now - insertedAt > USED_TX_TTL_MS) usedTransactions.delete(txHash)
+  }
 }, 60 * 60 * 1000)
 
 async function handler(req: any, res: any) {
@@ -261,13 +290,13 @@ async function handler(req: any, res: any) {
     const mission = missionRows[0]
 
     // Reserve txHash once inputs are validated so concurrent/duplicate calls skip expensive work below.
-    if (usedTransactions.has(txHash)) {
+    if (isUsedTransaction(txHash)) {
       return res.status(400).json({
         message:
           'This transaction has already been processed for contribution notification',
       })
     }
-    usedTransactions.add(txHash)
+    usedTransactions.set(txHash, Date.now())
     contributionTxConsumed = txHash
 
     const missionFundingGoal =

--- a/ui/pages/api/mission/contribution-notification.ts
+++ b/ui/pages/api/mission/contribution-notification.ts
@@ -101,12 +101,21 @@ function isUsedTransaction(txHash: string): boolean {
   return true
 }
 
-setInterval(() => {
+// Sweep on a cadence comparable to the TTL itself so memory stays bounded
+// on write-heavy warm instances. `isUsedTransaction` also lazy-evicts on
+// hit, but a sustained burst with no re-reads of the same hashes would
+// otherwise let the map grow until the next sweep — keeping the interval
+// near the TTL (60s vs. 90s TTL) caps that worst case at ~one minute of
+// expired entries. `.unref()` so this background timer never keeps a
+// serverless container alive past its idle deadline.
+const USED_TX_SWEEP_MS = 60 * 1000
+const usedTxSweepInterval = setInterval(() => {
   const now = Date.now()
   for (const [txHash, insertedAt] of usedTransactions) {
     if (now - insertedAt > USED_TX_TTL_MS) usedTransactions.delete(txHash)
   }
-}, 60 * 60 * 1000)
+}, USED_TX_SWEEP_MS)
+usedTxSweepInterval.unref?.()
 
 async function handler(req: any, res: any) {
   if (req.method !== 'POST') {

--- a/ui/pages/mission/[tokenId].tsx
+++ b/ui/pages/mission/[tokenId].tsx
@@ -35,6 +35,15 @@ type ProjectProfileProps = {
   _fundingGoal: number
   _ruleset: any[]
   _overviewLeaderboard?: LeaderboardEntry[]
+  /** $OVERVIEW total backing the candidate currently sitting at rank 25 on
+   *  the leaderboard. `null` when fewer than 25 candidates exist. Only
+   *  provided for the Overview Flight mission (id 4). */
+  _overviewTop25Threshold?: number | null
+  /** Number of citizens currently ranked on the $OVERVIEW leaderboard
+   *  (those with a registered Citizen NFT and at least one backer). Drives
+   *  honest copy in the Fly with Frank explainer when the top 25 isn't
+   *  full yet. Only provided for the Overview Flight mission. */
+  _overviewRankedCount?: number
 }
 
 /** Mission ID for the Overview Flight fundraiser; used to opportunistically
@@ -53,6 +62,8 @@ export default function MissionProfilePage({
   _fundingGoal,
   _ruleset,
   _overviewLeaderboard,
+  _overviewTop25Threshold,
+  _overviewRankedCount,
 }: ProjectProfileProps) {
   const selectedChain = DEFAULT_CHAIN_V5
 
@@ -76,6 +87,8 @@ export default function MissionProfilePage({
           _fundingGoal={_fundingGoal}
           _ruleset={_ruleset}
           _overviewLeaderboard={_overviewLeaderboard}
+          _overviewTop25Threshold={_overviewTop25Threshold}
+          _overviewRankedCount={_overviewRankedCount}
         />
       </JuiceProviders>
     </>
@@ -165,10 +178,15 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query, re
 
       // Kick off the (mission-4-only) Overview leaderboard fetch in parallel
       // with the IPFS metadata + token metadata round-trips so it doesn't
-      // serially extend page TTFB.
+      // serially extend page TTFB. We pull the full ranking (not just the
+      // top 25) so we can simultaneously populate the leaderboard preview
+      // (top 5), derive the live threshold to crack the top 25, and report
+      // the actual ranked count to the explainer so it never makes a false
+      // "fewer than 25 candidates" claim when a partial fetch happens to
+      // truncate results.
       const isOverviewMission = Number(tokenId) === OVERVIEW_MISSION_ID
       const overviewLeaderboardPromise = isOverviewMission
-        ? fetchOverviewLeaderboard(5).catch((error) => {
+        ? fetchOverviewLeaderboard().catch((error) => {
             console.warn(
               '[mission/4] overview leaderboard fetch failed:',
               error
@@ -204,7 +222,26 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query, re
           ]
         : [{ weight: 0 }, { reservedPercent: 0 }]
 
-      const _overviewLeaderboard = await overviewLeaderboardPromise
+      const _overviewLeaderboardFull = await overviewLeaderboardPromise
+
+      // Slice to the top 5 for the preview component (its existing UX),
+      // pull the 25th-place backing total for the explainer's threshold
+      // callout, and report the actual ranked count so the empty-state
+      // copy stays factual when the top 25 isn't filled yet.
+      const _overviewLeaderboard =
+        _overviewLeaderboardFull !== undefined
+          ? _overviewLeaderboardFull.slice(0, 5)
+          : undefined
+      const _overviewRankedCount =
+        _overviewLeaderboardFull !== undefined
+          ? _overviewLeaderboardFull.length
+          : undefined
+      const _overviewTop25Threshold =
+        _overviewLeaderboardFull !== undefined
+          ? _overviewLeaderboardFull.length >= 25
+            ? _overviewLeaderboardFull[24].totalDelegated
+            : null
+          : undefined
 
       return {
         props: {
@@ -220,6 +257,12 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query, re
           _ruleset,
           ...(_overviewLeaderboard !== undefined
             ? { _overviewLeaderboard }
+            : {}),
+          ...(_overviewTop25Threshold !== undefined
+            ? { _overviewTop25Threshold }
+            : {}),
+          ...(_overviewRankedCount !== undefined
+            ? { _overviewRankedCount }
             : {}),
         },
       }


### PR DESCRIPTION
## Summary

Three independent improvements to the mission page and contribution flow, bundled here because they touch overlapping files.

### 1. Live deadline countdown in the mission header
- Replaces the static `formatTimeUntilDeadline` text with a real-time countdown that ticks down to the millisecond using `requestAnimationFrame`.
- New `MissionDeadlineCountdown` component renders inline in `MissionProfileHeader` with the same `font-GoodTimes` styling.
- Layout uses an explicit responsive flexbox (column on mobile, row+nowrap on `sm:` and up) with `tabular-nums` so the component height stays stable while digits flicker — fixing the vertical jitter that showed up at narrow widths.
- Falls back to the original static text when the deadline has passed or is unset.

### 2. "Fly with Frank" explainer + live top-25 threshold (Overview Mission)
- New `MissionFlyWithFrankExplainer` rendered directly under `MissionContributorTiersPanel`, but only on the Overview Mission (id 4).
- Walks contributors through the 3 steps: contribute → become a citizen (`/join`) → back a citizen's candidacy (`/overview-vote`).
- Shows the live minimum \$OVERVIEW required to crack the top 25 by reading rank 25's `totalDelegated` from the same leaderboard fetch that powers the preview tab.
- Server-side: `getServerSideProps` now fetches the full leaderboard (instead of just the top 5) and derives three values from a single round-trip — the top-5 preview slice, the 25th-place threshold, and the actual ranked count. These are threaded as props through `MissionProfile → MissionInfo → MissionPayRedeem → MissionFlyWithFrankExplainer`.
- The explainer's empty-state copy uses the real ranked count so it can never falsely claim "fewer than 25 citizens are ranked" when a partial fetch happens to truncate results. Four states: threshold known, top-25 contested but threshold uncomputable, genuinely <25 ranked, and unknown (fetch hiccup).
- Drive-by fix in `lib/overview-delegate/fetchLeaderboard.ts`: `formatUnits` was being imported from `'ethers'`, which Next's Webpack barrel optimizer was rewriting to a runtime-broken reference (`(0 , formatUnits) is not a function`), making every balance read silently fall back to stored amounts. Pulling from `'ethers/lib/utils'` restores live on-chain balance reads.

### 3. Discord contribution-notification reliability
- Background: Ethereum contributions sometimes never produced a Discord ping. Root cause was a mix of (a) the client tearing down before the notification request completed and (b) the server marking a tx-hash as "used" even when the function timed out, permanently locking out retries.
- New `lib/mission/sendContributionNotification.ts` helper centralizes the client-side post with `keepalive: true`, retry on transient failures, and structured error reporting.
- `MissionContributeModal` now shows the success UI immediately after the on-chain tx confirms and dispatches the notification in the background through the helper, on both same-chain and cross-chain branches.
- `pages/api/mission/contribution-notification.ts`:
  - `export const config = { maxDuration: 60 }` so the serverless function has room to finish on slower chains.
  - Replaced the `usedTransactions: Set` with a `Map<string, number>` carrying a 90s TTL. Stale entries from timed-out invocations now expire instead of permanently blocking re-delivery.

## Test plan
- [ ] Visit `/mission/4` — verify the deadline header ticks down smoothly with no vertical jitter at mobile, tablet, and desktop widths.
- [ ] On `/mission/4`, scroll to the support tiers section and confirm the "How to fly with Frank" card renders with the three steps and a numeric "Top 25 threshold" (~24 \$OVERVIEW with current data, plus an "X citizens ranked" caption).
- [ ] On any non-Overview mission (e.g. `/mission/1`), confirm the explainer card does **not** render.
- [ ] Make a same-chain contribution on Arbitrum and confirm the Discord notification fires.
- [ ] Make a cross-chain contribution from Ethereum and confirm the Discord notification fires (this is the primary regression target).
- [ ] Confirm the contribution success UI appears immediately on tx confirmation, not after the notification call completes.