### PR TITLE
fix(auth): fully disconnect thirdweb wallet on Privy logout

### DIFF
--- a/ui/components/onboarding/CitizenTier.tsx
+++ b/ui/components/onboarding/CitizenTier.tsx
@@ -1,3 +1,4 @@
+import { usePrivy } from '@privy-io/react-auth'
 import CitizenABI from 'const/abis/Citizen.json'
 import { CITIZEN_ADDRESSES } from 'const/config'
 import { useContext } from 'react'
@@ -26,8 +27,19 @@ const CitizenTier = ({
   const chainSlug = getChainSlug(selectedChain)
   const account = useActiveAccount()
   const address = account?.address
+  const { authenticated } = usePrivy()
 
   const handleCitizenClick = async () => {
+    // Don't trust a stale thirdweb address that may linger after logout.
+    // The wrapping <Tier /> normally prompts login when there's no address,
+    // but if the thirdweb wallet hasn't disconnected yet the address can
+    // outlive the Privy session. Bail out so we don't read citizen status
+    // for a previously-signed-in wallet.
+    if (!authenticated) {
+      return toast.error('Please sign in to become a citizen.')
+    }
+    if (!address) return
+
     const citizenContract = getContract({
       client,
       address: CITIZEN_ADDRESSES[chainSlug],

--- a/ui/components/privy/PrivyConnectWallet.tsx
+++ b/ui/components/privy/PrivyConnectWallet.tsx
@@ -18,7 +18,7 @@ import { createPortal } from 'react-dom'
 import toast from 'react-hot-toast'
 import useSWR from 'swr'
 import { getContract, prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
-import { useActiveAccount } from 'thirdweb/react'
+import { useActiveAccount, useActiveWallet, useDisconnect } from 'thirdweb/react'
 import { clearAllCitizenCache } from '../../lib/citizen/CitizenProvider'
 import PrivyWalletContext from '../../lib/privy/privy-wallet-context'
 import { useNativeBalance } from '../../lib/thirdweb/hooks/useNativeBalance'
@@ -559,6 +559,8 @@ export function PrivyConnectWallet({ citizenContract, type }: PrivyConnectWallet
 
   const account = useActiveAccount()
   const address = account?.address
+  const activeWallet = useActiveWallet()
+  const { disconnect: disconnectThirdwebWallet } = useDisconnect()
   const { data: _ensData } = useENS(address)
   const ens = _ensData?.name
   const [walletChainId, setWalletChainId] = useState(1)
@@ -1356,9 +1358,24 @@ export function PrivyConnectWallet({ citizenContract, type }: PrivyConnectWallet
                   <button
                     className="w-full mt-4 bg-gradient-to-r from-red-500 to-pink-500 hover:from-red-600 hover:to-pink-600 text-white py-2.5 px-4 rounded-lg font-semibold transition-all duration-200 transform hover:scale-105 shadow-lg"
                     onClick={async () => {
+                      // Disconnect the thirdweb-side wallet first so hooks like
+                      // useActiveAccount() immediately stop returning the old
+                      // address. Without this, the previously connected wallet
+                      // can leak into pages (e.g. CitizenTier) and make the app
+                      // think the signed-out user is still a citizen.
+                      if (activeWallet) {
+                        try {
+                          disconnectThirdwebWallet(activeWallet)
+                        } catch (err) {
+                          console.warn(
+                            'Failed to disconnect thirdweb wallet:',
+                            err
+                          )
+                        }
+                      }
                       wallets.forEach((wallet) => wallet.disconnect())
                       clearAllCitizenCache()
-                      logout()
+                      await logout()
                     }}
                   >
                     Log Out
@@ -1374,6 +1391,18 @@ export function PrivyConnectWallet({ citizenContract, type }: PrivyConnectWallet
             id="sign-in-button"
             onClick={async () => {
               if (user) {
+                if (activeWallet) {
+                  try {
+                    disconnectThirdwebWallet(activeWallet)
+                  } catch (err) {
+                    console.warn(
+                      'Failed to disconnect thirdweb wallet:',
+                      err
+                    )
+                  }
+                }
+                wallets.forEach((wallet) => wallet.disconnect())
+                clearAllCitizenCache()
                 await logout()
                 login()
               } else {

--- a/ui/lib/privy/PrivyThirdwebV5Provider.tsx
+++ b/ui/lib/privy/PrivyThirdwebV5Provider.tsx
@@ -3,7 +3,11 @@ import { signIn, signOut } from 'next-auth/react'
 import { useContext, useEffect, useState } from 'react'
 import { defineChain } from 'thirdweb'
 import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
-import { useSetActiveWallet } from 'thirdweb/react'
+import {
+  useActiveWallet,
+  useDisconnect,
+  useSetActiveWallet,
+} from 'thirdweb/react'
 import { createWalletAdapter } from 'thirdweb/wallets'
 import client from '@/lib/thirdweb/client'
 import PrivyWalletContext from './privy-wallet-context'
@@ -13,6 +17,8 @@ export function PrivyThirdwebV5Provider({ selectedChain, children }: any) {
   const { selectedWallet } = useContext(PrivyWalletContext)
   const { wallets } = useWallets()
   const setActiveWallet = useSetActiveWallet()
+  const activeWallet = useActiveWallet()
+  const { disconnect: disconnectThirdwebWallet } = useDisconnect()
   const [isSigningIn, setIsSigningIn] = useState(false)
 
   useEffect(() => {
@@ -113,8 +119,19 @@ export function PrivyThirdwebV5Provider({ selectedChain, children }: any) {
   useEffect(() => {
     if (ready && !authenticated) {
       signOut({ redirect: false })
+      // Ensure the thirdweb active wallet is disconnected so hooks like
+      // useActiveAccount() stop returning the previously connected address.
+      // Without this, pages that read the address directly from thirdweb
+      // (e.g. CitizenTier) can still see the old wallet after Privy logout.
+      if (activeWallet) {
+        try {
+          disconnectThirdwebWallet(activeWallet)
+        } catch (err) {
+          console.warn('Failed to disconnect thirdweb wallet on logout:', err)
+        }
+      }
     }
-  }, [ready, authenticated, user])
+  }, [ready, authenticated, user, activeWallet, disconnectThirdwebWallet])
 
   return <>{children}</>
 }


### PR DESCRIPTION
## Summary

After signing out, the app sometimes still behaved as if the user was signed in — most visibly when trying to "Become a Citizen", which would report "This wallet is already registered as a citizen" even though Privy considered the user logged out (a hard refresh did not fix it).

## Root cause

The logout flow disconnected Privy's wallets and cleared the citizen cache but never disconnected the thirdweb-side wallet wired up in `PrivyThirdwebV5Provider` via `setActiveWallet`. As a result, `useActiveAccount()` kept returning the previously signed-in address indefinitely. `CitizenTier.handleCitizenClick` reads that address directly and calls `Citizen.balanceOf(address)`, which returned `> 0` for the previous owner — hence the "already a citizen" error.

## Changes

- **`ui/lib/privy/PrivyThirdwebV5Provider.tsx`** — Centralized cleanup. The existing `ready && !authenticated` effect (which already ran NextAuth `signOut`) now also calls `disconnect(activeWallet)` from `thirdweb/react`, so any logout path fully tears down thirdweb state.
- **`ui/components/privy/PrivyConnectWallet.tsx`** — Both the "Log Out" button and the "Sign in" button's logout-then-login path now eagerly disconnect the thirdweb wallet (in addition to disconnecting Privy wallets and clearing the citizen cache) before awaiting Privy's `logout()`, eliminating any stale-state flash.
- **`ui/components/onboarding/CitizenTier.tsx`** — Defense in depth. `handleCitizenClick` now bails out with a "Please sign in" toast when Privy is unauthenticated, so even a stale address can't trigger a misleading "already a citizen" error.

## Test plan

- [ ] Sign in with a wallet that owns a Citizen NFT, then sign out.
- [ ] Without refreshing, navigate to `/citizen` and click "Become a Citizen" — should prompt sign-in, not show "already a citizen".
- [ ] Hard refresh after sign-out — `useActiveAccount()` should return `undefined`; the wallet button should show "Sign in".
- [ ] Sign in with a different wallet immediately after sign-out — the new wallet's citizen status should be reflected, not the old one's.
- [ ] Verify normal sign-in / sign-out / re-sign-in flow still works for embedded Privy, MetaMask, and Coinbase wallets.