### PR TITLE
Clean up Frank's flight page (mission 4) post-raise

### DIFF
--- a/ui/components/mission/MissionProfile.tsx
+++ b/ui/components/mission/MissionProfile.tsx
@@ -33,6 +33,7 @@ import { useActiveAccount } from 'thirdweb/react'
 import useJBProjectTimeline from '@/lib/juicebox/useJBProjectTimeline'
 import useTotalFunding from '@/lib/juicebox/useTotalFunding'
 import { useDeadlineTracking } from '@/lib/mission/useDeadlineTracking'
+import type { MissionFundingStats } from '@/lib/mission/fetchMissionFundingStats'
 import {
   fetchNativeBalanceWei,
   pickChainWithMaxNativeBalance,
@@ -114,6 +115,11 @@ type MissionProfileProps = {
    *  with Frank explainer to show honest empty-state copy when the top 25
    *  isn't filled yet (vs. just claiming "fewer than 25"). */
   _overviewRankedCount?: number
+  /** Aggregated funding stats (count, unique backers, median contribution)
+   *  for the wrapped-up Overview Flight raise. Powers the success-metrics
+   *  panel + 30-day "seat procurement" countdown that replaced the live
+   *  progress bar / milestones / goal on the mission 4 header. */
+  _overviewStats?: MissionFundingStats | null
 }
 
 export default function MissionProfile({
@@ -130,6 +136,7 @@ export default function MissionProfile({
   _overviewLeaderboard,
   _overviewTop25Threshold,
   _overviewRankedCount,
+  _overviewStats,
 }: MissionProfileProps) {
   const account = useActiveAccount()
   const router = useRouter()
@@ -444,6 +451,11 @@ export default function MissionProfile({
         setMissionMetadataModalEnabled={setMissionMetadataModalEnabled}
         setDeployTokenModalEnabled={setDeployTokenModalEnabled}
         token={token}
+        overviewStats={
+          mission?.id === 4 || String(mission?.id) === '4'
+            ? _overviewStats ?? null
+            : undefined
+        }
         contributeButton={
           !deadlinePassed && Number(stage) !== 3 && (
             <MissionPayRedeem

--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -8,9 +8,10 @@ import {
 } from 'const/missionMilestones'
 import Image from 'next/image'
 import Link from 'next/link'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useActiveAccount } from 'thirdweb/react'
 import useETHPrice from '@/lib/etherscan/useETHPrice'
+import type { MissionFundingStats } from '@/lib/mission/fetchMissionFundingStats'
 import { generatePrettyLink } from '@/lib/subscription/pretty-links'
 import { truncateTokenValue } from '@/lib/utils/numbers'
 import IPFSRenderer from '../layout/IPFSRenderer'
@@ -82,7 +83,19 @@ interface MissionProfileHeaderProps {
   setMissionMetadataModalEnabled?: (enabled: boolean) => void
   setDeployTokenModalEnabled?: (enabled: boolean) => void
   contributeButton: React.ReactNode
+  /** SSR-aggregated funding stats (median contribution, unique backers,
+   *  total contributions). Provided only for the wrapped-up Overview Flight
+   *  mission (id 4); when present, the header swaps the live progress
+   *  bar / milestones / goal tile for a "campaign success" stat row plus a
+   *  30-day seat procurement countdown. */
+  overviewStats?: MissionFundingStats | null
 }
+
+/** 30-day post-deadline window during which Frank's team works to convert
+ *  contributions into an actual seat to space. After this period elapses,
+ *  contributors become eligible for a refund if a seat couldn't be secured. */
+const SEAT_PROCUREMENT_DAYS = 30
+const SEAT_PROCUREMENT_MS = SEAT_PROCUREMENT_DAYS * 24 * 60 * 60 * 1000
 
 const MissionProfileHeader = React.memo(
   ({
@@ -111,6 +124,7 @@ const MissionProfileHeader = React.memo(
     setMissionMetadataModalEnabled,
     setDeployTokenModalEnabled,
     contributeButton,
+    overviewStats,
   }: MissionProfileHeaderProps) => {
     const account = useActiveAccount()
     const { ethPrice } = useETHPrice(1, 'ETH_TO_USD')
@@ -122,7 +136,21 @@ const MissionProfileHeader = React.memo(
     const onChainRaisedWei = terminalWei >= subgraphWei ? terminalWei : subgraphWei
     const onChainEthRaised = weiBigintToEthNumber(onChainRaisedWei)
 
+    /** Mission 4 (Frank's Overview Flight) gets a special header layout where
+     *  the title + tagline span the full content width, with the image and
+     *  funding card sitting side-by-side underneath. Other missions keep the
+     *  original side-by-side title/image arrangement. */
+    const isOverviewMission =
+      mission?.id === 4 || String(mission?.id) === '4'
+
     const milestoneBar = useMemo(() => {
+      // The Overview Flight raise is wrapped up — the funding card now
+      // shows success stats + a seat procurement countdown instead of the
+      // milestone progress bar / list. Skip the milestone computation for
+      // mission 4 entirely so the bar/list never render even momentarily
+      // (and `MISSION_FUNDING_MILESTONES_USD` can keep its mission-4 entry
+      // for places like the home/featured sections that still want it).
+      if (isOverviewMission) return null
       const steps =
         mission?.id != null ? MISSION_FUNDING_MILESTONES_USD[mission.id] : undefined
       if (!steps?.length || !ethPrice || ethPrice <= 0 || isLoadingTotalFunding) return null
@@ -135,6 +163,7 @@ const MissionProfileHeader = React.memo(
           )} to go`
       return { seg, raisedUsd, steps, caption }
     }, [
+      isOverviewMission,
       mission?.id,
       ethPrice,
       isLoadingTotalFunding,
@@ -142,12 +171,66 @@ const MissionProfileHeader = React.memo(
       offChainCommittedUsd,
     ])
 
-    /** Mission 4 (Frank's Overview Flight) gets a special header layout where
-     *  the title + tagline span the full content width, with the image and
-     *  funding card sitting side-by-side underneath. Other missions keep the
-     *  original side-by-side title/image arrangement. */
-    const isOverviewMission =
-      mission?.id === 4 || String(mission?.id) === '4'
+    /** Now-anchored values for the seat procurement countdown. We avoid
+     *  rendering anything until after the first client commit so the SSR
+     *  HTML doesn't bake in a wall-clock that immediately disagrees with
+     *  the user's local Date. */
+    const [now, setNow] = useState<number | null>(null)
+    useEffect(() => {
+      if (!isOverviewMission || deadline == null || deadline <= 0) return
+      setNow(Date.now())
+      const id = window.setInterval(() => setNow(Date.now()), 60_000)
+      return () => window.clearInterval(id)
+    }, [isOverviewMission, deadline])
+
+    const seatProcurement = useMemo(() => {
+      if (!isOverviewMission || deadline == null || deadline <= 0) return null
+      const procurementEndMs = deadline + SEAT_PROCUREMENT_MS
+      const procurementEndDate = new Date(procurementEndMs)
+      const procurementEndLabel = procurementEndDate.toLocaleDateString(
+        'en-US',
+        { month: 'long', day: 'numeric', year: 'numeric' }
+      )
+      const periodElapsed = now != null && now >= procurementEndMs
+      let countdownLabel: string | null = null
+      if (now != null && !periodElapsed) {
+        const msLeft = Math.max(0, procurementEndMs - now)
+        const totalMinutes = Math.floor(msLeft / 60_000)
+        const days = Math.floor(totalMinutes / (60 * 24))
+        const hours = Math.floor((totalMinutes % (60 * 24)) / 60)
+        const minutes = totalMinutes % 60
+        countdownLabel =
+          days >= 1
+            ? `${days}d ${hours}h`
+            : hours >= 1
+            ? `${hours}h ${minutes}m`
+            : `${minutes}m`
+      }
+      return {
+        procurementEndMs,
+        procurementEndLabel,
+        periodElapsed,
+        countdownLabel,
+      }
+    }, [isOverviewMission, deadline, now])
+
+    const overviewMedianUsd = useMemo(() => {
+      if (!overviewStats || !ethPrice || ethPrice <= 0) return null
+      const wei = (() => {
+        try {
+          return BigInt(overviewStats.medianAmountWei || '0')
+        } catch {
+          return BigInt(0)
+        }
+      })()
+      if (wei === BigInt(0)) return 0
+      // Convert wei → ETH (float) → USD using the current ETH price. The
+      // raise spanned a price range so this is an approximation, but it's
+      // the same convention the headline "raised" number uses, which keeps
+      // the on-page numbers internally consistent.
+      const eth = Number(wei) / 1e18
+      return eth * ethPrice
+    }, [overviewStats, ethPrice])
 
     const titleBlock = (
       <div className="space-y-2">
@@ -440,120 +523,217 @@ const MissionProfileHeader = React.memo(
                   </div>
                 </div>
 
-                {/* Progress Bar (milestone-relative for missions with USD steps, e.g. Frank White / id 4) */}
-                <div className="mb-4">
-                  <MissionFundingProgressBar
-                    fundingGoal={fundingGoal}
-                    volume={onChainEthRaised}
-                    compact={true}
-                    progressOverride={
-                      milestoneBar ? milestoneBar.seg.progressPercent : undefined
-                    }
-                    caption={milestoneBar?.caption}
-                  />
-                  {milestoneBar ? (
-                    <MissionFundingMilestonesList
-                      milestones={milestoneBar.steps}
-                      raisedUsd={milestoneBar.raisedUsd}
-                      nextMilestoneIndex={milestoneBar.seg.nextMilestoneIndex}
+                {/* Progress Bar — hidden on the wrapped-up Overview Flight
+                    page (mission 4). Other missions still get the live bar
+                    + milestone list. */}
+                {!isOverviewMission && (
+                  <div className="mb-4">
+                    <MissionFundingProgressBar
+                      fundingGoal={fundingGoal}
+                      volume={onChainEthRaised}
+                      compact={true}
+                      progressOverride={
+                        milestoneBar ? milestoneBar.seg.progressPercent : undefined
+                      }
+                      caption={milestoneBar?.caption}
                     />
-                  ) : null}
-                </div>
+                    {milestoneBar ? (
+                      <MissionFundingMilestonesList
+                        milestones={milestoneBar.steps}
+                        raisedUsd={milestoneBar.raisedUsd}
+                        nextMilestoneIndex={milestoneBar.seg.nextMilestoneIndex}
+                      />
+                    ) : null}
+                  </div>
+                )}
+
+                {/* Contributions-closed banner — Overview Flight only. Sits
+                    directly above the Seat Procurement panel so the reader
+                    immediately understands why the live progress / pay UI
+                    is gone before reading about the 30-day refund window. */}
+                {isOverviewMission && (
+                  <div
+                    data-testid="overview-contributions-closed-banner"
+                    className="mb-3 rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 flex items-start gap-3"
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="mt-1 inline-block h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_0_3px_rgba(52,211,153,0.18)]"
+                    />
+                    <div className="min-w-0">
+                      <p className="text-white text-sm font-semibold leading-snug">
+                        Contributions are now closed
+                      </p>
+                      <p className="text-gray-400 text-xs sm:text-[13px] leading-relaxed mt-0.5">
+                        The Overview Flight raise has wrapped up — no further
+                        contributions are being accepted.
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                {/* Seat Procurement Period — Overview Flight only. Replaces
+                    the milestone progress UI now that the raise has wrapped
+                    up. Anchored to the on-chain deadline, hydrated client
+                    side so SSR doesn't bake a stale countdown into HTML. */}
+                {isOverviewMission && seatProcurement && (
+                  <div
+                    data-testid="overview-seat-procurement-panel"
+                    className="mb-4 rounded-2xl border border-indigo-400/20 bg-gradient-to-br from-indigo-500/10 via-indigo-500/5 to-transparent p-4 sm:p-5"
+                  >
+                    <div className="flex items-start justify-between gap-3 flex-wrap">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-[10px] sm:text-[11px] uppercase tracking-wider font-medium text-indigo-300/90">
+                            Seat Procurement Period
+                          </span>
+                          <Tooltip
+                            compact
+                            text={`A ${SEAT_PROCUREMENT_DAYS}-day window (starting at the close of the raise) during which Frank's team works to convert raised funds into a confirmed seat to space. After this window closes, contributors become eligible for a refund if a seat could not be secured.`}
+                            buttonClassName="!h-3.5 !w-3.5 !text-[8px] !pl-0 -ml-0.5"
+                          >
+                            ?
+                          </Tooltip>
+                        </div>
+                        <p className="text-white font-GoodTimes text-base sm:text-lg leading-tight mt-1">
+                          {seatProcurement.periodElapsed
+                            ? 'Period Closed'
+                            : `Ends ${seatProcurement.procurementEndLabel}`}
+                        </p>
+                      </div>
+                      {!seatProcurement.periodElapsed && (
+                        <div className="text-right">
+                          <span className="text-[10px] sm:text-[11px] uppercase tracking-wider font-medium text-gray-400">
+                            Time Remaining
+                          </span>
+                          <p
+                            data-testid="overview-seat-procurement-countdown"
+                            className="text-white font-GoodTimes text-base sm:text-lg leading-tight mt-1"
+                          >
+                            {seatProcurement.countdownLabel ?? '\u2014'}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                    <p className="text-gray-300/90 text-xs sm:text-sm leading-relaxed mt-3">
+                      {seatProcurement.periodElapsed
+                        ? `The ${SEAT_PROCUREMENT_DAYS}-day seat procurement period has ended. If Frank is unable to secure a seat to space, contributors are eligible for a refund.`
+                        : `Frank's team has ${SEAT_PROCUREMENT_DAYS} days from the close of the raise to secure a confirmed seat to space. Once this window ends, refunds will be made available if a seat cannot be secured.`}
+                    </p>
+                  </div>
+                )}
 
                 {/* Stats Row. On the Overview layout the funding card is
                     stretched to match the hero image; mt-auto pushes this
                     row to the card's bottom so the extra height shows up
                     as breathing room above the stats rather than a gap
-                    below them. */}
-                <div
-                  className={`grid grid-cols-3 gap-2 sm:gap-3 ${
-                    isOverviewMission ? 'lg:mt-auto' : ''
-                  }`}
-                >
-                  {/* Goal */}
-                  <div className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0">
-                    <div className="flex items-center gap-1 sm:gap-1.5 mb-1.5 min-w-0">
-                      <Image src="/assets/launchpad/target.svg" alt="Goal" width={14} height={14} className="opacity-60 flex-shrink-0" />
-                      <span className="text-gray-500 text-[11px] uppercase tracking-wider font-medium truncate">Goal</span>
-                      <span className="flex-shrink-0">
-                        <Tooltip
-                          compact
-                          text={
-                            minUsdGoal != null
-                              ? MISSION_MINIMUM_GOAL_TOOLTIP
-                              : 'This is an all-or-nothing mission. Refunds are available if the goal is not met.'
-                          }
-                          buttonClassName="!h-3.5 !w-3.5 !text-[8px] !pl-0 -ml-0.5"
-                        >
-                          ?
-                        </Tooltip>
-                      </span>
-                    </div>
-                    {minUsdGoal != null ? (
-                      <p className="text-white font-GoodTimes text-[11px] sm:text-sm truncate">
-                        ${minUsdGoal.toLocaleString('en-US')}
-                      </p>
-                    ) : (
-                      <Tooltip
-                        text={
-                          !isLoadingTotalFunding && ethPrice && ethPrice > 0
-                            ? `$${Math.round((fundingGoal / 1e18) * ethPrice).toLocaleString()}`
-                            : `Loading...`
-                        }
-                        wrap
-                      >
-                        <p className="text-white font-GoodTimes text-[11px] sm:text-sm truncate">
-                          {+(fundingGoal / 1e18).toFixed(3)} ETH
-                        </p>
-                      </Tooltip>
-                    )}
-                  </div>
+                    below them.
 
-                  {/* Deadline */}
-                  <div className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0">
-                    <div className="flex items-center gap-1 sm:gap-1.5 mb-1.5 min-w-0">
-                      <Image src="/assets/launchpad/clock.svg" alt="Deadline" width={14} height={14} className="opacity-60 flex-shrink-0" />
-                      <span className="text-gray-500 text-[11px] uppercase tracking-wider font-medium truncate">
-                        {refundPeriodPassed || Number(stage) === 3
-                          ? 'Status'
-                          : deadlinePassed
-                          ? 'Closed'
-                          : 'Deadline'}
-                      </span>
-                      {deadline != null && deadline > 0 ? (
+                    Mission 4 (Overview Flight, wrapped up) swaps the Goal
+                    tile for "Unique Backers" + "Median Contribution"
+                    success metrics, drops the Deadline tile (the Seat
+                    Procurement Period panel above already contains the
+                    relevant date), and keeps the Contributions tile. */}
+                <div
+                  className={`grid gap-2 sm:gap-3 ${
+                    isOverviewMission
+                      ? 'grid-cols-3'
+                      : 'grid-cols-3'
+                  } ${isOverviewMission ? 'lg:mt-auto' : ''}`}
+                  data-testid={
+                    isOverviewMission ? 'overview-stats-row' : undefined
+                  }
+                >
+                  {/* Goal — hidden on mission 4 (the page has been cleaned
+                      up post-raise; goal/progress no longer relevant). */}
+                  {!isOverviewMission && (
+                    <div className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0">
+                      <div className="flex items-center gap-1 sm:gap-1.5 mb-1.5 min-w-0">
+                        <Image src="/assets/launchpad/target.svg" alt="Goal" width={14} height={14} className="opacity-60 flex-shrink-0" />
+                        <span className="text-gray-500 text-[11px] uppercase tracking-wider font-medium truncate">Goal</span>
                         <span className="flex-shrink-0">
                           <Tooltip
-                            text={exactClosingTooltipText(deadline)}
                             compact
+                            text={
+                              minUsdGoal != null
+                                ? MISSION_MINIMUM_GOAL_TOOLTIP
+                                : 'This is an all-or-nothing mission. Refunds are available if the goal is not met.'
+                            }
                             buttonClassName="!h-3.5 !w-3.5 !text-[8px] !pl-0 -ml-0.5"
                           >
                             ?
                           </Tooltip>
                         </span>
-                      ) : null}
+                      </div>
+                      {minUsdGoal != null ? (
+                        <p className="text-white font-GoodTimes text-[11px] sm:text-sm truncate">
+                          ${minUsdGoal.toLocaleString('en-US')}
+                        </p>
+                      ) : (
+                        <Tooltip
+                          text={
+                            !isLoadingTotalFunding && ethPrice && ethPrice > 0
+                              ? `$${Math.round((fundingGoal / 1e18) * ethPrice).toLocaleString()}`
+                              : `Loading...`
+                          }
+                          wrap
+                        >
+                          <p className="text-white font-GoodTimes text-[11px] sm:text-sm truncate">
+                            {+(fundingGoal / 1e18).toFixed(3)} ETH
+                          </p>
+                        </Tooltip>
+                      )}
                     </div>
-                    {refundPeriodPassed || deadlinePassed ? (
-                      <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
-                        {deadlinePassed
-                          ? `${new Date(deadline || 0).toLocaleDateString('en-US', {
-                              month: 'short',
-                              day: 'numeric',
-                              year: 'numeric',
-                            })}`
-                          : 'REFUNDED'}
-                      </p>
-                    ) : Number(stage) === 3 ? (
-                      <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
-                        REFUND
-                      </p>
-                    ) : deadline != null && deadline > 0 ? (
-                      <MissionDeadlineCountdown deadline={deadline} />
-                    ) : (
-                      <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
-                        {duration}
-                      </p>
-                    )}
-                  </div>
+                  )}
+
+                  {/* Deadline — hidden on mission 4 (the Seat Procurement
+                      Period panel renders the relevant closing context). */}
+                  {!isOverviewMission && (
+                    <div className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0">
+                      <div className="flex items-center gap-1 sm:gap-1.5 mb-1.5 min-w-0">
+                        <Image src="/assets/launchpad/clock.svg" alt="Deadline" width={14} height={14} className="opacity-60 flex-shrink-0" />
+                        <span className="text-gray-500 text-[11px] uppercase tracking-wider font-medium truncate">
+                          {refundPeriodPassed || Number(stage) === 3
+                            ? 'Status'
+                            : deadlinePassed
+                            ? 'Closed'
+                            : 'Deadline'}
+                        </span>
+                        {deadline != null && deadline > 0 ? (
+                          <span className="flex-shrink-0">
+                            <Tooltip
+                              text={exactClosingTooltipText(deadline)}
+                              compact
+                              buttonClassName="!h-3.5 !w-3.5 !text-[8px] !pl-0 -ml-0.5"
+                            >
+                              ?
+                            </Tooltip>
+                          </span>
+                        ) : null}
+                      </div>
+                      {refundPeriodPassed || deadlinePassed ? (
+                        <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
+                          {deadlinePassed
+                            ? `${new Date(deadline || 0).toLocaleDateString('en-US', {
+                                month: 'short',
+                                day: 'numeric',
+                                year: 'numeric',
+                              })}`
+                            : 'REFUNDED'}
+                        </p>
+                      ) : Number(stage) === 3 ? (
+                        <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
+                          REFUND
+                        </p>
+                      ) : deadline != null && deadline > 0 ? (
+                        <MissionDeadlineCountdown deadline={deadline} />
+                      ) : (
+                        <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
+                          {duration}
+                        </p>
+                      )}
+                    </div>
+                  )}
 
                   {/* Contributions */}
                   <div className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0">
@@ -564,9 +744,77 @@ const MissionProfileHeader = React.memo(
                       </span>
                     </div>
                     <p className="text-white font-GoodTimes text-[11px] sm:text-sm">
-                      {paymentsCount || 0}
+                      {(isOverviewMission && overviewStats?.totalContributions != null
+                        ? overviewStats.totalContributions
+                        : paymentsCount) || 0}
                     </p>
                   </div>
+
+                  {/* Unique Backers — Overview Flight only */}
+                  {isOverviewMission && (
+                    <div
+                      className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0"
+                      data-testid="overview-unique-backers"
+                    >
+                      <div className="flex items-center gap-1 sm:gap-1.5 mb-1.5 min-w-0">
+                        <Image src="/assets/icon-backers.svg" alt="Unique backers" width={14} height={14} className="opacity-60 flex-shrink-0" />
+                        <span className="text-gray-500 text-[11px] uppercase tracking-wider font-medium truncate">
+                          Unique Backers
+                        </span>
+                        <span className="flex-shrink-0">
+                          <Tooltip
+                            compact
+                            text="Distinct wallets that contributed to this raise (counted by pay-event beneficiary on the Juicebox subgraph)."
+                            buttonClassName="!h-3.5 !w-3.5 !text-[8px] !pl-0 -ml-0.5"
+                          >
+                            ?
+                          </Tooltip>
+                        </span>
+                      </div>
+                      <p className="text-white font-GoodTimes text-[11px] sm:text-sm">
+                        {overviewStats?.uniqueBackers != null
+                          ? overviewStats.uniqueBackers.toLocaleString('en-US')
+                          : '—'}
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Median Contribution — Overview Flight only */}
+                  {isOverviewMission && (
+                    <div
+                      className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0"
+                      data-testid="overview-median-contribution"
+                    >
+                      <div className="flex items-center gap-1 sm:gap-1.5 mb-1.5 min-w-0">
+                        <Image src="/assets/launchpad/target.svg" alt="Median" width={14} height={14} className="opacity-60 flex-shrink-0" />
+                        <span className="text-gray-500 text-[11px] uppercase tracking-wider font-medium truncate">
+                          Median Contribution
+                        </span>
+                        <span className="flex-shrink-0">
+                          <Tooltip
+                            compact
+                            text="Median on-chain pay event amount. Converted to USD using the current ETH/USD rate, so it's an approximation across the raise's price range."
+                            buttonClassName="!h-3.5 !w-3.5 !text-[8px] !pl-0 -ml-0.5"
+                          >
+                            ?
+                          </Tooltip>
+                        </span>
+                      </div>
+                      {overviewMedianUsd == null ? (
+                        <p className="text-white font-GoodTimes text-[11px] sm:text-sm">—</p>
+                      ) : overviewMedianUsd <= 0 ? (
+                        <p className="text-white font-GoodTimes text-[11px] sm:text-sm">$0</p>
+                      ) : overviewMedianUsd >= 1 ? (
+                        <p className="text-white font-GoodTimes text-[11px] sm:text-sm">
+                          ${Math.round(overviewMedianUsd).toLocaleString('en-US')}
+                        </p>
+                      ) : (
+                        <p className="text-white font-GoodTimes text-[11px] sm:text-sm">
+                          ${overviewMedianUsd.toFixed(2)}
+                        </p>
+                      )}
+                    </div>
+                  )}
                 </div>
                 </div>
               </div>

--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -224,11 +224,11 @@ const MissionProfileHeader = React.memo(
         }
       })()
       if (wei === BigInt(0)) return 0
-      // Convert wei → ETH (float) → USD using the current ETH price. The
-      // raise spanned a price range so this is an approximation, but it's
-      // the same convention the headline "raised" number uses, which keeps
+      // Convert wei → ETH → USD using the current ETH price. The raise
+      // spanned a price range so this is an approximation, but it's the
+      // same convention the headline "raised" number uses, which keeps
       // the on-page numbers internally consistent.
-      const eth = Number(wei) / 1e18
+      const eth = weiBigintToEthNumber(wei)
       return eth * ethPrice
     }, [overviewStats, ethPrice])
 

--- a/ui/cypress/integration/mission/mission-profile-header-overview.cy.tsx
+++ b/ui/cypress/integration/mission/mission-profile-header-overview.cy.tsx
@@ -1,0 +1,277 @@
+import MissionProfileHeader from '../../../components/mission/MissionProfileHeader'
+import TestnetProviders from '../../mock/TestnetProviders'
+
+/**
+ * Component-level tests for the MissionProfileHeader's "Overview Flight"
+ * (mission id 4) variant — the wrapped-up raise has its progress bar /
+ * milestones / Goal tile replaced with success metrics (Contributions,
+ * Unique Backers, Median Contribution) and a 30-day Seat Procurement
+ * Period panel anchored to the mission deadline.
+ */
+
+const baseTeamNFT = {
+  metadata: {
+    name: 'Overview Crew',
+    image: '/Original.png',
+    attributes: [],
+  },
+}
+
+const baseRuleset = [
+  {
+    start: Math.floor(Date.now() / 1000) - 86400 * 60,
+    weight: BigInt('1000000000000000000000000'),
+  },
+  { reservedPercent: BigInt('0') },
+]
+
+const baseToken = {
+  tokenAddress: '0x1234567890123456789012345678901234567890',
+  tokenSymbol: 'OVERVIEW',
+  tokenName: 'Overview Token',
+  tokenSupply: BigInt('1000000000000000000000'),
+}
+
+const overviewStats = {
+  totalContributions: 250,
+  uniqueBackers: 173,
+  // 0.05 ETH median; at $3000/ETH → $150
+  medianAmountWei: '50000000000000000',
+  meanAmountWei: '100000000000000000',
+  largestAmountWei: '5000000000000000000',
+  totalAmountWei: '25000000000000000000',
+}
+
+function buildOverviewProps(overrides: Partial<any> = {}) {
+  // Deadline 5 days ago by default — well within the 30-day seat
+  // procurement window so the countdown should render.
+  const deadline = Date.now() - 5 * 86400000
+  return {
+    mission: {
+      id: 4,
+      projectId: 224,
+      teamId: 1,
+      metadata: {
+        name: 'Go to Space with Frank White',
+        tagline: 'Wrapped-up Overview Flight raise',
+        logoUri: '/Original.png',
+      },
+    },
+    teamNFT: baseTeamNFT,
+    ruleset: baseRuleset as any,
+    fundingGoal: 1e18,
+    paymentsCount: overviewStats.totalContributions,
+    deadline,
+    duration: 'closed',
+    deadlinePassed: true,
+    refundPeriodPassed: false,
+    refundPeriod: deadline + 60 * 60 * 1000,
+    stage: 2,
+    token: baseToken,
+    poolDeployerAddress: undefined,
+    isManager: false,
+    availableTokens: 0,
+    availablePayouts: 0,
+    sendReservedTokens: () => {},
+    sendPayouts: () => {},
+    deployLiquidityPool: () => {},
+    totalFunding: BigInt('5000000000000000000'),
+    isLoadingTotalFunding: false,
+    setMissionMetadataModalEnabled: undefined,
+    setDeployTokenModalEnabled: undefined,
+    contributeButton: <button id="mock-contribute-btn">Contribute</button>,
+    overviewStats,
+    ...overrides,
+  }
+}
+
+const setupMocks = () => {
+  // Cypress matches intercepts in last-registered-first order, so the
+  // specific ETH-price intercept must be registered AFTER the catch-all
+  // `**/api/**` one to actually win over it.
+  cy.intercept('GET', '**/api/**', { fixture: 'empty.json' }).as('apiCalls')
+  cy.intercept('POST', '**/api/**', { fixture: 'empty.json' }).as('apiPosts')
+  cy.intercept('GET', '**/api/etherscan/eth-price**', {
+    statusCode: 200,
+    body: { result: { ethusd: '3000' } },
+  }).as('ethPrice')
+}
+
+describe('MissionProfileHeader — Overview Flight (mission 4) wrapped-up layout', () => {
+  beforeEach(() => {
+    cy.mountNextRouter('/')
+    setupMocks()
+  })
+
+  it('does not render the funding progress bar', () => {
+    cy.mount(
+      <TestnetProviders>
+        <MissionProfileHeader {...buildOverviewProps()} />
+      </TestnetProviders>
+    )
+    // The progress bar wrapper carries a distinctive gradient class on its
+    // fill element. None should appear inside the funding card.
+    cy.get('[data-testid="overview-stats-row"]').should('exist')
+    cy.get('.from-blue-500.via-purple-600.to-blue-500').should('not.exist')
+  })
+
+  it('does not render the milestones list or "Goal" tile', () => {
+    cy.mount(
+      <TestnetProviders>
+        <MissionProfileHeader {...buildOverviewProps()} />
+      </TestnetProviders>
+    )
+    cy.contains('Goal').should('not.exist')
+    cy.contains('Stratospheric balloon seat #1').should('not.exist')
+  })
+
+  it('renders the success metrics (Contributions, Unique Backers, Median Contribution)', () => {
+    cy.mount(
+      <TestnetProviders>
+        <MissionProfileHeader {...buildOverviewProps()} />
+      </TestnetProviders>
+    )
+    cy.contains('Contributions').should('be.visible')
+    cy.contains('250').should('be.visible')
+    cy.get('[data-testid="overview-unique-backers"]').within(() => {
+      cy.contains('Unique Backers').should('be.visible')
+      cy.contains('173').should('be.visible')
+    })
+    cy.get('[data-testid="overview-median-contribution"]').within(() => {
+      cy.contains('Median Contribution').should('be.visible')
+      // 0.05 ETH * $3000 = $150
+      cy.contains('$150').should('be.visible')
+    })
+  })
+
+  it('renders the "contributions are now closed" banner directly above the Seat Procurement panel', () => {
+    cy.mount(
+      <TestnetProviders>
+        <MissionProfileHeader {...buildOverviewProps()} />
+      </TestnetProviders>
+    )
+    cy.get('[data-testid="overview-contributions-closed-banner"]').should(
+      'be.visible'
+    )
+    cy.contains('Contributions are now closed').should('be.visible')
+    cy.contains(/Overview Flight raise has wrapped up/).should('be.visible')
+    // The banner must precede the Seat Procurement panel in the DOM order
+    // so the user reads "closed" before "30-day refund window".
+    cy.get(
+      '[data-testid="overview-contributions-closed-banner"] ~ [data-testid="overview-seat-procurement-panel"]'
+    ).should('exist')
+  })
+
+  it('renders the 30-day Seat Procurement Period panel with a live countdown', () => {
+    const deadline = Date.now() - 5 * 86400000 // 5 days ago
+    cy.mount(
+      <TestnetProviders>
+        <MissionProfileHeader {...buildOverviewProps({ deadline })} />
+      </TestnetProviders>
+    )
+    cy.get('[data-testid="overview-seat-procurement-panel"]').should('exist')
+    cy.contains('Seat Procurement Period').should('be.visible')
+    // Expected end date label: deadline + 30 days
+    const endLabel = new Date(deadline + 30 * 86400000).toLocaleDateString(
+      'en-US',
+      { month: 'long', day: 'numeric', year: 'numeric' }
+    )
+    cy.contains(endLabel).should('be.visible')
+    cy.get('[data-testid="overview-seat-procurement-countdown"]').should(
+      ($el) => {
+        // ~25 days remain (30 - 5). Countdown format starts with "<n>d ".
+        expect($el.text()).to.match(/^\d+d\s+\d+h$/)
+      }
+    )
+    cy.contains(/Frank's team has 30 days from the close of the raise/).should(
+      'be.visible'
+    )
+  })
+
+  it('flips to the "period closed" copy after the 30-day window has elapsed', () => {
+    // Deadline 45 days ago → past the 30-day procurement window
+    const deadline = Date.now() - 45 * 86400000
+    cy.mount(
+      <TestnetProviders>
+        <MissionProfileHeader {...buildOverviewProps({ deadline })} />
+      </TestnetProviders>
+    )
+    cy.get('[data-testid="overview-seat-procurement-panel"]').should('exist')
+    cy.contains('Period Closed').should('be.visible')
+    cy.contains(/contributors are eligible for a refund/).should('be.visible')
+    cy.get('[data-testid="overview-seat-procurement-countdown"]').should(
+      'not.exist'
+    )
+  })
+
+  it('still renders the headline raised amount and contribute button slot', () => {
+    cy.mount(
+      <TestnetProviders>
+        <MissionProfileHeader {...buildOverviewProps()} />
+      </TestnetProviders>
+    )
+    cy.contains('raised').should('be.visible')
+    cy.get('#mock-contribute-btn').should('exist')
+  })
+})
+
+describe('MissionProfileHeader — non-Overview missions are unaffected', () => {
+  const baseMission = {
+    id: 5,
+    projectId: 999,
+    teamId: 1,
+    metadata: {
+      name: 'Other Mission',
+      tagline: 'Still uses progress bar / Goal',
+      logoUri: '/Original.png',
+    },
+  }
+
+  const defaultDeadline = Date.now() + 86400000
+  const defaultProps = {
+    mission: baseMission,
+    teamNFT: baseTeamNFT,
+    ruleset: baseRuleset as any,
+    fundingGoal: 1e18,
+    paymentsCount: 5,
+    deadline: defaultDeadline,
+    duration: '23h 59m',
+    deadlinePassed: false,
+    refundPeriodPassed: false,
+    refundPeriod: defaultDeadline + 60 * 60 * 1000,
+    stage: 1,
+    token: baseToken,
+    poolDeployerAddress: undefined,
+    isManager: false,
+    availableTokens: 0,
+    availablePayouts: 0,
+    sendReservedTokens: () => {},
+    sendPayouts: () => {},
+    deployLiquidityPool: () => {},
+    totalFunding: BigInt('500000000000000000'),
+    isLoadingTotalFunding: false,
+    setMissionMetadataModalEnabled: undefined,
+    setDeployTokenModalEnabled: undefined,
+    contributeButton: <button id="mock-contribute-btn-other">Contribute</button>,
+  }
+
+  beforeEach(() => {
+    cy.mountNextRouter('/')
+    setupMocks()
+  })
+
+  it('still renders the Goal tile and Deadline tile for non-overview missions', () => {
+    cy.mount(
+      <TestnetProviders>
+        <MissionProfileHeader {...defaultProps} />
+      </TestnetProviders>
+    )
+    cy.contains('Goal').should('be.visible')
+    cy.contains('Deadline').should('be.visible')
+    cy.contains('Contributions').should('be.visible')
+    cy.get('[data-testid="overview-seat-procurement-panel"]').should(
+      'not.exist'
+    )
+    cy.get('[data-testid="overview-stats-row"]').should('not.exist')
+  })
+})

--- a/ui/lib/mission/fetchMissionFundingStats.ts
+++ b/ui/lib/mission/fetchMissionFundingStats.ts
@@ -1,0 +1,201 @@
+import { BENDYSTRAW_JB_VERSION, DEFAULT_CHAIN_V5 } from 'const/config'
+
+/**
+ * Aggregate stats describing a wrapped-up Juicebox raise. Computed from the
+ * raw payEvents rather than the project totals so we can derive things the
+ * subgraph doesn't pre-aggregate (median contribution, unique beneficiaries).
+ *
+ * All amount values are wei-as-string so the object stays JSON-serializable
+ * across `getServerSideProps`. The UI converts to ETH/USD client-side.
+ */
+export interface MissionFundingStats {
+  totalContributions: number
+  uniqueBackers: number
+  medianAmountWei: string
+  meanAmountWei: string
+  largestAmountWei: string
+  totalAmountWei: string
+}
+
+const PAGE_SIZE = 1000
+const MAX_PAGES = 20 // safety net (~20K events) for runaway pagination
+
+function buildPayEventsQuery(
+  projectId: number,
+  timestampCursor: number | null
+): string {
+  const cursorClause =
+    timestampCursor != null && Number.isFinite(timestampCursor)
+      ? `, timestamp_lt: ${timestampCursor}`
+      : ''
+  return `
+    query {
+      payEvents(
+        limit: ${PAGE_SIZE},
+        orderBy: "timestamp",
+        orderDirection: "desc",
+        where: {
+          projectId: ${projectId},
+          version: ${BENDYSTRAW_JB_VERSION},
+          chainId: ${DEFAULT_CHAIN_V5.id}${cursorClause}
+        }
+      ) {
+        items {
+          amount
+          beneficiary
+          timestamp
+        }
+      }
+    }
+  `
+}
+
+interface PayEventRow {
+  amount: string | number | null | undefined
+  beneficiary: string | null | undefined
+  timestamp: number | null | undefined
+}
+
+/**
+ * Fetch every payEvent for a project from Bendystraw and aggregate funding
+ * stats. Designed to run in `getServerSideProps` (SSR) — uses a direct
+ * fetch to the subgraph URL rather than going through `/api/juicebox/query`
+ * (which would require an absolute URL during SSR).
+ *
+ * Returns null on any subgraph error so the caller can render a graceful
+ * fallback. Pagination uses `timestamp_lt` cursors to walk the dataset
+ * deterministically without relying on offset (Bendystraw caps `limit` at
+ * 1000 per query).
+ */
+export async function fetchMissionFundingStats(
+  projectId: number | undefined
+): Promise<MissionFundingStats | null> {
+  if (
+    projectId == null ||
+    !Number.isFinite(projectId) ||
+    projectId <= 0
+  ) {
+    return null
+  }
+
+  const apiKey = process.env.BENDYSTRAW_API_KEY
+  if (!apiKey) return null
+  const subgraphUrl = `https://${
+    process.env.NEXT_PUBLIC_CHAIN !== 'mainnet' ? 'testnet.' : ''
+  }bendystraw.xyz/${apiKey}/graphql`
+
+  const allEvents: PayEventRow[] = []
+  let cursor: number | null = null
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    let res: Response
+    try {
+      res = await fetch(subgraphUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: buildPayEventsQuery(projectId, cursor) }),
+      })
+    } catch (error) {
+      console.warn('[fetchMissionFundingStats] network error:', error)
+      return null
+    }
+
+    if (!res.ok) {
+      console.warn(
+        `[fetchMissionFundingStats] non-OK status ${res.status} for project ${projectId}`
+      )
+      return null
+    }
+
+    let payload: any
+    try {
+      payload = await res.json()
+    } catch (error) {
+      console.warn('[fetchMissionFundingStats] invalid JSON:', error)
+      return null
+    }
+
+    if (payload?.errors?.length) {
+      console.warn(
+        '[fetchMissionFundingStats] subgraph errors:',
+        payload.errors
+      )
+      return null
+    }
+
+    const items: PayEventRow[] = payload?.data?.payEvents?.items ?? []
+    if (items.length === 0) break
+    allEvents.push(...items)
+
+    // Find the oldest timestamp in this page; use it as the next cursor
+    // (timestamp_lt strictly excludes equality, so we may miss events that
+    // share the exact same timestamp as the cursor — extremely unlikely for
+    // payments, but if it ever happens, the safety bound below kicks in).
+    let oldest = Number.POSITIVE_INFINITY
+    for (const ev of items) {
+      const ts = Number(ev.timestamp ?? NaN)
+      if (Number.isFinite(ts) && ts < oldest) oldest = ts
+    }
+    if (!Number.isFinite(oldest) || items.length < PAGE_SIZE) break
+    cursor = oldest
+  }
+
+  if (allEvents.length === 0) {
+    return {
+      totalContributions: 0,
+      uniqueBackers: 0,
+      medianAmountWei: '0',
+      meanAmountWei: '0',
+      largestAmountWei: '0',
+      totalAmountWei: '0',
+    }
+  }
+
+  const amounts: bigint[] = []
+  const backers = new Set<string>()
+  let total = BigInt(0)
+  let largest = BigInt(0)
+  for (const ev of allEvents) {
+    let amt: bigint
+    try {
+      amt = BigInt(ev.amount ?? 0)
+    } catch {
+      continue
+    }
+    if (amt <= BigInt(0)) continue
+    amounts.push(amt)
+    total += amt
+    if (amt > largest) largest = amt
+    if (typeof ev.beneficiary === 'string' && ev.beneficiary) {
+      backers.add(ev.beneficiary.toLowerCase())
+    }
+  }
+
+  if (amounts.length === 0) {
+    return {
+      totalContributions: 0,
+      uniqueBackers: 0,
+      medianAmountWei: '0',
+      meanAmountWei: '0',
+      largestAmountWei: '0',
+      totalAmountWei: '0',
+    }
+  }
+
+  amounts.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+  const mid = Math.floor(amounts.length / 2)
+  const median =
+    amounts.length % 2 === 1
+      ? amounts[mid]
+      : (amounts[mid - 1] + amounts[mid]) / BigInt(2)
+  const mean = total / BigInt(amounts.length)
+
+  return {
+    totalContributions: amounts.length,
+    uniqueBackers: backers.size,
+    medianAmountWei: median.toString(),
+    meanAmountWei: mean.toString(),
+    largestAmountWei: largest.toString(),
+    totalAmountWei: total.toString(),
+  }
+}

--- a/ui/lib/mission/fetchMissionFundingStats.ts
+++ b/ui/lib/mission/fetchMissionFundingStats.ts
@@ -24,9 +24,12 @@ function buildPayEventsQuery(
   projectId: number,
   timestampCursor: number | null
 ): string {
+  // Use `timestamp_lte` (not `_lt`) so that we don't drop events that share
+  // the cursor's exact timestamp — block timestamps frequently tie. We
+  // dedupe by `id` across pages to absorb the resulting overlap.
   const cursorClause =
     timestampCursor != null && Number.isFinite(timestampCursor)
-      ? `, timestamp_lt: ${timestampCursor}`
+      ? `, timestamp_lte: ${timestampCursor}`
       : ''
   return `
     query {
@@ -41,6 +44,7 @@ function buildPayEventsQuery(
         }
       ) {
         items {
+          id
           amount
           beneficiary
           timestamp
@@ -51,6 +55,7 @@ function buildPayEventsQuery(
 }
 
 interface PayEventRow {
+  id: string | null | undefined
   amount: string | number | null | undefined
   beneficiary: string | null | undefined
   timestamp: number | null | undefined
@@ -63,9 +68,11 @@ interface PayEventRow {
  * (which would require an absolute URL during SSR).
  *
  * Returns null on any subgraph error so the caller can render a graceful
- * fallback. Pagination uses `timestamp_lt` cursors to walk the dataset
+ * fallback. Pagination uses `timestamp_lte` cursors to walk the dataset
  * deterministically without relying on offset (Bendystraw caps `limit` at
- * 1000 per query).
+ * 1000 per query). Because block timestamps often tie, we use `_lte` rather
+ * than `_lt` and dedupe by event `id` across pages so we never drop events
+ * that share the boundary timestamp.
  */
 export async function fetchMissionFundingStats(
   projectId: number | undefined
@@ -85,6 +92,7 @@ export async function fetchMissionFundingStats(
   }bendystraw.xyz/${apiKey}/graphql`
 
   const allEvents: PayEventRow[] = []
+  const seenIds = new Set<string>()
   let cursor: number | null = null
 
   for (let page = 0; page < MAX_PAGES; page++) {
@@ -125,17 +133,24 @@ export async function fetchMissionFundingStats(
 
     const items: PayEventRow[] = payload?.data?.payEvents?.items ?? []
     if (items.length === 0) break
-    allEvents.push(...items)
 
-    // Find the oldest timestamp in this page; use it as the next cursor
-    // (timestamp_lt strictly excludes equality, so we may miss events that
-    // share the exact same timestamp as the cursor — extremely unlikely for
-    // payments, but if it ever happens, the safety bound below kicks in).
+    // Track the oldest timestamp on this page and how many of its rows are
+    // genuinely new (vs. carried over from the previous page's `_lte` overlap).
     let oldest = Number.POSITIVE_INFINITY
+    let newRows = 0
     for (const ev of items) {
+      const id = typeof ev.id === 'string' ? ev.id : null
+      if (id && seenIds.has(id)) continue
+      if (id) seenIds.add(id)
+      allEvents.push(ev)
+      newRows++
       const ts = Number(ev.timestamp ?? NaN)
       if (Number.isFinite(ts) && ts < oldest) oldest = ts
     }
+
+    // If the entire page collapsed to duplicates we have no way to advance
+    // the cursor without revisiting the same events forever — bail out.
+    if (newRows === 0) break
     if (!Number.isFinite(oldest) || items.length < PAGE_SIZE) break
     cursor = oldest
   }

--- a/ui/lib/mission/fetchMissionFundingStats.ts
+++ b/ui/lib/mission/fetchMissionFundingStats.ts
@@ -94,6 +94,7 @@ export async function fetchMissionFundingStats(
   const allEvents: PayEventRow[] = []
   const seenIds = new Set<string>()
   let cursor: number | null = null
+  let exhausted = false
 
   for (let page = 0; page < MAX_PAGES; page++) {
     let res: Response
@@ -132,7 +133,10 @@ export async function fetchMissionFundingStats(
     }
 
     const items: PayEventRow[] = payload?.data?.payEvents?.items ?? []
-    if (items.length === 0) break
+    if (items.length === 0) {
+      exhausted = true
+      break
+    }
 
     // Track the oldest timestamp on this page and how many of its rows are
     // genuinely new (vs. carried over from the previous page's `_lte` overlap).
@@ -150,9 +154,27 @@ export async function fetchMissionFundingStats(
 
     // If the entire page collapsed to duplicates we have no way to advance
     // the cursor without revisiting the same events forever — bail out.
-    if (newRows === 0) break
-    if (!Number.isFinite(oldest) || items.length < PAGE_SIZE) break
+    // Treat this as exhausted: the only way we'd still be missing rows is
+    // > PAGE_SIZE events sharing one timestamp, which is not a real scenario.
+    if (newRows === 0) {
+      exhausted = true
+      break
+    }
+    if (!Number.isFinite(oldest) || items.length < PAGE_SIZE) {
+      exhausted = true
+      break
+    }
     cursor = oldest
+  }
+
+  // If we ran out the safety bound without ever seeing a short page, the
+  // dataset is larger than we can safely page through and any aggregate we
+  // return would silently undercount. Refuse to publish partial stats.
+  if (!exhausted) {
+    console.warn(
+      `[fetchMissionFundingStats] hit MAX_PAGES (${MAX_PAGES}) cap for project ${projectId}; refusing to return partial aggregates`
+    )
+    return null
   }
 
   if (allEvents.length === 0) {

--- a/ui/pages/mission/[tokenId].tsx
+++ b/ui/pages/mission/[tokenId].tsx
@@ -3,6 +3,10 @@ import { BLOCKED_MISSIONS } from 'const/whitelist'
 import { GetServerSideProps } from 'next'
 import dynamic from 'next/dynamic'
 import { fetchFromIPFSWithFallback, getIPFSGateway } from '@/lib/ipfs/gateway'
+import {
+  fetchMissionFundingStats,
+  type MissionFundingStats,
+} from '@/lib/mission/fetchMissionFundingStats'
 import { getMissionServerData } from '@/lib/mission/fetchMissionServerData'
 import { fetchTokenMetadata } from '@/lib/mission/fetchTokenServerData'
 import { fetchOverviewLeaderboard } from '@/lib/overview-delegate/fetchLeaderboard'
@@ -44,6 +48,11 @@ type ProjectProfileProps = {
    *  honest copy in the Fly with Frank explainer when the top 25 isn't
    *  full yet. Only provided for the Overview Flight mission. */
   _overviewRankedCount?: number
+  /** Aggregated funding stats (total contributions, unique backers, median
+   *  / mean / largest contribution amounts in wei) computed from the full
+   *  payEvents list at SSR time. Powers the wrapped-up "campaign success"
+   *  panel on the Overview Flight mission page. Only provided for mission 4. */
+  _overviewStats?: MissionFundingStats | null
 }
 
 /** Mission ID for the Overview Flight fundraiser; used to opportunistically
@@ -64,6 +73,7 @@ export default function MissionProfilePage({
   _overviewLeaderboard,
   _overviewTop25Threshold,
   _overviewRankedCount,
+  _overviewStats,
 }: ProjectProfileProps) {
   const selectedChain = DEFAULT_CHAIN_V5
 
@@ -89,6 +99,7 @@ export default function MissionProfilePage({
           _overviewLeaderboard={_overviewLeaderboard}
           _overviewTop25Threshold={_overviewTop25Threshold}
           _overviewRankedCount={_overviewRankedCount}
+          _overviewStats={_overviewStats}
         />
       </JuiceProviders>
     </>
@@ -195,6 +206,19 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query, re
           })
         : Promise.resolve(undefined)
 
+      // The Overview Flight raise is wrapped up — its mission page now
+      // surfaces success metrics (total/unique backers, median contribution)
+      // instead of a live progress bar. Compute them at SSR time so they
+      // ship in the initial HTML and benefit from the page's s-maxage cache
+      // rather than triggering a separate client-side subgraph round-trip.
+      const overviewStatsPromise: Promise<MissionFundingStats | null | undefined> =
+        isOverviewMission
+          ? fetchMissionFundingStats(missionRow.projectId).catch((error) => {
+              console.warn('[mission/4] funding stats fetch failed:', error)
+              return null
+            })
+          : Promise.resolve(undefined)
+
       const metadata = await fetchFromIPFSWithFallback(ipfsHash).catch((error: any) => {
         console.warn('All IPFS gateways failed:', error)
         return {
@@ -222,7 +246,10 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query, re
           ]
         : [{ weight: 0 }, { reservedPercent: 0 }]
 
-      const _overviewLeaderboardFull = await overviewLeaderboardPromise
+      const [_overviewLeaderboardFull, _overviewStatsResult] = await Promise.all([
+        overviewLeaderboardPromise,
+        overviewStatsPromise,
+      ])
 
       // Slice to the top 5 for the preview component (its existing UX),
       // pull the 25th-place backing total for the explainer's threshold
@@ -263,6 +290,9 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query, re
             : {}),
           ...(_overviewRankedCount !== undefined
             ? { _overviewRankedCount }
+            : {}),
+          ...(_overviewStatsResult !== undefined
+            ? { _overviewStats: _overviewStatsResult }
             : {}),
         },
       }


### PR DESCRIPTION
## Summary

Mission 4 (Overview Flight, "Go to Space with Frank White") finished fundraising, so the live funding UI on its mission page is no longer relevant. This PR cleans the page up:

- **Removes** the funding progress bar, the milestones list, and the Goal stat tile on the mission 4 page only — other mission pages keep the existing layout.
- **Adds a new SSR helper** (`ui/lib/mission/fetchMissionFundingStats.ts`) that paginates the Juicebox/Bendystraw `payEvents` and returns serializable totals: `totalContributions`, `uniqueBackers`, and `median`/`mean`/`largest` contribution amounts (wei strings).
- **Adds new success metrics** to the funding card: Contributions, Unique Backers, Median Contribution (USD via the current ETH/USD rate, with a tooltip explaining the approximation).
- **Adds a "Contributions are now closed" banner** directly above the new...
- **30-day Seat Procurement Period panel** — anchored to the on-chain deadline, with a live countdown that ticks every minute. Once the window elapses, copy flips to refund-eligibility messaging.
- **Hydrates the countdown client-side** so SSR HTML never bakes in a stale wall-clock.
- **Cypress tests** cover: banner renders above procurement panel, three new stat tiles, in-window countdown formatting, post-window copy flip, and that non-overview missions are unaffected.

## Test plan

- [ ] Visit `/mission/4` and confirm: no progress bar, no milestones list, no Goal tile, three new stat tiles (Contributions / Unique Backers / Median Contribution), "Contributions are now closed" banner, and the 30-day Seat Procurement panel with countdown.
- [ ] Hover the Median Contribution `?` tooltip — confirm it explains the USD conversion caveat.
- [ ] Visit any other mission page (e.g. `/mission/3`) and confirm the existing progress bar / milestones / Goal tile still render unchanged.
- [ ] Run the new component tests: `cd ui && yarn cypress run --component --spec cypress/integration/mission/mission-profile-header-overview.cy.tsx`
- [ ] (Optional) Spot-check the SSR funding stats: load `/mission/4`, view source, confirm `_overviewStats` is hydrated with non-zero `totalContributions` / `uniqueBackers` / `medianAmountWei`.

## Notes

- The mission-4 entry in `MISSION_FUNDING_MILESTONES_USD` and the off-chain committed USD constant are untouched — `FeaturedMissionSection`, `MissionWideCard`, and `SignedInDashboard` still consume them. If those home/dashboard surfaces should also be cleaned up, that's a quick follow-up.
