### PR TITLE
Wrap up Q2 2026 member vote: advisory multisig audit + outcomes display

### DIFF
--- a/ui/components/nance/MemberVoteResults.tsx
+++ b/ui/components/nance/MemberVoteResults.tsx
@@ -18,15 +18,9 @@ import type { MemberVoteOutcome } from '@/lib/proposals/computeMemberVoteOutcome
 type Props = {
   quarter: number
   year: number
-  /** USD pool the budget cap is derived from — surfaced in the header for context. */
-  quarterBudgetUsd: number
 }
 
-export default function MemberVoteResults({
-  quarter,
-  year,
-  quarterBudgetUsd,
-}: Props) {
+export default function MemberVoteResults({ quarter, year }: Props) {
   // SWR with conservative refresh: results only change when the EB re-runs
   // the tally (rare). 60s dedupe matches the endpoint's `s-maxage=60`.
   const { data, error, isLoading } = useSWR<{
@@ -47,6 +41,11 @@ export default function MemberVoteResults({
   const totalApprovedBudget = outcome.results
     .filter((r) => r.approved)
     .reduce((sum, r) => sum + (r.budget || 0), 0)
+  // Source the pool size from the outcome itself rather than a separately-
+  // passed prop so the header can never disagree with the budget cap the
+  // tally pipeline actually applied (`getApprovedProjects` uses
+  // `outcome.quarterBudgetUsd` end-to-end).
+  const quarterBudgetUsd = outcome.quarterBudgetUsd
   const closeDate = new Date(outcome.voteCloseTimestamp * 1000)
 
   return (

--- a/ui/components/nance/MemberVoteResults.tsx
+++ b/ui/components/nance/MemberVoteResults.tsx
@@ -1,0 +1,152 @@
+/**
+ * Member Vote results panel for `/projects`.
+ *
+ * Fetches the read-only outcome from `/api/proposals/vote-results` and
+ * renders a ranked list (% share, approved/failed badge, budget, MDP).
+ *
+ * Renders nothing when:
+ *   - The fetch is still loading (avoid empty-state flicker on every page
+ *     load — the heavy server-side compute can take 5–20s on a cold cache).
+ *   - There are no votes for the requested quarter yet.
+ *   - The endpoint errors out.
+ */
+import Link from 'next/link'
+import useSWR from 'swr'
+import fetcher from '@/lib/swr/fetcher'
+import type { MemberVoteOutcome } from '@/lib/proposals/computeMemberVoteOutcome'
+
+type Props = {
+  quarter: number
+  year: number
+  /** USD pool the budget cap is derived from — surfaced in the header for context. */
+  quarterBudgetUsd: number
+}
+
+export default function MemberVoteResults({
+  quarter,
+  year,
+  quarterBudgetUsd,
+}: Props) {
+  // SWR with conservative refresh: results only change when the EB re-runs
+  // the tally (rare). 60s dedupe matches the endpoint's `s-maxage=60`.
+  const { data, error, isLoading } = useSWR<{
+    outcome: MemberVoteOutcome | null
+    quarter: number
+    year: number
+  }>(`/api/proposals/vote-results?quarter=${quarter}&year=${year}`, fetcher, {
+    revalidateOnFocus: false,
+    dedupingInterval: 60_000,
+    errorRetryCount: 1,
+  })
+
+  if (isLoading || error) return null
+  const outcome = data?.outcome
+  if (!outcome || !outcome.results?.length) return null
+
+  const approvedCount = outcome.results.filter((r) => r.approved).length
+  const totalApprovedBudget = outcome.results
+    .filter((r) => r.approved)
+    .reduce((sum, r) => sum + (r.budget || 0), 0)
+  const closeDate = new Date(outcome.voteCloseTimestamp * 1000)
+
+  return (
+    <div className="mb-4 sm:mb-6 bg-gradient-to-br from-emerald-900/20 via-slate-800/30 to-slate-900/40 border border-emerald-400/20 rounded-xl p-4 sm:p-5">
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 sm:gap-4 mb-3 sm:mb-4">
+        <div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-GoodTimes text-white text-base sm:text-lg">
+              Member Vote Results
+            </h3>
+            <span className="text-[10px] font-RobotoMono uppercase tracking-wider text-emerald-300 bg-emerald-400/15 border border-emerald-400/30 px-1.5 py-0.5 rounded">
+              Q{outcome.quarter} {outcome.year}
+            </span>
+          </div>
+          <p className="text-xs text-gray-400 mt-1">
+            Snapshot at vote close ({closeDate.toLocaleDateString()}). Voting
+            power is √vMOONEY across all chains; author self-votes are
+            stripped before the tally.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-[11px] font-RobotoMono">
+          <span className="bg-black/30 border border-white/10 text-gray-200 px-2 py-1 rounded">
+            {outcome.voterCount} voter{outcome.voterCount === 1 ? '' : 's'}
+          </span>
+          <span className="bg-emerald-500/10 border border-emerald-400/30 text-emerald-200 px-2 py-1 rounded">
+            {approvedCount}/{outcome.results.length} approved
+          </span>
+          <span className="bg-blue-500/10 border border-blue-400/30 text-blue-200 px-2 py-1 rounded">
+            ${totalApprovedBudget.toLocaleString()} of $
+            {quarterBudgetUsd.toLocaleString()}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        {outcome.results.map((r) => {
+          const proposalLink =
+            r.MDP != null && r.MDP !== '' ? `/proposal/${r.MDP}` : null
+          return (
+            <div
+              key={r.projectId}
+              className={`flex items-center gap-2 sm:gap-3 px-2 sm:px-3 py-2 rounded-lg border ${
+                r.approved
+                  ? 'bg-emerald-500/5 border-emerald-400/20'
+                  : 'bg-black/20 border-white/10'
+              }`}
+            >
+              <div
+                className={`flex-shrink-0 w-7 h-7 sm:w-8 sm:h-8 flex items-center justify-center rounded-full font-bold text-xs ${
+                  r.approved
+                    ? 'bg-emerald-500/20 text-emerald-200 border border-emerald-400/30'
+                    : 'bg-white/5 text-gray-400 border border-white/10'
+                }`}
+              >
+                {r.rank}
+              </div>
+              <div className="flex-1 min-w-0">
+                {proposalLink ? (
+                  <Link
+                    href={proposalLink}
+                    className={`text-sm font-medium hover:underline truncate block ${
+                      r.approved ? 'text-white' : 'text-gray-300'
+                    }`}
+                  >
+                    {r.MDP != null ? `MDP-${r.MDP}: ` : ''}
+                    {r.name}
+                  </Link>
+                ) : (
+                  <p
+                    className={`text-sm font-medium truncate ${
+                      r.approved ? 'text-white' : 'text-gray-300'
+                    }`}
+                  >
+                    {r.name}
+                  </p>
+                )}
+                <p className="text-[11px] text-gray-500">
+                  Budget: ${r.budget.toLocaleString()}
+                </p>
+              </div>
+              <div className="text-right flex-shrink-0 min-w-[72px]">
+                <p
+                  className={`font-GoodTimes text-base sm:text-lg leading-none ${
+                    r.approved ? 'text-emerald-300' : 'text-gray-400'
+                  }`}
+                >
+                  {r.percentage.toFixed(2)}%
+                </p>
+                <p
+                  className={`text-[10px] font-RobotoMono uppercase tracking-wider mt-1 ${
+                    r.approved ? 'text-emerald-400' : 'text-gray-500'
+                  }`}
+                >
+                  {r.approved ? 'Approved' : 'Failed'}
+                </p>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -61,6 +61,7 @@ import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import SectionCard from '@/components/layout/SectionCard'
 import StandardButtonRight from '@/components/layout/StandardButtonRight'
 import Tooltip from '@/components/layout/Tooltip'
+import MemberVoteResults from '@/components/nance/MemberVoteResults'
 import OperatorPanel from '@/components/operator/OperatorPanel'
 import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
 import PastProjects, { hasFinalReport } from '@/components/project/PastProjects'
@@ -1597,6 +1598,15 @@ export function ProjectRewards({
                     These proposals have been submitted and are awaiting the next voting cycle.
                   </p>
                 )}
+                {/* Member Vote results panel — renders only when there are
+                    votes for the current proposal quarter. The component
+                    self-hides during loading / error so it doesn't add a
+                    flicker on cold cache. */}
+                <MemberVoteResults
+                  quarter={proposalQuarter}
+                  year={proposalYear}
+                  quarterBudgetUsd={USD_BUDGET}
+                />
                 <div className="flex flex-col gap-1.5 sm:gap-6">
                   {proposals && proposals.length > 0 ? (
                     proposals

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -1601,11 +1601,13 @@ export function ProjectRewards({
                 {/* Member Vote results panel — renders only when there are
                     votes for the current proposal quarter. The component
                     self-hides during loading / error so it doesn't add a
-                    flicker on cold cache. */}
+                    flicker on cold cache. The quarter budget the panel
+                    displays comes from the API response itself, not from
+                    a prop, so the header can't drift from the budget cap
+                    the tally actually used. */}
                 <MemberVoteResults
                   quarter={proposalQuarter}
                   year={proposalYear}
-                  quarterBudgetUsd={USD_BUDGET}
                 />
                 <div className="flex flex-col gap-1.5 sm:gap-6">
                   {proposals && proposals.length > 0 ? (

--- a/ui/lib/proposals/computeMemberVoteOutcome.ts
+++ b/ui/lib/proposals/computeMemberVoteOutcome.ts
@@ -252,7 +252,9 @@ export async function computeMemberVoteOutcome({
     for (const [projectId, value] of Object.entries(parsedDistribution)) {
       const author = projectIdToAuthorAddress[projectId]?.toLowerCase()
       if (author && author === voterAddr) continue
-      distribution[projectId] = Number(value)
+      const numericValue = Number(value)
+      if (!Number.isFinite(numericValue) || numericValue < 0) continue
+      distribution[projectId] = numericValue
     }
     return { ...row, distribution }
   })

--- a/ui/lib/proposals/computeMemberVoteOutcome.ts
+++ b/ui/lib/proposals/computeMemberVoteOutcome.ts
@@ -157,47 +157,65 @@ export async function computeMemberVoteOutcome({
   }
   if (passedProjects.length === 0) return null
 
-  // USD budgets pulled from each proposal's IPFS payload. We batch the
-  // fetches in small groups so the endpoint doesn't fan a hundred-plus
-  // concurrent requests at IPFS gateways every time it runs (the gateway
-  // often rate-limits or just collapses under the burst, which used to
-  // surface as zeroed-out budgets and a misranked outcome). The matching
-  // author-IPFS fetch below uses the same `BATCH_SIZE` for the same
-  // reason — keep them in sync if you tune one.
+  // Each proposal's IPFS payload is the source of truth for both the USD
+  // budget (used by the budget-cap inside `getApprovedProjects`) and the
+  // author address (used to strip self-votes). Fetch the payload once per
+  // project, derive both in the same pass, and batch in small groups so
+  // we don't fan a hundred-plus concurrent requests at the IPFS gateway —
+  // bursts there used to rate-limit us and surface as zeroed-out budgets
+  // / unstripped self-votes.
   const BATCH_SIZE = 5
-  const usdBudgetEntries: [string, number][] = []
+  const usdBudgets: Record<string, number> = {}
+  const projectIdToAuthorAddress: Record<string, string> = {}
+
+  function extractUsdBudget(proposal: any): number {
+    let budget = 0
+    if (proposal?.budget && Array.isArray(proposal.budget)) {
+      for (const item of proposal.budget) {
+        if (
+          item.token === 'USD' ||
+          item.token === 'USDC' ||
+          item.token === 'USDT' ||
+          item.token === 'DAI'
+        ) {
+          budget += Number(item.amount) || 0
+        }
+      }
+    }
+    return budget
+  }
+
   for (let i = 0; i < passedProjects.length; i += BATCH_SIZE) {
     const batch = passedProjects.slice(i, i + BATCH_SIZE)
-    const batchEntries = await Promise.all(
-      batch.map(async (project: any): Promise<[string, number]> => {
+    await Promise.all(
+      batch.map(async (project: any) => {
+        const projectId = String(project.id)
+        // Default the budget to 0 so a missing IPFS payload doesn't drop
+        // the project out of `getApprovedProjects`'s budget-cap loop —
+        // it'll just count as $0 toward the cap (same behavior as before).
+        usdBudgets[projectId] = 0
+        if (!project.proposalIPFS) return
         try {
           const proposalResponse = await fetch(project.proposalIPFS)
+          if (!proposalResponse.ok) return
           const proposal = await proposalResponse.json()
-          let budget = 0
-          if (proposal.budget) {
-            proposal.budget.forEach((item: any) => {
-              budget +=
-                item.token === 'USD' ||
-                item.token === 'USDC' ||
-                item.token === 'USDT' ||
-                item.token === 'DAI'
-                  ? Number(item.amount)
-                  : 0
-            })
+          usdBudgets[projectId] = extractUsdBudget(proposal)
+          if (
+            proposal &&
+            typeof proposal.authorAddress === 'string' &&
+            proposal.authorAddress.length > 0
+          ) {
+            projectIdToAuthorAddress[projectId] = proposal.authorAddress
           }
-          return [String(project.id), budget]
         } catch (error) {
           console.error(
-            `[computeMemberVoteOutcome] Failed to fetch budget for project ${project.id}:`,
+            `[computeMemberVoteOutcome] proposal IPFS fetch failed for project ${project.id}:`,
             error
           )
-          return [String(project.id), 0]
         }
       })
     )
-    usdBudgetEntries.push(...batchEntries)
   }
-  const usdBudgets = Object.fromEntries(usdBudgetEntries)
 
   const voteOpenTimestamp = Math.floor(
     getThirdThursdayOfQuarterTimestamp(quarter, year).getTime() / 1000
@@ -214,32 +232,6 @@ export async function computeMemberVoteOutcome({
       return [address.toLowerCase(), power]
     })
   )
-
-  // Resolve author addresses so we can strip self-votes from each row.
-  // Reuses the same `BATCH_SIZE` as the budget fetch above so we stay
-  // under the IPFS gateway's per-second cap on a single endpoint hit.
-  const projectIdToAuthorAddress: Record<string, string> = {}
-  for (let i = 0; i < passedProjects.length; i += BATCH_SIZE) {
-    const batch = passedProjects.slice(i, i + BATCH_SIZE)
-    await Promise.all(
-      batch.map(async (project: any) => {
-        if (!project.proposalIPFS) return
-        try {
-          const fetchRes = await fetch(project.proposalIPFS)
-          if (!fetchRes.ok) return
-          const json = await fetchRes.json()
-          if (json && typeof json.authorAddress === 'string' && json.authorAddress.length > 0) {
-            projectIdToAuthorAddress[String(project.id)] = json.authorAddress
-          }
-        } catch (error) {
-          console.error(
-            `[computeMemberVoteOutcome] author fetch failed for project ${project.id}:`,
-            error
-          )
-        }
-      })
-    )
-  }
 
   type VoteRow = DistributionVote & {
     distribution?: string | Record<string, number>

--- a/ui/lib/proposals/computeMemberVoteOutcome.ts
+++ b/ui/lib/proposals/computeMemberVoteOutcome.ts
@@ -1,0 +1,316 @@
+/**
+ * Read-only counterpart to `pages/api/proposals/vote.ts`.
+ *
+ * Replays the same quadratic-voting pipeline used at tally-time so the
+ * outcome can be displayed on `/projects` (and previewed by the EB before
+ * they trigger the on-chain close) WITHOUT touching the chain or doing the
+ * heavier Safe-multisig audit.
+ *
+ * Differences vs. the POST handler:
+ *   - No `updateTableCol` writes (it's purely a computation).
+ *   - No multisig audit (advisory only at tally time; not needed for display).
+ *   - No `currentTimestamp <= voteCloseTimestamp` guard. We always project
+ *     vMOONEY at `voteCloseTimestamp`, so live previews during voting are
+ *     consistent with what the tally will produce.
+ *   - Returns `null` on the "no votes / no eligible projects" cases instead
+ *     of throwing, so callers can treat it as "nothing to show".
+ *
+ * Keep this in sync with `pages/api/proposals/vote.ts` if the tally math
+ * changes — it intentionally mirrors that file's normalization → quadratic
+ * voting → top-half-with-budget-cap pipeline.
+ */
+import ProposalsABI from 'const/abis/Proposals.json'
+import {
+  PROJECT_TABLE_NAMES,
+  PROPOSALS_ADDRESSES,
+  PROPOSALS_TABLE_NAMES,
+  NEXT_QUARTER_BUDGET_USD,
+} from 'const/config'
+import { readContract, getContract } from 'thirdweb'
+import { getThirdThursdayOfQuarterTimestamp } from '@/lib/utils/dates'
+import queryTable from '@/lib/tableland/queryTable'
+import { DistributionVote } from '@/lib/tableland/types'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import { serverClient } from '@/lib/thirdweb/client'
+import { fetchTotalVMOONEYs } from '@/lib/tokens/hooks/useTotalVMOONEY'
+import {
+  runQuadraticVoting,
+  runIterativeNormalization,
+  getApprovedProjects,
+} from '@/lib/utils/rewards'
+
+export type MemberVoteResult = {
+  rank: number
+  projectId: string
+  MDP: number | string | null
+  name: string
+  percentage: number
+  approved: boolean
+  budget: number
+}
+
+export type MemberVoteOutcome = {
+  quarter: number
+  year: number
+  voteCount: number
+  voterCount: number
+  voteOpenTimestamp: number
+  voteCloseTimestamp: number
+  totalVotingPower: number
+  quarterBudgetUsd: number
+  results: MemberVoteResult[]
+  computedAt: number
+}
+
+// Mirror of the same retry helper inside the POST handler — RPC reads against
+// the Proposals contract occasionally come back as undefined buffers and a
+// single retry usually clears it. Keep this local so we don't pull a Next API
+// route into a shared lib.
+async function readContractWithRetry<T>(
+  contract: any,
+  method: string,
+  params: any[],
+  maxRetries = 3,
+  baseDelayMs = 500
+): Promise<T> {
+  let lastError: any
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const result = await readContract({ contract, method, params })
+      return result as T
+    } catch (error) {
+      lastError = error
+      const isRetryableError =
+        error instanceof TypeError &&
+        String(error.message).includes('buffer')
+      if (!isRetryableError || attempt === maxRetries - 1) {
+        throw error
+      }
+      const delay = baseDelayMs * Math.pow(2, attempt)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
+  throw lastError
+}
+
+export async function computeMemberVoteOutcome({
+  chain,
+  quarter,
+  year,
+}: {
+  chain: any
+  quarter: number
+  year: number
+}): Promise<MemberVoteOutcome | null> {
+  if (
+    !Number.isInteger(quarter) ||
+    !Number.isInteger(year) ||
+    quarter < 1 ||
+    quarter > 4 ||
+    year < 2020
+  ) {
+    return null
+  }
+
+  const chainSlug = getChainSlug(chain)
+  const proposalsTableName = PROPOSALS_TABLE_NAMES[chainSlug]
+  const projectTableName = PROJECT_TABLE_NAMES[chainSlug]
+  const proposalsContractAddress = PROPOSALS_ADDRESSES[chainSlug]
+  if (!proposalsTableName || !projectTableName || !proposalsContractAddress) {
+    return null
+  }
+
+  const voteStatement = `SELECT * FROM ${proposalsTableName} WHERE quarter = ${quarter} AND year = ${year}`
+  const votes = (await queryTable(chain, voteStatement)) as DistributionVote[]
+  if (!votes || votes.length === 0) return null
+  const voteAddresses = votes.map((pv) => pv.address)
+
+  const projectStatement = `SELECT * FROM ${projectTableName} WHERE QUARTER = ${quarter} AND YEAR = ${year}`
+  const projects = (await queryTable(chain, projectStatement)) || []
+  if (!projects.length) return null
+
+  const proposalContract = getContract({
+    client: serverClient,
+    address: proposalsContractAddress,
+    abi: ProposalsABI.abi as any,
+    chain,
+  })
+
+  // Filter to senate-approved projects (`tempCheckApproved` on-chain). Mirror
+  // the POST handler's sequential read pattern to avoid hammering the RPC.
+  const passedProjects: any[] = []
+  for (const project of projects) {
+    if (project.MDP === undefined || project.MDP === null) continue
+    try {
+      const approved = await readContractWithRetry<boolean>(
+        proposalContract,
+        'tempCheckApproved',
+        [project.MDP]
+      )
+      if (approved) passedProjects.push(project)
+    } catch (error) {
+      console.error(
+        '[computeMemberVoteOutcome] tempCheckApproved read failed:',
+        { projectId: project.id, MDP: project.MDP, error }
+      )
+    }
+  }
+  if (passedProjects.length === 0) return null
+
+  // USD budgets pulled from each proposal's IPFS payload.
+  const usdBudgets = Object.fromEntries(
+    await Promise.all(
+      passedProjects.map(async (project: any) => {
+        try {
+          const proposalResponse = await fetch(project.proposalIPFS)
+          const proposal = await proposalResponse.json()
+          let budget = 0
+          if (proposal.budget) {
+            proposal.budget.forEach((item: any) => {
+              budget +=
+                item.token === 'USD' ||
+                item.token === 'USDC' ||
+                item.token === 'USDT' ||
+                item.token === 'DAI'
+                  ? Number(item.amount)
+                  : 0
+            })
+          }
+          return [project.id, budget]
+        } catch (error) {
+          console.error(
+            `[computeMemberVoteOutcome] Failed to fetch budget for project ${project.id}:`,
+            error
+          )
+          return [project.id, 0]
+        }
+      })
+    )
+  )
+
+  const voteOpenTimestamp = Math.floor(
+    getThirdThursdayOfQuarterTimestamp(quarter, year).getTime() / 1000
+  )
+  const voteCloseTimestamp = voteOpenTimestamp + 60 * 60 * 24 * 5
+
+  const vMOONEYs = await fetchTotalVMOONEYs(voteAddresses, voteCloseTimestamp)
+  if (!vMOONEYs || vMOONEYs.length === 0) return null
+
+  const addressToQuadraticVotingPower: Record<string, number> = Object.fromEntries(
+    voteAddresses.map((address, index) => {
+      const vMOONEY = vMOONEYs[index] || 0
+      const power = isNaN(vMOONEY) ? 0 : Math.sqrt(vMOONEY)
+      return [address.toLowerCase(), power]
+    })
+  )
+
+  // Resolve author addresses so we can strip self-votes from each row.
+  const projectIdToAuthorAddress: Record<string, string> = {}
+  const AUTHOR_FETCH_BATCH_SIZE = 5
+  for (let i = 0; i < passedProjects.length; i += AUTHOR_FETCH_BATCH_SIZE) {
+    const batch = passedProjects.slice(i, i + AUTHOR_FETCH_BATCH_SIZE)
+    await Promise.all(
+      batch.map(async (project: any) => {
+        if (!project.proposalIPFS) return
+        try {
+          const fetchRes = await fetch(project.proposalIPFS)
+          if (!fetchRes.ok) return
+          const json = await fetchRes.json()
+          if (json && typeof json.authorAddress === 'string' && json.authorAddress.length > 0) {
+            projectIdToAuthorAddress[String(project.id)] = json.authorAddress
+          }
+        } catch (error) {
+          console.error(
+            `[computeMemberVoteOutcome] author fetch failed for project ${project.id}:`,
+            error
+          )
+        }
+      })
+    )
+  }
+
+  type VoteRow = DistributionVote & {
+    distribution?: string | Record<string, number>
+    quarter?: number
+    year?: number
+  }
+  const votesWithAuthorOwnExcluded: VoteRow[] = votes.map((v) => {
+    const row = v as VoteRow
+    const voterAddr = row.address?.toLowerCase()
+    const raw = row.distribution
+    const distribution: Record<string, number> = {}
+    let parsedDistribution: Record<string, number> = {}
+    if (typeof raw === 'string') {
+      try {
+        parsedDistribution = JSON.parse(raw)
+      } catch {
+        parsedDistribution = {}
+      }
+    } else if (raw && typeof raw === 'object') {
+      parsedDistribution = raw as Record<string, number>
+    }
+    for (const [projectId, value] of Object.entries(parsedDistribution)) {
+      const author = projectIdToAuthorAddress[projectId]?.toLowerCase()
+      if (author && author === voterAddr) continue
+      distribution[projectId] = Number(value)
+    }
+    return { ...row, distribution }
+  })
+
+  const [normalizedDistributions] = runIterativeNormalization(
+    votesWithAuthorOwnExcluded,
+    passedProjects
+  )
+
+  const SUM_TO_ONE_HUNDRED = 100
+  const outcome = runQuadraticVoting(
+    normalizedDistributions,
+    addressToQuadraticVotingPower,
+    SUM_TO_ONE_HUNDRED
+  )
+  const totalVotingPower = Object.values(addressToQuadraticVotingPower).reduce(
+    (sum, v) => sum + v,
+    0
+  )
+  if (totalVotingPower === 0 || Object.keys(outcome).length === 0) return null
+
+  const projectIdToApproved = getApprovedProjects(
+    passedProjects,
+    outcome,
+    usdBudgets,
+    NEXT_QUARTER_BUDGET_USD
+  )
+
+  const projectMeta = Object.fromEntries(
+    passedProjects.map((p: any) => [String(p.id), p])
+  )
+
+  const results: MemberVoteResult[] = Object.entries(outcome)
+    .map(([projectId, percentage]) => {
+      const project = projectMeta[projectId]
+      return {
+        projectId,
+        percentage: Number(percentage) || 0,
+        approved: !!projectIdToApproved[projectId],
+        budget: usdBudgets[projectId] || 0,
+        MDP: project?.MDP ?? null,
+        name: project?.name ?? `Unknown (ID: ${projectId})`,
+        rank: 0,
+      }
+    })
+    .sort((a, b) => b.percentage - a.percentage)
+    .map((r, i) => ({ ...r, rank: i + 1 }))
+
+  return {
+    quarter,
+    year,
+    voteCount: votes.length,
+    voterCount: voteAddresses.length,
+    voteOpenTimestamp,
+    voteCloseTimestamp,
+    totalVotingPower,
+    quarterBudgetUsd: NEXT_QUARTER_BUDGET_USD,
+    results,
+    computedAt: Math.floor(Date.now() / 1000),
+  }
+}

--- a/ui/lib/proposals/computeMemberVoteOutcome.ts
+++ b/ui/lib/proposals/computeMemberVoteOutcome.ts
@@ -157,10 +157,19 @@ export async function computeMemberVoteOutcome({
   }
   if (passedProjects.length === 0) return null
 
-  // USD budgets pulled from each proposal's IPFS payload.
-  const usdBudgets = Object.fromEntries(
-    await Promise.all(
-      passedProjects.map(async (project: any) => {
+  // USD budgets pulled from each proposal's IPFS payload. We batch the
+  // fetches in small groups so the endpoint doesn't fan a hundred-plus
+  // concurrent requests at IPFS gateways every time it runs (the gateway
+  // often rate-limits or just collapses under the burst, which used to
+  // surface as zeroed-out budgets and a misranked outcome). The matching
+  // author-IPFS fetch below uses the same `BATCH_SIZE` for the same
+  // reason — keep them in sync if you tune one.
+  const BATCH_SIZE = 5
+  const usdBudgetEntries: [string, number][] = []
+  for (let i = 0; i < passedProjects.length; i += BATCH_SIZE) {
+    const batch = passedProjects.slice(i, i + BATCH_SIZE)
+    const batchEntries = await Promise.all(
+      batch.map(async (project: any): Promise<[string, number]> => {
         try {
           const proposalResponse = await fetch(project.proposalIPFS)
           const proposal = await proposalResponse.json()
@@ -176,17 +185,19 @@ export async function computeMemberVoteOutcome({
                   : 0
             })
           }
-          return [project.id, budget]
+          return [String(project.id), budget]
         } catch (error) {
           console.error(
             `[computeMemberVoteOutcome] Failed to fetch budget for project ${project.id}:`,
             error
           )
-          return [project.id, 0]
+          return [String(project.id), 0]
         }
       })
     )
-  )
+    usdBudgetEntries.push(...batchEntries)
+  }
+  const usdBudgets = Object.fromEntries(usdBudgetEntries)
 
   const voteOpenTimestamp = Math.floor(
     getThirdThursdayOfQuarterTimestamp(quarter, year).getTime() / 1000
@@ -205,10 +216,11 @@ export async function computeMemberVoteOutcome({
   )
 
   // Resolve author addresses so we can strip self-votes from each row.
+  // Reuses the same `BATCH_SIZE` as the budget fetch above so we stay
+  // under the IPFS gateway's per-second cap on a single endpoint hit.
   const projectIdToAuthorAddress: Record<string, string> = {}
-  const AUTHOR_FETCH_BATCH_SIZE = 5
-  for (let i = 0; i < passedProjects.length; i += AUTHOR_FETCH_BATCH_SIZE) {
-    const batch = passedProjects.slice(i, i + AUTHOR_FETCH_BATCH_SIZE)
+  for (let i = 0; i < passedProjects.length; i += BATCH_SIZE) {
+    const batch = passedProjects.slice(i, i + BATCH_SIZE)
     await Promise.all(
       batch.map(async (project: any) => {
         if (!project.proposalIPFS) return

--- a/ui/pages/api/proposals/vote-results.ts
+++ b/ui/pages/api/proposals/vote-results.ts
@@ -1,0 +1,56 @@
+/**
+ * Read-only Member Vote results.
+ *
+ * Returns the same outcome the on-chain tally (`POST /api/proposals/vote`)
+ * would produce, without doing any writes or the multisig audit. Used by the
+ * `/projects` page to display percentages + approval status post-vote (and
+ * as a live preview during voting).
+ *
+ * GET only. Quarter/year default to the current calendar quarter, but can
+ * be overridden via `?quarter=&year=` for backfills / debugging.
+ */
+import { DEFAULT_CHAIN_V5 } from 'const/config'
+import { getCurrentQuarter } from 'lib/utils/dates'
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { computeMemberVoteOutcome } from '@/lib/proposals/computeMemberVoteOutcome'
+
+const chain = DEFAULT_CHAIN_V5
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const current = getCurrentQuarter()
+  const quarter = req.query.quarter
+    ? Number(req.query.quarter)
+    : current.quarter
+  const year = req.query.year ? Number(req.query.year) : current.year
+
+  try {
+    const outcome = await computeMemberVoteOutcome({ chain, quarter, year })
+    if (!outcome) {
+      return res.status(200).json({ outcome: null, quarter, year })
+    }
+
+    // Cache at the edge briefly. The underlying computation is heavy
+    // (Tableland + multi-chain RPC + IPFS + vMOONEY snapshot) but the
+    // result is deterministic for a given (quarter, year, vote-set), so a
+    // short shared cache with stale-while-revalidate keeps the page snappy
+    // without serving wildly stale numbers.
+    res.setHeader(
+      'Cache-Control',
+      'public, s-maxage=60, stale-while-revalidate=300'
+    )
+    return res.status(200).json({ outcome, quarter, year })
+  } catch (error: any) {
+    console.error('[vote-results] computeMemberVoteOutcome failed:', error)
+    return res
+      .status(500)
+      .json({ error: error?.message || 'Failed to compute member vote results' })
+  }
+}
+
+export default withMiddleware(handler, rateLimit)

--- a/ui/pages/api/proposals/vote-results.ts
+++ b/ui/pages/api/proposals/vote-results.ts
@@ -31,20 +31,21 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   try {
     const outcome = await computeMemberVoteOutcome({ chain, quarter, year })
-    if (!outcome) {
-      return res.status(200).json({ outcome: null, quarter, year })
-    }
 
     // Cache at the edge briefly. The underlying computation is heavy
     // (Tableland + multi-chain RPC + IPFS + vMOONEY snapshot) but the
     // result is deterministic for a given (quarter, year, vote-set), so a
     // short shared cache with stale-while-revalidate keeps the page snappy
-    // without serving wildly stale numbers.
+    // without serving wildly stale numbers. The `outcome: null` case
+    // (no votes yet, no eligible projects, etc.) is just as expensive to
+    // re-derive as the populated one — every traffic spike pre-vote
+    // would otherwise re-run the full pipeline — so it gets the same
+    // cache treatment.
     res.setHeader(
       'Cache-Control',
       'public, s-maxage=60, stale-while-revalidate=300'
     )
-    return res.status(200).json({ outcome, quarter, year })
+    return res.status(200).json({ outcome: outcome ?? null, quarter, year })
   } catch (error: any) {
     console.error('[vote-results] computeMemberVoteOutcome failed:', error)
     return res

--- a/ui/pages/api/proposals/vote.ts
+++ b/ui/pages/api/proposals/vote.ts
@@ -281,8 +281,8 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
   // any flagged team after the vote so they can fix their treasury before
   // funds move; gating the tally itself caused legitimate winners to be
   // silently dropped when they had a smaller / lower-threshold Safe at vote
-  // close. The misconfigured projects are surfaced via a console warning
-  // table and returned in the API response as `multisigFollowUps`.
+  // close. The misconfigured projects are surfaced via console warnings
+  // and returned in the API response as `multisigFollowUps`.
   const MIN_SAFE_OWNERS = 5
   const MIN_SAFE_THRESHOLD = 3
   const projectContract = getContract({

--- a/ui/pages/api/proposals/vote.ts
+++ b/ui/pages/api/proposals/vote.ts
@@ -276,7 +276,13 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
     })
   }
 
-  // Filter out projects whose Safe does not meet the 3/5 multisig requirement
+  // Audit each project's Safe against the 3-of-5 requirement, but DO NOT
+  // remove non-conforming projects from the tally. The EB will reach out to
+  // any flagged team after the vote so they can fix their treasury before
+  // funds move; gating the tally itself caused legitimate winners to be
+  // silently dropped when they had a smaller / lower-threshold Safe at vote
+  // close. The misconfigured projects are surfaced via a console warning
+  // table and returned in the API response as `multisigFollowUps`.
   const MIN_SAFE_OWNERS = 5
   const MIN_SAFE_THRESHOLD = 3
   const projectContract = getContract({
@@ -286,10 +292,18 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
     chain: chain,
   })
   const rpcUrl = getRpcUrlForChain({ client: serverClient, chain })
-  const skippedProjects: any[] = []
+  type MultisigAudit = {
+    projectId: string
+    MDP: number | string
+    name: string
+    safeAddress: string | null
+    owners: number | null
+    threshold: number | null
+    reason: string
+  }
+  const multisigFollowUps: MultisigAudit[] = []
 
-  for (let i = passedProjects.length - 1; i >= 0; i--) {
-    const project = passedProjects[i]
+  for (const project of passedProjects) {
     try {
       const safeAddress = await readContractWithRetry<string>(
         projectContract,
@@ -300,32 +314,54 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
       const owners = await safe.getOwners()
       const threshold = await safe.getThreshold()
       if (owners.length < MIN_SAFE_OWNERS || threshold < MIN_SAFE_THRESHOLD) {
+        const reason = `Safe ${safeAddress} has ${owners.length} owner(s) with threshold ${threshold} (requires ${MIN_SAFE_OWNERS} owners and ${MIN_SAFE_THRESHOLD} threshold)`
         console.warn(
-          `[vote tally] Skipping project MDP-${project.MDP} "${project.name}": Safe ${safeAddress} has ${owners.length} owner(s) with threshold ${threshold} (requires ${MIN_SAFE_OWNERS} owners and ${MIN_SAFE_THRESHOLD} threshold)`
+          `[vote tally] Multisig follow-up needed for MDP-${project.MDP} "${project.name}": ${reason}`
         )
-        skippedProjects.push(project)
-        passedProjects.splice(i, 1)
+        multisigFollowUps.push({
+          projectId: String(project.id),
+          MDP: project.MDP,
+          name: project.name,
+          safeAddress,
+          owners: owners.length,
+          threshold,
+          reason,
+        })
       }
     } catch (error) {
+      const reason = `Failed to read Safe config: ${
+        error instanceof Error ? error.message : String(error)
+      }`
       console.error(
-        `[vote tally] Error checking Safe config for project MDP-${project.MDP} "${project.name}":`,
+        `[vote tally] Multisig audit error for MDP-${project.MDP} "${project.name}":`,
         error
       )
+      multisigFollowUps.push({
+        projectId: String(project.id),
+        MDP: project.MDP,
+        name: project.name,
+        safeAddress: null,
+        owners: null,
+        threshold: null,
+        reason,
+      })
     }
   }
 
-  if (skippedProjects.length > 0) {
-    console.log(
-      `[vote tally] ${skippedProjects.length} project(s) excluded due to insufficient multisig config: ${skippedProjects.map((p) => `MDP-${p.MDP}`).join(', ')}`
+  if (multisigFollowUps.length > 0) {
+    console.warn(
+      `\n[vote tally] ⚠️  ${multisigFollowUps.length} project(s) need a treasury follow-up (kept in tally):`
+    )
+    for (const audit of multisigFollowUps) {
+      console.warn(
+        `  - MDP-${audit.MDP} "${audit.name}" → ${audit.reason}`
+      )
+    }
+    console.warn(
+      `[vote tally] These projects WILL be tallied and (if approved) flipped to active. Reach out manually to fix their Safe before any treasury actions.\n`
     )
   }
-  console.log(`[vote tally] ${passedProjects.length} projects eligible for vote after multisig check`)
-
-  if (passedProjects.length === 0) {
-    return res.status(400).json({
-      error: `No projects have a properly configured multisig (${MIN_SAFE_OWNERS} signers with threshold ${MIN_SAFE_THRESHOLD} required).`,
-    })
-  }
+  console.log(`[vote tally] ${passedProjects.length} projects eligible for vote (multisig check is advisory only)`)
 
   const usdBudgets = Object.fromEntries(
     await Promise.all(
@@ -529,10 +565,29 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
     console.log(`[vote tally] Updated project ${projectId}: active=${approved ? PROJECT_ACTIVE : PROJECT_VOTE_FAILED} (tx: ${receipt.transactionHash})`)
   }
 
+  // Surface only the *approved* projects whose Safe still needs a fix —
+  // those are the ones that actually need a manual outreach before any
+  // treasury action. Failed projects with bad Safes don't matter (no funds
+  // will move to them) so we don't bother including them.
+  const approvedMultisigFollowUps = multisigFollowUps.filter(
+    (audit) => projectIdToApproved[audit.projectId] === true
+  )
+
+  if (approvedMultisigFollowUps.length > 0) {
+    console.warn(
+      `[vote tally] ⚠️  ${approvedMultisigFollowUps.length} APPROVED project(s) need a treasury fix before payout:`
+    )
+    for (const audit of approvedMultisigFollowUps) {
+      console.warn(`  - MDP-${audit.MDP} "${audit.name}" → ${audit.reason}`)
+    }
+  }
+
   return res.status(200).json({
     url: 'https://moondao.com/projects',
     outcome: outcome,
     approved: projectIdToApproved,
+    multisigFollowUps,
+    approvedMultisigFollowUps,
   })
 }
 export default withMiddleware(POST, rateLimit)


### PR DESCRIPTION
## Summary

Two changes paired for the Q2 2026 Member Vote close:

- **Multisig audit becomes advisory.** `pages/api/proposals/vote.ts` no longer drops Senate-approved projects whose Safe isn't 5-owner / 3-of-5 from the tally. They're included in the quadratic vote and (if approved) flipped to `active` like everyone else. The audit now collects them into `multisigFollowUps` / `approvedMultisigFollowUps` (returned in the API response and warned to the function logs) so the EB can manually reach out and have those teams fix their treasury before any payouts move.
- **Member Vote results panel on `/projects`.** New `lib/proposals/computeMemberVoteOutcome.ts` shared helper mirrors the on-chain tally math (vMOONEY snapshot at vote close, author self-vote stripping, iterative normalization, quadratic voting, top-half + budget cap) without the multisig audit or chain writes. New `GET /api/proposals/vote-results` endpoint exposes it (60s edge cache + 5min stale-while-revalidate). New `MemberVoteResults` component renders a ranked list (rank, MDP link, name, % share, approved/failed pill, USD budget, voter count, $ approved / $ pool) inside the Project Proposals tab. Self-hides during loading/error so it doesn't flicker on cold cache.

The display works as a live preview before the tally and a permanent record after.

## Test plan

- [ ] After deploy, hit `https://moondao.com/api/proposals/vote-results` and verify the JSON returns `outcome` with the expected ranked results for Q2 2026.
- [ ] Visit `https://moondao.com/projects` and confirm the **Member Vote Results** panel renders at the top of the Project Proposals tab with the same ranking, % shares, and approved/failed badges.
- [ ] Confirm projects with non-5/3 Safes appear in the panel (they previously would have been silently dropped).
- [ ] Run the on-chain tally via `curl -X POST https://moondao.com/api/proposals/vote -H 'Content-Type: application/json' -d '{}'`. Verify:
  - Response includes `outcome`, `approved`, and the new `multisigFollowUps` + `approvedMultisigFollowUps` arrays.
  - Vercel function logs show the per-voter `[vote tally]` table and the `⚠️  N APPROVED project(s) need a treasury fix` warning block (if any).
  - Approved projects appear under **Active Projects** on `/projects` after the next ISR revalidation.
  - The Member Vote Results panel keeps showing the finalized rankings.
- [ ] Manually reach out to any teams in `approvedMultisigFollowUps` to fix their Safe configuration before any retroactive payouts.
