### PR TITLE
Wrap up Q2 2026 Member Vote: end Member/Retroactive phases, surface new cohort in Active Projects

### DIFF
--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -726,15 +726,20 @@ export function ProjectRewards({
   let citizenDistributions = distributions?.filter((_, i) => isCitizens[i])
   const nonCitizenDistributions = distributions?.filter((_, i) => !isCitizens[i])
 
-  // Scope the eligible / ineligible cohorts to the cycle the page is
-  // currently showing. `quarter`/`year` already adapt:
-  //   - IS_REWARDS_CYCLE = true  → previous calendar quarter (the cohort
-  //     being voted on right now).
-  //   - IS_REWARDS_CYCLE = false → current calendar quarter (the cohort
-  //     whose retros will be voted on next).
-  // Without this filter, projects from a closed cycle whose `eligible = 1`
-  // flag was never cleared keep appearing in the live retro tab and the
-  // active-projects empty-state hint, which mixes cohorts.
+  // `eligibleProjects` is cohort-scoped on purpose: the Retroactive
+  // Rewards tab votes on a *specific* cycle's eligible cohort, so it has
+  // to track `quarter`/`year` (which adapt to the rewards-cycle flag).
+  // Otherwise projects from a closed cycle whose `eligible = 1` was
+  // never cleared would bleed into the live retro tab.
+  //
+  // `ineligibleProjects` (the Active Projects tab body) is intentionally
+  // NOT cohort-scoped. A project being "active and not yet eligible for
+  // retro" is a property of the project, not of the cycle the page is
+  // currently focused on. Scoping it to a single quarter caused the
+  // freshly-approved cohort to disappear from the Active Projects tab
+  // immediately after a Member Vote close — they're `active = 2` on
+  // chain but their quarter doesn't match the rewards-cycle quarter
+  // the page is otherwise viewing.
   const eligibleProjects = useMemo(
     () =>
       currentProjects.filter(
@@ -747,14 +752,8 @@ export function ProjectRewards({
   )
 
   const ineligibleProjects = useMemo(
-    () =>
-      currentProjects.filter(
-        (p) =>
-          !p.eligible &&
-          Number(p.quarter) === quarter &&
-          Number(p.year) === year
-      ),
-    [currentProjects, quarter, year]
+    () => currentProjects.filter((p) => !p.eligible),
+    [currentProjects]
   )
   // All projects need at least one citizen distribution to do iterative normalization
   const allProjectsHaveCitizenDistribution = eligibleProjects?.every(({ id }) =>

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -648,7 +648,7 @@ export const PROJECT_SYSTEM_CONFIG = {
 // Set IS_MEMBER_VOTE to true during Member Vote phase - shows proposals with "Voting" status (passed Senate vote)
 // Only one should be true at a time, or both false when no voting is active
 export const IS_SENATE_VOTE = false
-export const IS_MEMBER_VOTE = true
+export const IS_MEMBER_VOTE = false
 
 // When false, the Member Vote phase is still on (results panel, "Member
 // Vote" badge, etc. still render) but the actual submit/edit Distribution
@@ -674,7 +674,7 @@ export const MEMBER_VOTE_EXCLUDED_ADDRESSES: string[] = [
 // Set IS_REWARDS_CYCLE to true during the retroactive rewards distribution
 // window. When true, the projects page treats the prior quarter as the active
 // retro cycle and surfaces the Citizen / Voting Member distribution UI.
-export const IS_REWARDS_CYCLE = true
+export const IS_REWARDS_CYCLE = false
 
 // Quarterly budget in USD (stablecoins)
 // 5% of liquid non-MOONEY assets, denominated in USD


### PR DESCRIPTION
## Summary

Wraps up the Q2 2026 Member Vote and Q1 2026 retroactive cycles, and unhides the freshly-approved cohort on `/projects`.

### 1. Phase flags — both off

- `IS_MEMBER_VOTE = false`: the phase is over. Approved projects (MDP-235, 237, 240, 245) have already been flipped on chain to `active = 2`, so the Member Vote badge, phase-callout, and senate/member-only proposal filter shouldn't keep rendering as if voting is still live.
- `IS_REWARDS_CYCLE = false`: the Q1 2026 retroactive window has completed (`/api/proposals/retro-results?quarter=1&year=2026` already returns a tallied outcome with 10 voters). With the flag off:
  - The "Retroactive · Rewards" phase no longer highlights as active in the timeline.
  - The Retroactive Rewards tab now scopes to the *current* calendar quarter (Q2 2026, which has no eligible projects yet — they need to submit final reports first).
  - The "Previous Cycle Results" panel repoints from Q4 2025 → Q1 2026 via the existing `getRelativeQuarter(rewardVotingActive ? -2 : -1)` switch.

### 2. Active Projects tab includes the just-approved cohort

`ineligibleProjects` was previously cohort-scoped (`Number(p.quarter) === quarter && Number(p.year) === year`). After the Q2 close, that quarter pointer was Q1 2026 (because we were still in the rewards cycle), so the four newly-approved Q2 2026 projects rendered nowhere on the page despite being `active = 2` on chain.

Fix: drop the cohort filter from `ineligibleProjects`. A project being "active and not yet eligible for retro" is a property of the project, not of the cycle the page is currently focused on. `eligibleProjects` (used by the Retro tab) stays cohort-scoped because the retro tally itself is per-cycle.

After this PR, the Active Projects tab body lists all `active = 2 && !eligible` projects across cohorts:
- Q2 2026 cohort (4 newly approved): MDP-235, MDP-237, MDP-240, MDP-245
- Q1 2026 cohort still in flight (6): MDP-209, 210, 214, 218, 219, 224
- = 10 in-flight active projects (the count badge still shows the full `currentProjects.length`, which also includes 2 already-eligible Q4 2025 ones, so 12 total there).

## Files touched

- `ui/const/config.ts` — `IS_MEMBER_VOTE` and `IS_REWARDS_CYCLE` flipped to false.
- `ui/components/nance/ProjectRewards.tsx` — `ineligibleProjects` no longer cohort-scoped; updated the comment block to explain the (intentional) asymmetry between `eligibleProjects` and `ineligibleProjects`.

## Test plan

- [ ] Visit `/projects` after deploy.
- [ ] Phase timeline: no phase highlighted as active beyond "Submit Proposal" (the default).
- [ ] Project Proposals tab header reads "Pending Proposals (n)" — no Member Vote badge.
- [ ] Active Projects tab body lists the 4 Q2 2026 winners alongside the 6 Q1 2026 in-flight projects.
- [ ] Retroactive Rewards tab header reads "Retroactive Rewards Q2 2026" with the empty-state copy ("No projects in the current cycle yet"), since no Q2 project has yet submitted a final report.
- [ ] Below it, "Previous Cycle Results · Q1 2026" panel populates with the tallied retro outcome (2 results, 10 voters).
- [ ] `/api/proposals/vote-results?quarter=2&year=2026` still returns the same outcome as right after close (e-Cat exclusion stays in effect for audit consistency until we move past Q2).
