### PR TITLE
Polish app copy and fix broken Celestrak link

### DIFF
--- a/ui/components/dashboard/treasury/transactions/TransactionDisclaimer.tsx
+++ b/ui/components/dashboard/treasury/transactions/TransactionDisclaimer.tsx
@@ -34,9 +34,9 @@ const TransactionDisclaimer = () => {
               </p>
               <br/>
               <p>
-                Like many other web3 Organizations & DAOs, MoonDAO gets
-                targetted by scammers. They use the tactic of sending tokens
-                that can drain a wallet if it's owner interacts with them.
+                Like many other web3 organizations and DAOs, MoonDAO gets
+                targeted by scammers. They use the tactic of sending tokens
+                that can drain a wallet if its owner interacts with them.
               </p>
             </Disclosure.Panel>
           </>

--- a/ui/components/home/Callout3.tsx
+++ b/ui/components/home/Callout3.tsx
@@ -62,7 +62,7 @@ const indexCardData = [
     paragraph: (
       <>
         Established a constitution for self-governance, which landed on
-        the surface of the Moon in early-2025.
+        the surface of the Moon in early 2025.
       </>
     ),
   },

--- a/ui/components/home/Timeline.tsx
+++ b/ui/components/home/Timeline.tsx
@@ -53,7 +53,7 @@ const timelineEvents: TimelineEvent[] = [
     year: 2024,
     title: 'Zero Gravity',
     description:
-      'Organized a zero gravity flight experience with three astronauts, advancing space training and research capabilities.',
+      'Organized a zero-gravity flight experience with three astronauts, advancing space training and research capabilities.',
     icon: '/assets/icon-plane.svg',
     iconAlt: 'Zero Gravity',
   },

--- a/ui/components/launchpad/LaunchpadFAQs.tsx
+++ b/ui/components/launchpad/LaunchpadFAQs.tsx
@@ -32,7 +32,7 @@ const FAQS = [
   {
     question: 'How much does it cost to launch a campaign?',
     answer:
-      'There is no upfront cost to create a Mission, but standard Ethereum network (gas) fees apply when deploying smart contracts. Additionally, MoonDAO/Juicebox receive a small percentage (10% in total) of successfully raised funds to sustain the platform and support other space related projects within the community governed treasury. Likewise, 10% of the tokens created for a Mission will be reserved for the MoonDAO treasury to align long term interests, with a 1-year cliff and three years streaming, meaning that tokens cannot be immediately sold. Furthermore, any outlays from the MoonDAO treasury require a vote.',
+      'There is no upfront cost to create a Mission, but standard Ethereum network (gas) fees apply when deploying smart contracts. Additionally, MoonDAO/Juicebox receive a small percentage (10% in total) of successfully raised funds to sustain the platform and support other space-related projects within the community-governed treasury. Likewise, 10% of the tokens created for a Mission will be reserved for the MoonDAO treasury to align long-term interests, with a 1-year cliff and three years of streaming, meaning that tokens cannot be immediately sold. Furthermore, any outlays from the MoonDAO treasury require a vote.',
   },
   {
     question: 'How does the cliff and streaming work?',
@@ -40,7 +40,7 @@ const FAQS = [
       "Funds raised through the MoonDAO Launch Pad are subject to a 1-year cliff, meaning they remain locked for the first year. After this period, they stream gradually over three years, ensuring sustainable, long-term funding. This applies to both the project's funds and MoonDAO's 10% reserve allocation, preventing immediate sell-offs and promoting ecosystem stability.",
   },
   {
-    question: 'Should I create an erc-20 token for my campaign?',
+    question: 'Should I create an ERC-20 token for my campaign?',
     answer:
       "It depends on your project's goals. An ERC-20 token can provide liquidity, community ownership, and governance features, but it also introduces risks like speculation and regulatory concerns. Tokens allow for tradability on decentralized exchanges, enabling supporters to buy, sell, or hold them as part of the project's ecosystem. They can also incentivize engagement through governance rights or utility within the project. However, speculative trading can create volatility, potentially impacting long-term sustainability.",
   },

--- a/ui/components/launchpad/PowerOfDecentralization.tsx
+++ b/ui/components/launchpad/PowerOfDecentralization.tsx
@@ -18,7 +18,7 @@ const features = [
   },
   {
     title: 'Battle Tested',
-    description: 'Powered by Juicebox, a proven and audited platform with over 1,000+ projects and over $200,000,000+ raised.',
+    description: 'Powered by Juicebox, a proven and audited platform with 1,000+ projects and over $200,000,000 raised.',
     icon: '/assets/icon-checkmark.svg',
     gradientFrom: 'from-[#5159CC]',
     gradientTo: 'to-[#4660E7]',

--- a/ui/components/onboarding/CitizenTier.tsx
+++ b/ui/components/onboarding/CitizenTier.tsx
@@ -67,7 +67,7 @@ const CitizenTier = ({
         points={[
           'Unique Identity: Create a personalized, AI-generated passport image representing your on-chain identity.',
           'Professional Networking: Connect with top space startups, non-profits, and ambitious teams.',
-          'Career Advancement: Access jobs, gigs, hackathons, and more; building on-chain credentials to showcase your experience.',
+          'Career Advancement: Access jobs, gigs, hackathons, and more, building on-chain credentials to showcase your experience.',
           'Early Project Access: Engage in space projects, earn money, and advance your career.',
         ]}
         buttoncta={compact ? 'Learn More' : 'Become a Citizen'}

--- a/ui/pages/final-reports.tsx
+++ b/ui/pages/final-reports.tsx
@@ -66,7 +66,7 @@ export default function FinalReportsPage({
                     target="_blank"
                     rel="noreferrer"
                   >
-                    Google doc template
+                    Google Doc template
                   </Link>
                   .
                 </p>

--- a/ui/pages/join.tsx
+++ b/ui/pages/join.tsx
@@ -337,7 +337,7 @@ export default function Join({
                       </div>
                       <div className="text-sm text-slate-400">({CITIZEN_PRICE} Arbitrum ETH)</div>
                       <div className="text-green-400 text-sm font-medium mt-2">
-                        ✓ 12 Month Passport
+                        ✓ 12-Month Passport
                       </div>
                     </div>
                     <StandardButton
@@ -377,7 +377,7 @@ export default function Join({
                       </div>
                       <div className="text-sm text-slate-400">({TEAM_PRICE} Arbitrum ETH)</div>
                       <div className="text-green-400 text-sm font-medium mt-2">
-                        ✓ 12 Month Passport
+                        ✓ 12-Month Passport
                       </div>
                     </div>
                     <StandardButton

--- a/ui/pages/projects-overview.tsx
+++ b/ui/pages/projects-overview.tsx
@@ -546,7 +546,7 @@ const ProjectsOverview: React.FC<{
                       <div>
                         <h5 className="font-bold text-white mb-1">Present & Vote</h5>
                         <p className="text-sm text-gray-300">
-                          Present at the Townhall meeting. Members vote to allocate funding. Top 50%
+                          Present at the Town Hall meeting. Members vote to allocate funding. Top 50%
                           of proposals get funded (budget permitting).
                         </p>
                       </div>

--- a/ui/pages/resources.tsx
+++ b/ui/pages/resources.tsx
@@ -66,7 +66,7 @@ const resourceCategories = [
       },
       {
         name: 'Celestrak',
-        url: 'https://celestrak.com/',
+        url: 'https://celestrak.org/',
         description: 'Satellite tracking data, orbital elements, and space situational awareness information.'
       },
       {


### PR DESCRIPTION
## Summary
- Light copy polish across pages and components: spelling, grammar, hyphenation of compound modifiers, and capitalization of proper nouns (e.g., `ERC-20`, `Google Doc`, `Town Hall`).
- Removed redundant phrasing on the Launchpad stats (`over X+` → `X+ ... over $...`).
- Fixed a real broken external link on the Resources page: Celestrak migrated from `celestrak.com` (expired TLS cert) to `celestrak.org`.

## Scope
- Reviewed every page in `ui/pages` and user-facing strings across `ui/components`.
- Style: American English, light polish only (no rewrites, no tone changes).
- Verified all internal `href` / `router.push` targets resolve to real Next.js routes — no internal 404s.
- Checked all unique external `href` URLs in non-archive code; the only genuinely broken one was Celestrak. A few sites returned `403`/`429` to a curl probe but are working in browsers (Cloudflare/Vercel bot challenges).

## Files touched
- `ui/components/dashboard/treasury/transactions/TransactionDisclaimer.tsx`
- `ui/components/home/Callout3.tsx`
- `ui/components/home/Timeline.tsx`
- `ui/components/launchpad/LaunchpadFAQs.tsx`
- `ui/components/launchpad/PowerOfDecentralization.tsx`
- `ui/components/onboarding/CitizenTier.tsx`
- `ui/pages/final-reports.tsx`
- `ui/pages/join.tsx`
- `ui/pages/projects-overview.tsx`
- `ui/pages/resources.tsx`

## Test plan
- [ ] Visually skim affected pages (`/`, `/join`, `/launch`, `/projects-overview`, `/final-reports`, `/treasury`, `/resources`) for the updated strings.
- [ ] Click the Celestrak link on `/resources` and confirm it opens `celestrak.org`.
- [ ] No new lint errors (`npm run lint`).


Made with [Cursor](https://cursor.com)