### PR TITLE
Fix Q1 2026 retro pool totals and surface community circle in audit + results

### DIFF
--- a/ui/components/nance/RetroactiveResults.tsx
+++ b/ui/components/nance/RetroactiveResults.tsx
@@ -93,9 +93,26 @@ export default function RetroactiveResults({ quarter, year }: Props) {
             {outcome.citizenVoterCount} citizen
             {outcome.citizenVoterCount === 1 ? '' : 's'})
           </span>
-          <span className="bg-blue-500/10 border border-blue-400/30 text-blue-200 px-2 py-1 rounded">
-            Pool: {formatPrimary(outcome.pool.primaryAmount, outcome.pool.primaryAsset)}{' '}
-            + {formatMooney(outcome.pool.mooneyAmount)}
+          <span
+            className="bg-blue-500/10 border border-blue-400/30 text-blue-200 px-2 py-1 rounded"
+            title="The pool distributed to projects via this retroactive tally (post-upfront remainder of the quarterly project budget)."
+          >
+            Project pool:{' '}
+            {formatPrimary(outcome.pool.primaryAmount, outcome.pool.primaryAsset)}
+            {' + '}
+            {formatMooney(outcome.pool.mooneyAmount)}
+          </span>
+          <span
+            className="bg-purple-500/10 border border-purple-400/30 text-purple-200 px-2 py-1 rounded"
+            title="The community circle's parallel slice (10% of the original quarterly budget, set aside before upfront project funding). Distributed separately and not part of this tally."
+          >
+            Community circle:{' '}
+            {formatPrimary(
+              outcome.pool.communityCirclePrimary,
+              outcome.pool.primaryAsset
+            )}
+            {' + '}
+            {formatMooney(outcome.pool.communityCircleMooney)}
           </span>
           <Link
             href={`/projects/retro-audit?quarter=${outcome.quarter}&year=${outcome.year}`}
@@ -177,10 +194,11 @@ export default function RetroactiveResults({ quarter, year }: Props) {
       </div>
 
       {/* Footer summary — totals across all projects so an auditor can
-          eyeball that "% of pool" sums to ~90 (the 10% community-circle
-          carve-out is invisible here because the panel only ranks
-          projects), and that the per-project pool shares add up to the
-          headline pool minus that 10%. */}
+          eyeball that "% of pool" sums to ~100 (each project's share of
+          the project pool — community circle is tracked separately on
+          the header chip, so it's intentionally NOT included in this
+          allocation), and that the per-project pool shares add up to
+          the headline project pool. */}
       <div className="mt-3 sm:mt-4 grid grid-cols-3 gap-2 sm:gap-3 text-[11px] font-RobotoMono">
         <div className="bg-slate-800/40 border border-white/10 rounded-lg px-3 py-2 min-w-0">
           <div className="text-[10px] uppercase tracking-wider text-gray-400 truncate">

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -703,13 +703,14 @@ export const OPERATORS: string[] = [
 // 'USDC' (and RETRO_USD_BUDGET) is the default for stablecoin retros.
 export const RETRO_PAYOUT_TOKEN: 'ETH' | 'USDC' = 'USDC'
 
-// Q1 2026 retroactives (last cycle, ETH-paid): 2.215 ETH.
+// Q1 2026 retroactives (last cycle, ETH-paid): 2.215 ETH for projects.
 // The quarter's total ETH budget was 11.6, of which 90% goes to projects
 // (10.44 ETH). 8.225 ETH was paid out upfront to funded projects, so the
 // remainder for retroactive distribution is (11.6 * 0.9) - 8.225 = 2.215 ETH.
+// The community circle slice for that cycle was 1.16 ETH (10% of 11.6).
 export const RETRO_ETH_BUDGET = 2.215
 
-// Q2 2026 retroactives (current cycle, USDC-paid): $5,629.26.
+// Q2 2026 retroactives (current cycle, USDC-paid): $5,629.26 for projects.
 // The quarter's total USD budget is $23,409 (NEXT_QUARTER_BUDGET_USD).
 // 90% goes to projects ($21,068.10); $15,438.84 was committed upfront
 // to the 4 Member-Vote winners (MDP-240 $3,955 + MDP-235 $3,600 +
@@ -718,3 +719,20 @@ export const RETRO_ETH_BUDGET = 2.215
 // upfront past the 3/4 cap of $17,556.75.
 // Retroactive remainder = ($23,409 * 0.9) - $15,438.84 = $5,629.26.
 export const RETRO_USD_BUDGET = 5629.26
+
+// Community circle's slice of the primary asset for the *currently-voting*
+// cycle. The community circle is reserved as 10% of the original quarterly
+// budget (before any upfront project funding), in the same asset paid out
+// to projects via `RETRO_PAYOUT_TOKEN`. This is a parallel cohort, NOT a
+// carve-out of the retro project pool: it does NOT scale down when projects
+// receive upfront funding. Audit / results displays surface this value
+// alongside the project pool so every part of the cycle's spend is visible.
+//
+// USDC cycles: 10% of NEXT_QUARTER_BUDGET_USD (Q2 2026 = $2,340.90).
+// ETH cycles: must be hardcoded against the cycle's quarterly ETH total
+// (e.g. Q1 2026 was 1.16 ETH, set when RETRO_PAYOUT_TOKEN was 'ETH').
+// Past cycles are pinned in `HISTORICAL_RETRO_POOLS` (see
+// `lib/proposals/computeRetroactiveOutcome.ts`) so this constant only
+// needs to track the current cycle.
+export const RETRO_PRIMARY_COMMUNITY_CIRCLE: number =
+  RETRO_PAYOUT_TOKEN === 'USDC' ? NEXT_QUARTER_BUDGET_USD * 0.1 : 0

--- a/ui/lib/proposals/computeRetroactiveOutcome.ts
+++ b/ui/lib/proposals/computeRetroactiveOutcome.ts
@@ -36,6 +36,7 @@ import {
   PROJECT_TABLE_NAMES,
   RETRO_ETH_BUDGET,
   RETRO_PAYOUT_TOKEN,
+  RETRO_PRIMARY_COMMUNITY_CIRCLE,
   RETRO_USD_BUDGET,
 } from 'const/config'
 import { getContract, readContract } from 'thirdweb'
@@ -61,6 +62,28 @@ function getMooneyBudgetForCycle(year: number, quarter: number): number {
   return MOONEY_INITIAL_BUDGET * MOONEY_DECAY_RATE ** numQuartersPastQ4Y2022
 }
 
+// Standard 90/10 split between project rewards and the community circle,
+// expressed as a fraction of the original quarterly budget (before any
+// upfront project funding). Used to derive the live cycle's defaults
+// when a (quarter, year) hasn't been frozen into `HISTORICAL_RETRO_POOLS`
+// yet. The community circle reservation is taken off the original
+// quarterly budget — NOT the post-upfront retro remainder — so it does
+// NOT scale down when projects get funded upfront.
+const COMMUNITY_CIRCLE_FRACTION = 0.1
+const PROJECT_REWARDS_FRACTION = 0.9
+
+type FrozenRetroPool = {
+  primaryAsset: 'ETH' | 'USDC'
+  /** ETH/USDC distributed to projects via the retro vote (post-upfront remainder). */
+  primaryProjectsAmount: number
+  /** MOONEY distributed to projects via the retro vote. */
+  mooneyProjectsAmount: number
+  /** Community circle's slice of the primary asset for the cycle. */
+  communityCirclePrimary: number
+  /** Community circle's slice of MOONEY for the cycle. */
+  communityCircleMooney: number
+}
+
 // Frozen per-cycle retro pool snapshots. We can't infer historical
 // pools from `RETRO_PAYOUT_TOKEN` / `RETRO_*_BUDGET` because those
 // constants only ever describe the *current* cycle — once the EB rolls
@@ -68,14 +91,23 @@ function getMooneyBudgetForCycle(year: number, quarter: number): number {
 // actually paid out. Each completed cycle gets pinned here so audits
 // of past quarters render their real pool. New cycles fall through
 // to the live config values; when a cycle closes, copy its config
-// snapshot into a new entry below.
-const HISTORICAL_RETRO_POOLS: Record<
-  string,
-  { primaryAsset: 'ETH' | 'USDC'; primaryAmount: number }
-> = {
+// snapshot into a new entry below — including the community circle
+// amounts so the audit page can show every cent the cycle paid out.
+const HISTORICAL_RETRO_POOLS: Record<string, FrozenRetroPool> = {
   // Q1 2026 retroactives (paid in ETH, voting closed Apr 21, 2026).
-  // Source: `RETRO_ETH_BUDGET` doc comment in `const/config.ts`.
-  '2026-Q1': { primaryAsset: 'ETH', primaryAmount: 2.215 },
+  // Quarterly total: 11.6 ETH + 7,700,000 MOONEY.
+  //   - 90% projects (10.44 ETH / 6,930,000 MOONEY).
+  //     8.225 ETH was paid upfront to funded projects, leaving
+  //     2.215 ETH for retro distribution. MOONEY had no upfront
+  //     payouts so the full 6,930,000 went to retro.
+  //   - 10% community circle (1.16 ETH / 770,000 MOONEY).
+  '2026-Q1': {
+    primaryAsset: 'ETH',
+    primaryProjectsAmount: 2.215,
+    mooneyProjectsAmount: 6_930_000,
+    communityCirclePrimary: 1.16,
+    communityCircleMooney: 770_000,
+  },
 }
 
 /**
@@ -147,11 +179,18 @@ export type RetroactiveResult = {
   projectId: string
   MDP: number | string | null
   name: string
-  /** Quadratic-voting % of the project pool. Sums (across all results) to ≤ 90 because `runQuadraticVoting` reserves 10% for the community circle. */
+  /**
+   * Project's share of the retro project pool, expressed as a percentage.
+   * Sums to 100 across all results in the cycle (modulo float drift).
+   * The community-circle slice is tracked separately on `outcome.pool`
+   * — it's a parallel cohort, NOT a slice of this same pool — so this
+   * percentage is renormalized over eligible projects only after the
+   * shared `runQuadraticVoting` carve-out is filtered out.
+   */
   percentage: number
-  /** Project's slice of the configured retro pool (ETH or USDC, depending on `RETRO_PAYOUT_TOKEN`). */
+  /** Project's slice of the retro primary-asset pool (ETH or USDC, depending on `pool.primaryAsset`). */
   primaryShare: number
-  /** Project's slice of the MOONEY pool. */
+  /** Project's slice of the retro MOONEY pool. */
   mooneyShare: number
 }
 
@@ -202,8 +241,22 @@ export type RetroactiveOutcome = {
   totalPower: number
   pool: {
     primaryAsset: 'ETH' | 'USDC'
+    /** ETH/USDC distributed to projects via the retro vote (post-upfront). */
     primaryAmount: number
+    /** MOONEY distributed to projects via the retro vote. */
     mooneyAmount: number
+    /**
+     * Community circle's slice of the primary asset for this cycle.
+     * Tracked alongside the project pool so audits can show every cent
+     * the cycle paid out. The community circle is a parallel cohort
+     * (10% of the original quarterly budget, set aside before upfront
+     * project funding) — it's NOT carved out of `primaryAmount`, so
+     * the two values do NOT sum to a fixed total once upfront payouts
+     * have shifted the project pool.
+     */
+    communityCirclePrimary: number
+    /** Community circle's slice of the MOONEY pool for this cycle. */
+    communityCircleMooney: number
   }
   results: RetroactiveResult[]
   computedAt: number
@@ -402,16 +455,32 @@ export async function computeRetroactiveOutcome({
     addressToPowerOriginalCase
   )
 
-  // Drop bogus keys produced by the non-citizen best-fit path. That
-  // helper returns array-shaped distributions, so when fed back into
-  // `runQuadraticVoting` they get bucketed under integer index keys
-  // ("0", "1", "2", …) that don't correspond to real Tableland project
-  // ids. Filter the outcome to the eligible cohort so the rendered
-  // results only reflect actual projects.
+  // Drop bogus keys produced by the non-citizen best-fit path AND
+  // renormalize across eligible projects so the resulting percentages
+  // describe each project's share of the *retro project pool* (which
+  // is what `pool.primaryAmount` / `pool.mooneyAmount` represent).
+  //
+  // Why renormalize? `runQuadraticVoting` reserves a 10% slice for
+  // the community circle by normalizing its output to sum to 90
+  // across every key it sees — including integer-indexed keys that
+  // come out of the non-citizen best-fit projection (the helper
+  // returns an array, and `Object.entries` exposes it under '0',
+  // '1', '2', …). Those bogus keys aren't projects, and the community
+  // circle is now tracked as its own pool on `outcome.pool` (see
+  // `HISTORICAL_RETRO_POOLS`), so neither belongs in the per-project
+  // percentage. Filtering to `eligibleIdSet` and rescaling to sum to
+  // 100 gives a clean "% of project pool" that matches the displayed
+  // ETH/MOONEY shares (which are computed as `pct * primaryAmount`
+  // and `pct * mooneyAmount`).
   const eligibleIdSet = new Set(eligibleProjects.map((p: any) => String(p.id)))
-  const cleanedOutcome: Record<string, number> = {}
+  const filteredOutcome: Record<string, number> = {}
   for (const [pid, pct] of Object.entries(projectIdToEstimatedPercentage)) {
-    if (eligibleIdSet.has(String(pid))) cleanedOutcome[String(pid)] = pct
+    if (eligibleIdSet.has(String(pid))) filteredOutcome[String(pid)] = pct
+  }
+  const filteredSum = Object.values(filteredOutcome).reduce((s, v) => s + v, 0)
+  const cleanedOutcome: Record<string, number> = {}
+  for (const [pid, pct] of Object.entries(filteredOutcome)) {
+    cleanedOutcome[pid] = filteredSum > 0 ? (pct / filteredSum) * 100 : 0
   }
 
   const totalCitizenPower = citizenDistributions.reduce(
@@ -425,23 +494,36 @@ export async function computeRetroactiveOutcome({
 
   // Pool sizes per voting cycle. Each completed cycle gets a frozen
   // entry in `HISTORICAL_RETRO_POOLS` so audits of past quarters render
-  // their actual pool (asset + amount) rather than the live config
-  // values. The current cycle falls through to `RETRO_PAYOUT_TOKEN` /
-  // `RETRO_*_BUDGET`, which is what `ProjectRewards.tsx` reads when
-  // showing the live retro tab. When a cycle is closed and the next
-  // one's config goes in, copy the now-historical `RETRO_*_BUDGET`
-  // values into a new entry below.
+  // their actual pool (project + community circle, in both the primary
+  // asset and MOONEY) rather than the live config values. The current
+  // cycle falls through to `RETRO_PAYOUT_TOKEN` / `RETRO_*_BUDGET` /
+  // `RETRO_PRIMARY_COMMUNITY_CIRCLE`, which is what `ProjectRewards.tsx`
+  // reads when showing the live retro tab. When a cycle closes and
+  // config rolls forward to the next cycle, copy the now-historical
+  // values (including the community circle) into a new entry above.
   const cycleKey = `${year}-Q${quarter}`
   const historicalPool = HISTORICAL_RETRO_POOLS[cycleKey]
   const isEthPayoutCycle = historicalPool
     ? historicalPool.primaryAsset === 'ETH'
     : RETRO_PAYOUT_TOKEN === 'ETH'
+  // For the live cycle, MOONEY has no upfront carve-out (we only spend
+  // MOONEY via retro), so projects get the full 90% slice of the
+  // quarterly MOONEY budget and the community circle gets 10%.
+  const liveMooneyTotal = getMooneyBudgetForCycle(year, quarter)
   const primaryAmount = historicalPool
-    ? historicalPool.primaryAmount
+    ? historicalPool.primaryProjectsAmount
     : isEthPayoutCycle
     ? RETRO_ETH_BUDGET
     : RETRO_USD_BUDGET
-  const mooneyAmount = getMooneyBudgetForCycle(year, quarter)
+  const mooneyAmount = historicalPool
+    ? historicalPool.mooneyProjectsAmount
+    : liveMooneyTotal * PROJECT_REWARDS_FRACTION
+  const communityCirclePrimary = historicalPool
+    ? historicalPool.communityCirclePrimary
+    : RETRO_PRIMARY_COMMUNITY_CIRCLE
+  const communityCircleMooney = historicalPool
+    ? historicalPool.communityCircleMooney
+    : liveMooneyTotal * COMMUNITY_CIRCLE_FRACTION
 
   const projectMeta = Object.fromEntries(
     eligibleProjects.map((p: any) => [String(p.id), p])
@@ -610,6 +692,8 @@ export async function computeRetroactiveOutcome({
       primaryAsset: isEthPayoutCycle ? 'ETH' : 'USDC',
       primaryAmount,
       mooneyAmount,
+      communityCirclePrimary,
+      communityCircleMooney,
     },
     results,
     computedAt: Math.floor(Date.now() / 1000),

--- a/ui/pages/projects/retro-audit.tsx
+++ b/ui/pages/projects/retro-audit.tsx
@@ -311,7 +311,6 @@ function AuditBody({
         audit={audit}
         addressToPower={addressToPower}
         totalCitizenPower={totalCitizenPower}
-        totalPower={outcome.totalPower}
       />
     </>
   )
@@ -341,22 +340,38 @@ function SummaryCard({
           </p>
         </div>
       </div>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 sm:gap-3">
         <StatTile label="Voters" value={String(voterCount)} />
         <StatTile
           label="Citizen power"
           value={formatNumber(outcome.totalCitizenPower, 0)}
+          sub="√vMOONEY at vote close"
         />
         <StatTile
-          label={`Pool (${outcome.pool.primaryAsset})`}
+          label={`Project pool (${outcome.pool.primaryAsset})`}
           value={formatPrimary(
             outcome.pool.primaryAmount,
             outcome.pool.primaryAsset
           )}
+          sub="Distributed via this tally"
         />
         <StatTile
-          label="Pool (MOONEY)"
+          label="Project pool (MOONEY)"
           value={formatMooney(outcome.pool.mooneyAmount)}
+          sub="Distributed via this tally"
+        />
+        <StatTile
+          label={`Community circle (${outcome.pool.primaryAsset})`}
+          value={formatPrimary(
+            outcome.pool.communityCirclePrimary,
+            outcome.pool.primaryAsset
+          )}
+          sub="Parallel 10% cohort (not in tally)"
+        />
+        <StatTile
+          label="Community circle (MOONEY)"
+          value={formatMooney(outcome.pool.communityCircleMooney)}
+          sub="Parallel 10% cohort (not in tally)"
         />
       </div>
     </div>
@@ -394,13 +409,11 @@ function ProjectsList({
   audit,
   addressToPower,
   totalCitizenPower,
-  totalPower,
 }: {
   outcome: RetroactiveOutcome
   audit: RetroactiveAudit
   addressToPower: Record<string, number>
   totalCitizenPower: number
-  totalPower: number
 }) {
   // Single-expand for the same reason as the member-vote audit page —
   // multiple-open is hard to scan on mobile and there's no real
@@ -431,7 +444,6 @@ function ProjectsList({
             onToggle={() => setExpandedId(expanded ? null : r.projectId)}
             addressToPower={addressToPower}
             totalCitizenPower={totalCitizenPower}
-            totalPower={totalPower}
             contributorAddresses={
               audit.projectIdToContributors[r.projectId] || []
             }
@@ -450,7 +462,6 @@ function ProjectRow({
   onToggle,
   addressToPower,
   totalCitizenPower,
-  totalPower,
   contributorAddresses,
 }: {
   outcomeRow: RetroactiveOutcome['results'][number]
@@ -461,8 +472,6 @@ function ProjectRow({
   addressToPower: Record<string, number>
   /** Total √vMOONEY across all CITIZEN voters in the cycle. */
   totalCitizenPower: number
-  /** Total √vMOONEY across ALL voters (citizen + non-citizen) in the cycle. */
-  totalPower: number
   contributorAddresses: string[]
 }) {
   // Per-voter weighted contribution (citizens only) is in voting-power
@@ -476,26 +485,31 @@ function ProjectRow({
         (addressToPower[c.voterAddress] || 0),
     0
   )
-  // Reproduce `outcomeRow.percentage` from first principles so the
-  // footer reconciles with the value shown at the top of the row.
-  // Derivation: `runQuadraticVoting` (rewards.ts) computes raw
-  // weighted shares for every key fed in (real project ids from
-  // citizen rows + integer indices from the non-citizen best-fit
-  // projection), then renormalizes the whole vector so it sums to
-  // 90 (10% community-circle reservation). For a real project P:
-  //   raw[P] = Σ_citizens (norm_pct[c,P] × power[c]) / votingPowerSum
-  // The renormalizer's sum is dominated by citizens because each
-  // citizen row sums to 100 while each non-citizen best-fit row sums
-  // to 1 (`minimizeL1Distance` constraint), so:
-  //   sum = (100·citizenPower + nonCitizenPower) / votingPowerSum
-  //   final[P] = raw[P] / sum × 90
-  //            = totalWeighted × 9000
-  //              / (100·citizenPower + nonCitizenPower)
-  // (totalWeighted absorbs the /100 already, so multiply by 100·90
-  //  in the numerator.)
-  const denom = 100 * totalCitizenPower + (totalPower - totalCitizenPower)
+  // Reproduce `outcomeRow.percentage` from first principles. After
+  // `computeRetroactiveOutcome` filters out the bogus integer keys
+  // produced by the non-citizen best-fit projection and renormalizes
+  // the survivors to sum to 100, every project's % share collapses
+  // to a clean ratio of citizen weighted contributions:
+  //
+  //   final[P] = totalWeighted[P] / Σ_Q totalWeighted[Q] × 100
+  //
+  // And because each citizen's normalized row sums to 100, the
+  // denominator equals the total citizen power (Σ_v power[v] × 1):
+  //
+  //   Σ_Q totalWeighted[Q]
+  //     = Σ_Q Σ_v (norm_pct[v,Q]/100) × power[v]
+  //     = Σ_v power[v] × (Σ_Q norm_pct[v,Q] / 100)
+  //     = Σ_v power[v]
+  //     = totalCitizenPower
+  //
+  // So the reproduction simplifies to: weighted / citizenPower × 100.
+  // Non-citizen power is no longer in the formula — their contribution
+  // is filtered out of the per-project shares because it lands on
+  // bogus integer keys (the L1 best-fit returns array coefficients,
+  // not project IDs). They still count as voters in the audit voter
+  // list, but don't directly move project percentages.
   const reproducedFinal =
-    denom > 0 ? (totalWeighted * 100 * 90) / denom : 0
+    totalCitizenPower > 0 ? (totalWeighted * 100) / totalCitizenPower : 0
 
   const projectLink =
     outcomeRow.MDP != null && outcomeRow.MDP !== ''
@@ -668,7 +682,6 @@ function ProjectRow({
               <ProjectFooter
                 totalWeighted={totalWeighted}
                 totalCitizenPower={totalCitizenPower}
-                totalNonCitizenPower={totalPower - totalCitizenPower}
                 reproducedFinal={reproducedFinal}
                 finalPercentage={outcomeRow.percentage}
               />
@@ -683,13 +696,11 @@ function ProjectRow({
 function ProjectFooter({
   totalWeighted,
   totalCitizenPower,
-  totalNonCitizenPower,
   reproducedFinal,
   finalPercentage,
 }: {
   totalWeighted: number
   totalCitizenPower: number
-  totalNonCitizenPower: number
   reproducedFinal: number
   finalPercentage: number
 }) {
@@ -710,20 +721,9 @@ function ProjectFooter({
           {formatNumber(totalCitizenPower, 2)}
         </span>
       </div>
-      {totalNonCitizenPower > 0 && (
-        <div className="flex items-center justify-between gap-4 flex-wrap mt-1">
-          <span className="text-gray-400">
-            Total non-citizen power (× 0.01 vs. citizens via L1 best-fit)
-          </span>
-          <span className="text-white">
-            {formatNumber(totalNonCitizenPower, 2)}
-          </span>
-        </div>
-      )}
       <div className="border-t border-white/10 mt-2 pt-2 flex items-center justify-between gap-4 flex-wrap">
         <span className="text-gray-400">
-          Final share = Σ weighted × 9000 ÷ (100 × citizen power +
-          non-citizen power)
+          Final share = Σ weighted ÷ total citizen power × 100
         </span>
         <span className={matches ? 'text-emerald-200' : 'text-amber-200'}>
           {reproducedFinal.toFixed(4)}%


### PR DESCRIPTION
## Summary

The Q1 2026 retroactive results / audit page was showing the full quarterly MOONEY budget (`~7.69M`, derived from the decay formula) as the "pool" and then silently carving 10% inside `runQuadraticVoting`, so per-project shares only summed to ~90% of the headline total and the community circle never appeared in the UI at all.

This PR pins Q1 2026 to the actual on-chain amounts and surfaces the community circle as a parallel cohort everywhere it shows up.

### Q1 2026 numbers (now displayed exactly)

Quarter total: **11.6 ETH + 7,700,000 MOONEY**

- 90% project rewards: 10.44 ETH / 6.93M MOONEY
  - 8.225 ETH paid upfront to funded projects
  - **Project retro pool**: `2.215 ETH + 6,930,000 MOONEY`
- 10% **community circle**: `1.16 ETH + 770,000 MOONEY`

### What changed

- `lib/proposals/computeRetroactiveOutcome.ts`
  - `HISTORICAL_RETRO_POOLS` now stores all four amounts per cycle (project primary + project MOONEY + community-circle primary + community-circle MOONEY); Q1 2026 entry pinned to the values above.
  - `RetroactiveOutcome.pool` exposes `communityCirclePrimary` and `communityCircleMooney` alongside the project pool.
  - After the shared `runQuadraticVoting` pass, drop the bogus integer keys produced by the non-citizen best-fit projection and renormalize survivors to sum to 100, so each project's `percentage` cleanly describes its share of the displayed project pool. (Math justification documented inline; the `ProjectFooter` reproduction collapses to `Σ weighted / totalCitizenPower × 100`.)
  - For non-historical cycles, community circle defaults to 10% of the quarterly budget via the new `RETRO_PRIMARY_COMMUNITY_CIRCLE` constant for the primary asset and `0.1 × getMooneyBudgetForCycle` for MOONEY.
- `const/config.ts`: added `RETRO_PRIMARY_COMMUNITY_CIRCLE` (USDC cycles compute `0.1 × NEXT_QUARTER_BUDGET_USD`; ETH cycles need a manual value, with the Q1 2026 example documented).
- `pages/projects/retro-audit.tsx`: `SummaryCard` shows project pool + community-circle tiles for both ETH/USDC and MOONEY; `ProjectFooter` math/explanation simplified to match the renormalization; dropped the now-unused `totalPower` plumbing through `ProjectsList` / `ProjectRow`.
- `components/nance/RetroactiveResults.tsx`: header chips split into "Project pool" and "Community circle"; footer note updated for sum-to-100 semantics.

### Forward-compatibility

When a future cycle closes, copy its four amounts (project primary + project MOONEY + community-circle primary + community-circle MOONEY) into a new `HISTORICAL_RETRO_POOLS[year-Qq]` entry, the same way `'2026-Q1'` is set up. Until then the live cycle (Q2 2026 USDC, etc.) falls through to the live config.

### Out of scope

The on-chain CSV / payout generator in `ProjectRewards.tsx` + `getPayouts` still uses the older 90/10 carve-out from `runQuadraticVoting`. This PR is focused on the audit / results display per the request; happy to follow up to bring the live tally's payout path in line with the same semantic if desired.

## Test plan

- [ ] Visit `/projects/retro-audit?quarter=1&year=2026` and confirm the SummaryCard shows:
  - Project pool: `2.215 ETH` + `6,930,000 MOONEY`
  - Community circle: `1.16 ETH` + `770,000 MOONEY`
- [ ] Confirm per-project ETH/MOONEY shares sum to the project pool (2.215 ETH and 6.93M MOONEY) within float drift.
- [ ] Confirm `outcomeRow.percentage` values across all eligible projects sum to ~100.
- [ ] Expand a project row and confirm `ProjectFooter` reproduces the percentage via `Σ weighted / totalCitizenPower × 100` and the "matches" check stays green.
- [ ] On `/projects` Retroactive Rewards panel, confirm the header chips show the new project-pool + community-circle split.
- [ ] Visit `/projects/retro-audit?quarter=2&year=2026` (live USDC cycle) and confirm community circle displays `$2,340.90` + `~731K MOONEY` and project pool stays at `$5,629.26` + `~6.58M MOONEY`.


Made with [Cursor](https://cursor.com)