### PR TITLE
Tally retroactive rewards: results panel + public audit page

### DIFF
--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -1812,11 +1812,44 @@ export function ProjectRewards({
                 </div>
 
                 {/* Read-only retro tally panel: same shared compute the
-                    audit page uses, scoped to the same (quarter, year)
-                    the rewards-cycle window is currently distributing
-                    against. Self-hides during loading / error / empty
-                    so it doesn't flicker on cold cache. */}
-                <RetroactiveResults quarter={quarter} year={year} />
+                    audit page uses. Pinned to the cycle of the
+                    currently-eligible projects on screen so the panel
+                    always matches the cohort the user is looking at —
+                    independent of `IS_REWARDS_CYCLE` and of the page's
+                    own `quarter`/`year` (which shifts back to the
+                    current calendar quarter once the rewards cycle
+                    flag is off, even though the eligible projects
+                    belong to a prior quarter). Falls back to the
+                    previous calendar quarter when no eligible cohort
+                    exists yet so the audit endpoint at least gets a
+                    sensible default. Self-hides during loading / error
+                    / empty so it doesn't flicker on cold cache. */}
+                {(() => {
+                  const fallback = getRelativeQuarter(-1)
+                  // Eligible projects within a single cycle all share
+                  // the same (quarter, year). Take the first one so we
+                  // tally against the cohort the user can actually see;
+                  // if (in some odd transition) eligibility spans
+                  // multiple quarters, the audit page can be linked
+                  // directly with explicit `?quarter=&year=`.
+                  const seed = eligibleProjects?.[0] as
+                    | { quarter?: number; year?: number }
+                    | undefined
+                  const panelQuarter =
+                    seed?.quarter && Number.isFinite(seed.quarter)
+                      ? Number(seed.quarter)
+                      : fallback.quarter
+                  const panelYear =
+                    seed?.year && Number.isFinite(seed.year)
+                      ? Number(seed.year)
+                      : fallback.year
+                  return (
+                    <RetroactiveResults
+                      quarter={panelQuarter}
+                      year={panelYear}
+                    />
+                  )
+                })()}
 
                 {eligibleProjects && eligibleProjects.length > 0 ? (
                   <div className="flex flex-col gap-1.5 sm:gap-6">

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -63,6 +63,7 @@ import SectionCard from '@/components/layout/SectionCard'
 import StandardButtonRight from '@/components/layout/StandardButtonRight'
 import Tooltip from '@/components/layout/Tooltip'
 import MemberVoteResults from '@/components/nance/MemberVoteResults'
+import RetroactiveResults from '@/components/nance/RetroactiveResults'
 import OperatorPanel from '@/components/operator/OperatorPanel'
 import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
 import PastProjects, { hasFinalReport } from '@/components/project/PastProjects'
@@ -1809,6 +1810,13 @@ export function ProjectRewards({
                     </span>
                   </div>
                 </div>
+
+                {/* Read-only retro tally panel: same shared compute the
+                    audit page uses, scoped to the same (quarter, year)
+                    the rewards-cycle window is currently distributing
+                    against. Self-hides during loading / error / empty
+                    so it doesn't flicker on cold cache. */}
+                <RetroactiveResults quarter={quarter} year={year} />
 
                 {eligibleProjects && eligibleProjects.length > 0 ? (
                   <div className="flex flex-col gap-1.5 sm:gap-6">

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -361,10 +361,15 @@ export function ProjectRewards({
     if (!currentProjects?.length) return new Set<string>()
     return new Set(
       currentProjects
-        .filter((p: any) => p.eligible)
+        .filter(
+          (p: any) =>
+            p.eligible &&
+            Number(p.quarter) === quarter &&
+            Number(p.year) === year
+        )
         .map((p: any) => String(p.id))
     )
-  }, [currentProjects])
+  }, [currentProjects, quarter, year])
 
   // Helper: keep only the entries whose key appears in `validKeys`. Used to
   // strip orphan project ids from a distribution loaded out of the
@@ -716,14 +721,35 @@ export function ProjectRewards({
   let citizenDistributions = distributions?.filter((_, i) => isCitizens[i])
   const nonCitizenDistributions = distributions?.filter((_, i) => !isCitizens[i])
 
+  // Scope the eligible / ineligible cohorts to the cycle the page is
+  // currently showing. `quarter`/`year` already adapt:
+  //   - IS_REWARDS_CYCLE = true  → previous calendar quarter (the cohort
+  //     being voted on right now).
+  //   - IS_REWARDS_CYCLE = false → current calendar quarter (the cohort
+  //     whose retros will be voted on next).
+  // Without this filter, projects from a closed cycle whose `eligible = 1`
+  // flag was never cleared keep appearing in the live retro tab and the
+  // active-projects empty-state hint, which mixes cohorts.
   const eligibleProjects = useMemo(
-    () => currentProjects.filter((p) => p.eligible),
-    [currentProjects]
+    () =>
+      currentProjects.filter(
+        (p) =>
+          p.eligible &&
+          Number(p.quarter) === quarter &&
+          Number(p.year) === year
+      ),
+    [currentProjects, quarter, year]
   )
 
   const ineligibleProjects = useMemo(
-    () => currentProjects.filter((p) => !p.eligible),
-    [currentProjects]
+    () =>
+      currentProjects.filter(
+        (p) =>
+          !p.eligible &&
+          Number(p.quarter) === quarter &&
+          Number(p.year) === year
+      ),
+    [currentProjects, quarter, year]
   )
   // All projects need at least one citizen distribution to do iterative normalization
   const allProjectsHaveCitizenDistribution = eligibleProjects?.every(({ id }) =>
@@ -1811,27 +1837,6 @@ export function ProjectRewards({
                   </div>
                 </div>
 
-                {/* Read-only retro tally panel: same shared compute the
-                    audit page uses. Pinned to the previous calendar
-                    quarter — that's the *voting* cycle the most recent
-                    retro distributions were submitted under (the cohort
-                    of projects voted on usually belongs to a still
-                    earlier quarter; the panel's compute resolves that
-                    automatically from the distribution rows). Decoupled
-                    from `IS_REWARDS_CYCLE` so the panel persists as the
-                    permanent record after the cycle flag flips off.
-                    Self-hides during loading / error / empty so it
-                    doesn't flicker on cold cache. */}
-                {(() => {
-                  const prev = getRelativeQuarter(-1)
-                  return (
-                    <RetroactiveResults
-                      quarter={prev.quarter}
-                      year={prev.year}
-                    />
-                  )
-                })()}
-
                 {eligibleProjects && eligibleProjects.length > 0 ? (
                   <div className="flex flex-col gap-1.5 sm:gap-6">
                     {rewardVotingActive && (
@@ -1985,13 +1990,93 @@ export function ProjectRewards({
                     })()}
                   </div>
                 ) : (
-                  <div className="text-center py-8 text-gray-400">
-                    <p>No projects are eligible for retroactive rewards yet.</p>
-                    <p className="text-xs text-gray-500 mt-1">
-                      Operators can mark a project eligible from the panel above.
+                  <div className="bg-gradient-to-br from-slate-700/20 to-slate-800/30 border border-white/10 rounded-lg sm:rounded-xl p-4 sm:p-6 text-sm text-gray-300 space-y-3">
+                    <h2 className="font-GoodTimes text-base sm:text-lg text-white tracking-wider">
+                      No projects in the current cycle yet
+                    </h2>
+                    <p>
+                      Q{quarter} {year} retroactives don&apos;t have any
+                      projects yet — no team has submitted a final report for
+                      this cohort, so there&apos;s nothing for Citizens and
+                      Voting Members to allocate against.
                     </p>
+                    <div className="bg-black/30 border border-white/10 rounded-md p-3 sm:p-4 space-y-2 text-xs sm:text-sm text-gray-300">
+                      <p className="font-RobotoMono uppercase tracking-wider text-[11px] text-gray-400">
+                        How retroactive rewards work
+                      </p>
+                      <ol className="list-decimal pl-5 space-y-1">
+                        <li>
+                          Project teams complete their funded work during the
+                          quarter and submit a final report.
+                        </li>
+                        <li>
+                          The Executive Branch reviews the report and marks
+                          the project <code>eligible = 1</code> via the
+                          operator panel.
+                        </li>
+                        <li>
+                          Once the cycle&apos;s voting window opens, Citizens
+                          and Voting Members distribute 100% of their voting
+                          power across the eligible cohort.
+                        </li>
+                        <li>
+                          A quadratic tally splits the cycle&apos;s ETH/USDC +
+                          MOONEY pool between projects in proportion to the
+                          weighted vote.
+                        </li>
+                      </ol>
+                      <p className="text-[11px] text-gray-500 pt-1">
+                        Read the full mechanism in the{' '}
+                        <Link
+                          href="https://docs.moondao.com/Projects/Project-System#retroactive-rewards"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline text-blue-300 hover:text-blue-200"
+                        >
+                          docs
+                        </Link>
+                        .
+                      </p>
+                    </div>
                   </div>
                 )}
+
+                {/* Previous cycle results — always rendered below the
+                    current-cycle block, regardless of whether the current
+                    cycle has any projects yet. Self-hides on loading /
+                    error / empty so it doesn't flicker on cold cache.
+                    The (quarter, year) is one cohort behind whatever's
+                    being shown above:
+                      - voting active  → shown cohort = Q-1, prev = Q-2
+                      - between cycles → shown cohort = Q0,  prev = Q-1
+                    `RetroactiveResults` already links out to the public
+                    audit page (`/projects/retro-audit`). */}
+                {(() => {
+                  const prev = getRelativeQuarter(
+                    rewardVotingActive ? -2 : -1
+                  )
+                  return (
+                    <div className="mt-6 sm:mt-8 pt-4 sm:pt-6 border-t border-white/10">
+                      <div className="px-1 sm:px-0 mb-3 sm:mb-4">
+                        <h2 className="font-GoodTimes text-sm sm:text-base text-white/80 tracking-wider uppercase">
+                          Previous Cycle Results
+                          <span className="ml-2 text-xs font-normal text-gray-400 normal-case">
+                            Q{prev.quarter} {prev.year}
+                          </span>
+                        </h2>
+                        <p className="text-[11px] sm:text-xs text-gray-400 mt-1">
+                          Final per-project breakdown of the most recently
+                          completed retro tally, plus a link to the full
+                          public audit.
+                        </p>
+                      </div>
+                      <RetroactiveResults
+                        quarter={prev.quarter}
+                        year={prev.year}
+                      />
+                    </div>
+                  )
+                })()}
               </div>
             )}
             {activeTab === 'past' && (

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -1812,41 +1812,22 @@ export function ProjectRewards({
                 </div>
 
                 {/* Read-only retro tally panel: same shared compute the
-                    audit page uses. Pinned to the cycle of the
-                    currently-eligible projects on screen so the panel
-                    always matches the cohort the user is looking at —
-                    independent of `IS_REWARDS_CYCLE` and of the page's
-                    own `quarter`/`year` (which shifts back to the
-                    current calendar quarter once the rewards cycle
-                    flag is off, even though the eligible projects
-                    belong to a prior quarter). Falls back to the
-                    previous calendar quarter when no eligible cohort
-                    exists yet so the audit endpoint at least gets a
-                    sensible default. Self-hides during loading / error
-                    / empty so it doesn't flicker on cold cache. */}
+                    audit page uses. Pinned to the previous calendar
+                    quarter — that's the *voting* cycle the most recent
+                    retro distributions were submitted under (the cohort
+                    of projects voted on usually belongs to a still
+                    earlier quarter; the panel's compute resolves that
+                    automatically from the distribution rows). Decoupled
+                    from `IS_REWARDS_CYCLE` so the panel persists as the
+                    permanent record after the cycle flag flips off.
+                    Self-hides during loading / error / empty so it
+                    doesn't flicker on cold cache. */}
                 {(() => {
-                  const fallback = getRelativeQuarter(-1)
-                  // Eligible projects within a single cycle all share
-                  // the same (quarter, year). Take the first one so we
-                  // tally against the cohort the user can actually see;
-                  // if (in some odd transition) eligibility spans
-                  // multiple quarters, the audit page can be linked
-                  // directly with explicit `?quarter=&year=`.
-                  const seed = eligibleProjects?.[0] as
-                    | { quarter?: number; year?: number }
-                    | undefined
-                  const panelQuarter =
-                    seed?.quarter && Number.isFinite(seed.quarter)
-                      ? Number(seed.quarter)
-                      : fallback.quarter
-                  const panelYear =
-                    seed?.year && Number.isFinite(seed.year)
-                      ? Number(seed.year)
-                      : fallback.year
+                  const prev = getRelativeQuarter(-1)
                   return (
                     <RetroactiveResults
-                      quarter={panelQuarter}
-                      year={panelYear}
+                      quarter={prev.quarter}
+                      year={prev.year}
                     />
                   )
                 })()}

--- a/ui/components/nance/RetroactiveResults.tsx
+++ b/ui/components/nance/RetroactiveResults.tsx
@@ -1,0 +1,212 @@
+/**
+ * Retroactive Rewards results panel for `/projects`.
+ *
+ * Fetches the read-only outcome from `/api/proposals/retro-results`
+ * and renders a ranked list (% of pool, ETH/USDC + MOONEY shares per
+ * project). Doubles as a live preview during the rewards-cycle
+ * voting window and a permanent record once the cycle has closed.
+ *
+ * Renders nothing when:
+ *   - The fetch is still loading (avoid flicker on every page load —
+ *     the heavy server-side compute can take 5–30s on a cold cache).
+ *   - There are no eligible projects / no votes for the requested
+ *     quarter yet.
+ *   - The endpoint errors out.
+ */
+import Link from 'next/link'
+import useSWR from 'swr'
+import fetcher from '@/lib/swr/fetcher'
+import type { RetroactiveOutcome } from '@/lib/proposals/computeRetroactiveOutcome'
+
+type Props = {
+  quarter: number
+  year: number
+}
+
+const formatPrimary = (amount: number, asset: 'ETH' | 'USDC') =>
+  asset === 'ETH'
+    ? `${amount.toLocaleString(undefined, { maximumFractionDigits: 4 })} ETH`
+    : `$${amount.toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+
+const formatMooney = (amount: number) =>
+  `${Number(amount.toPrecision(3)).toLocaleString()} MOONEY`
+
+export default function RetroactiveResults({ quarter, year }: Props) {
+  // SWR with conservative refresh: results only change when new
+  // distribution rows land or eligibility flips. 60s dedupe matches
+  // the endpoint's `s-maxage=60`.
+  const { data, error, isLoading } = useSWR<{
+    outcome: RetroactiveOutcome | null
+    quarter: number
+    year: number
+  }>(
+    `/api/proposals/retro-results?quarter=${quarter}&year=${year}`,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 60_000,
+      errorRetryCount: 1,
+    }
+  )
+
+  if (isLoading || error) return null
+  const outcome = data?.outcome
+  if (!outcome || !outcome.results?.length) return null
+
+  const closeDate = new Date(outcome.voteCloseTimestamp * 1000)
+  const totalPctAllocated = outcome.results.reduce(
+    (s, r) => s + (r.percentage || 0),
+    0
+  )
+  const totalPrimaryAllocated = outcome.results.reduce(
+    (s, r) => s + (r.primaryShare || 0),
+    0
+  )
+  const totalMooneyAllocated = outcome.results.reduce(
+    (s, r) => s + (r.mooneyShare || 0),
+    0
+  )
+
+  return (
+    <div className="mb-4 sm:mb-6 bg-gradient-to-br from-emerald-900/20 via-slate-800/30 to-slate-900/40 border border-emerald-400/20 rounded-xl p-4 sm:p-5">
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2 sm:gap-4 mb-3 sm:mb-4">
+        <div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-GoodTimes text-white text-base sm:text-lg">
+              Retroactive Rewards Results
+            </h3>
+            <span className="text-[10px] font-RobotoMono uppercase tracking-wider text-emerald-300 bg-emerald-400/15 border border-emerald-400/30 px-1.5 py-0.5 rounded">
+              Q{outcome.quarter} {outcome.year}
+            </span>
+          </div>
+          <p className="text-xs text-gray-400 mt-1">
+            Snapshot at vote close ({closeDate.toLocaleDateString()}).
+            Voting power is √vMOONEY across all chains; citizen votes get
+            zeroed for projects they contributed to and refilled with the
+            column average. Non-citizen votes are projected onto the
+            citizen-vote basis via L1 best-fit before the quadratic tally.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-[11px] font-RobotoMono">
+          <span className="bg-black/30 border border-white/10 text-gray-200 px-2 py-1 rounded">
+            {outcome.voterCount} voter{outcome.voterCount === 1 ? '' : 's'} (
+            {outcome.citizenVoterCount} citizen
+            {outcome.citizenVoterCount === 1 ? '' : 's'})
+          </span>
+          <span className="bg-blue-500/10 border border-blue-400/30 text-blue-200 px-2 py-1 rounded">
+            Pool: {formatPrimary(outcome.pool.primaryAmount, outcome.pool.primaryAsset)}{' '}
+            + {formatMooney(outcome.pool.mooneyAmount)}
+          </span>
+          <Link
+            href={`/projects/retro-audit?quarter=${outcome.quarter}&year=${outcome.year}`}
+            className="bg-white/5 border border-white/15 text-gray-200 px-2 py-1 rounded hover:bg-white/10 hover:text-white transition-colors"
+          >
+            View audit →
+          </Link>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        {outcome.results.map((r) => {
+          const projectLink =
+            r.MDP != null && r.MDP !== '' ? `/project/${r.MDP}` : null
+          const hasShare = r.percentage > 0
+          return (
+            <div
+              key={r.projectId}
+              className={`flex items-center gap-2 sm:gap-3 px-2 sm:px-3 py-2 rounded-lg border ${
+                hasShare
+                  ? 'bg-emerald-500/5 border-emerald-400/20'
+                  : 'bg-black/20 border-white/10'
+              }`}
+            >
+              <div
+                className={`flex-shrink-0 w-7 h-7 sm:w-8 sm:h-8 flex items-center justify-center rounded-full font-bold text-xs ${
+                  hasShare
+                    ? 'bg-emerald-500/20 text-emerald-200 border border-emerald-400/30'
+                    : 'bg-white/5 text-gray-400 border border-white/10'
+                }`}
+              >
+                {r.rank}
+              </div>
+              <div className="flex-1 min-w-0">
+                {projectLink ? (
+                  <Link
+                    href={projectLink}
+                    className={`text-sm font-medium hover:underline truncate block ${
+                      hasShare ? 'text-white' : 'text-gray-300'
+                    }`}
+                  >
+                    {r.MDP != null ? `MDP-${r.MDP}: ` : ''}
+                    {r.name}
+                  </Link>
+                ) : (
+                  <p
+                    className={`text-sm font-medium truncate ${
+                      hasShare ? 'text-white' : 'text-gray-300'
+                    }`}
+                  >
+                    {r.name}
+                  </p>
+                )}
+                <p className="text-[11px] text-gray-500">
+                  {formatPrimary(r.primaryShare, outcome.pool.primaryAsset)}
+                  {' • '}
+                  {formatMooney(r.mooneyShare)}
+                </p>
+              </div>
+              <div className="text-right flex-shrink-0 min-w-[72px]">
+                <p
+                  className={`font-GoodTimes text-base sm:text-lg leading-none ${
+                    hasShare ? 'text-emerald-300' : 'text-gray-400'
+                  }`}
+                >
+                  {r.percentage.toFixed(2)}%
+                </p>
+                <p
+                  className={`text-[10px] font-RobotoMono uppercase tracking-wider mt-1 ${
+                    hasShare ? 'text-emerald-400' : 'text-gray-500'
+                  }`}
+                >
+                  of pool
+                </p>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Footer summary — totals across all projects so an auditor can
+          eyeball that "% of pool" sums to ~90 (the 10% community-circle
+          carve-out is invisible here because the panel only ranks
+          projects), and that the per-project pool shares add up to the
+          headline pool minus that 10%. */}
+      <div className="mt-3 sm:mt-4 grid grid-cols-3 gap-2 sm:gap-3 text-[11px] font-RobotoMono">
+        <div className="bg-slate-800/40 border border-white/10 rounded-lg px-3 py-2 min-w-0">
+          <div className="text-[10px] uppercase tracking-wider text-gray-400 truncate">
+            Allocated
+          </div>
+          <div className="mt-0.5 text-white truncate">
+            {totalPctAllocated.toFixed(2)}%
+          </div>
+        </div>
+        <div className="bg-slate-800/40 border border-white/10 rounded-lg px-3 py-2 min-w-0">
+          <div className="text-[10px] uppercase tracking-wider text-gray-400 truncate">
+            Distributed ({outcome.pool.primaryAsset})
+          </div>
+          <div className="mt-0.5 text-white truncate">
+            {formatPrimary(totalPrimaryAllocated, outcome.pool.primaryAsset)}
+          </div>
+        </div>
+        <div className="bg-slate-800/40 border border-white/10 rounded-lg px-3 py-2 min-w-0">
+          <div className="text-[10px] uppercase tracking-wider text-gray-400 truncate">
+            Distributed (MOONEY)
+          </div>
+          <div className="mt-0.5 text-white truncate">
+            {formatMooney(totalMooneyAllocated)}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/components/nance/RetroactiveResults.tsx
+++ b/ui/components/nance/RetroactiveResults.tsx
@@ -137,7 +137,7 @@ export default function RetroactiveResults({ quarter, year }: Props) {
                       hasShare ? 'text-white' : 'text-gray-300'
                     }`}
                   >
-                    {r.MDP != null ? `MDP-${r.MDP}: ` : ''}
+                    {r.MDP != null && r.MDP !== '' ? `MDP-${r.MDP}: ` : ''}
                     {r.name}
                   </Link>
                 ) : (

--- a/ui/components/operator/AddToRetroactivesModal.tsx
+++ b/ui/components/operator/AddToRetroactivesModal.tsx
@@ -11,6 +11,7 @@ type Props = {
 }
 
 type SignStatus = 'idle' | 'submitting' | 'success' | 'error'
+type EligibleAction = 'noop' | 'set' | 'clear'
 
 function tryParseJson(value: string): unknown | null {
   if (!value?.trim()) return null
@@ -27,7 +28,12 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
     project.rewardDistribution || ''
   )
   const [upfrontPayments, setUpfrontPayments] = useState(project.upfrontPayments || '')
-  const [markEligible, setMarkEligible] = useState(project.eligible !== 1)
+  // Default: if the project isn't yet eligible, propose adding it; if it
+  // already is, propose no change (the operator can flip to "clear" to
+  // retire it from the closed cycle's cohort).
+  const [eligibleAction, setEligibleAction] = useState<EligibleAction>(
+    project.eligible === 1 ? 'noop' : 'set'
+  )
   const [markActive, setMarkActive] = useState(project.active !== 2)
   const [status, setStatus] = useState<SignStatus>('idle')
   const [resultTxs, setResultTxs] = useState<Array<{ label: string; hash: string }>>([])
@@ -50,7 +56,7 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
       !finalReportLink &&
       !rewardDistribution &&
       !upfrontPayments &&
-      !markEligible &&
+      eligibleAction === 'noop' &&
       !markActive
     ) {
       toast.error('Nothing to update — fill in at least one field or toggle.', {
@@ -64,9 +70,10 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
     try {
       const body: Record<string, any> = {
         projectId: project.id,
-        markEligible,
         markActive,
       }
+      if (eligibleAction === 'set') body.markEligible = true
+      else if (eligibleAction === 'clear') body.markEligible = false
       if (finalReportLink) body.finalReportLink = finalReportLink
       if (rewardDistribution) body.rewardDistribution = rewardDistribution
       if (upfrontPayments) body.upfrontPayments = upfrontPayments
@@ -174,19 +181,62 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
           )}
         </label>
 
-        <div className="flex flex-col gap-2 bg-white/5 rounded-lg p-4 border border-white/10">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={markEligible}
-              onChange={(e) => setMarkEligible(e.target.checked)}
-              disabled={isSubmitting}
-            />
-            <span className="text-gray-200">Set <code>eligible = 1</code></span>
-            {project.eligible === 1 && (
-              <span className="text-[11px] text-green-400">already eligible</span>
-            )}
-          </label>
+        <div className="flex flex-col gap-3 bg-white/5 rounded-lg p-4 border border-white/10">
+          <div className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wider text-gray-400 flex items-center gap-2">
+              Eligible flag
+              <span className="text-[11px] normal-case tracking-normal text-gray-500">
+                current: <code>{String(project.eligible)}</code>
+              </span>
+            </span>
+            <div className="flex flex-col gap-1 mt-1">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="eligible-action"
+                  value="noop"
+                  checked={eligibleAction === 'noop'}
+                  onChange={() => setEligibleAction('noop')}
+                  disabled={isSubmitting}
+                />
+                <span className="text-gray-200">Leave unchanged</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="eligible-action"
+                  value="set"
+                  checked={eligibleAction === 'set'}
+                  onChange={() => setEligibleAction('set')}
+                  disabled={isSubmitting}
+                />
+                <span className="text-gray-200">
+                  Add to retro cohort (<code>eligible = 1</code>)
+                </span>
+                {project.eligible === 1 && (
+                  <span className="text-[11px] text-green-400">already 1</span>
+                )}
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="eligible-action"
+                  value="clear"
+                  checked={eligibleAction === 'clear'}
+                  onChange={() => setEligibleAction('clear')}
+                  disabled={isSubmitting}
+                />
+                <span className="text-gray-200">
+                  Remove from retro cohort (<code>eligible = 0</code>)
+                </span>
+                {project.eligible !== 1 && (
+                  <span className="text-[11px] text-amber-400">
+                    not currently 1
+                  </span>
+                )}
+              </label>
+            </div>
+          </div>
           <label className="flex items-center gap-2 cursor-pointer">
             <input
               type="checkbox"

--- a/ui/components/operator/OperatorPanel.tsx
+++ b/ui/components/operator/OperatorPanel.tsx
@@ -12,6 +12,12 @@ type Props = {
   onAfterChange?: () => void
 }
 
+type ClearProgress = {
+  total: number
+  done: number
+  failed: Array<{ projectId: number; error: string }>
+}
+
 // EB-only operator panel. Renders nothing for non-EB members.
 //
 // Phase flags (`IS_SENATE_VOTE`, `IS_MEMBER_VOTE`, `IS_REWARDS_CYCLE`) live in
@@ -27,6 +33,8 @@ export default function OperatorPanel({
   const { isExecutive } = useIsExecutive()
   const [selectedProjectId, setSelectedProjectId] = useState<string>('')
   const [modalProject, setModalProject] = useState<Project | null>(null)
+  const [clearProgress, setClearProgress] = useState<ClearProgress | null>(null)
+  const [isClearing, setIsClearing] = useState(false)
 
   const allProjects = useMemo(
     () => [...currentProjects, ...pastProjects, ...proposals],
@@ -38,6 +46,99 @@ export default function OperatorPanel({
     for (const p of allProjects) m.set(String(p.id), p)
     return m
   }, [allProjects])
+
+  // Cohort = every project currently flagged eligible across both
+  // currentProjects and pastProjects. Past quarters' projects can carry
+  // a stale `eligible = 1` if the prior cycle was never explicitly
+  // cleared, and the bulk action exists precisely to retire them.
+  const eligibleCohort = useMemo(
+    () =>
+      [...currentProjects, ...pastProjects]
+        .filter((p) => p.eligible === 1)
+        .sort((a, b) => b.id - a.id),
+    [currentProjects, pastProjects]
+  )
+
+  const clearCohort = async () => {
+    if (eligibleCohort.length === 0) {
+      toast.error('No projects currently have eligible = 1.', {
+        style: toastStyle,
+      })
+      return
+    }
+    const confirmed = window.confirm(
+      `Clear eligible flag (set to 0) on ${eligibleCohort.length} project(s)?\n\nEach project requires one HSM-signed transaction.`
+    )
+    if (!confirmed) return
+
+    setIsClearing(true)
+    setClearProgress({
+      total: eligibleCohort.length,
+      done: 0,
+      failed: [],
+    })
+
+    // Sequential rather than parallel: the HSM signer rate-limits and
+    // ordered submission keeps the on-chain history readable.
+    for (const project of eligibleCohort) {
+      try {
+        const res = await fetch('/api/operator/project-add-to-retroactives', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            projectId: project.id,
+            markEligible: false,
+          }),
+        })
+        const json = await res.json()
+        if (!res.ok) {
+          throw new Error(
+            json?.error || `Request failed with status ${res.status}`
+          )
+        }
+        setClearProgress((prev) =>
+          prev
+            ? { ...prev, done: prev.done + 1 }
+            : { total: eligibleCohort.length, done: 1, failed: [] }
+        )
+      } catch (err: any) {
+        console.error(`Clear cohort failed for project ${project.id}:`, err)
+        setClearProgress((prev) =>
+          prev
+            ? {
+                ...prev,
+                done: prev.done + 1,
+                failed: [
+                  ...prev.failed,
+                  {
+                    projectId: project.id,
+                    error: err?.message || 'unknown',
+                  },
+                ],
+              }
+            : prev
+        )
+      }
+    }
+    setIsClearing(false)
+    setClearProgress((finalProgress) => {
+      if (!finalProgress) return finalProgress
+      const successCount = finalProgress.done - finalProgress.failed.length
+      if (finalProgress.failed.length === 0) {
+        toast.success(`Cleared eligible flag on ${successCount} project(s).`, {
+          style: toastStyle,
+        })
+      } else {
+        toast.error(
+          `Cleared ${successCount}/${finalProgress.total}; ${finalProgress.failed.length} failed (see panel).`,
+          { style: toastStyle }
+        )
+      }
+      return finalProgress
+    })
+    onAfterChange?.()
+  }
 
   if (!isExecutive) return null
 
@@ -105,6 +206,75 @@ export default function OperatorPanel({
               Open
             </button>
           </div>
+        </div>
+
+        {/* Clear retro cohort — end-of-cycle cleanup */}
+        <div className="min-w-0 bg-black/30 rounded-lg p-3 border border-white/10 flex flex-col gap-2">
+          <h4 className="text-xs uppercase tracking-wider text-gray-300 font-RobotoMono">
+            Clear Retro Cohort
+          </h4>
+          <p className="text-xs text-gray-400">
+            Sets <code>eligible = 0</code> on every project currently flagged
+            <code className="mx-1">eligible = 1</code>. Run this once a cycle&apos;s
+            retro voting has closed and payouts have been settled, before
+            marking next cycle&apos;s projects eligible.
+          </p>
+          {eligibleCohort.length === 0 ? (
+            <p className="text-[11px] text-gray-500 italic">
+              No projects are currently eligible — nothing to clear.
+            </p>
+          ) : (
+            <details className="text-[11px] text-gray-300">
+              <summary className="cursor-pointer text-gray-400 hover:text-gray-200">
+                {eligibleCohort.length} project(s) will be cleared
+              </summary>
+              <ul className="mt-1 ml-4 list-disc space-y-0.5">
+                {eligibleCohort.map((p) => (
+                  <li key={p.id}>
+                    #{p.id} — {p.name}{' '}
+                    <span className="text-gray-500">
+                      (Q{p.quarter} {p.year})
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+          <button
+            type="button"
+            onClick={clearCohort}
+            disabled={isClearing || eligibleCohort.length === 0}
+            className="self-start mt-1 px-3 py-2 rounded-lg bg-gradient-to-r from-amber-500 to-rose-600 hover:from-amber-600 hover:to-rose-700 text-white text-xs font-RobotoMono shadow disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isClearing
+              ? `Clearing… ${clearProgress?.done ?? 0}/${
+                  clearProgress?.total ?? 0
+                }`
+              : `Clear ${eligibleCohort.length} project(s)`}
+          </button>
+          {clearProgress && !isClearing && (
+            <div className="mt-1 text-[11px] text-gray-300">
+              <p>
+                Done: {clearProgress.done - clearProgress.failed.length}/
+                {clearProgress.total}
+                {clearProgress.failed.length > 0 && (
+                  <span className="text-rose-400">
+                    {' '}
+                    • {clearProgress.failed.length} failed
+                  </span>
+                )}
+              </p>
+              {clearProgress.failed.length > 0 && (
+                <ul className="mt-1 ml-4 list-disc text-rose-300 space-y-0.5">
+                  {clearProgress.failed.map((f) => (
+                    <li key={f.projectId}>
+                      #{f.projectId}: {f.error}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/ui/lib/proposals/computeRetroactiveOutcome.ts
+++ b/ui/lib/proposals/computeRetroactiveOutcome.ts
@@ -1,0 +1,566 @@
+/**
+ * Read-only counterpart to the retroactive-rewards tally that lives
+ * client-side in `components/nance/ProjectRewards.tsx`.
+ *
+ * Replays the same `computeRewardPercentages` pipeline used by the
+ * Retroactive Rewards tab so the outcome can be displayed on `/projects`
+ * (and previewed by anyone before the cycle closes) WITHOUT touching
+ * the chain. Mirrors the structure of `computeMemberVoteOutcome.ts`:
+ *
+ *   - Pulls eligible projects + retro distributions from Tableland.
+ *   - Splits voters into citizens / non-citizens via the Citizen NFT
+ *     contract (same `getOwnedToken` probe `useCitizens` uses).
+ *   - Snapshots √vMOONEY across all chains at the rewards-cycle close.
+ *   - Feeds the result into the shared `computeRewardPercentages`
+ *     pipeline (fill-in-zeros → zero-out-contributors → iterative
+ *     normalization → best-fit projection for non-citizens →
+ *     quadratic voting).
+ *   - Annotates each project with its ETH and MOONEY share for the
+ *     configured pool.
+ *
+ * Differences vs. the client tally in `ProjectRewards.tsx`:
+ *   - No on-chain transaction or CSV generation; this is purely a
+ *     read-only computation for the audit/preview UI.
+ *   - The contributor-payout logic in `getPayouts` (per-address
+ *     splits, MOONEY/USD upfront overlays) is intentionally skipped
+ *     because projects are now funded directly — the audit only
+ *     surfaces the per-project pool share, not per-contributor wires.
+ *
+ * Keep this in sync with `computeRewardPercentages` / `getPayouts` /
+ * the retro pool config in `ProjectRewards.tsx` if the math changes.
+ */
+import CitizenABI from 'const/abis/Citizen.json'
+import {
+  CITIZEN_ADDRESSES,
+  DISTRIBUTION_TABLE_NAMES,
+  PROJECT_TABLE_NAMES,
+  RETRO_ETH_BUDGET,
+  RETRO_PAYOUT_TOKEN,
+  RETRO_USD_BUDGET,
+} from 'const/config'
+import { getContract, readContract } from 'thirdweb'
+import { getProjectDisplayName } from '@/lib/project/getProjectDisplayName'
+import queryTable from '@/lib/tableland/queryTable'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import { serverClient } from '@/lib/thirdweb/client'
+import { fetchTotalVMOONEYs } from '@/lib/tokens/hooks/useTotalVMOONEY'
+import {
+  computeRewardPercentages,
+  normalizeJsonString,
+} from '@/lib/utils/rewards'
+
+// MOONEY budget per quarter: identical to `getBudget()` in
+// `lib/utils/rewards.ts` so the audit pool matches what the live UI
+// shows. Kept here so this file doesn't need to assemble the full
+// treasury-tokens array (which is browser-only via `useAssets`).
+const MOONEY_INITIAL_BUDGET = 15_000_000
+const MOONEY_DECAY_RATE = 0.95
+
+function getMooneyBudgetForCycle(year: number, quarter: number): number {
+  const numQuartersPastQ4Y2022 = (year - 2023) * 4 + quarter
+  return MOONEY_INITIAL_BUDGET * MOONEY_DECAY_RATE ** numQuartersPastQ4Y2022
+}
+
+/**
+ * Mirror of `getRetroVoteCloseTimestamp` semantics from `isRewardsCycle`:
+ * the rewards window for a (quarter, year) cycle ends on the first
+ * Tuesday on or after 14 days into the *following* quarter. Using that
+ * close as the vMOONEY snapshot means the audit reproduces the same
+ * power values the on-chain tally would have used.
+ */
+function getRetroVoteCloseTimestamp(quarter: number, year: number): number {
+  const nextQuarterIndex = quarter % 4 // 0..3
+  const nextQuarterYear = quarter === 4 ? year + 1 : year
+  const nextQuarterStart = new Date(Date.UTC(nextQuarterYear, nextQuarterIndex * 3, 1))
+  const fourteenIn = new Date(nextQuarterStart)
+  fourteenIn.setUTCDate(fourteenIn.getUTCDate() + 14)
+  const TUESDAY = 2
+  const dow = fourteenIn.getUTCDay()
+  const daysUntilTuesday = ((TUESDAY - dow + 7) % 7) || 7
+  const close = new Date(fourteenIn)
+  close.setUTCDate(close.getUTCDate() + daysUntilTuesday)
+  return Math.floor(close.getTime() / 1000)
+}
+
+// Sequential read with retry so a transient RPC blip on the citizen
+// probe doesn't flip a real citizen into "non-citizen" (which would
+// silently move them into the best-fit cohort and skew the tally).
+async function readContractWithRetry<T>(
+  contract: any,
+  method: string,
+  params: any[],
+  maxRetries = 3,
+  baseDelayMs = 400
+): Promise<T> {
+  let lastError: any
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const result = await readContract({ contract, method, params })
+      return result as T
+    } catch (error) {
+      lastError = error
+      const isRetryable =
+        error instanceof TypeError &&
+        String(error.message).includes('buffer')
+      if (!isRetryable || attempt === maxRetries - 1) throw error
+      await new Promise((r) => setTimeout(r, baseDelayMs * Math.pow(2, attempt)))
+    }
+  }
+  throw lastError
+}
+
+// Same hard-coded "citizen-equivalent voting addresses" allowlist as
+// `ProjectRewards.tsx` — payout addresses for citizens whose primary
+// wallet differs from the one they vote with. Kept in sync by hand;
+// adding a new entry here AND in the component is a small ask given
+// how rarely the list changes.
+const CITIZEN_VOTING_ADDRESSES = new Set<string>([
+  '0x78176eaabcb3255e898079dc67428e15149cdc99',
+  '0x9fdf876a50ea8f95017dcfc7709356887025b5bb',
+])
+
+export type RetroactiveResult = {
+  rank: number
+  projectId: string
+  MDP: number | string | null
+  name: string
+  /** Quadratic-voting % of the project pool. Sums (across all results) to ≤ 90 because `runQuadraticVoting` reserves 10% for the community circle. */
+  percentage: number
+  /** Project's slice of the configured retro pool (ETH or USDC, depending on `RETRO_PAYOUT_TOKEN`). */
+  primaryShare: number
+  /** Project's slice of the MOONEY pool. */
+  mooneyShare: number
+}
+
+export type RetroactiveAudit = {
+  voters: Array<{
+    address: string
+    isCitizen: boolean
+    /** vMOONEY balance at vote close, summed across all chains. */
+    vMOONEY: number
+    /** Quadratic voting power = √vMOONEY (clamped to 0 on NaN). */
+    power: number
+    /** Raw allocation as written to the Distribution table, before any normalization. */
+    rawDistribution: Record<string, number>
+  }>
+  /**
+   * Per-project supporter list. For citizen voters this surfaces the
+   * post-zero-out + iterative-normalization weight that actually fed
+   * the quadratic tally. Non-citizen voters are NOT included here:
+   * their contribution is projected through `getBestFitDistributions`
+   * (an L1-minimization onto the citizen-vote basis), which produces
+   * coefficients over citizens rather than per-project weights — there's
+   * no honest per-project number to show. They still appear in `voters`
+   * with their raw distribution so auditors can see what they wrote.
+   */
+  contributions: Record<
+    string,
+    Array<{
+      voterAddress: string
+      isContributor: boolean
+      /** Raw allocation before zero-out / normalization. null if voter didn't allocate. */
+      rawPct: number | null
+      /** Post-zero-out + iterative-normalization value (sums to 100 per row across non-contributor cells). */
+      normalizedPct: number
+    }>
+  >
+  /** projectId → lowercased contributor address set, for the per-project header. */
+  projectIdToContributors: Record<string, string[]>
+}
+
+export type RetroactiveOutcome = {
+  quarter: number
+  year: number
+  voteCount: number
+  voterCount: number
+  citizenVoterCount: number
+  voteCloseTimestamp: number
+  totalCitizenPower: number
+  totalPower: number
+  pool: {
+    primaryAsset: 'ETH' | 'USDC'
+    primaryAmount: number
+    mooneyAmount: number
+  }
+  results: RetroactiveResult[]
+  computedAt: number
+  /**
+   * Optional per-voter / per-project breakdown for the public audit
+   * page. Only populated when `computeRetroactiveOutcome` is called
+   * with `{ includeAudit: true }`. Same trade-off as the member-vote
+   * audit — heavy enough that the lightweight panel endpoint leaves
+   * it off and the audit endpoint opts in.
+   */
+  audit?: RetroactiveAudit
+}
+
+export async function computeRetroactiveOutcome({
+  chain,
+  quarter,
+  year,
+  includeAudit = false,
+}: {
+  chain: any
+  quarter: number
+  year: number
+  includeAudit?: boolean
+}): Promise<RetroactiveOutcome | null> {
+  if (
+    !Number.isInteger(quarter) ||
+    !Number.isInteger(year) ||
+    quarter < 1 ||
+    quarter > 4 ||
+    year < 2020
+  ) {
+    return null
+  }
+
+  const chainSlug = getChainSlug(chain)
+  const projectTableName = PROJECT_TABLE_NAMES[chainSlug]
+  const distributionTableName = DISTRIBUTION_TABLE_NAMES[chainSlug]
+  const citizenAddress = CITIZEN_ADDRESSES[chainSlug]
+  if (!projectTableName || !distributionTableName || !citizenAddress) {
+    return null
+  }
+
+  // Eligible projects only. Retro distributions in the UI are scoped to
+  // the eligible cohort (`currentProjects.filter(p => p.eligible)`) and
+  // ineligible projects don't enter `computeRewardPercentages` either.
+  // Mirror that here so audit numbers match the live tab.
+  const projectStatement = `SELECT * FROM ${projectTableName} WHERE QUARTER = ${quarter} AND YEAR = ${year}`
+  const allProjects = (await queryTable(chain, projectStatement)) || []
+  const eligibleProjects = allProjects.filter((p: any) => !!p?.eligible)
+  if (eligibleProjects.length === 0) return null
+
+  const distributionStatement = `SELECT * FROM ${distributionTableName} WHERE quarter = ${quarter} AND year = ${year}`
+  const rawDistributions = (await queryTable(chain, distributionStatement)) || []
+  if (rawDistributions.length === 0) return null
+
+  // Normalize the on-chain distribution column (sometimes object,
+  // sometimes JSON string) to an object up front so downstream callers
+  // (`computeRewardPercentages`, the audit collector below) don't each
+  // need to redo the same parse.
+  type NormalizedDistRow = {
+    id?: number | string
+    address: string
+    year: number
+    quarter: number
+    distribution: Record<string, number>
+  }
+  const distributions: NormalizedDistRow[] = rawDistributions
+    .map((d: any) => {
+      const address = typeof d?.address === 'string' ? d.address : ''
+      if (!address) return null
+      const parsed = normalizeJsonString(d.distribution)
+      const cleaned: Record<string, number> = {}
+      for (const [pid, value] of Object.entries(parsed || {})) {
+        const n = Number(value)
+        if (Number.isFinite(n)) cleaned[pid] = n
+      }
+      return {
+        id: d?.id,
+        address,
+        year: Number(d?.year) || year,
+        quarter: Number(d?.quarter) || quarter,
+        distribution: cleaned,
+      } as NormalizedDistRow
+    })
+    .filter((d: NormalizedDistRow | null): d is NormalizedDistRow => !!d)
+
+  if (distributions.length === 0) return null
+
+  const voteAddresses = distributions.map((d) => d.address)
+
+  // Citizen membership at compute-time. We probe `getOwnedToken` on the
+  // Citizen NFT contract for each voter — same exact check `useCitizens`
+  // does in the browser — and merge in the hard-coded payout-address
+  // allowlist so designated citizen-equivalent wallets still count as
+  // citizens for the tally. A revert means "no token owned" → not a
+  // citizen; any other unexpected error is logged and the voter falls
+  // back to non-citizen so they go through the best-fit path rather
+  // than getting their distribution counted as a citizen on a transient
+  // RPC error.
+  const citizenContract = getContract({
+    client: serverClient,
+    address: citizenAddress,
+    abi: CitizenABI as any,
+    chain,
+  })
+  const isCitizenByAddress: Record<string, boolean> = {}
+  for (const address of voteAddresses) {
+    const lower = address.toLowerCase()
+    if (CITIZEN_VOTING_ADDRESSES.has(lower)) {
+      isCitizenByAddress[lower] = true
+      continue
+    }
+    try {
+      const ownedTokenId = await readContractWithRetry<any>(
+        citizenContract,
+        'getOwnedToken',
+        [address]
+      )
+      isCitizenByAddress[lower] = !!ownedTokenId
+    } catch (error: any) {
+      // `getOwnedToken` reverts with "No token owned" for non-citizens;
+      // surface only unexpected failures so they don't silently count
+      // as anything other than non-citizen.
+      const reason: string | undefined = error?.reason || error?.shortMessage
+      if (typeof reason === 'string' && /no token owned/i.test(reason)) {
+        isCitizenByAddress[lower] = false
+      } else {
+        console.warn(
+          `[computeRetroactiveOutcome] citizen probe failed for ${address}; treating as non-citizen.`,
+          error
+        )
+        isCitizenByAddress[lower] = false
+      }
+    }
+  }
+
+  const voteCloseTimestamp = getRetroVoteCloseTimestamp(quarter, year)
+
+  // vMOONEY snapshot at vote close. This intentionally uses the same
+  // multi-chain summed `√vMOONEY` calculation as `useTotalVPs` so the
+  // audit reproduces what the on-chain tally would have used. A
+  // failure to fetch returns 0s rather than throwing, mirroring the
+  // production hook's behavior.
+  const vMOONEYs = await fetchTotalVMOONEYs(voteAddresses, voteCloseTimestamp)
+  if (!vMOONEYs || vMOONEYs.length === 0) return null
+
+  const addressToVMOONEY: Record<string, number> = {}
+  const addressToQuadraticVotingPower: Record<string, number> = {}
+  for (let i = 0; i < voteAddresses.length; i++) {
+    const lower = voteAddresses[i].toLowerCase()
+    const v = Number(vMOONEYs[i]) || 0
+    addressToVMOONEY[lower] = v
+    addressToQuadraticVotingPower[lower] = isNaN(v) ? 0 : Math.sqrt(v)
+  }
+
+  // Split votes by citizen status. The shared compute fn expects the
+  // two cohorts separately and runs different pipelines on each.
+  const citizenDistributions = distributions.filter(
+    (d) => isCitizenByAddress[d.address.toLowerCase()]
+  )
+  const nonCitizenDistributions = distributions.filter(
+    (d) => !isCitizenByAddress[d.address.toLowerCase()]
+  )
+
+  // The shared `computeRewardPercentages` keys voting power by the
+  // *original* address (not lowercased). Build a parallel map so the
+  // citizen / non-citizen rows downstream find the right power.
+  const addressToPowerOriginalCase: Record<string, number> = {}
+  for (const d of distributions) {
+    addressToPowerOriginalCase[d.address] =
+      addressToQuadraticVotingPower[d.address.toLowerCase()] || 0
+  }
+
+  const projectIdToEstimatedPercentage = computeRewardPercentages(
+    citizenDistributions,
+    nonCitizenDistributions,
+    eligibleProjects,
+    addressToPowerOriginalCase
+  )
+
+  // Drop bogus keys produced by the non-citizen best-fit path. That
+  // helper returns array-shaped distributions, so when fed back into
+  // `runQuadraticVoting` they get bucketed under integer index keys
+  // ("0", "1", "2", …) that don't correspond to real Tableland project
+  // ids. Filter the outcome to the eligible cohort so the rendered
+  // results only reflect actual projects.
+  const eligibleIdSet = new Set(eligibleProjects.map((p: any) => String(p.id)))
+  const cleanedOutcome: Record<string, number> = {}
+  for (const [pid, pct] of Object.entries(projectIdToEstimatedPercentage)) {
+    if (eligibleIdSet.has(String(pid))) cleanedOutcome[String(pid)] = pct
+  }
+
+  const totalCitizenPower = citizenDistributions.reduce(
+    (sum, d) => sum + (addressToQuadraticVotingPower[d.address.toLowerCase()] || 0),
+    0
+  )
+  const totalPower = Object.values(addressToQuadraticVotingPower).reduce(
+    (sum, v) => sum + v,
+    0
+  )
+
+  // Pool sizes. We surface both cycle-config values plus a flag so the
+  // panel/audit can render the active pool unit (ETH vs USDC). For
+  // historical quarters this still shows the *current* config — there's
+  // no per-quarter pool ledger yet — but the response carries the
+  // numbers explicitly so a future fix can swap in archived values.
+  const isEthPayoutCycle = RETRO_PAYOUT_TOKEN === 'ETH'
+  const primaryAmount = isEthPayoutCycle ? RETRO_ETH_BUDGET : RETRO_USD_BUDGET
+  const mooneyAmount = getMooneyBudgetForCycle(year, quarter)
+
+  const projectMeta = Object.fromEntries(
+    eligibleProjects.map((p: any) => [String(p.id), p])
+  )
+
+  const unrankedResults: RetroactiveResult[] = eligibleProjects.map(
+    (project: any): RetroactiveResult => {
+      const projectId = String(project.id)
+      const percentage = Number(cleanedOutcome[projectId] || 0)
+      const displayName = getProjectDisplayName(projectMeta[projectId])
+      return {
+        projectId,
+        percentage,
+        primaryShare: (percentage / 100) * primaryAmount,
+        mooneyShare: (percentage / 100) * mooneyAmount,
+        MDP: project?.MDP ?? null,
+        name: displayName,
+        rank: 0,
+      }
+    }
+  )
+  const results: RetroactiveResult[] = unrankedResults
+    .sort((a, b) => b.percentage - a.percentage)
+    .map((r, i) => ({ ...r, rank: i + 1 }))
+
+  let audit: RetroactiveAudit | undefined
+  if (includeAudit) {
+    // Build a citizen-only normalized matrix the same way
+    // `computeRewardPercentages` does internally so per-project
+    // contributions reflect what the quadratic tally actually saw.
+    // Inlined here (rather than threaded through the shared helper)
+    // because the shared helper returns only the final per-project
+    // percentages — not the intermediate per-voter weights.
+    const {
+      runIterativeNormalization,
+    } = await import('@/lib/utils/rewards')
+
+    const fillInZeros = (rows: NormalizedDistRow[]) =>
+      rows.map((d) => {
+        const newDist: Record<string, number> = {}
+        for (const project of eligibleProjects) {
+          const pid = String(project.id)
+          newDist[pid] = pid in d.distribution ? d.distribution[pid] : 0
+        }
+        return { ...d, distribution: newDist }
+      })
+
+    const projectIdToContributors: Record<string, string[]> = {}
+    for (const project of eligibleProjects) {
+      const pid = String(project.id)
+      const contributors = normalizeJsonString(project.rewardDistribution) as Record<
+        string,
+        number
+      >
+      projectIdToContributors[pid] = Object.keys(contributors || {}).map((a) =>
+        a.toLowerCase()
+      )
+    }
+
+    // Mirror `zeroOutDistributionForContributors`: contributors get NaN
+    // on their own project (filled with column average by iterative
+    // normalization), then each row is rescaled so the surviving cells
+    // sum to 100. Doing this inline (instead of importing the private
+    // helper from `rewards.ts`) keeps the audit shape decoupled from
+    // the unexported pipeline internals.
+    const filledCitizen = fillInZeros(citizenDistributions)
+    const zeroedForContributors = filledCitizen.map((d) => {
+      const lower = d.address.toLowerCase()
+      const newDist: Record<string, number> = {}
+      for (const [pid, value] of Object.entries(d.distribution)) {
+        const contributors = projectIdToContributors[pid] || []
+        if (contributors.includes(lower)) {
+          newDist[pid] = NaN
+        } else {
+          newDist[pid] = value
+        }
+      }
+      // Renormalize across surviving cells to sum to 100, matching
+      // the helper's behavior so iterative normalization receives a
+      // pre-normalized row.
+      const rowSum = Object.values(newDist)
+        .filter((n) => Number.isFinite(n))
+        .reduce((s, n) => s + n, 0)
+      const normRow: Record<string, number> = {}
+      for (const [pid, val] of Object.entries(newDist)) {
+        if (!Number.isFinite(val)) continue
+        normRow[pid] = rowSum > 0 ? (val / rowSum) * 100 : 0
+      }
+      return { ...d, distribution: normRow }
+    })
+
+    const [normalizedCitizenRows] = runIterativeNormalization(
+      zeroedForContributors,
+      eligibleProjects
+    )
+
+    const lowerToNormalized: Record<string, Record<string, number>> = {}
+    for (const row of normalizedCitizenRows as any[]) {
+      const lower = (row?.address || '').toLowerCase()
+      if (!lower) continue
+      lowerToNormalized[lower] = (row?.distribution || {}) as Record<string, number>
+    }
+
+    const voters = distributions
+      .map((d) => {
+        const lower = d.address.toLowerCase()
+        return {
+          address: lower,
+          isCitizen: !!isCitizenByAddress[lower],
+          vMOONEY: addressToVMOONEY[lower] || 0,
+          power: addressToQuadraticVotingPower[lower] || 0,
+          rawDistribution: { ...d.distribution },
+        }
+      })
+      .sort((a, b) => b.power - a.power)
+
+    const contributions: RetroactiveAudit['contributions'] = {}
+    for (const project of eligibleProjects) {
+      const projectId = String(project.id)
+      const contributorSet = new Set(projectIdToContributors[projectId] || [])
+      const rows: RetroactiveAudit['contributions'][string] = []
+      for (const voter of voters) {
+        if (!voter.isCitizen) continue // see RetroactiveAudit doc for rationale
+        const rawVal = voter.rawDistribution[projectId]
+        const normalizedVal = lowerToNormalized[voter.address]?.[projectId] || 0
+        if (
+          (rawVal == null || rawVal === 0) &&
+          (!Number.isFinite(normalizedVal) || normalizedVal === 0)
+        ) {
+          continue
+        }
+        rows.push({
+          voterAddress: voter.address,
+          isContributor: contributorSet.has(voter.address),
+          rawPct: typeof rawVal === 'number' ? rawVal : null,
+          normalizedPct: Number.isFinite(normalizedVal) ? normalizedVal : 0,
+        })
+      }
+      // Highest weighted contribution first so the audit page can
+      // spotlight the top supporters without re-sorting client-side.
+      rows.sort((a, b) => {
+        const aPower = addressToQuadraticVotingPower[a.voterAddress] || 0
+        const bPower = addressToQuadraticVotingPower[b.voterAddress] || 0
+        return b.normalizedPct * bPower - a.normalizedPct * aPower
+      })
+      contributions[projectId] = rows
+    }
+
+    audit = {
+      voters,
+      contributions,
+      projectIdToContributors,
+    }
+  }
+
+  return {
+    quarter,
+    year,
+    voteCount: distributions.length,
+    voterCount: voteAddresses.length,
+    citizenVoterCount: citizenDistributions.length,
+    voteCloseTimestamp,
+    totalCitizenPower,
+    totalPower,
+    pool: {
+      primaryAsset: isEthPayoutCycle ? 'ETH' : 'USDC',
+      primaryAmount,
+      mooneyAmount,
+    },
+    results,
+    computedAt: Math.floor(Date.now() / 1000),
+    ...(audit ? { audit } : {}),
+  }
+}

--- a/ui/lib/proposals/computeRetroactiveOutcome.ts
+++ b/ui/lib/proposals/computeRetroactiveOutcome.ts
@@ -290,7 +290,7 @@ export async function computeRetroactiveOutcome({
       const cleaned: Record<string, number> = {}
       for (const [pid, value] of Object.entries(parsed || {})) {
         const n = Number(value)
-        if (Number.isFinite(n)) cleaned[pid] = n
+        if (Number.isFinite(n) && n >= 0 && n <= 100) cleaned[pid] = n
       }
       return {
         id: d?.id,

--- a/ui/lib/proposals/computeRetroactiveOutcome.ts
+++ b/ui/lib/proposals/computeRetroactiveOutcome.ts
@@ -61,6 +61,23 @@ function getMooneyBudgetForCycle(year: number, quarter: number): number {
   return MOONEY_INITIAL_BUDGET * MOONEY_DECAY_RATE ** numQuartersPastQ4Y2022
 }
 
+// Frozen per-cycle retro pool snapshots. We can't infer historical
+// pools from `RETRO_PAYOUT_TOKEN` / `RETRO_*_BUDGET` because those
+// constants only ever describe the *current* cycle — once the EB rolls
+// the config forward they no longer reflect what the prior cycle
+// actually paid out. Each completed cycle gets pinned here so audits
+// of past quarters render their real pool. New cycles fall through
+// to the live config values; when a cycle closes, copy its config
+// snapshot into a new entry below.
+const HISTORICAL_RETRO_POOLS: Record<
+  string,
+  { primaryAsset: 'ETH' | 'USDC'; primaryAmount: number }
+> = {
+  // Q1 2026 retroactives (paid in ETH, voting closed Apr 21, 2026).
+  // Source: `RETRO_ETH_BUDGET` doc comment in `const/config.ts`.
+  '2026-Q1': { primaryAsset: 'ETH', primaryAmount: 2.215 },
+}
+
 /**
  * Mirror of `getRetroVoteCloseTimestamp` semantics from `isRewardsCycle`:
  * the rewards window for a (quarter, year) cycle ends on the first
@@ -223,18 +240,36 @@ export async function computeRetroactiveOutcome({
     return null
   }
 
-  // Eligible projects only. Retro distributions in the UI are scoped to
-  // the eligible cohort (`currentProjects.filter(p => p.eligible)`) and
-  // ineligible projects don't enter `computeRewardPercentages` either.
-  // Mirror that here so audit numbers match the live tab.
-  const projectStatement = `SELECT * FROM ${projectTableName} WHERE QUARTER = ${quarter} AND YEAR = ${year}`
-  const allProjects = (await queryTable(chain, projectStatement)) || []
-  const eligibleProjects = allProjects.filter((p: any) => !!p?.eligible)
-  if (eligibleProjects.length === 0) return null
-
+  // The (quarter, year) parameter is the *voting cycle* (when distributions
+  // were submitted) — NOT the cohort's project quarter. The eligible projects
+  // voted on usually belong to a prior cycle (e.g. Q1 2026 voting tallies
+  // Q4 2025 projects), and the project table's `eligible` column is mutable
+  // state that gets reused across cycles, so neither the voting (quarter,
+  // year) nor the current `eligible` flag is reliable for picking the
+  // tally cohort. Instead, derive the cohort from the project ids actually
+  // referenced in this cycle's distribution rows — those are the projects
+  // that were eligible at vote time, and the set is immutable after the
+  // fact (distributions can be edited but only across the same project
+  // surface a voter saw).
   const distributionStatement = `SELECT * FROM ${distributionTableName} WHERE quarter = ${quarter} AND year = ${year}`
   const rawDistributions = (await queryTable(chain, distributionStatement)) || []
   if (rawDistributions.length === 0) return null
+
+  const referencedProjectIds = new Set<string>()
+  for (const d of rawDistributions) {
+    const parsed = normalizeJsonString(d?.distribution) as Record<string, unknown>
+    for (const pid of Object.keys(parsed || {})) referencedProjectIds.add(String(pid))
+  }
+  if (referencedProjectIds.size === 0) return null
+
+  const idList = [...referencedProjectIds]
+    .filter((pid) => /^\d+$/.test(pid))
+    .map((pid) => Number(pid))
+  if (idList.length === 0) return null
+
+  const projectStatement = `SELECT * FROM ${projectTableName} WHERE id IN (${idList.join(',')})`
+  const eligibleProjects = (await queryTable(chain, projectStatement)) || []
+  if (eligibleProjects.length === 0) return null
 
   // Normalize the on-chain distribution column (sometimes object,
   // sometimes JSON string) to an object up front so downstream callers
@@ -382,13 +417,24 @@ export async function computeRetroactiveOutcome({
     0
   )
 
-  // Pool sizes. We surface both cycle-config values plus a flag so the
-  // panel/audit can render the active pool unit (ETH vs USDC). For
-  // historical quarters this still shows the *current* config — there's
-  // no per-quarter pool ledger yet — but the response carries the
-  // numbers explicitly so a future fix can swap in archived values.
-  const isEthPayoutCycle = RETRO_PAYOUT_TOKEN === 'ETH'
-  const primaryAmount = isEthPayoutCycle ? RETRO_ETH_BUDGET : RETRO_USD_BUDGET
+  // Pool sizes per voting cycle. Each completed cycle gets a frozen
+  // entry in `HISTORICAL_RETRO_POOLS` so audits of past quarters render
+  // their actual pool (asset + amount) rather than the live config
+  // values. The current cycle falls through to `RETRO_PAYOUT_TOKEN` /
+  // `RETRO_*_BUDGET`, which is what `ProjectRewards.tsx` reads when
+  // showing the live retro tab. When a cycle is closed and the next
+  // one's config goes in, copy the now-historical `RETRO_*_BUDGET`
+  // values into a new entry below.
+  const cycleKey = `${year}-Q${quarter}`
+  const historicalPool = HISTORICAL_RETRO_POOLS[cycleKey]
+  const isEthPayoutCycle = historicalPool
+    ? historicalPool.primaryAsset === 'ETH'
+    : RETRO_PAYOUT_TOKEN === 'ETH'
+  const primaryAmount = historicalPool
+    ? historicalPool.primaryAmount
+    : isEthPayoutCycle
+    ? RETRO_ETH_BUDGET
+    : RETRO_USD_BUDGET
   const mooneyAmount = getMooneyBudgetForCycle(year, quarter)
 
   const projectMeta = Object.fromEntries(

--- a/ui/lib/proposals/computeRetroactiveOutcome.ts
+++ b/ui/lib/proposals/computeRetroactiveOutcome.ts
@@ -79,11 +79,14 @@ const HISTORICAL_RETRO_POOLS: Record<
 }
 
 /**
- * Mirror of `getRetroVoteCloseTimestamp` semantics from `isRewardsCycle`:
+ * Mirror of `isRewardsCycle` (lib/utils/dates.ts) cycle-close semantics:
  * the rewards window for a (quarter, year) cycle ends on the first
- * Tuesday on or after 14 days into the *following* quarter. Using that
- * close as the vMOONEY snapshot means the audit reproduces the same
- * power values the on-chain tally would have used.
+ * Tuesday strictly after the date 14 days into the *following* quarter.
+ * The "strictly after" comes from `daysUntilDay`'s
+ * `daysUntil === 0 ? 7 : daysUntil` rule — if day-14 itself lands on a
+ * Tuesday, the close jumps to the following Tuesday, exactly like the
+ * on-chain tally does. Using that close as the vMOONEY snapshot means
+ * the audit reproduces the same power values the on-chain tally used.
  */
 function getRetroVoteCloseTimestamp(quarter: number, year: number): number {
   const nextQuarterIndex = quarter % 4 // 0..3
@@ -93,6 +96,9 @@ function getRetroVoteCloseTimestamp(quarter: number, year: number): number {
   fourteenIn.setUTCDate(fourteenIn.getUTCDate() + 14)
   const TUESDAY = 2
   const dow = fourteenIn.getUTCDay()
+  // `|| 7` mirrors `daysUntilDay`'s `daysUntil === 0 ? 7 : daysUntil`:
+  // when day-14 itself is a Tuesday, advance to the next Tuesday so the
+  // snapshot timestamp matches `isRewardsCycle`'s window edge.
   const daysUntilTuesday = ((TUESDAY - dow + 7) % 7) || 7
   const close = new Date(fourteenIn)
   close.setUTCDate(close.getUTCDate() + daysUntilTuesday)

--- a/ui/lib/proposals/parseCycleParams.ts
+++ b/ui/lib/proposals/parseCycleParams.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared `?quarter=&year=` validator for the retro/member-vote API
+ * endpoints. Intentionally distinguishes "missing → fall back to the
+ * caller's default" from "present but invalid → return a 400" so:
+ *   - bare `/api/proposals/retro-results` (the panel's hot path) keeps
+ *     hitting the same edge-cache key,
+ *   - typos like `?quarter=foo` or `?year=2019` surface immediately
+ *     instead of silently returning `outcome: null`.
+ *
+ * Mirrors the same `1 <= quarter <= 4` / `year >= 2020` ranges
+ * `computeRetroactiveOutcome` already enforces internally — keeping
+ * them in sync here means the caller gets a clean error message
+ * rather than an opaque `null` payload that's expensive to debug.
+ */
+import type { NextApiRequest } from 'next'
+
+const MIN_YEAR = 2020
+
+export type CycleParams = { quarter: number; year: number }
+
+export type CycleParamsResult =
+  | { ok: true; params: CycleParams }
+  | { ok: false; error: string }
+
+/**
+ * Coerce a raw query value (`string | string[] | undefined`) to its
+ * first string entry. Multiple `?quarter=1&quarter=2` rarely happens
+ * in practice but is well-defined behavior in Next.js — fall back to
+ * the first occurrence so a stray duplicate param doesn't 400.
+ */
+function firstParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0]
+  return value
+}
+
+export function parseCycleParams(
+  req: NextApiRequest,
+  fallback: CycleParams
+): CycleParamsResult {
+  const rawQuarter = firstParam(req.query.quarter)
+  const rawYear = firstParam(req.query.year)
+
+  let quarter = fallback.quarter
+  if (rawQuarter !== undefined && rawQuarter !== '') {
+    const parsed = Number(rawQuarter)
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 4) {
+      return {
+        ok: false,
+        error: `quarter must be an integer 1-4 (got "${rawQuarter}")`,
+      }
+    }
+    quarter = parsed
+  }
+
+  let year = fallback.year
+  if (rawYear !== undefined && rawYear !== '') {
+    const parsed = Number(rawYear)
+    if (!Number.isInteger(parsed) || parsed < MIN_YEAR) {
+      return {
+        ok: false,
+        error: `year must be an integer >= ${MIN_YEAR} (got "${rawYear}")`,
+      }
+    }
+    year = parsed
+  }
+
+  return { ok: true, params: { quarter, year } }
+}

--- a/ui/pages/api/operator/project-add-to-retroactives.ts
+++ b/ui/pages/api/operator/project-add-to-retroactives.ts
@@ -152,10 +152,19 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     })
   }
 
-  if (body.markEligible) {
+  // Tri-state: `true` → set eligible=1 (mark for retro), `false` → set
+  // eligible=0 (clear at cycle end), `undefined` → leave column alone.
+  // The explicit-false branch is what the operator panel's "clear cohort"
+  // bulk action uses to retire a closed cycle's projects.
+  if (body.markEligible === true) {
     calls.push({
       label: 'updateTableCol(eligible=1)',
       data: iface.encodeFunctionData('updateTableCol', [projectId, 'eligible', '1']),
+    })
+  } else if (body.markEligible === false) {
+    calls.push({
+      label: 'updateTableCol(eligible=0)',
+      data: iface.encodeFunctionData('updateTableCol', [projectId, 'eligible', '0']),
     })
   }
 

--- a/ui/pages/api/proposals/retro-audit.ts
+++ b/ui/pages/api/proposals/retro-audit.ts
@@ -22,14 +22,54 @@ import { computeRetroactiveOutcome } from '@/lib/proposals/computeRetroactiveOut
 
 const chain = DEFAULT_CHAIN_V5
 
+function parseIntegerQueryParam(
+  value: string | string[] | undefined,
+  {
+    min,
+    max,
+  }: {
+    min?: number
+    max?: number
+  } = {}
+) {
+  if (value === undefined) return { provided: false as const }
+  if (Array.isArray(value)) return { provided: true as const, valid: false as const }
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+    return { provided: true as const, valid: false as const }
+  }
+
+  if ((min !== undefined && parsed < min) || (max !== undefined && parsed > max)) {
+    return { provided: true as const, valid: false as const }
+  }
+
+  return { provided: true as const, valid: true as const, value: parsed }
+}
+
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
   const fallback = getRelativeQuarter(-1)
-  const quarter = req.query.quarter ? Number(req.query.quarter) : fallback.quarter
-  const year = req.query.year ? Number(req.query.year) : fallback.year
+  const quarterParam = parseIntegerQueryParam(req.query.quarter, { min: 1, max: 4 })
+  const yearParam = parseIntegerQueryParam(req.query.year, { min: 1 })
+
+  if (quarterParam.provided && !quarterParam.valid) {
+    return res
+      .status(400)
+      .json({ error: 'Invalid quarter parameter. Expected an integer from 1 to 4.' })
+  }
+
+  if (yearParam.provided && !yearParam.valid) {
+    return res
+      .status(400)
+      .json({ error: 'Invalid year parameter. Expected a positive integer.' })
+  }
+
+  const quarter = quarterParam.provided ? quarterParam.value : fallback.quarter
+  const year = yearParam.provided ? yearParam.value : fallback.year
 
   try {
     const outcome = await computeRetroactiveOutcome({

--- a/ui/pages/api/proposals/retro-audit.ts
+++ b/ui/pages/api/proposals/retro-audit.ts
@@ -19,33 +19,9 @@ import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { computeRetroactiveOutcome } from '@/lib/proposals/computeRetroactiveOutcome'
+import { parseCycleParams } from '@/lib/proposals/parseCycleParams'
 
 const chain = DEFAULT_CHAIN_V5
-
-function parseIntegerQueryParam(
-  value: string | string[] | undefined,
-  {
-    min,
-    max,
-  }: {
-    min?: number
-    max?: number
-  } = {}
-) {
-  if (value === undefined) return { provided: false as const }
-  if (Array.isArray(value)) return { provided: true as const, valid: false as const }
-
-  const parsed = Number(value)
-  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
-    return { provided: true as const, valid: false as const }
-  }
-
-  if ((min !== undefined && parsed < min) || (max !== undefined && parsed > max)) {
-    return { provided: true as const, valid: false as const }
-  }
-
-  return { provided: true as const, valid: true as const, value: parsed }
-}
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -53,23 +29,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const fallback = getRelativeQuarter(-1)
-  const quarterParam = parseIntegerQueryParam(req.query.quarter, { min: 1, max: 4 })
-  const yearParam = parseIntegerQueryParam(req.query.year, { min: 1 })
-
-  if (quarterParam.provided && !quarterParam.valid) {
-    return res
-      .status(400)
-      .json({ error: 'Invalid quarter parameter. Expected an integer from 1 to 4.' })
+  const parsed = parseCycleParams(req, fallback)
+  if (!parsed.ok) {
+    return res.status(400).json({ error: parsed.error })
   }
-
-  if (yearParam.provided && !yearParam.valid) {
-    return res
-      .status(400)
-      .json({ error: 'Invalid year parameter. Expected a positive integer.' })
-  }
-
-  const quarter = quarterParam.provided ? quarterParam.value : fallback.quarter
-  const year = yearParam.provided ? yearParam.value : fallback.year
+  const { quarter, year } = parsed.params
 
   try {
     const outcome = await computeRetroactiveOutcome({

--- a/ui/pages/api/proposals/retro-audit.ts
+++ b/ui/pages/api/proposals/retro-audit.ts
@@ -1,0 +1,59 @@
+/**
+ * Read-only Retroactive Rewards audit data.
+ *
+ * Same compute as `/api/proposals/retro-results` but with the
+ * per-voter and per-project breakdown (`outcome.audit`) attached.
+ * Powers the public `/projects/retro-audit` page so anyone can
+ * verify the retro tally — voters and their voting power, every
+ * project's citizen supporters (raw → normalized → weighted), and
+ * the resulting per-project pool share — without rerunning the
+ * tally locally.
+ *
+ * GET only. Quarter/year default to the previous calendar quarter
+ * (matches `/api/proposals/retro-results`); override with
+ * `?quarter=&year=` for older cycles.
+ */
+import { DEFAULT_CHAIN_V5 } from 'const/config'
+import { getRelativeQuarter } from 'lib/utils/dates'
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { computeRetroactiveOutcome } from '@/lib/proposals/computeRetroactiveOutcome'
+
+const chain = DEFAULT_CHAIN_V5
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const fallback = getRelativeQuarter(-1)
+  const quarter = req.query.quarter ? Number(req.query.quarter) : fallback.quarter
+  const year = req.query.year ? Number(req.query.year) : fallback.year
+
+  try {
+    const outcome = await computeRetroactiveOutcome({
+      chain,
+      quarter,
+      year,
+      includeAudit: true,
+    })
+
+    // Cache more aggressively than `/retro-results`. The audit payload
+    // is larger but identical for the same (quarter, year, vote-set),
+    // and the page is meant for occasional verification rather than
+    // frequent polling — a 5min shared cache keeps repeat visits cheap.
+    res.setHeader(
+      'Cache-Control',
+      'public, s-maxage=300, stale-while-revalidate=900'
+    )
+    return res.status(200).json({ outcome: outcome ?? null, quarter, year })
+  } catch (error: any) {
+    console.error('[retro-audit] computeRetroactiveOutcome failed:', error)
+    return res
+      .status(500)
+      .json({ error: error?.message || 'Failed to compute retro audit' })
+  }
+}
+
+export default withMiddleware(handler, rateLimit)

--- a/ui/pages/api/proposals/retro-results.ts
+++ b/ui/pages/api/proposals/retro-results.ts
@@ -1,0 +1,62 @@
+/**
+ * Read-only Retroactive Rewards results.
+ *
+ * Returns the same per-project pool shares the on-chain retro tally
+ * would produce, without doing any writes. Used by the `/projects`
+ * Retroactive Rewards tab to render a ranked list (% of pool, ETH/USDC
+ * + MOONEY shares) — works as both a live preview during the rewards
+ * cycle and a permanent record once the cycle has closed.
+ *
+ * GET only. Quarter/year default to the previous calendar quarter
+ * (the one whose projects are typically being retro-tallied right now),
+ * but can be overridden via `?quarter=&year=` for backfills / audits.
+ */
+import { DEFAULT_CHAIN_V5 } from 'const/config'
+import { getRelativeQuarter } from 'lib/utils/dates'
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { computeRetroactiveOutcome } from '@/lib/proposals/computeRetroactiveOutcome'
+
+const chain = DEFAULT_CHAIN_V5
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  // Default to the *previous* calendar quarter — that's the cohort
+  // currently in the retro-distribution window. The member-vote results
+  // endpoint defaults to the current quarter because that's the cycle
+  // being voted on; for retros the cycle being voted on belongs to the
+  // prior quarter. Override with `?quarter=&year=` for older audits.
+  const fallback = getRelativeQuarter(-1)
+  const quarter = req.query.quarter ? Number(req.query.quarter) : fallback.quarter
+  const year = req.query.year ? Number(req.query.year) : fallback.year
+
+  try {
+    const outcome = await computeRetroactiveOutcome({ chain, quarter, year })
+
+    // Cache at the edge briefly. The underlying computation is heavy
+    // (Tableland + multi-chain RPC + per-voter citizen probes +
+    // vMOONEY snapshot) but the result is deterministic for a given
+    // (quarter, year, vote-set), so a short shared cache with
+    // stale-while-revalidate keeps the panel snappy without serving
+    // wildly stale numbers. The `outcome: null` case (no eligible
+    // projects, no votes, etc.) is just as expensive to re-derive as
+    // the populated one — every traffic spike pre-vote would otherwise
+    // re-run the full pipeline — so it gets the same cache treatment.
+    res.setHeader(
+      'Cache-Control',
+      'public, s-maxage=60, stale-while-revalidate=300'
+    )
+    return res.status(200).json({ outcome: outcome ?? null, quarter, year })
+  } catch (error: any) {
+    console.error('[retro-results] computeRetroactiveOutcome failed:', error)
+    return res
+      .status(500)
+      .json({ error: error?.message || 'Failed to compute retro results' })
+  }
+}
+
+export default withMiddleware(handler, rateLimit)

--- a/ui/pages/api/proposals/retro-results.ts
+++ b/ui/pages/api/proposals/retro-results.ts
@@ -17,6 +17,7 @@ import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { computeRetroactiveOutcome } from '@/lib/proposals/computeRetroactiveOutcome'
+import { parseCycleParams } from '@/lib/proposals/parseCycleParams'
 
 const chain = DEFAULT_CHAIN_V5
 
@@ -31,8 +32,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   // being voted on; for retros the cycle being voted on belongs to the
   // prior quarter. Override with `?quarter=&year=` for older audits.
   const fallback = getRelativeQuarter(-1)
-  const quarter = req.query.quarter ? Number(req.query.quarter) : fallback.quarter
-  const year = req.query.year ? Number(req.query.year) : fallback.year
+  const parsed = parseCycleParams(req, fallback)
+  if (!parsed.ok) {
+    return res.status(400).json({ error: parsed.error })
+  }
+  const { quarter, year } = parsed.params
 
   try {
     const outcome = await computeRetroactiveOutcome({ chain, quarter, year })

--- a/ui/pages/projects/retro-audit.tsx
+++ b/ui/pages/projects/retro-audit.tsx
@@ -53,6 +53,25 @@ const formatPrimary = (amount: number, asset: 'ETH' | 'USDC') =>
 const formatMooney = (amount: number) =>
   `${Number(amount.toPrecision(3)).toLocaleString()} MOONEY`
 
+// Compact unit-stripped variants for tight summary tiles where the
+// asset is already named in the label. ETH stays decimal; USDC and
+// MOONEY collapse to k/M suffixes so two values + a separator fit on
+// one line without truncation.
+const formatPrimaryCompact = (amount: number, asset: 'ETH' | 'USDC') => {
+  if (asset === 'ETH')
+    return amount.toLocaleString(undefined, { maximumFractionDigits: 4 })
+  return amount.toLocaleString(undefined, {
+    notation: 'compact',
+    maximumFractionDigits: 2,
+  })
+}
+
+const formatMooneyCompact = (amount: number) =>
+  amount.toLocaleString(undefined, {
+    notation: 'compact',
+    maximumFractionDigits: 2,
+  })
+
 export default function ProjectsRetroAuditPage() {
   const router = useRouter()
   // Default to the previous calendar quarter — the cohort currently
@@ -356,44 +375,59 @@ function SummaryCard({
         </div>
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3">
-        <StatTile
-          label="Voters"
-          value={`${voterCount} (${outcome.citizenVoterCount} citizen)`}
-        />
+        <StatTile label="Voters" value={String(voterCount)} />
         <StatTile
           label="Citizen power"
           value={formatNumber(outcome.totalCitizenPower, 0)}
         />
         <StatTile
           label={`Pool (${outcome.pool.primaryAsset})`}
-          value={`${formatPrimary(
+          value={`${formatPrimaryCompact(
             allocatedPrimary,
             outcome.pool.primaryAsset
-          )} / ${formatPrimary(
+          )} / ${formatPrimaryCompact(
             outcome.pool.primaryAmount,
             outcome.pool.primaryAsset
           )}`}
+          sub={`${formatPrimary(
+            allocatedPrimary,
+            outcome.pool.primaryAsset
+          )} allocated`}
         />
         <StatTile
           label="Pool (MOONEY)"
-          value={`${formatMooney(allocatedMooney)} / ${formatMooney(
-            outcome.pool.mooneyAmount
-          )}`}
+          value={`${formatMooneyCompact(
+            allocatedMooney
+          )} / ${formatMooneyCompact(outcome.pool.mooneyAmount)}`}
+          sub={`${formatMooney(allocatedMooney)} allocated`}
         />
       </div>
     </div>
   )
 }
 
-function StatTile({ label, value }: { label: string; value: string }) {
+function StatTile({
+  label,
+  value,
+  sub,
+}: {
+  label: string
+  value: string
+  sub?: string
+}) {
   return (
     <div className="bg-slate-800/40 border border-white/10 rounded-lg px-3 py-2 sm:px-4 sm:py-3 min-w-0">
       <div className="text-[10px] sm:text-xs uppercase tracking-wider text-gray-400 font-RobotoMono truncate">
         {label}
       </div>
-      <div className="mt-0.5 sm:mt-1 font-GoodTimes text-base sm:text-lg tracking-wider text-white truncate">
+      <div className="mt-0.5 sm:mt-1 font-GoodTimes text-sm sm:text-base tracking-wider text-white truncate">
         {value}
       </div>
+      {sub && (
+        <div className="mt-0.5 text-[10px] font-RobotoMono text-gray-500 truncate">
+          {sub}
+        </div>
+      )}
     </div>
   )
 }

--- a/ui/pages/projects/retro-audit.tsx
+++ b/ui/pages/projects/retro-audit.tsx
@@ -532,7 +532,9 @@ function ProjectRow({
               hasShare ? 'text-white' : 'text-gray-300'
             }`}
           >
-            {outcomeRow.MDP != null ? `MDP-${outcomeRow.MDP}: ` : ''}
+            {outcomeRow.MDP != null && outcomeRow.MDP !== ''
+              ? `MDP-${outcomeRow.MDP}: `
+              : ''}
             {outcomeRow.name}
           </p>
           <p className="text-[11px] text-gray-500">

--- a/ui/pages/projects/retro-audit.tsx
+++ b/ui/pages/projects/retro-audit.tsx
@@ -399,11 +399,10 @@ function StatTile({ label, value }: { label: string; value: string }) {
 }
 
 function VotersTable({ voters }: { voters: RetroactiveAudit['voters'] }) {
-  // Default-collapsed: a 100+ voter table dumped above the project
+  // Default-collapsed: a long voter table dumped above the project
   // list would push the actual tally below the fold on mobile.
-  // Citizenship + power share is the audit-relevant column; raw
-  // vMOONEY balance + allocations cast are informational and live
-  // behind expand.
+  // Power share is the audit-relevant column; the per-project
+  // tables below carry per-voter raw/normalized %.
   const [expanded, setExpanded] = useState(false)
   const totalPower = voters.reduce((s, v) => s + v.power, 0)
   const citizenCount = voters.filter((v) => v.isCitizen).length
@@ -440,20 +439,14 @@ function VotersTable({ voters }: { voters: RetroactiveAudit['voters'] }) {
               <tr className="text-[11px] uppercase tracking-wider text-gray-400 font-RobotoMono">
                 <th className="text-left py-2 px-2 sm:px-3">#</th>
                 <th className="text-left py-2 px-2 sm:px-3">Address</th>
-                <th className="text-left py-2 px-2 sm:px-3">Cohort</th>
-                <th className="text-right py-2 px-2 sm:px-3">vMOONEY</th>
                 <th className="text-right py-2 px-2 sm:px-3">Power</th>
                 <th className="text-right py-2 px-2 sm:px-3">Share</th>
-                <th className="text-right py-2 px-2 sm:px-3">Allocations</th>
               </tr>
             </thead>
             <tbody>
               {voters.map((v, idx) => {
                 const share =
                   totalPower > 0 ? (v.power / totalPower) * 100 : 0
-                const nonZeroAlloc = Object.values(v.rawDistribution).filter(
-                  (n) => Number(n) > 0
-                ).length
                 return (
                   <tr
                     key={v.address}
@@ -471,29 +464,17 @@ function VotersTable({ voters }: { voters: RetroactiveAudit['voters'] }) {
                       >
                         {truncateAddress(v.address)}
                       </a>
-                    </td>
-                    <td className="py-2 px-2 sm:px-3 font-RobotoMono text-xs">
-                      {v.isCitizen ? (
-                        <span className="bg-emerald-500/15 border border-emerald-400/30 text-emerald-200 px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider">
-                          Citizen
-                        </span>
-                      ) : (
-                        <span className="bg-amber-500/15 border border-amber-400/30 text-amber-200 px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider">
+                      {!v.isCitizen && (
+                        <span className="ml-2 inline-block text-[10px] uppercase tracking-wider bg-amber-500/15 border border-amber-400/30 text-amber-200 px-1.5 py-0.5 rounded">
                           Non-citizen
                         </span>
                       )}
-                    </td>
-                    <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
-                      {formatNumber(v.vMOONEY, 0)}
                     </td>
                     <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
                       {formatNumber(v.power, 1)}
                     </td>
                     <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
                       {share.toFixed(2)}%
-                    </td>
-                    <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs text-gray-400">
-                      {nonZeroAlloc}
                     </td>
                   </tr>
                 )

--- a/ui/pages/projects/retro-audit.tsx
+++ b/ui/pages/projects/retro-audit.tsx
@@ -91,9 +91,24 @@ export default function ProjectsRetroAuditPage() {
       ? `/api/proposals/retro-audit?quarter=${quarter}&year=${year}`
       : null,
     fetcher,
-    { revalidateOnFocus: false, dedupingInterval: 60_000, errorRetryCount: 1 }
+    {
+      revalidateOnFocus: false,
+      // Always revalidate on mount so a stale `{outcome: null}` left over
+      // from an earlier failed compute (e.g. before the cohort detection
+      // was fixed) doesn't survive a navigation to the audit page.
+      revalidateOnMount: true,
+      revalidateIfStale: true,
+      dedupingInterval: 60_000,
+      errorRetryCount: 1,
+    }
   )
 
+  // Treat "router not ready" the same as "loading" — until the URL
+  // params are parsed and SWR has actually been keyed, we have no idea
+  // whether the requested cycle has data. Without this guard the
+  // "no data" ErrorState briefly renders on every fresh mount because
+  // `data` is undefined → `!outcome` is truthy.
+  const showLoading = !router.isReady || isLoading || (!data && !error)
   const outcome = data?.outcome
   const audit = outcome?.audit
 
@@ -168,11 +183,11 @@ export default function ProjectsRetroAuditPage() {
               onChange={updateUrl}
             />
 
-            {isLoading && <LoadingState />}
-            {error && !isLoading && (
+            {showLoading && <LoadingState />}
+            {error && !showLoading && (
               <ErrorState message="Could not load the audit data. Try again in a moment." />
             )}
-            {!isLoading && !error && outcome && audit && (
+            {!showLoading && !error && outcome && audit && (
               <AuditBody
                 outcome={outcome}
                 audit={audit}
@@ -180,7 +195,11 @@ export default function ProjectsRetroAuditPage() {
                 totalCitizenPower={totalCitizenPower}
               />
             )}
-            {!isLoading && !error && (!outcome || !audit) && (
+            {/* Only surface "no data" when we've actually received a
+                response (i.e. `data` is defined) — otherwise an
+                in-flight request would briefly flash the empty-state
+                message before the payload lands. */}
+            {!showLoading && !error && data && (!outcome || !audit) && (
               <ErrorState
                 message={`No retro tally data is available yet for Q${quarter} ${year}. Either no projects are eligible for retro rewards or no votes have been cast.`}
               />

--- a/ui/pages/projects/retro-audit.tsx
+++ b/ui/pages/projects/retro-audit.tsx
@@ -1,0 +1,799 @@
+/**
+ * Public Retroactive Rewards audit page (`/projects/retro-audit`).
+ *
+ * Lets anyone verify the per-quarter retro tally end-to-end without
+ * rerunning the pipeline locally. Mirrors `/projects/audit` (member
+ * vote) but reflects the retro-specific math: voters split into
+ * citizens / non-citizens, contributor zero-out before iterative
+ * normalization, and per-project ETH/USDC + MOONEY pool shares
+ * instead of approve/fail badges.
+ *
+ * Defaults to the previous calendar quarter (the one whose projects
+ * are typically being retro-tallied right now). `?quarter=` and
+ * `?year=` let auditors pin a past cycle.
+ */
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { useMemo, useState } from 'react'
+import useSWR from 'swr'
+import fetcher from '@/lib/swr/fetcher'
+import type {
+  RetroactiveAudit,
+  RetroactiveOutcome,
+} from '@/lib/proposals/computeRetroactiveOutcome'
+import { getRelativeQuarter } from '@/lib/utils/dates'
+import Container from '@/components/layout/Container'
+import ContentLayout from '@/components/layout/ContentLayout'
+import Head from '@/components/layout/Head'
+import { NoticeFooter } from '@/components/layout/NoticeFooter'
+
+type AuditResponse = {
+  outcome: (RetroactiveOutcome & { audit?: RetroactiveAudit }) | null
+  quarter: number
+  year: number
+}
+
+const QUARTERS = [1, 2, 3, 4] as const
+
+const truncateAddress = (addr: string) =>
+  addr.length > 12 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr
+
+const formatNumber = (n: number, digits = 0) =>
+  n.toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  })
+
+const formatPrimary = (amount: number, asset: 'ETH' | 'USDC') =>
+  asset === 'ETH'
+    ? `${amount.toLocaleString(undefined, { maximumFractionDigits: 4 })} ETH`
+    : `$${amount.toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+
+const formatMooney = (amount: number) =>
+  `${Number(amount.toPrecision(3)).toLocaleString()} MOONEY`
+
+export default function ProjectsRetroAuditPage() {
+  const router = useRouter()
+  // Default to the previous calendar quarter — the cohort currently
+  // in the retro-distribution window. Older cycles can be pinned via
+  // the URL params.
+  const fallback = getRelativeQuarter(-1)
+
+  const { quarter, year } = useMemo(() => {
+    if (!router.isReady)
+      return { quarter: fallback.quarter, year: fallback.year }
+    const rawQuarter = Array.isArray(router.query.quarter)
+      ? router.query.quarter[0]
+      : router.query.quarter
+    const rawYear = Array.isArray(router.query.year)
+      ? router.query.year[0]
+      : router.query.year
+    const parsedQuarter = rawQuarter ? Number(rawQuarter) : NaN
+    const parsedYear = rawYear ? Number(rawYear) : NaN
+    return {
+      quarter:
+        parsedQuarter >= 1 && parsedQuarter <= 4
+          ? parsedQuarter
+          : fallback.quarter,
+      year: parsedYear >= 2020 ? parsedYear : fallback.year,
+    }
+  }, [
+    router.isReady,
+    router.query.quarter,
+    router.query.year,
+    fallback.quarter,
+    fallback.year,
+  ])
+
+  const { data, error, isLoading } = useSWR<AuditResponse>(
+    router.isReady
+      ? `/api/proposals/retro-audit?quarter=${quarter}&year=${year}`
+      : null,
+    fetcher,
+    { revalidateOnFocus: false, dedupingInterval: 60_000, errorRetryCount: 1 }
+  )
+
+  const outcome = data?.outcome
+  const audit = outcome?.audit
+
+  // Citizen power lookup — used to compute per-row weighted
+  // contributions on the project breakdowns. Built off the audit
+  // voters list so the ratios match what the tally actually saw.
+  const addressToPower = useMemo(() => {
+    const map: Record<string, number> = {}
+    if (audit?.voters)
+      for (const v of audit.voters) if (v.isCitizen) map[v.address] = v.power
+    return map
+  }, [audit])
+
+  const totalCitizenPower = outcome?.totalCitizenPower || 0
+
+  const updateUrl = (nextQuarter: number, nextYear: number) => {
+    router.push(
+      {
+        pathname: router.pathname,
+        query: { quarter: nextQuarter, year: nextYear },
+      },
+      undefined,
+      { shallow: true }
+    )
+  }
+
+  const yearOptions = useMemo(() => {
+    const base = fallback.year
+    return [base - 1, base, base + 1]
+  }, [fallback.year])
+
+  return (
+    <section id="retro-audit-container" className="overflow-hidden">
+      <Head
+        title="Retroactive Rewards Audit"
+        description="Per-voter and per-project breakdown of MoonDAO's quarterly Retroactive Rewards tally."
+      />
+      <Container>
+        <ContentLayout
+          header="Retroactive Rewards Audit"
+          headerSize="max(20px, 3vw)"
+          description={
+            <p>
+              Public, reproducible breakdown of the quarterly Retroactive
+              Rewards tally — voters and their voting power, every
+              project&apos;s citizen supporters, and the resulting share
+              of the ETH/USDC and MOONEY pools. Voting power is √vMOONEY
+              at vote close; citizen votes get zeroed for projects they
+              contributed to and refilled with the column average;
+              non-citizen votes are projected onto the citizen-vote basis
+              via L1 best-fit before the quadratic tally.{' '}
+              <Link
+                href="/projects"
+                className="underline text-blue-300 hover:text-blue-200"
+              >
+                Back to projects
+              </Link>
+              .
+            </p>
+          }
+          preFooter={<NoticeFooter />}
+          mainPadding
+          mode="compact"
+          popOverEffect={false}
+          isProfile
+        >
+          <div className="flex flex-col gap-4 sm:gap-6 w-full">
+            <QuarterPicker
+              quarter={quarter}
+              year={year}
+              yearOptions={yearOptions}
+              onChange={updateUrl}
+            />
+
+            {isLoading && <LoadingState />}
+            {error && !isLoading && (
+              <ErrorState message="Could not load the audit data. Try again in a moment." />
+            )}
+            {!isLoading && !error && outcome && audit && (
+              <AuditBody
+                outcome={outcome}
+                audit={audit}
+                addressToPower={addressToPower}
+                totalCitizenPower={totalCitizenPower}
+              />
+            )}
+            {!isLoading && !error && (!outcome || !audit) && (
+              <ErrorState
+                message={`No retro tally data is available yet for Q${quarter} ${year}. Either no projects are eligible for retro rewards or no votes have been cast.`}
+              />
+            )}
+          </div>
+        </ContentLayout>
+      </Container>
+    </section>
+  )
+}
+
+function QuarterPicker({
+  quarter,
+  year,
+  yearOptions,
+  onChange,
+}: {
+  quarter: number
+  year: number
+  yearOptions: number[]
+  onChange: (quarter: number, year: number) => void
+}) {
+  return (
+    <div className="bg-slate-800/40 border border-white/10 rounded-lg sm:rounded-xl p-3 sm:p-4 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+      <span className="text-xs uppercase tracking-wider text-gray-400 font-RobotoMono">
+        Viewing
+      </span>
+      <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+        <label className="flex items-center gap-2 text-sm text-gray-300">
+          <span>Quarter</span>
+          <select
+            value={quarter}
+            onChange={(e) => onChange(Number(e.target.value), year)}
+            className="bg-black/40 border border-white/15 text-white rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400/40"
+          >
+            {QUARTERS.map((q) => (
+              <option key={q} value={q}>
+                Q{q}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm text-gray-300">
+          <span>Year</span>
+          <select
+            value={year}
+            onChange={(e) => onChange(quarter, Number(e.target.value))}
+            className="bg-black/40 border border-white/15 text-white rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400/40"
+          >
+            {yearOptions.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </div>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div className="flex flex-col gap-3">
+      {[0, 1, 2, 3].map((i) => (
+        <div
+          key={`retro-audit-skeleton-${i}`}
+          className="bg-slate-800/40 border border-white/10 rounded-lg p-4 sm:p-5 animate-pulse"
+        >
+          <div className="h-3 w-1/3 bg-white/10 rounded" />
+          <div className="mt-3 h-2 w-full bg-white/5 rounded-full" />
+          <div className="mt-2 h-2 w-2/3 bg-white/5 rounded-full" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="bg-rose-500/5 border border-rose-400/20 text-rose-100 rounded-lg p-4 sm:p-5 text-sm">
+      {message}
+    </div>
+  )
+}
+
+function AuditBody({
+  outcome,
+  audit,
+  addressToPower,
+  totalCitizenPower,
+}: {
+  outcome: RetroactiveOutcome
+  audit: RetroactiveAudit
+  addressToPower: Record<string, number>
+  totalCitizenPower: number
+}) {
+  const closeDate = new Date(outcome.voteCloseTimestamp * 1000)
+  const allocatedPrimary = outcome.results.reduce(
+    (sum, r) => sum + (r.primaryShare || 0),
+    0
+  )
+  const allocatedMooney = outcome.results.reduce(
+    (sum, r) => sum + (r.mooneyShare || 0),
+    0
+  )
+
+  return (
+    <>
+      <SummaryCard
+        outcome={outcome}
+        closeDate={closeDate}
+        voterCount={audit.voters.length}
+        allocatedPrimary={allocatedPrimary}
+        allocatedMooney={allocatedMooney}
+      />
+      <VotersTable voters={audit.voters} />
+      <ProjectsList
+        outcome={outcome}
+        audit={audit}
+        addressToPower={addressToPower}
+        totalCitizenPower={totalCitizenPower}
+      />
+    </>
+  )
+}
+
+function SummaryCard({
+  outcome,
+  closeDate,
+  voterCount,
+  allocatedPrimary,
+  allocatedMooney,
+}: {
+  outcome: RetroactiveOutcome
+  closeDate: Date
+  voterCount: number
+  allocatedPrimary: number
+  allocatedMooney: number
+}) {
+  return (
+    <div className="bg-gradient-to-br from-slate-700/20 to-slate-800/30 border border-white/10 rounded-lg sm:rounded-xl p-4 sm:p-6">
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 sm:gap-4 mb-3 sm:mb-4">
+        <div>
+          <h2 className="font-GoodTimes text-base sm:text-lg text-white tracking-wider">
+            Q{outcome.quarter} {outcome.year} Retro Tally
+          </h2>
+          <p className="text-xs sm:text-sm text-gray-400 mt-1">
+            Snapshot at vote close ({closeDate.toLocaleString()}). Voting
+            power = √vMOONEY across all chains. Citizens drive the
+            tally; non-citizen votes are projected onto the citizen-vote
+            basis via L1 best-fit.
+          </p>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3">
+        <StatTile
+          label="Voters"
+          value={`${voterCount} (${outcome.citizenVoterCount} citizen)`}
+        />
+        <StatTile
+          label="Citizen power"
+          value={formatNumber(outcome.totalCitizenPower, 0)}
+        />
+        <StatTile
+          label={`Pool (${outcome.pool.primaryAsset})`}
+          value={`${formatPrimary(
+            allocatedPrimary,
+            outcome.pool.primaryAsset
+          )} / ${formatPrimary(
+            outcome.pool.primaryAmount,
+            outcome.pool.primaryAsset
+          )}`}
+        />
+        <StatTile
+          label="Pool (MOONEY)"
+          value={`${formatMooney(allocatedMooney)} / ${formatMooney(
+            outcome.pool.mooneyAmount
+          )}`}
+        />
+      </div>
+    </div>
+  )
+}
+
+function StatTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-slate-800/40 border border-white/10 rounded-lg px-3 py-2 sm:px-4 sm:py-3 min-w-0">
+      <div className="text-[10px] sm:text-xs uppercase tracking-wider text-gray-400 font-RobotoMono truncate">
+        {label}
+      </div>
+      <div className="mt-0.5 sm:mt-1 font-GoodTimes text-base sm:text-lg tracking-wider text-white truncate">
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function VotersTable({ voters }: { voters: RetroactiveAudit['voters'] }) {
+  // Default-collapsed: a 100+ voter table dumped above the project
+  // list would push the actual tally below the fold on mobile.
+  // Citizenship + power share is the audit-relevant column; raw
+  // vMOONEY balance + allocations cast are informational and live
+  // behind expand.
+  const [expanded, setExpanded] = useState(false)
+  const totalPower = voters.reduce((s, v) => s + v.power, 0)
+  const citizenCount = voters.filter((v) => v.isCitizen).length
+
+  return (
+    <div className="bg-gradient-to-br from-slate-700/20 to-slate-800/30 border border-white/10 rounded-lg sm:rounded-xl">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="w-full flex items-center justify-between gap-3 px-4 sm:px-6 py-3 sm:py-4 text-left hover:bg-white/5 rounded-lg sm:rounded-xl transition-colors"
+      >
+        <div>
+          <h3 className="font-GoodTimes text-base sm:text-lg text-white tracking-wider">
+            Voters ({voters.length}, {citizenCount} citizen)
+          </h3>
+          <p className="text-xs text-gray-400 mt-1">
+            Voting power per address at vote close. √vMOONEY summed
+            across chains. Non-citizen rows have power but go through
+            the L1 best-fit projection rather than the iterative
+            normalizer.
+          </p>
+        </div>
+        {expanded ? (
+          <ChevronUpIcon className="w-5 h-5 text-gray-300 shrink-0" />
+        ) : (
+          <ChevronDownIcon className="w-5 h-5 text-gray-300 shrink-0" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="border-t border-white/10 p-3 sm:p-4 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-[11px] uppercase tracking-wider text-gray-400 font-RobotoMono">
+                <th className="text-left py-2 px-2 sm:px-3">#</th>
+                <th className="text-left py-2 px-2 sm:px-3">Address</th>
+                <th className="text-left py-2 px-2 sm:px-3">Cohort</th>
+                <th className="text-right py-2 px-2 sm:px-3">vMOONEY</th>
+                <th className="text-right py-2 px-2 sm:px-3">Power</th>
+                <th className="text-right py-2 px-2 sm:px-3">Share</th>
+                <th className="text-right py-2 px-2 sm:px-3">Allocations</th>
+              </tr>
+            </thead>
+            <tbody>
+              {voters.map((v, idx) => {
+                const share =
+                  totalPower > 0 ? (v.power / totalPower) * 100 : 0
+                const nonZeroAlloc = Object.values(v.rawDistribution).filter(
+                  (n) => Number(n) > 0
+                ).length
+                return (
+                  <tr
+                    key={v.address}
+                    className="border-t border-white/5 text-gray-200"
+                  >
+                    <td className="py-2 px-2 sm:px-3 text-gray-500">
+                      {idx + 1}
+                    </td>
+                    <td className="py-2 px-2 sm:px-3 font-RobotoMono text-xs">
+                      <a
+                        href={`https://arbiscan.io/address/${v.address}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-blue-300 hover:underline"
+                      >
+                        {truncateAddress(v.address)}
+                      </a>
+                    </td>
+                    <td className="py-2 px-2 sm:px-3 font-RobotoMono text-xs">
+                      {v.isCitizen ? (
+                        <span className="bg-emerald-500/15 border border-emerald-400/30 text-emerald-200 px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider">
+                          Citizen
+                        </span>
+                      ) : (
+                        <span className="bg-amber-500/15 border border-amber-400/30 text-amber-200 px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider">
+                          Non-citizen
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
+                      {formatNumber(v.vMOONEY, 0)}
+                    </td>
+                    <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
+                      {formatNumber(v.power, 1)}
+                    </td>
+                    <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
+                      {share.toFixed(2)}%
+                    </td>
+                    <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs text-gray-400">
+                      {nonZeroAlloc}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProjectsList({
+  outcome,
+  audit,
+  addressToPower,
+  totalCitizenPower,
+}: {
+  outcome: RetroactiveOutcome
+  audit: RetroactiveAudit
+  addressToPower: Record<string, number>
+  totalCitizenPower: number
+}) {
+  // Single-expand for the same reason as the member-vote audit page —
+  // multiple-open is hard to scan on mobile and there's no real
+  // use case for diffing two project supporter lists side-by-side.
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const ranked = outcome.results
+
+  return (
+    <div className="flex flex-col gap-2 sm:gap-3">
+      <div className="flex items-end justify-between flex-wrap gap-2">
+        <h3 className="font-GoodTimes text-base sm:text-lg text-white tracking-wider">
+          Projects ({ranked.length})
+        </h3>
+        <span className="text-[11px] uppercase tracking-wider text-gray-400 font-RobotoMono">
+          Click a row to see who voted for it
+        </span>
+      </div>
+      {ranked.map((r) => {
+        const expanded = expandedId === r.projectId
+        const contributions = audit.contributions[r.projectId] || []
+        return (
+          <ProjectRow
+            key={r.projectId}
+            outcomeRow={r}
+            outcome={outcome}
+            contributions={contributions}
+            expanded={expanded}
+            onToggle={() => setExpandedId(expanded ? null : r.projectId)}
+            addressToPower={addressToPower}
+            totalCitizenPower={totalCitizenPower}
+            contributorAddresses={
+              audit.projectIdToContributors[r.projectId] || []
+            }
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+function ProjectRow({
+  outcomeRow,
+  outcome,
+  contributions,
+  expanded,
+  onToggle,
+  addressToPower,
+  totalCitizenPower,
+  contributorAddresses,
+}: {
+  outcomeRow: RetroactiveOutcome['results'][number]
+  outcome: RetroactiveOutcome
+  contributions: RetroactiveAudit['contributions'][string]
+  expanded: boolean
+  onToggle: () => void
+  addressToPower: Record<string, number>
+  /** Total √vMOONEY across all CITIZEN voters in the cycle. */
+  totalCitizenPower: number
+  contributorAddresses: string[]
+}) {
+  // Per-voter weighted contribution (citizens only) is in voting-power
+  // units: weighted = (normalizedPct / 100) × voter power. Summed
+  // across the project's citizen supporters, that gives the project's
+  // total weighted citizen support. The citizen-only share = sum ÷
+  // total citizen power; this is the dominant component of the final
+  // outcome share but doesn't include the non-citizen best-fit
+  // contribution (which is hard to surface honestly per project, see
+  // RetroactiveAudit doc).
+  const totalWeighted = contributions.reduce(
+    (sum, c) =>
+      sum +
+      ((c.normalizedPct || 0) / 100) *
+        (addressToPower[c.voterAddress] || 0),
+    0
+  )
+  const citizenShare =
+    totalCitizenPower > 0 ? (totalWeighted / totalCitizenPower) * 100 : 0
+
+  const projectLink =
+    outcomeRow.MDP != null && outcomeRow.MDP !== ''
+      ? `/project/${outcomeRow.MDP}`
+      : null
+  const hasShare = outcomeRow.percentage > 0
+
+  return (
+    <div
+      className={`border rounded-lg ${
+        hasShare
+          ? 'bg-emerald-500/5 border-emerald-400/20'
+          : 'bg-black/20 border-white/10'
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center gap-2 sm:gap-3 px-2 sm:px-3 py-2 sm:py-3 text-left hover:bg-white/5 rounded-lg transition-colors"
+        aria-expanded={expanded}
+      >
+        <div
+          className={`flex-shrink-0 w-7 h-7 sm:w-8 sm:h-8 flex items-center justify-center rounded-full font-bold text-xs ${
+            hasShare
+              ? 'bg-emerald-500/20 text-emerald-200 border border-emerald-400/30'
+              : 'bg-white/5 text-gray-400 border border-white/10'
+          }`}
+        >
+          {outcomeRow.rank}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p
+            className={`text-sm font-medium truncate ${
+              hasShare ? 'text-white' : 'text-gray-300'
+            }`}
+          >
+            {outcomeRow.MDP != null ? `MDP-${outcomeRow.MDP}: ` : ''}
+            {outcomeRow.name}
+          </p>
+          <p className="text-[11px] text-gray-500">
+            {formatPrimary(outcomeRow.primaryShare, outcome.pool.primaryAsset)}
+            {' • '}
+            {formatMooney(outcomeRow.mooneyShare)}
+            {' • '}
+            {contributions.length} citizen supporter
+            {contributions.length === 1 ? '' : 's'}
+          </p>
+        </div>
+        <div className="text-right flex-shrink-0 min-w-[72px]">
+          <p
+            className={`font-GoodTimes text-base sm:text-lg leading-none ${
+              hasShare ? 'text-emerald-300' : 'text-gray-400'
+            }`}
+          >
+            {outcomeRow.percentage.toFixed(2)}%
+          </p>
+          <p
+            className={`text-[10px] font-RobotoMono uppercase tracking-wider mt-1 ${
+              hasShare ? 'text-emerald-400' : 'text-gray-500'
+            }`}
+          >
+            of pool
+          </p>
+        </div>
+        <div className="ml-1 sm:ml-2 shrink-0">
+          {expanded ? (
+            <ChevronUpIcon className="w-4 h-4 text-gray-400" />
+          ) : (
+            <ChevronDownIcon className="w-4 h-4 text-gray-400" />
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-white/10 px-2 sm:px-4 pb-3 sm:pb-4">
+          <div className="flex flex-wrap items-center gap-2 mt-3 mb-2 text-[11px] font-RobotoMono">
+            {projectLink && (
+              <Link
+                href={projectLink}
+                className="bg-blue-500/10 border border-blue-400/30 text-blue-200 px-2 py-1 rounded hover:bg-blue-500/20"
+              >
+                Open project →
+              </Link>
+            )}
+            {contributorAddresses.length > 0 && (
+              <span className="bg-black/30 border border-white/10 text-gray-300 px-2 py-1 rounded">
+                Contributors: {contributorAddresses.length}
+              </span>
+            )}
+          </div>
+
+          {contributions.length === 0 ? (
+            <p className="text-xs text-gray-500 italic mt-1">
+              No citizen allocations after contributor zero-out.
+            </p>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-[11px] uppercase tracking-wider text-gray-400 font-RobotoMono">
+                      <th className="text-left py-2 px-2 sm:px-3">Voter</th>
+                      <th className="text-right py-2 px-2 sm:px-3">Power</th>
+                      <th
+                        className="text-right py-2 px-2 sm:px-3"
+                        title="What this voter wrote in their distribution before contributor zero-out / normalization."
+                      >
+                        Raw %
+                      </th>
+                      <th
+                        className="text-right py-2 px-2 sm:px-3"
+                        title="What was counted after zero-out + iterative normalization. For voters who didn't contribute to this project and whose row already sums to 100, this equals Raw %. Contributor cells are imputed with the column average of the other voters."
+                      >
+                        Normalized %
+                      </th>
+                      <th
+                        className="text-right py-2 px-2 sm:px-3"
+                        title="The slice of this voter's power that went to this project: (normalized % / 100) × power."
+                      >
+                        Weighted
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {contributions.map((c) => {
+                      const power = addressToPower[c.voterAddress] || 0
+                      const weighted = ((c.normalizedPct || 0) / 100) * power
+                      return (
+                        <tr
+                          key={c.voterAddress}
+                          className="border-t border-white/5 text-gray-200"
+                        >
+                          <td className="py-2 px-2 sm:px-3 font-RobotoMono text-xs">
+                            <a
+                              href={`https://arbiscan.io/address/${c.voterAddress}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="hover:text-blue-300 hover:underline"
+                            >
+                              {truncateAddress(c.voterAddress)}
+                            </a>
+                            {c.isContributor && (
+                              <span className="ml-2 inline-block text-[10px] uppercase tracking-wider bg-amber-500/15 border border-amber-400/30 text-amber-200 px-1.5 py-0.5 rounded">
+                                Contributor
+                              </span>
+                            )}
+                          </td>
+                          <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
+                            {formatNumber(power, 1)}
+                          </td>
+                          <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs text-gray-400">
+                            {c.rawPct == null
+                              ? '—'
+                              : `${c.rawPct.toFixed(1)}%`}
+                          </td>
+                          <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
+                            {c.normalizedPct.toFixed(2)}%
+                          </td>
+                          <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
+                            {formatNumber(weighted, 1)}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <ProjectFooter
+                totalWeighted={totalWeighted}
+                totalCitizenPower={totalCitizenPower}
+                citizenShare={citizenShare}
+                finalPercentage={outcomeRow.percentage}
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProjectFooter({
+  totalWeighted,
+  totalCitizenPower,
+  citizenShare,
+  finalPercentage,
+}: {
+  totalWeighted: number
+  totalCitizenPower: number
+  citizenShare: number
+  finalPercentage: number
+}) {
+  return (
+    <div className="mt-3 bg-black/30 border border-white/10 rounded-md px-3 py-2 sm:px-4 sm:py-3 font-RobotoMono text-xs text-gray-200">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <span className="text-gray-400">
+          Σ weighted (citizens only, this project)
+        </span>
+        <span className="text-white">{formatNumber(totalWeighted, 2)}</span>
+      </div>
+      <div className="flex items-center justify-between gap-4 flex-wrap mt-1">
+        <span className="text-gray-400">Total citizen power</span>
+        <span className="text-white">
+          {formatNumber(totalCitizenPower, 2)}
+        </span>
+      </div>
+      <div className="border-t border-white/10 mt-2 pt-2 flex items-center justify-between gap-4 flex-wrap">
+        <span className="text-gray-400">
+          Citizen share = Σ weighted ÷ total citizen power
+        </span>
+        <span className="text-emerald-200">
+          {citizenShare.toFixed(4)}%
+          {Math.abs(citizenShare - finalPercentage) > 0.5 && (
+            <span className="ml-2 text-gray-400">
+              (final {finalPercentage.toFixed(4)}% — non-citizen best-fit
+              + 90% pool cap account for the gap)
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/ui/pages/projects/retro-audit.tsx
+++ b/ui/pages/projects/retro-audit.tsx
@@ -53,25 +53,6 @@ const formatPrimary = (amount: number, asset: 'ETH' | 'USDC') =>
 const formatMooney = (amount: number) =>
   `${Number(amount.toPrecision(3)).toLocaleString()} MOONEY`
 
-// Compact unit-stripped variants for tight summary tiles where the
-// asset is already named in the label. ETH stays decimal; USDC and
-// MOONEY collapse to k/M suffixes so two values + a separator fit on
-// one line without truncation.
-const formatPrimaryCompact = (amount: number, asset: 'ETH' | 'USDC') => {
-  if (asset === 'ETH')
-    return amount.toLocaleString(undefined, { maximumFractionDigits: 4 })
-  return amount.toLocaleString(undefined, {
-    notation: 'compact',
-    maximumFractionDigits: 2,
-  })
-}
-
-const formatMooneyCompact = (amount: number) =>
-  amount.toLocaleString(undefined, {
-    notation: 'compact',
-    maximumFractionDigits: 2,
-  })
-
 export default function ProjectsRetroAuditPage() {
   const router = useRouter()
   // Default to the previous calendar quarter — the cohort currently
@@ -317,14 +298,6 @@ function AuditBody({
   totalCitizenPower: number
 }) {
   const closeDate = new Date(outcome.voteCloseTimestamp * 1000)
-  const allocatedPrimary = outcome.results.reduce(
-    (sum, r) => sum + (r.primaryShare || 0),
-    0
-  )
-  const allocatedMooney = outcome.results.reduce(
-    (sum, r) => sum + (r.mooneyShare || 0),
-    0
-  )
 
   return (
     <>
@@ -332,8 +305,6 @@ function AuditBody({
         outcome={outcome}
         closeDate={closeDate}
         voterCount={audit.voters.length}
-        allocatedPrimary={allocatedPrimary}
-        allocatedMooney={allocatedMooney}
       />
       <ProjectsList
         outcome={outcome}
@@ -350,14 +321,10 @@ function SummaryCard({
   outcome,
   closeDate,
   voterCount,
-  allocatedPrimary,
-  allocatedMooney,
 }: {
   outcome: RetroactiveOutcome
   closeDate: Date
   voterCount: number
-  allocatedPrimary: number
-  allocatedMooney: number
 }) {
   return (
     <div className="bg-gradient-to-br from-slate-700/20 to-slate-800/30 border border-white/10 rounded-lg sm:rounded-xl p-4 sm:p-6">
@@ -382,24 +349,14 @@ function SummaryCard({
         />
         <StatTile
           label={`Pool (${outcome.pool.primaryAsset})`}
-          value={`${formatPrimaryCompact(
-            allocatedPrimary,
-            outcome.pool.primaryAsset
-          )} / ${formatPrimaryCompact(
+          value={formatPrimary(
             outcome.pool.primaryAmount,
             outcome.pool.primaryAsset
-          )}`}
-          sub={`${formatPrimary(
-            allocatedPrimary,
-            outcome.pool.primaryAsset
-          )} allocated`}
+          )}
         />
         <StatTile
           label="Pool (MOONEY)"
-          value={`${formatMooneyCompact(
-            allocatedMooney
-          )} / ${formatMooneyCompact(outcome.pool.mooneyAmount)}`}
-          sub={`${formatMooney(allocatedMooney)} allocated`}
+          value={formatMooney(outcome.pool.mooneyAmount)}
         />
       </div>
     </div>

--- a/ui/pages/projects/retro-audit.tsx
+++ b/ui/pages/projects/retro-audit.tsx
@@ -316,12 +316,12 @@ function AuditBody({
         allocatedPrimary={allocatedPrimary}
         allocatedMooney={allocatedMooney}
       />
-      <VotersTable voters={audit.voters} />
       <ProjectsList
         outcome={outcome}
         audit={audit}
         addressToPower={addressToPower}
         totalCitizenPower={totalCitizenPower}
+        totalPower={outcome.totalPower}
       />
     </>
   )
@@ -398,105 +398,18 @@ function StatTile({ label, value }: { label: string; value: string }) {
   )
 }
 
-function VotersTable({ voters }: { voters: RetroactiveAudit['voters'] }) {
-  // Default-collapsed: a long voter table dumped above the project
-  // list would push the actual tally below the fold on mobile.
-  // Power share is the audit-relevant column; the per-project
-  // tables below carry per-voter raw/normalized %.
-  const [expanded, setExpanded] = useState(false)
-  const totalPower = voters.reduce((s, v) => s + v.power, 0)
-  const citizenCount = voters.filter((v) => v.isCitizen).length
-
-  return (
-    <div className="bg-gradient-to-br from-slate-700/20 to-slate-800/30 border border-white/10 rounded-lg sm:rounded-xl">
-      <button
-        type="button"
-        onClick={() => setExpanded((e) => !e)}
-        className="w-full flex items-center justify-between gap-3 px-4 sm:px-6 py-3 sm:py-4 text-left hover:bg-white/5 rounded-lg sm:rounded-xl transition-colors"
-      >
-        <div>
-          <h3 className="font-GoodTimes text-base sm:text-lg text-white tracking-wider">
-            Voters ({voters.length}, {citizenCount} citizen)
-          </h3>
-          <p className="text-xs text-gray-400 mt-1">
-            Voting power per address at vote close. √vMOONEY summed
-            across chains. Non-citizen rows have power but go through
-            the L1 best-fit projection rather than the iterative
-            normalizer.
-          </p>
-        </div>
-        {expanded ? (
-          <ChevronUpIcon className="w-5 h-5 text-gray-300 shrink-0" />
-        ) : (
-          <ChevronDownIcon className="w-5 h-5 text-gray-300 shrink-0" />
-        )}
-      </button>
-
-      {expanded && (
-        <div className="border-t border-white/10 p-3 sm:p-4 overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-[11px] uppercase tracking-wider text-gray-400 font-RobotoMono">
-                <th className="text-left py-2 px-2 sm:px-3">#</th>
-                <th className="text-left py-2 px-2 sm:px-3">Address</th>
-                <th className="text-right py-2 px-2 sm:px-3">Power</th>
-                <th className="text-right py-2 px-2 sm:px-3">Share</th>
-              </tr>
-            </thead>
-            <tbody>
-              {voters.map((v, idx) => {
-                const share =
-                  totalPower > 0 ? (v.power / totalPower) * 100 : 0
-                return (
-                  <tr
-                    key={v.address}
-                    className="border-t border-white/5 text-gray-200"
-                  >
-                    <td className="py-2 px-2 sm:px-3 text-gray-500">
-                      {idx + 1}
-                    </td>
-                    <td className="py-2 px-2 sm:px-3 font-RobotoMono text-xs">
-                      <a
-                        href={`https://arbiscan.io/address/${v.address}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:text-blue-300 hover:underline"
-                      >
-                        {truncateAddress(v.address)}
-                      </a>
-                      {!v.isCitizen && (
-                        <span className="ml-2 inline-block text-[10px] uppercase tracking-wider bg-amber-500/15 border border-amber-400/30 text-amber-200 px-1.5 py-0.5 rounded">
-                          Non-citizen
-                        </span>
-                      )}
-                    </td>
-                    <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
-                      {formatNumber(v.power, 1)}
-                    </td>
-                    <td className="py-2 px-2 sm:px-3 text-right font-RobotoMono text-xs">
-                      {share.toFixed(2)}%
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
-  )
-}
-
 function ProjectsList({
   outcome,
   audit,
   addressToPower,
   totalCitizenPower,
+  totalPower,
 }: {
   outcome: RetroactiveOutcome
   audit: RetroactiveAudit
   addressToPower: Record<string, number>
   totalCitizenPower: number
+  totalPower: number
 }) {
   // Single-expand for the same reason as the member-vote audit page —
   // multiple-open is hard to scan on mobile and there's no real
@@ -527,6 +440,7 @@ function ProjectsList({
             onToggle={() => setExpandedId(expanded ? null : r.projectId)}
             addressToPower={addressToPower}
             totalCitizenPower={totalCitizenPower}
+            totalPower={totalPower}
             contributorAddresses={
               audit.projectIdToContributors[r.projectId] || []
             }
@@ -545,6 +459,7 @@ function ProjectRow({
   onToggle,
   addressToPower,
   totalCitizenPower,
+  totalPower,
   contributorAddresses,
 }: {
   outcomeRow: RetroactiveOutcome['results'][number]
@@ -555,16 +470,14 @@ function ProjectRow({
   addressToPower: Record<string, number>
   /** Total √vMOONEY across all CITIZEN voters in the cycle. */
   totalCitizenPower: number
+  /** Total √vMOONEY across ALL voters (citizen + non-citizen) in the cycle. */
+  totalPower: number
   contributorAddresses: string[]
 }) {
   // Per-voter weighted contribution (citizens only) is in voting-power
   // units: weighted = (normalizedPct / 100) × voter power. Summed
   // across the project's citizen supporters, that gives the project's
-  // total weighted citizen support. The citizen-only share = sum ÷
-  // total citizen power; this is the dominant component of the final
-  // outcome share but doesn't include the non-citizen best-fit
-  // contribution (which is hard to surface honestly per project, see
-  // RetroactiveAudit doc).
+  // total weighted citizen support feeding into `runQuadraticVoting`.
   const totalWeighted = contributions.reduce(
     (sum, c) =>
       sum +
@@ -572,8 +485,26 @@ function ProjectRow({
         (addressToPower[c.voterAddress] || 0),
     0
   )
-  const citizenShare =
-    totalCitizenPower > 0 ? (totalWeighted / totalCitizenPower) * 100 : 0
+  // Reproduce `outcomeRow.percentage` from first principles so the
+  // footer reconciles with the value shown at the top of the row.
+  // Derivation: `runQuadraticVoting` (rewards.ts) computes raw
+  // weighted shares for every key fed in (real project ids from
+  // citizen rows + integer indices from the non-citizen best-fit
+  // projection), then renormalizes the whole vector so it sums to
+  // 90 (10% community-circle reservation). For a real project P:
+  //   raw[P] = Σ_citizens (norm_pct[c,P] × power[c]) / votingPowerSum
+  // The renormalizer's sum is dominated by citizens because each
+  // citizen row sums to 100 while each non-citizen best-fit row sums
+  // to 1 (`minimizeL1Distance` constraint), so:
+  //   sum = (100·citizenPower + nonCitizenPower) / votingPowerSum
+  //   final[P] = raw[P] / sum × 90
+  //            = totalWeighted × 9000
+  //              / (100·citizenPower + nonCitizenPower)
+  // (totalWeighted absorbs the /100 already, so multiply by 100·90
+  //  in the numerator.)
+  const denom = 100 * totalCitizenPower + (totalPower - totalCitizenPower)
+  const reproducedFinal =
+    denom > 0 ? (totalWeighted * 100 * 90) / denom : 0
 
   const projectLink =
     outcomeRow.MDP != null && outcomeRow.MDP !== ''
@@ -744,7 +675,8 @@ function ProjectRow({
               <ProjectFooter
                 totalWeighted={totalWeighted}
                 totalCitizenPower={totalCitizenPower}
-                citizenShare={citizenShare}
+                totalNonCitizenPower={totalPower - totalCitizenPower}
+                reproducedFinal={reproducedFinal}
                 finalPercentage={outcomeRow.percentage}
               />
             </>
@@ -758,20 +690,25 @@ function ProjectRow({
 function ProjectFooter({
   totalWeighted,
   totalCitizenPower,
-  citizenShare,
+  totalNonCitizenPower,
+  reproducedFinal,
   finalPercentage,
 }: {
   totalWeighted: number
   totalCitizenPower: number
-  citizenShare: number
+  totalNonCitizenPower: number
+  reproducedFinal: number
   finalPercentage: number
 }) {
+  // Tiny float drift between the from-first-principles reproduction
+  // and what the server sent is fine — flag a visible mismatch only
+  // when the gap is large enough to indicate a real audit failure.
+  const drift = Math.abs(reproducedFinal - finalPercentage)
+  const matches = drift < 0.01
   return (
     <div className="mt-3 bg-black/30 border border-white/10 rounded-md px-3 py-2 sm:px-4 sm:py-3 font-RobotoMono text-xs text-gray-200">
       <div className="flex items-center justify-between gap-4 flex-wrap">
-        <span className="text-gray-400">
-          Σ weighted (citizens only, this project)
-        </span>
+        <span className="text-gray-400">Σ weighted (this project)</span>
         <span className="text-white">{formatNumber(totalWeighted, 2)}</span>
       </div>
       <div className="flex items-center justify-between gap-4 flex-wrap mt-1">
@@ -780,16 +717,30 @@ function ProjectFooter({
           {formatNumber(totalCitizenPower, 2)}
         </span>
       </div>
+      {totalNonCitizenPower > 0 && (
+        <div className="flex items-center justify-between gap-4 flex-wrap mt-1">
+          <span className="text-gray-400">
+            Total non-citizen power (× 0.01 vs. citizens via L1 best-fit)
+          </span>
+          <span className="text-white">
+            {formatNumber(totalNonCitizenPower, 2)}
+          </span>
+        </div>
+      )}
       <div className="border-t border-white/10 mt-2 pt-2 flex items-center justify-between gap-4 flex-wrap">
         <span className="text-gray-400">
-          Citizen share = Σ weighted ÷ total citizen power
+          Final share = Σ weighted × 9000 ÷ (100 × citizen power +
+          non-citizen power)
         </span>
-        <span className="text-emerald-200">
-          {citizenShare.toFixed(4)}%
-          {Math.abs(citizenShare - finalPercentage) > 0.5 && (
+        <span className={matches ? 'text-emerald-200' : 'text-amber-200'}>
+          {reproducedFinal.toFixed(4)}%
+          {matches ? (
+            <span className="ml-2 text-gray-500">
+              (matches {finalPercentage.toFixed(2)}% above)
+            </span>
+          ) : (
             <span className="ml-2 text-gray-400">
-              (final {finalPercentage.toFixed(4)}% — non-citizen best-fit
-              + 90% pool cap account for the gap)
+              (server reported {finalPercentage.toFixed(4)}%)
             </span>
           )}
         </span>


### PR DESCRIPTION
## Summary

Same pattern that PR #1282 set up for the Member Vote, now applied to the Retroactive Rewards cycle.

- **`lib/proposals/computeRetroactiveOutcome.ts`** — read-only mirror of the client-side retro tally that lives in `components/nance/ProjectRewards.tsx`. Pulls eligible projects + retro distributions from Tableland, splits voters into citizens / non-citizens via the Citizen NFT contract (`getOwnedToken`, with the same hard-coded payout-address allowlist `ProjectRewards` uses), snapshots √vMOONEY across all chains at the rewards-cycle close (first Tuesday on or after 14 days into the next quarter), and feeds it into the shared `computeRewardPercentages` pipeline (fill-in-zeros → contributor zero-out → iterative normalization → non-citizen L1 best-fit → quadratic voting). Annotates each project with its ETH/USDC + MOONEY pool share. Optional `includeAudit` returns a per-voter (citizenship, vMOONEY, power, raw distribution) + per-project (citizen supporters with raw / normalized / weighted) breakdown for the audit page. Filters out the integer-index ghost keys produced by the non-citizen best-fit projection so only real Tableland project ids show up in the results.
- **`GET /api/proposals/retro-results`** — lightweight ranked outcome for the panel (60s edge cache + 5min stale-while-revalidate). Defaults to the previous calendar quarter (the cohort currently in the retro window); override with `?quarter=&year=`.
- **`GET /api/proposals/retro-audit`** — same compute but with the audit payload attached (5min edge cache + 15min stale-while-revalidate).
- **`components/nance/RetroactiveResults.tsx`** — drop-in panel rendered at the top of the Retroactive Rewards tab on `/projects`. Ranked list (rank, MDP link, name, % of pool, ETH/USDC share, MOONEY share), pool / voter / citizen-count chips, link to the full audit. Self-hides during loading / error / empty so cold caches don't flicker.
- **`pages/projects/retro-audit.tsx`** — public audit page mirroring `/projects/audit`. Quarter/year picker, summary stat tiles (voters, citizen power, ETH/USDC pool used vs total, MOONEY pool used vs total), collapsible voters table (citizen vs non-citizen badge), per-project supporter rows showing raw → normalized → weighted contribution and a footer that reproduces the citizen-share math (with a callout when it diverges from the final percentage because of non-citizen best-fit + the 90% pool cap).

The display works as a live preview during the rewards cycle and a permanent record after.

## Test plan

- [ ] After deploy, hit `https://moondao.com/api/proposals/retro-results` and verify the JSON returns `outcome` with the expected ranked per-project results, pool sizes, and voter counts for the most recent retro cycle.
- [ ] Hit `https://moondao.com/api/proposals/retro-audit` and verify it returns the same outcome plus an `audit` block (`voters[]`, `contributions{}`, `projectIdToContributors{}`).
- [ ] Visit `https://moondao.com/projects` and click the **Retroactive Rewards** tab. Confirm the new **Retroactive Rewards Results** panel renders at the top with the same ranking, pool shares, and "View audit →" link as the API.
- [ ] Visit `https://moondao.com/projects/retro-audit` and confirm:
  - Summary tiles show voter count (citizen vs total), citizen power, allocated vs total pool for both assets.
  - Expanding the voters table shows each voter's address, citizen badge, vMOONEY, power, share, and allocations cast.
  - Expanding a project row shows each citizen supporter's raw / normalized / weighted contribution with the contributor badge applied where appropriate.
  - The footer math (Σ weighted ÷ total citizen power) reproduces the displayed percentage within a small tolerance; when it diverges, the "(final X% — non-citizen best-fit + 90% pool cap account for the gap)" callout appears.
- [ ] Override `?quarter=&year=` on both the API and the audit page to spot-check a past retro cycle.
- [ ] During an active rewards-cycle window, confirm the panel updates as new distribution rows are submitted (within the 60s edge cache window).
