### PR TITLE
fix(team): make team profile pages resilient to Tableland/RPC blips

### DIFF
--- a/ui/lib/tableland/queryTable.ts
+++ b/ui/lib/tableland/queryTable.ts
@@ -32,8 +32,14 @@ export default async function queryTable(
 ): Promise<any> {
   const provider = new ethers.providers.JsonRpcProvider(chain.rpc)
 
-  const wallet = new ethers.Wallet(process.env.TABLELAND_PRIVATE_KEY as string)
-  wallet.connect(provider)
+  // NOTE: ethers' Wallet.connect returns a NEW wallet rather than mutating
+  // the receiver, so we have to bind the provider via the constructor here.
+  // Without this, the Tableland SDK falls back to the public validator for
+  // every request, which is heavily rate limited.
+  const wallet = new ethers.Wallet(
+    process.env.TABLELAND_PRIVATE_KEY as string,
+    provider
+  )
 
   const signer = createTablelandSigner(wallet, chain.id)
 

--- a/ui/lib/team/teamDataService.ts
+++ b/ui/lib/team/teamDataService.ts
@@ -160,7 +160,16 @@ export async function fetchTeamsWithOwners(
 }
 
 /**
- * Fetch a single team with owner data
+ * Fetch a single team with owner data.
+ *
+ * Returns `null` only when the team genuinely does not exist (i.e. the
+ * Tableland row is missing or the team is on the blocklist). Infrastructure
+ * failures while talking to Tableland are propagated to the caller so they
+ * can be surfaced as a server error rather than masked as a 404.
+ *
+ * Failures while resolving the on-chain `ownerOf` are tolerated: the team
+ * is returned with `owner: ''` so the page can still render basic metadata
+ * even when the RPC is degraded.
  */
 export async function fetchTeamWithOwner(
   chain: Chain,
@@ -168,55 +177,62 @@ export async function fetchTeamWithOwner(
 ): Promise<TeamWithOwner | null> {
   const chainSlug = getChainSlug(chain)
 
-  try {
-    let teamTableName = TEAM_TABLE_NAMES[chainSlug]
-    if (!teamTableName && TEAM_TABLE_ADDRESSES[chainSlug]) {
-      const teamTableContract = getContract({
-        client: serverClient,
-        address: TEAM_TABLE_ADDRESSES[chainSlug],
-        chain,
-        abi: TeamTableABI as any,
-      })
-      teamTableName = (await readContract({
-        contract: teamTableContract,
-        method: 'getTableName',
-      })) as string
-    }
-
-    if (!teamTableName) {
-      return null
-    }
-
-    const teamStatement = `SELECT * FROM ${teamTableName} WHERE id = ${teamId}`
-    const teamRows: any = await queryTable(chain, teamStatement)
-
-    if (!teamRows || teamRows.length === 0 || BLOCKED_TEAMS.has(Number(teamId))) {
-      return null
-    }
-
-    const team = teamRowToNFT(teamRows[0] as TeamRow)
-
-    const teamContract = getContract({
+  let teamTableName = TEAM_TABLE_NAMES[chainSlug]
+  if (!teamTableName && TEAM_TABLE_ADDRESSES[chainSlug]) {
+    const teamTableContract = getContract({
       client: serverClient,
-      address: TEAM_ADDRESSES[chainSlug],
-      abi: TeamABI as any,
+      address: TEAM_TABLE_ADDRESSES[chainSlug],
       chain,
+      abi: TeamTableABI as any,
     })
+    teamTableName = (await readContract({
+      contract: teamTableContract,
+      method: 'getTableName',
+    })) as string
+  }
 
-    const owner = await readContract({
+  if (!teamTableName) {
+    return null
+  }
+
+  if (BLOCKED_TEAMS.has(Number(teamId))) {
+    return null
+  }
+
+  const teamStatement = `SELECT * FROM ${teamTableName} WHERE id = ${teamId}`
+  const teamRows: any = await queryTable(chain, teamStatement)
+
+  if (!teamRows || teamRows.length === 0) {
+    return null
+  }
+
+  const team = teamRowToNFT(teamRows[0] as TeamRow)
+
+  const teamContract = getContract({
+    client: serverClient,
+    address: TEAM_ADDRESSES[chainSlug],
+    abi: TeamABI as any,
+    chain,
+  })
+
+  let owner = ''
+  try {
+    owner = (await readContract({
       contract: teamContract,
       method: 'ownerOf',
       params: [teamId],
-    })
-
-    return {
-      ...team,
-      owner: owner as string,
-    } as TeamWithOwner
+    })) as string
   } catch (error) {
-    console.error(`Error fetching team ${teamId}:`, error)
-    return null
+    console.error(
+      `Failed to read ownerOf for team ${teamId} – rendering without owner:`,
+      (error as Error)?.message || error
+    )
   }
+
+  return {
+    ...team,
+    owner,
+  } as TeamWithOwner
 }
 
 /**

--- a/ui/lib/team/teamPrettyLinks.ts
+++ b/ui/lib/team/teamPrettyLinks.ts
@@ -1,0 +1,101 @@
+/**
+ * Server-side pretty-link resolver for teams.
+ *
+ * Resolving a pretty link (e.g. `/team/aethero`) requires the full set of
+ * team names so we can apply the same de-duplication rules as
+ * `generatePrettyLinks`. That query is expensive — it goes through the
+ * Tableland SDK on every server render — so we keep an in-process cache
+ * with a short TTL and a single in-flight refresh promise.
+ *
+ * On refresh failure we keep serving the previous snapshot so a transient
+ * Tableland blip doesn't 404 every team page at once.
+ */
+import { TEAM_TABLE_NAMES } from 'const/config'
+import { Chain } from 'thirdweb'
+import { generatePrettyLinks } from '@/lib/subscription/pretty-links'
+import queryTable from '@/lib/tableland/queryTable'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+
+const CACHE_TTL_MS = 60_000
+const STALE_TTL_MS = 10 * 60_000
+
+type PrettyLinksSnapshot = {
+  prettyLinks: Record<string, string | number>
+  fetchedAt: number
+}
+
+const snapshotByChainSlug = new Map<string, PrettyLinksSnapshot>()
+const inflightByChainSlug = new Map<string, Promise<PrettyLinksSnapshot>>()
+
+async function refreshSnapshot(
+  chain: Chain,
+  chainSlug: string,
+  tableName: string
+): Promise<PrettyLinksSnapshot> {
+  const rows = (await queryTable(
+    chain,
+    `SELECT id, name FROM ${tableName}`
+  )) as Array<{ id: string | number; name: string }>
+
+  const { prettyLinks } = generatePrettyLinks(rows || [])
+
+  const snapshot: PrettyLinksSnapshot = {
+    prettyLinks,
+    fetchedAt: Date.now(),
+  }
+  snapshotByChainSlug.set(chainSlug, snapshot)
+  return snapshot
+}
+
+async function getSnapshot(chain: Chain): Promise<PrettyLinksSnapshot | null> {
+  const chainSlug = getChainSlug(chain)
+  const tableName = TEAM_TABLE_NAMES[chainSlug]
+
+  if (!tableName) return null
+
+  const cached = snapshotByChainSlug.get(chainSlug)
+  const now = Date.now()
+
+  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached
+  }
+
+  let inflight = inflightByChainSlug.get(chainSlug)
+  if (!inflight) {
+    inflight = refreshSnapshot(chain, chainSlug, tableName).finally(() => {
+      inflightByChainSlug.delete(chainSlug)
+    })
+    inflightByChainSlug.set(chainSlug, inflight)
+  }
+
+  try {
+    return await inflight
+  } catch (error) {
+    console.error(
+      `Failed to refresh team pretty-links for ${chainSlug}:`,
+      (error as Error)?.message || error
+    )
+    if (cached && now - cached.fetchedAt < STALE_TTL_MS) {
+      return cached
+    }
+    return null
+  }
+}
+
+/**
+ * Resolve a pretty-link slug (e.g. "aethero") to a numeric team id.
+ * Returns `null` if the slug doesn't map to a known team.
+ *
+ * If the underlying Tableland query is failing and we have no usable cache,
+ * the caller will get `null`. They should treat that as "could not resolve"
+ * (and probably 404) rather than retrying inline.
+ */
+export async function resolveTeamIdFromPrettyLink(
+  chain: Chain,
+  slug: string
+): Promise<string | number | null> {
+  const snapshot = await getSnapshot(chain)
+  if (!snapshot) return null
+  const id = snapshot.prettyLinks[slug.toLowerCase()]
+  return id ?? null
+}

--- a/ui/lib/team/teamPrettyLinks.ts
+++ b/ui/lib/team/teamPrettyLinks.ts
@@ -34,7 +34,7 @@ async function refreshSnapshot(
 ): Promise<PrettyLinksSnapshot> {
   const rows = (await queryTable(
     chain,
-    `SELECT id, name FROM ${tableName}`
+    `SELECT id, name FROM ${tableName} ORDER BY id`
   )) as Array<{ id: string | number; name: string }>
 
   const { prettyLinks } = generatePrettyLinks(rows || [])

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -29,7 +29,6 @@ import {
   HATS_ADDRESS,
   JOBS_TABLE_ADDRESSES,
   MARKETPLACE_TABLE_ADDRESSES,
-  TEAM_TABLE_NAMES,
   DEFAULT_CHAIN_V5,
   JBV5_CONTROLLER_ADDRESS,
   JBV5_TOKENS_ADDRESS,
@@ -52,9 +51,8 @@ import CitizenContext from '@/lib/citizen/citizen-context'
 import { useSubHats } from '@/lib/hats/useSubHats'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
 import useSafe from '@/lib/safe/useSafe'
-import { generatePrettyLinks } from '@/lib/subscription/pretty-links'
-import { teamRowToNFT } from '@/lib/tableland/convertRow'
 import queryTable from '@/lib/tableland/queryTable'
+import { resolveTeamIdFromPrettyLink } from '@/lib/team/teamPrettyLinks'
 import { useTeamData } from '@/lib/team/useTeamData'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
@@ -652,86 +650,118 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
   const chain = DEFAULT_CHAIN_V5
   const chainSlug = getChainSlug(chain)
 
-  const teamTableStatement = `SELECT * FROM ${TEAM_TABLE_NAMES[chainSlug]}`
-  const allTeams = (await queryTable(chain, teamTableStatement)) as any
-  const { prettyLinks } = generatePrettyLinks(allTeams)
-
-  let tokenId
+  // Resolve the URL segment to a numeric token id. For numeric segments we
+  // can skip the (expensive) full-team lookup entirely. For pretty-link
+  // segments we hit a cached resolver so a single Tableland blip doesn't
+  // 404 every team page at once.
+  let tokenId: string | number | null = null
   if (!Number.isNaN(Number(tokenIdOrName))) {
     tokenId = tokenIdOrName
-  } else {
-    tokenId = prettyLinks[tokenIdOrName]
-  }
-
-  if (tokenId === undefined) {
-    return {
-      notFound: true,
+  } else if (typeof tokenIdOrName === 'string') {
+    try {
+      tokenId = await resolveTeamIdFromPrettyLink(chain, tokenIdOrName)
+    } catch (error) {
+      console.error('Failed to resolve team pretty link:', error)
+      tokenId = null
     }
   }
 
-  const { fetchTeamWithOwner } = await import('@/lib/team/teamDataService')
-  const nft = await fetchTeamWithOwner(chain, tokenId)
+  if (tokenId === undefined || tokenId === null) {
+    return { notFound: true }
+  }
+
+  let nft: Awaited<
+    ReturnType<typeof import('@/lib/team/teamDataService').fetchTeamWithOwner>
+  > | null = null
+  try {
+    const { fetchTeamWithOwner } = await import('@/lib/team/teamDataService')
+    nft = await fetchTeamWithOwner(chain, tokenId)
+  } catch (error) {
+    // Tableland or RPC failure while loading the team. Treat this as "not
+    // found" rather than crashing the route — a fresh request will retry.
+    console.error(`Failed to fetch team ${tokenId}:`, error)
+    return { notFound: true }
+  }
 
   if (!nft || BLOCKED_TEAMS.has(Number(nft.metadata.id))) {
-    return {
-      notFound: true,
-    }
+    return { notFound: true }
   }
 
-  const rpcUrl = getRpcUrlForChain({
-    client: serverClient,
-    chain: DEFAULT_CHAIN_V5,
-  })
-
-  const teamSafe = await Safe.init({
-    provider: rpcUrl,
-    safeAddress: nft.owner,
-  })
-
-  const safeOwners = await teamSafe.getOwners()
+  // Safe owners are best-effort: if the address isn't a Safe yet, or the
+  // RPC is degraded, render the team page with an empty signer list rather
+  // than 500-ing the entire route.
+  let safeOwners: string[] = []
+  if (nft.owner) {
+    try {
+      const rpcUrl = getRpcUrlForChain({
+        client: serverClient,
+        chain: DEFAULT_CHAIN_V5,
+      })
+      const teamSafe = await Safe.init({
+        provider: rpcUrl,
+        safeAddress: nft.owner,
+      })
+      safeOwners = await teamSafe.getOwners()
+    } catch (error) {
+      console.error(
+        `Failed to load Safe owners for team ${tokenId} (${nft.owner}):`,
+        (error as Error)?.message || error
+      )
+    }
+  }
 
   const imageIpfsLink = nft.metadata.image
 
-  //Check for a jobId in the url and get the queried job if it exists
+  // Optional ?job= and ?listing= query params hydrate the page with metadata
+  // for a specific job/listing (used for OG previews when sharing). They are
+  // best-effort: a Tableland or RPC failure here should not break the team
+  // page itself.
   const jobId = query?.job
   let queriedJob = null
   if (jobId !== undefined) {
-    const jobTableContract = getContract({
-      client: serverClient,
-      address: JOBS_TABLE_ADDRESSES[chainSlug],
-      abi: JobBoardTableABI as any,
-      chain: chain,
-    })
-    const jobTableName = await readContract({
-      contract: jobTableContract,
-      method: 'getTableName' as string,
-      params: [],
-    })
-    const jobTableStatement = `SELECT * FROM ${jobTableName} WHERE id = ${jobId}`
+    try {
+      const jobTableContract = getContract({
+        client: serverClient,
+        address: JOBS_TABLE_ADDRESSES[chainSlug],
+        abi: JobBoardTableABI as any,
+        chain: chain,
+      })
+      const jobTableName = await readContract({
+        contract: jobTableContract,
+        method: 'getTableName' as string,
+        params: [],
+      })
+      const jobTableStatement = `SELECT * FROM ${jobTableName} WHERE id = ${jobId}`
 
-    const jobData = await queryTable(chain, jobTableStatement)
-    queriedJob = jobData?.[0] || null
+      const jobData = await queryTable(chain, jobTableStatement)
+      queriedJob = jobData?.[0] || null
+    } catch (error) {
+      console.error(`Failed to load queried job ${jobId}:`, error)
+    }
   }
 
-  //Check for a listingId in the url and get the queried listing if it exists
   const listingId = query?.listing
   let queriedListing = null
   if (listingId !== undefined) {
-    const marketplaceTableContract = getContract({
-      client: serverClient,
-      address: MARKETPLACE_TABLE_ADDRESSES[chainSlug],
-      abi: MarketplaceTableABI as any,
-      chain: chain,
-    })
-    const marketplaceTableName = await readContract({
-      contract: marketplaceTableContract,
-      method: 'getTableName' as string,
-      params: [],
-    })
-    const marketplaceTableStatement = `SELECT * FROM ${marketplaceTableName} WHERE id = ${listingId}`
+    try {
+      const marketplaceTableContract = getContract({
+        client: serverClient,
+        address: MARKETPLACE_TABLE_ADDRESSES[chainSlug],
+        abi: MarketplaceTableABI as any,
+        chain: chain,
+      })
+      const marketplaceTableName = await readContract({
+        contract: marketplaceTableContract,
+        method: 'getTableName' as string,
+        params: [],
+      })
+      const marketplaceTableStatement = `SELECT * FROM ${marketplaceTableName} WHERE id = ${listingId}`
 
-    const marketplaceData = await queryTable(chain, marketplaceTableStatement)
-    queriedListing = marketplaceData?.[0] || null
+      const marketplaceData = await queryTable(chain, marketplaceTableStatement)
+      queriedListing = marketplaceData?.[0] || null
+    } catch (error) {
+      console.error(`Failed to load queried listing ${listingId}:`, error)
+    }
   }
 
   return {

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -673,15 +673,8 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
   let nft: Awaited<
     ReturnType<typeof import('@/lib/team/teamDataService').fetchTeamWithOwner>
   > | null = null
-  try {
-    const { fetchTeamWithOwner } = await import('@/lib/team/teamDataService')
-    nft = await fetchTeamWithOwner(chain, tokenId)
-  } catch (error) {
-    // Tableland or RPC failure while loading the team. Treat this as "not
-    // found" rather than crashing the route — a fresh request will retry.
-    console.error(`Failed to fetch team ${tokenId}:`, error)
-    return { notFound: true }
-  }
+  const { fetchTeamWithOwner } = await import('@/lib/team/teamDataService')
+  nft = await fetchTeamWithOwner(chain, tokenId)
 
   if (!nft || BLOCKED_TEAMS.has(Number(nft.metadata.id))) {
     return { notFound: true }

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -655,8 +655,8 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
   // segments we hit a cached resolver so a single Tableland blip doesn't
   // 404 every team page at once.
   let tokenId: string | number | null = null
-  if (!Number.isNaN(Number(tokenIdOrName))) {
-    tokenId = tokenIdOrName
+  if (typeof tokenIdOrName === 'string' && /^\d+$/.test(tokenIdOrName)) {
+    tokenId = BigInt(tokenIdOrName).toString()
   } else if (typeof tokenIdOrName === 'string') {
     try {
       tokenId = await resolveTeamIdFromPrettyLink(chain, tokenIdOrName)


### PR DESCRIPTION
Team detail pages were intermittently returning 404 or 500 because getServerSideProps fanned out to ~5 Tableland/RPC calls per request and either crashed unhandled or silently returned null on transient failures.

- Cache the pretty-link to tokenId map in-process with a short TTL and a stale fallback so a single Tableland blip does not 404 every team page. Numeric URLs now skip the lookup entirely.
- Wrap Safe.init/getOwners in try/catch and render with an empty signer list instead of 500-ing when the team owner Safe cannot be read.
- Wrap the optional ?job/?listing hydrators in try/catch for the same reason.
- Stop swallowing infrastructure errors in fetchTeamWithOwner; only return null when the team genuinely does not exist. Tolerate a failing ownerOf by rendering with owner: ''.
- Bind the Tableland signer's wallet to the configured RPC provider (ethers' Wallet.connect returns a new instance, so the previous code was leaving the wallet provider-less and falling back to the public validator).

Made-with: Cursor