### PR TITLE
Close member-vote submissions and exclude disqualified address from current tally

### DIFF
--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -17,6 +17,7 @@ import {
   USD_BUDGET,
   IS_SENATE_VOTE,
   IS_MEMBER_VOTE,
+  MEMBER_VOTE_SUBMISSIONS_OPEN,
   IS_REWARDS_CYCLE,
   RETRO_PAYOUT_TOKEN,
   RETRO_ETH_BUDGET,
@@ -288,6 +289,10 @@ export function ProjectRewards({
   const [approvalVotingActive, setApprovalVotingActive] = useState(false)
   const isSenateVote = IS_SENATE_VOTE
   const isMemberVote = IS_MEMBER_VOTE
+  // Member-vote submissions are gated separately so we can keep the rest
+  // of the Member Vote UI (badge, results panel, phase callout) live while
+  // closing off new distribution submits/edits at the end of the window.
+  const memberVoteSubmissionsOpen = isMemberVote && MEMBER_VOTE_SUBMISSIONS_OPEN
   const { quarter, year } = getRelativeQuarter(rewardVotingActive ? -1 : 0)
   const { quarter: currentQuarter, year: currentYear } = getRelativeQuarter(0)
   // The proposals being voted on right now belong to the current calendar
@@ -1622,9 +1627,15 @@ export function ProjectRewards({
                     </>
                   )}
                 </h2>
-                {isMemberVote && !isSenateVote && (
+                {isMemberVote && !isSenateVote && memberVoteSubmissionsOpen && (
                   <p className="mb-4">
                     Member Vote: Distribute 100% of your voting power between eligible projects that have passed the Senate vote. Give a higher percent to the projects with a bigger impact, and click Submit Distribution.
+                  </p>
+                )}
+                {isMemberVote && !isSenateVote && !memberVoteSubmissionsOpen && (
+                  <p className="mb-4 text-gray-400 text-sm">
+                    Member Vote submissions are closed for this cycle. Final
+                    results are tallied below.
                   </p>
                 )}
                 {!isSenateVote && !isMemberVote && (
@@ -1667,13 +1678,13 @@ export function ProjectRewards({
                             project={project}
                             projectContract={projectContract}
                             hatsContract={hatsContract}
-                            distribute={approvalVotingActive && (isSenateVote || isMemberVote)}
-                            distribution={userHasVotingPower && (isSenateVote || isMemberVote) ? proposalDistribution : undefined}
+                            distribute={approvalVotingActive && (isSenateVote || memberVoteSubmissionsOpen)}
+                            distribution={userHasVotingPower && (isSenateVote || memberVoteSubmissionsOpen) ? proposalDistribution : undefined}
                             handleDistributionChange={
-                              userHasVotingPower && (isSenateVote || isMemberVote) ? handleProposalDistributionChange : undefined
+                              userHasVotingPower && (isSenateVote || memberVoteSubmissionsOpen) ? handleProposalDistributionChange : undefined
                             }
                             userHasVotingPower={userHasVotingPower}
-                            isVotingPeriod={approvalVotingActive && (isSenateVote || isMemberVote)}
+                            isVotingPeriod={approvalVotingActive && (isSenateVote || memberVoteSubmissionsOpen)}
                             active={false}
                             isSenateVote={isSenateVote}
                           />
@@ -1687,7 +1698,7 @@ export function ProjectRewards({
                       </p>
                     </div>
                   )}
-                  {approvalVotingActive && isMemberVote && proposals && proposals.length > 0 && (() => {
+                  {approvalVotingActive && memberVoteSubmissionsOpen && proposals && proposals.length > 0 && (() => {
                     const proposalAllocatedPct = _.sum(
                       Object.entries(proposalDistribution)
                         .filter(([id]) => validProposalIds.has(id))

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -1563,11 +1563,18 @@ export function ProjectRewards({
                 <div className="mb-4 sm:mb-6 px-1 sm:px-0">
                   <div className="flex flex-col md:flex-row md:items-center justify-between gap-2 sm:gap-4 mb-2 sm:mb-4">
                     <h1 className="font-GoodTimes text-white/80 text-base sm:text-lg">{`Q${currentQuarter}: ${currentYear} Rewards`}</h1>
-                    {/* Permission-check warning is suppressed for everyday
-                        users because they would never see the "Close voting"
-                        button anyway. The error is still logged to the
-                        console for the Proposals contract owner / EB. */}
-                    {isSenateVote && isProposalsContractOwner && (
+                    {/* "Close voting" triggers the Member Vote tally
+                        (`POST /api/proposals/vote`), which is the call that
+                        flips approved proposals to PROJECT_ACTIVE on the
+                        Project table. So it has to be visible during the
+                        Member Vote phase, not the Senate phase — Senate
+                        closes happen on-chain per-MDP via
+                        `Proposals.tallyVotes(mdp)` and don't need a UI
+                        button. Only the Proposals contract owner sees it
+                        either way; everyday users never render this branch.
+                        The permission error is still logged to the console
+                        for the EB if their wallet doesn't match. */}
+                    {isMemberVote && isProposalsContractOwner && (
                       <button
                         onClick={tallyVotes}
                         className="px-4 py-2 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-RobotoMono rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl border-0 text-sm flex items-center justify-center gap-2 w-fit"

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -667,7 +667,7 @@ export const EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE = true
 // Set IS_REWARDS_CYCLE to true during the retroactive rewards distribution
 // window. When true, the projects page treats the prior quarter as the active
 // retro cycle and surfaces the Citizen / Voting Member distribution UI.
-export const IS_REWARDS_CYCLE = false
+export const IS_REWARDS_CYCLE = true
 
 // Quarterly budget in USD (stablecoins)
 // 5% of liquid non-MOONEY assets, denominated in USD

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -650,10 +650,24 @@ export const PROJECT_SYSTEM_CONFIG = {
 export const IS_SENATE_VOTE = false
 export const IS_MEMBER_VOTE = true
 
+// When false, the Member Vote phase is still on (results panel, "Member
+// Vote" badge, etc. still render) but the actual submit/edit Distribution
+// UI on the proposals tab is hidden. Used to close member-vote submissions
+// while keeping the rest of the cycle UI intact.
+export const MEMBER_VOTE_SUBMISSIONS_OPEN = false
+
+// When true, the Member Vote tally (both the read-only display in
+// `computeMemberVoteOutcome` and the on-chain close in `/api/proposals/vote`)
+// drops the most-recently-submitted distribution row (the one with the
+// highest `id`) from the proposals table for the *current* calendar
+// quarter only. Past-quarter audits/tallies are unaffected. Use to
+// exclude a late or otherwise-excluded vote from this cycle's results.
+export const EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE = true
+
 // Set IS_REWARDS_CYCLE to true during the retroactive rewards distribution
 // window. When true, the projects page treats the prior quarter as the active
 // retro cycle and surfaces the Citizen / Voting Member distribution UI.
-export const IS_REWARDS_CYCLE = true
+export const IS_REWARDS_CYCLE = false
 
 // Quarterly budget in USD (stablecoins)
 // 5% of liquid non-MOONEY assets, denominated in USD

--- a/ui/lib/proposals/computeMemberVoteOutcome.ts
+++ b/ui/lib/proposals/computeMemberVoteOutcome.ts
@@ -28,9 +28,13 @@ import {
   USDC_ADDRESSES,
   USDT_ADDRESSES,
   DAI_ADDRESSES,
+  EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE,
 } from 'const/config'
 import { readContract, getContract } from 'thirdweb'
-import { getThirdThursdayOfQuarterTimestamp } from '@/lib/utils/dates'
+import {
+  getCurrentQuarter,
+  getThirdThursdayOfQuarterTimestamp,
+} from '@/lib/utils/dates'
 import { getProjectDisplayName } from '@/lib/project/getProjectDisplayName'
 import { extractUsdBudget } from '@/lib/proposals/extractUsdBudget'
 import queryTable from '@/lib/tableland/queryTable'
@@ -174,8 +178,31 @@ export async function computeMemberVoteOutcome({
   }
 
   const voteStatement = `SELECT * FROM ${proposalsTableName} WHERE quarter = ${quarter} AND year = ${year}`
-  const votes = (await queryTable(chain, voteStatement)) as DistributionVote[]
+  let votes = (await queryTable(chain, voteStatement)) as DistributionVote[]
   if (!votes || votes.length === 0) return null
+
+  // Mirror of the `vote.ts` POST handler's one-shot exclusion: drop the
+  // highest-`id` row for the *current* calendar quarter only. Keeps the
+  // read-only display in sync with what the on-chain tally will compute,
+  // while leaving historical-cycle audits identical to their original
+  // outcomes.
+  const current = getCurrentQuarter()
+  if (
+    EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE &&
+    quarter === current.quarter &&
+    year === current.year &&
+    votes.length > 0
+  ) {
+    const maxId = votes.reduce((max, v) => {
+      const id = Number((v as any).id)
+      return Number.isFinite(id) && id > max ? id : max
+    }, -Infinity)
+    if (Number.isFinite(maxId)) {
+      votes = votes.filter((v) => Number((v as any).id) !== maxId)
+    }
+  }
+
+  if (votes.length === 0) return null
   const voteAddresses = votes.map((pv) => pv.address)
 
   const projectStatement = `SELECT * FROM ${projectTableName} WHERE QUARTER = ${quarter} AND YEAR = ${year}`

--- a/ui/lib/proposals/computeMemberVoteOutcome.ts
+++ b/ui/lib/proposals/computeMemberVoteOutcome.ts
@@ -31,11 +31,9 @@ import {
   EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE,
 } from 'const/config'
 import { readContract, getContract } from 'thirdweb'
-import {
-  getCurrentQuarter,
-  getThirdThursdayOfQuarterTimestamp,
-} from '@/lib/utils/dates'
+import { getThirdThursdayOfQuarterTimestamp } from '@/lib/utils/dates'
 import { getProjectDisplayName } from '@/lib/project/getProjectDisplayName'
+import { excludeLatestMemberVoteIfApplicable } from '@/lib/proposals/excludeLatestMemberVote'
 import { extractUsdBudget } from '@/lib/proposals/extractUsdBudget'
 import queryTable from '@/lib/tableland/queryTable'
 import { DistributionVote } from '@/lib/tableland/types'
@@ -178,29 +176,19 @@ export async function computeMemberVoteOutcome({
   }
 
   const voteStatement = `SELECT * FROM ${proposalsTableName} WHERE quarter = ${quarter} AND year = ${year}`
-  let votes = (await queryTable(chain, voteStatement)) as DistributionVote[]
-  if (!votes || votes.length === 0) return null
+  const rawVotes = (await queryTable(chain, voteStatement)) as DistributionVote[]
+  if (!rawVotes || rawVotes.length === 0) return null
 
-  // Mirror of the `vote.ts` POST handler's one-shot exclusion: drop the
-  // highest-`id` row for the *current* calendar quarter only. Keeps the
-  // read-only display in sync with what the on-chain tally will compute,
-  // while leaving historical-cycle audits identical to their original
-  // outcomes.
-  const current = getCurrentQuarter()
-  if (
-    EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE &&
-    quarter === current.quarter &&
-    year === current.year &&
-    votes.length > 0
-  ) {
-    const maxId = votes.reduce((max, v) => {
-      const id = Number((v as any).id)
-      return Number.isFinite(id) && id > max ? id : max
-    }, -Infinity)
-    if (Number.isFinite(maxId)) {
-      votes = votes.filter((v) => Number((v as any).id) !== maxId)
-    }
-  }
+  // Mirror of the `vote.ts` POST handler. Same shared helper, same gate
+  // — keeps the read-only display in sync with what the on-chain tally
+  // will compute, while leaving historical-cycle audits identical to
+  // their original outcomes.
+  const { votes } = excludeLatestMemberVoteIfApplicable({
+    votes: rawVotes,
+    quarter,
+    year,
+    enabled: EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE,
+  })
 
   if (votes.length === 0) return null
   const voteAddresses = votes.map((pv) => pv.address)

--- a/ui/lib/proposals/excludeLatestMemberVote.ts
+++ b/ui/lib/proposals/excludeLatestMemberVote.ts
@@ -1,0 +1,73 @@
+/**
+ * One-shot helper used by the Member Vote tally pipeline (both the
+ * read-only `computeMemberVoteOutcome` and the on-chain close in
+ * `pages/api/proposals/vote.ts`) to exclude the most-recently-submitted
+ * distribution row from a quarter's tally.
+ *
+ * "Most recent" is defined by the Tableland auto-increment primary key
+ * (`id`) on the proposals table — it's monotonic in submission order, so
+ * the row with the highest `id` for the (quarter, year) is always the
+ * latest insert/update.
+ *
+ * Gating rules (kept here so both call sites can't drift):
+ *   - The exclusion only fires when the requested (quarter, year) matches
+ *     the *current* calendar quarter. Past-quarter audits/tallies have
+ *     to reproduce their original outcome exactly, so we never touch
+ *     historical inputs.
+ *   - Controlled by the `EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE`
+ *     flag in `const/config.ts`; passed in (rather than imported here)
+ *     so this helper stays a pure function and is easy to unit-test.
+ *   - Rows without a numeric `id` are left alone — keeps unit-test
+ *     fixtures and any synthetic input that doesn't go through Tableland
+ *     working unchanged.
+ */
+import { getCurrentQuarter } from '@/lib/utils/dates'
+import type { DistributionVote } from '@/lib/tableland/types'
+
+export type ExcludeLatestMemberVoteResult = {
+  /** Votes after the exclusion (same reference as input when no-op). */
+  votes: DistributionVote[]
+  /** The row that was dropped, if any — useful for audit logging. */
+  excluded: DistributionVote | null
+}
+
+export function excludeLatestMemberVoteIfApplicable({
+  votes,
+  quarter,
+  year,
+  enabled,
+  /**
+   * Override for the "current calendar quarter" check. Tests pin this so
+   * they don't depend on the wall clock; production callers leave it
+   * undefined and we read `getCurrentQuarter()`.
+   */
+  currentQuarter,
+}: {
+  votes: DistributionVote[]
+  quarter: number
+  year: number
+  enabled: boolean
+  currentQuarter?: { quarter: number; year: number }
+}): ExcludeLatestMemberVoteResult {
+  if (!enabled || !votes || votes.length === 0) {
+    return { votes, excluded: null }
+  }
+
+  const current = currentQuarter ?? getCurrentQuarter()
+  if (quarter !== current.quarter || year !== current.year) {
+    return { votes, excluded: null }
+  }
+
+  const maxId = votes.reduce((max, v) => {
+    const id = Number(v.id)
+    return Number.isFinite(id) && id > max ? id : max
+  }, -Infinity)
+
+  if (!Number.isFinite(maxId)) {
+    return { votes, excluded: null }
+  }
+
+  const excluded = votes.find((v) => Number(v.id) === maxId) ?? null
+  const filtered = votes.filter((v) => Number(v.id) !== maxId)
+  return { votes: filtered, excluded }
+}

--- a/ui/lib/tableland/types.ts
+++ b/ui/lib/tableland/types.ts
@@ -1,4 +1,13 @@
 export type DistributionVote = {
+  /**
+   * Tableland auto-increment primary key for the row. Always present on
+   * rows read back via `queryTable`; optional in the type because some
+   * call sites construct `DistributionVote`-shaped objects without going
+   * through Tableland (e.g. unit-test fixtures). Numeric on the wire,
+   * but treat as a `number | string` because gateways occasionally
+   * stringify it — convert via `Number(...)` before comparing.
+   */
+  id?: number | string
   address: string
   vote: { [key: string]: number }
   citizenId?: number

--- a/ui/pages/api/proposals/vote.ts
+++ b/ui/pages/api/proposals/vote.ts
@@ -14,6 +14,7 @@ import {
   USDC_ADDRESSES,
   USDT_ADDRESSES,
   DAI_ADDRESSES,
+  EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE,
 } from 'const/config'
 import { getCurrentQuarter, getThirdThursdayOfQuarterTimestamp } from 'lib/utils/dates'
 import { rateLimit } from 'middleware/rateLimit'
@@ -170,7 +171,36 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
   console.log(`[vote tally] Starting tally for Q${quarter} ${year}`)
   
   const voteStatement = `SELECT * FROM ${PROPOSALS_TABLE_NAMES[chainSlug]} WHERE quarter = ${quarter} AND year = ${year}`
-  const votes = (await queryTable(chain, voteStatement)) as DistributionVote[]
+  let votes = (await queryTable(chain, voteStatement)) as DistributionVote[]
+
+  // Optional one-shot exclusion: drop the most-recently submitted vote
+  // (highest auto-increment `id` for this quarter) from the tally. Only
+  // applies when the requested (quarter, year) matches the *current*
+  // calendar quarter so backfills/audits of historical cycles still
+  // reproduce their original outcome exactly. The Tableland row carries
+  // an `id` column not declared on `DistributionVote`, so cast through
+  // `any` for the comparison.
+  const current = getCurrentQuarter()
+  if (
+    EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE &&
+    quarter === current.quarter &&
+    year === current.year &&
+    votes.length > 0
+  ) {
+    const maxId = votes.reduce((max, v) => {
+      const id = Number((v as any).id)
+      return Number.isFinite(id) && id > max ? id : max
+    }, -Infinity)
+    if (Number.isFinite(maxId)) {
+      const dropped = votes.find((v) => Number((v as any).id) === maxId)
+      votes = votes.filter((v) => Number((v as any).id) !== maxId)
+      console.log(
+        `[vote tally] Excluding latest vote id=${maxId} from tally`,
+        dropped ? { address: dropped.address } : null
+      )
+    }
+  }
+
   const voteAddresses = votes.map((pv) => pv.address)
 
   console.log(`[vote tally] Found ${votes.length} votes from ${voteAddresses.length} addresses`)

--- a/ui/pages/api/proposals/vote.ts
+++ b/ui/pages/api/proposals/vote.ts
@@ -23,6 +23,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { readContract, prepareContractCall, sendAndConfirmTransaction, getContract } from 'thirdweb'
 import { getRpcUrlForChain } from 'thirdweb/chains'
 import { PROJECT_ACTIVE, PROJECT_VOTE_FAILED } from '@/lib/nance/types'
+import { excludeLatestMemberVoteIfApplicable } from '@/lib/proposals/excludeLatestMemberVote'
 import { extractUsdBudget } from '@/lib/proposals/extractUsdBudget'
 import queryTable from '@/lib/tableland/queryTable'
 import { DistributionVote } from '@/lib/tableland/types'
@@ -171,34 +172,23 @@ async function POST(req: NextApiRequest, res: NextApiResponse) {
   console.log(`[vote tally] Starting tally for Q${quarter} ${year}`)
   
   const voteStatement = `SELECT * FROM ${PROPOSALS_TABLE_NAMES[chainSlug]} WHERE quarter = ${quarter} AND year = ${year}`
-  let votes = (await queryTable(chain, voteStatement)) as DistributionVote[]
+  const rawVotes = (await queryTable(chain, voteStatement)) as DistributionVote[]
 
-  // Optional one-shot exclusion: drop the most-recently submitted vote
-  // (highest auto-increment `id` for this quarter) from the tally. Only
-  // applies when the requested (quarter, year) matches the *current*
-  // calendar quarter so backfills/audits of historical cycles still
-  // reproduce their original outcome exactly. The Tableland row carries
-  // an `id` column not declared on `DistributionVote`, so cast through
-  // `any` for the comparison.
-  const current = getCurrentQuarter()
-  if (
-    EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE &&
-    quarter === current.quarter &&
-    year === current.year &&
-    votes.length > 0
-  ) {
-    const maxId = votes.reduce((max, v) => {
-      const id = Number((v as any).id)
-      return Number.isFinite(id) && id > max ? id : max
-    }, -Infinity)
-    if (Number.isFinite(maxId)) {
-      const dropped = votes.find((v) => Number((v as any).id) === maxId)
-      votes = votes.filter((v) => Number((v as any).id) !== maxId)
-      console.log(
-        `[vote tally] Excluding latest vote id=${maxId} from tally`,
-        dropped ? { address: dropped.address } : null
-      )
-    }
+  // Defer to the shared helper so the on-chain close and the read-only
+  // `computeMemberVoteOutcome` can never disagree on which row gets
+  // excluded. The helper is a no-op for past-quarter tallies and when
+  // the flag is off, so this stays safe to call unconditionally here.
+  const { votes, excluded } = excludeLatestMemberVoteIfApplicable({
+    votes: rawVotes,
+    quarter,
+    year,
+    enabled: EXCLUDE_LATEST_MEMBER_VOTE_FOR_CURRENT_CYCLE,
+  })
+  if (excluded) {
+    console.log(
+      `[vote tally] Excluding latest vote id=${excluded.id} from tally`,
+      { address: excluded.address }
+    )
   }
 
   const voteAddresses = votes.map((pv) => pv.address)


### PR DESCRIPTION
## Summary

Stacks on top of #1286. End-of-cycle handling for the Q2 2026 Member Vote, in three pieces — none of which touches the rest of the Member Vote UI.

### 1. Close Member Vote submissions on `/projects`

New flag `MEMBER_VOTE_SUBMISSIONS_OPEN` in `const/config.ts`. When `false`:
- The per-card distribute inputs and the Submit Distribution panel disappear from the Project Proposals tab.
- The "Distribute 100% of your voting power… click Submit Distribution." copy is replaced with a "Member Vote submissions are closed for this cycle" note.
- The Member Vote badge, phase-timeline highlight, and `MemberVoteResults` panel still render — the page reads as "Member Vote phase, here are the results".

### 2. Exclude disqualified addresses from the current cycle's tally

New list `MEMBER_VOTE_EXCLUDED_ADDRESSES` in `const/config.ts`. Initialized with one entry: `0x47cc4c7fef42187f9f7901838f316b033e92be05` (e-Cat) for Q2 2026, per EB decision.

The shared helper `excludeMemberVotesByAddress` (in `lib/proposals/excludeMemberVotes.ts`) is called by both:
- `pages/api/proposals/vote.ts` (the on-chain close), and
- `lib/proposals/computeMemberVoteOutcome.ts` (the read-only display behind `/api/proposals/vote-results` and `/api/proposals/vote-audit`).

So the live results panel and the on-chain tally always agree on who's been dropped. The exclusion is gated to the current calendar quarter only, so historical-cycle audits reproduce their original outcomes exactly. Disqualified rows stay in the on-chain Proposals table for the audit trail; they just don't count toward the result. Each dropped row is logged with its `id` + address by the on-chain handler.

### 3. Show the "Close voting" button to the proposals owner during member vote

Existing button in `ProjectRewards.tsx` was gated on `isSenateVote && isProposalsContractOwner`, but the API it calls (`POST /api/proposals/vote`) is the Member Vote tally that flips approved proposals to `PROJECT_ACTIVE`. Senate-vote closes happen on-chain per-MDP via `Proposals.tallyVotes(mdp)` and don't need a UI control. Gate is now `isMemberVote && isProposalsContractOwner`.

## Files touched

- `ui/const/config.ts` — `MEMBER_VOTE_SUBMISSIONS_OPEN` and `MEMBER_VOTE_EXCLUDED_ADDRESSES` flags.
- `ui/lib/tableland/types.ts` — typed `id?: number | string` on `DistributionVote` so the exclusion helper doesn't need `(v as any)` casts.
- `ui/lib/proposals/excludeMemberVotes.ts` — pure shared helper used by both tally paths.
- `ui/lib/proposals/computeMemberVoteOutcome.ts` — calls the helper.
- `ui/pages/api/proposals/vote.ts` — calls the helper, logs each dropped row.
- `ui/components/nance/ProjectRewards.tsx` — gates the proposal-vote submit/edit UI on the new flag, and fixes the "Close voting" button gate.

## Test plan

- [ ] Visit `/projects` on a wallet with vMOONEY: confirm the Member Vote badge, phase callout, and `MemberVoteResults` panel still render, but the per-card distribute inputs and Submit Distribution button are gone, replaced with the "submissions are closed" copy.
- [ ] Hit `/api/proposals/vote-results?quarter=2&year=2026`: confirm `voterCount` is `15` (down from the live `16`) and the row at `id=7` (`0x47cc...be05`, e-Cat) is no longer reflected in the percentages.
- [ ] Hit `/api/proposals/vote-results?quarter=<prior-q>&year=<prior-y>`: confirm previous-cycle results are unchanged (regression check on the current-quarter gate).
- [ ] (EB only, when ready) Connect with the Proposals contract owner wallet → "Close voting." button appears next to the "Q2: 2026 Rewards" header → click → server logs include `[vote tally] Excluding disqualified vote id=7 from tally { address: '0x47cc...be05' }` and a `Updated project … active=2 (tx: 0x…)` line per approved project.
- [ ] Existing cypress unit suites (`vote-tally.cy.tsx`, `budget-overrides.cy.tsx`) still pass — the active tests exercise invalid-quarter / invalid-year early-return paths and the lower-level normalization helpers, neither of which the new exclusion gate intersects.
