### PR TITLE
Add Close Senate Vote button for non-project proposals

### DIFF
--- a/ui/components/project/SenateVote.tsx
+++ b/ui/components/project/SenateVote.tsx
@@ -12,10 +12,17 @@
 import { usePrivy } from '@privy-io/react-auth'
 import confetti from 'canvas-confetti'
 import ProposalsABI from 'const/abis/Proposals.json'
-import { DEFAULT_CHAIN_V5, PROPOSALS_ADDRESSES } from 'const/config'
-import React, { memo, useEffect } from 'react'
-import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
+import {
+  DEFAULT_CHAIN_V5,
+  OPERATORS,
+  PROPOSALS_ADDRESSES,
+} from 'const/config'
+import { useRouter } from 'next/router'
+import React, { memo, useEffect, useMemo, useState } from 'react'
+import toast from 'react-hot-toast'
+import { prepareContractCall, readContract, sendAndConfirmTransaction } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
+import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import useProposalData from '@/lib/project/useProposalData'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
@@ -211,6 +218,158 @@ export const SenateVoteButtons = memo(
 SenateVoteButtons.displayName = 'SenateVoteButtons'
 
 // ---------------------------------------------------------------------------
+// Executive-Lead "Close Senate Vote" controls.
+//
+// Mirrors the pattern of `CloseAndTallyButton` (which closes the Member
+// Vote): visible only to OPERATORS (Executive Lead allowlist), POSTs to a
+// backend endpoint which signs `Proposals.tallyVotes(mdp)` as the Proposals
+// contract owner — the owner is the team's HSM/server wallet
+// (`createHSMWallet()`), not any individual EOA, so we can't call
+// `tallyVotes` straight from the browser. The contract's `tallyVotes` is a
+// no-op below quorum, so we disable the button until quorum is met to
+// avoid burning gas on a no-op tx; the API performs the same check before
+// signing as a defense in depth.
+// ---------------------------------------------------------------------------
+function CloseSenateVoteButton({
+  mdp,
+  proposalContract,
+  votedCount,
+  approvalCount,
+  rejectionCount,
+  onClosed,
+}: {
+  mdp: number
+  proposalContract: any
+  votedCount: number
+  approvalCount: number
+  rejectionCount: number
+  onClosed?: () => void
+}) {
+  const router = useRouter()
+  const account = useActiveAccount()
+  const address = account?.address
+
+  const isOperator = useMemo(() => {
+    if (!address) return false
+    return OPERATORS.includes(address.toLowerCase())
+  }, [address])
+
+  const [quorum, setQuorum] = useState<number | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!proposalContract) return
+    let cancelled = false
+    readContract({
+      contract: proposalContract,
+      method: 'function getQuorum() view returns (uint256)',
+      params: [],
+    })
+      .then((result: unknown) => {
+        if (cancelled) return
+        try {
+          setQuorum(Number(result))
+        } catch {
+          setQuorum(null)
+        }
+      })
+      .catch(() => {
+        if (cancelled) return
+        setQuorum(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [proposalContract])
+
+  if (!isOperator) return null
+
+  const quorumReached = quorum != null && votedCount >= quorum
+  const wouldPass = approvalCount * 3 >= votedCount * 2 && votedCount > 0
+  const projectedOutcome = quorumReached
+    ? wouldPass
+      ? 'Will pass — advances to Member Vote'
+      : 'Will fail — proposal cancelled'
+    : null
+
+  const handleClose = async () => {
+    if (submitting || !quorumReached) return
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/proposals/closeSenate', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mdp }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        // Surface the underlying contract revert reason (e.g.
+        // `OwnableUnauthorizedAccount`) when the API includes it; falls
+        // back to the high-level message otherwise. The diagnostic detail
+        // is what the EB needs to fix the actual failure mode without
+        // having to read the server log.
+        const detail =
+          typeof data?.details === 'string' && data.details.length > 0
+            ? `${data.error || 'Failed to close senate vote.'} — ${data.details}`
+            : data?.error || 'Failed to close senate vote.'
+        throw new Error(detail)
+      }
+      toast.success(
+        data?.passed
+          ? 'Senate vote closed — advancing to Member Vote.'
+          : 'Senate vote closed — proposal did not pass.',
+        { style: toastStyle }
+      )
+      onClosed?.()
+      // Re-trigger getServerSideProps so `proposalStatus` flips from
+      // Temperature Check → Voting / Cancelled.
+      router.replace(router.asPath)
+    } catch (err: any) {
+      console.error('Close senate vote failed:', err)
+      toast.error(err?.message || 'Failed to close senate vote.', {
+        style: toastStyle,
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-2 mt-2 p-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5 w-full">
+      <div className="text-[11px] uppercase tracking-wider text-yellow-300/80">
+        Executive Lead Controls
+      </div>
+      <button
+        type="button"
+        onClick={handleClose}
+        disabled={!quorumReached || submitting}
+        className="px-4 py-2 rounded-lg text-sm font-semibold transition-all bg-gradient-to-r from-yellow-500 to-orange-500 hover:from-yellow-400 hover:to-orange-400 text-black disabled:from-gray-600 disabled:to-gray-700 disabled:text-white/60 disabled:cursor-not-allowed"
+      >
+        {submitting
+          ? 'Closing…'
+          : quorumReached
+          ? 'Close Senate Vote'
+          : 'Awaiting senate quorum'}
+      </button>
+      <p className="text-[11px] text-white/60">
+        {quorum == null
+          ? 'Loading quorum…'
+          : `Quorum: ${votedCount}/${quorum} senators voted (${approvalCount} for · ${rejectionCount} against)`}
+      </p>
+      {projectedOutcome && (
+        <p className="text-[11px] text-white/50">{projectedOutcome}</p>
+      )}
+      <p className="text-[11px] text-white/40">
+        Signs{' '}
+        <code className="text-white/60">Proposals.tallyVotes({mdp})</code>{' '}
+        with the HSM owner wallet. Approval threshold is 2/3 of votes cast.
+      </p>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Default export: full-width project-page Senate Vote layout.
 // ---------------------------------------------------------------------------
 
@@ -380,6 +539,16 @@ export default function SenateVote({ mdp }: { mdp: number }) {
           </p>
         )}
       </div>
+
+      {/* Owner controls — close the senate vote and advance the state machine. */}
+      <CloseSenateVoteButton
+        mdp={mdp}
+        proposalContract={proposalContract}
+        votedCount={votedCount}
+        approvalCount={approvalCount}
+        rejectionCount={rejectionCount}
+        onClosed={refetch}
+      />
 
       {/* Senator roster */}
       {senatorTotal > 0 && (

--- a/ui/pages/api/proposals/closeSenate.ts
+++ b/ui/pages/api/proposals/closeSenate.ts
@@ -1,0 +1,239 @@
+import ProposalsABI from 'const/abis/Proposals.json'
+import {
+  PROPOSALS_ADDRESSES,
+  DEFAULT_CHAIN_V5,
+} from 'const/config'
+import { isOperator } from 'middleware/isOperator'
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import { NextApiRequest, NextApiResponse } from 'next'
+import {
+  getContract,
+  prepareContractCall,
+  readContract,
+  sendAndConfirmTransaction,
+} from 'thirdweb'
+import { createHSMWallet } from '@/lib/google/hsm-signer'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import { serverClient } from '@/lib/thirdweb/client'
+
+const chain = DEFAULT_CHAIN_V5
+const chainSlug = getChainSlug(chain)
+
+// thirdweb's RPC layer occasionally returns `undefined` for a successful
+// view call, which then crashes viem's decoder ("Cannot read properties of
+// undefined (reading 'buffer')"). The `vote.ts` endpoint hits the same
+// race and uses an identical retry helper — copied here so each closeSenate
+// click stays self-contained instead of throwing on a flaky read.
+async function readContractWithRetry<T>(
+  contract: any,
+  method: string,
+  params: any[],
+  maxRetries = 4,
+  baseDelayMs = 400
+): Promise<T> {
+  let lastError: any
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const result = await readContract({ contract, method, params })
+      return result as T
+    } catch (error) {
+      lastError = error
+      const message =
+        error instanceof Error ? error.message : String(error ?? '')
+      const transient =
+        (error instanceof TypeError && message.includes('buffer')) ||
+        message.includes('Block not found') ||
+        message.includes('block not found') ||
+        message.includes('rate limit') ||
+        message.includes('timeout') ||
+        message.includes('ECONNRESET')
+      if (!transient || attempt === maxRetries - 1) throw error
+      const delay = baseDelayMs * Math.pow(2, attempt)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
+  throw lastError
+}
+
+// Close the Senate Vote on a non-project proposal by calling
+// `Proposals.tallyVotes(mdp)` from the HSM wallet that owns the Proposals
+// contract. Mirrors `nonProjectVote.ts` (which closes the Member Vote): the
+// Executive Lead clicks the UI button, this endpoint actually signs the tx
+// because `tallyVotes` is `onlyOwner` and the owner is the HSM/server wallet
+// (`createHSMWallet()`) — Executive Lead EOAs cannot call it directly.
+//
+// `tallyVotes` is a no-op below quorum, so we pre-check on-chain and return
+// 400 instead of burning gas on a tx that does nothing. We also reject if
+// the senate vote has already been closed (either approved or failed), and
+// surface the resulting flags so the UI can show "passed" / "failed".
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const mdp = parseInt(req.body?.mdp, 10)
+  if (!Number.isInteger(mdp) || mdp <= 0) {
+    return res
+      .status(400)
+      .json({ error: 'Invalid mdp: must be a positive integer.' })
+  }
+
+  const proposalContract = getContract({
+    client: serverClient,
+    address: PROPOSALS_ADDRESSES[chainSlug],
+    abi: ProposalsABI.abi as any,
+    chain: chain,
+  })
+
+  // The Proposals JSON ABI in the repo (newer, unreleased version) omits
+  // `getQuorum()` — the live Arbitrum contract is the older Proposals.sol
+  // which still exposes it. We pass fully-qualified signatures here so
+  // thirdweb's readContract bypasses the JSON ABI lookup and just calls
+  // the on-chain function directly.
+  let tempCheckApproved: boolean
+  let tempCheckFailed: boolean
+  let voteCount: number
+  let approvalCount: number
+  let quorum: number
+  try {
+    const [approvedRaw, failedRaw, countRaw, approvalRaw, quorumRaw] =
+      await Promise.all([
+        readContractWithRetry<boolean>(
+          proposalContract,
+          'function tempCheckApproved(uint256) view returns (bool)',
+          [mdp]
+        ),
+        readContractWithRetry<boolean>(
+          proposalContract,
+          'function tempCheckFailed(uint256) view returns (bool)',
+          [mdp]
+        ),
+        readContractWithRetry<bigint>(
+          proposalContract,
+          'function tempCheckVoteCount(uint256) view returns (uint256)',
+          [mdp]
+        ),
+        readContractWithRetry<bigint>(
+          proposalContract,
+          'function tempCheckApprovalCount(uint256) view returns (uint256)',
+          [mdp]
+        ),
+        readContractWithRetry<bigint>(
+          proposalContract,
+          'function getQuorum() view returns (uint256)',
+          []
+        ),
+      ])
+    tempCheckApproved = Boolean(approvedRaw)
+    tempCheckFailed = Boolean(failedRaw)
+    voteCount = Number(countRaw)
+    approvalCount = Number(approvalRaw)
+    quorum = Number(quorumRaw)
+  } catch (error) {
+    console.error('[closeSenate] failed to read proposal state:', error)
+    return res
+      .status(500)
+      .json({ error: 'Failed to read proposal state from chain.' })
+  }
+
+  if (tempCheckApproved) {
+    return res.status(400).json({
+      error: 'Senate vote already closed: proposal already passed temp check.',
+    })
+  }
+  if (tempCheckFailed) {
+    return res.status(400).json({
+      error: 'Senate vote already closed: proposal already failed temp check.',
+    })
+  }
+  if (voteCount < quorum) {
+    return res.status(400).json({
+      error: `Senate quorum not reached: ${voteCount}/${quorum} senators voted.`,
+      voteCount,
+      quorum,
+    })
+  }
+
+  // Arbitrum blocks land every ~250ms and thirdweb's gas estimator
+  // occasionally hits "Block not found" mid-call when the RPC node serves
+  // a `latest` it can't immediately fetch. Retry a few times before giving
+  // up — every other path that signs Proposals txs (e.g. nonProjectVote.ts)
+  // hits the same race in practice.
+  let txHash: string | undefined
+  let lastError: unknown
+  const account = await createHSMWallet()
+  const transaction = prepareContractCall({
+    contract: proposalContract,
+    method: 'function tallyVotes(uint256)',
+    params: [mdp],
+  })
+  const MAX_TX_ATTEMPTS = 4
+  for (let attempt = 1; attempt <= MAX_TX_ATTEMPTS; attempt++) {
+    try {
+      const receipt = await sendAndConfirmTransaction({ transaction, account })
+      txHash = receipt.transactionHash
+      break
+    } catch (error) {
+      lastError = error
+      const message =
+        error instanceof Error ? error.message : String(error ?? '')
+      const transient =
+        message.includes('Block not found') ||
+        message.includes('block not found') ||
+        message.includes('rate limit') ||
+        message.includes('timeout')
+      console.error(
+        `[closeSenate] tallyVotes tx attempt ${attempt}/${MAX_TX_ATTEMPTS} failed:`,
+        error
+      )
+      if (!transient || attempt === MAX_TX_ATTEMPTS) break
+      const delayMs = 750 * Math.pow(2, attempt - 1)
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+  if (!txHash) {
+    return res.status(500).json({
+      error: 'Failed to send tallyVotes transaction.',
+      details:
+        lastError instanceof Error ? lastError.message : String(lastError),
+    })
+  }
+
+  // Re-read state so the UI can show the actual outcome rather than guess
+  // from the pre-tally numbers (the tx already confirmed at this point).
+  let passed = false
+  try {
+    const [approvedAfter, failedAfter] = await Promise.all([
+      readContractWithRetry<boolean>(
+        proposalContract,
+        'function tempCheckApproved(uint256) view returns (bool)',
+        [mdp]
+      ),
+      readContractWithRetry<boolean>(
+        proposalContract,
+        'function tempCheckFailed(uint256) view returns (bool)',
+        [mdp]
+      ),
+    ])
+    passed = Boolean(approvedAfter) && !Boolean(failedAfter)
+  } catch (error) {
+    console.warn(
+      '[closeSenate] post-tx read failed; defaulting passed flag to vote ratio.',
+      error
+    )
+    passed = approvalCount * 3 >= voteCount * 2
+  }
+
+  return res.status(200).json({
+    mdp,
+    passed,
+    voteCount,
+    approvalCount,
+    quorum,
+    txHash,
+  })
+}
+
+export default withMiddleware(handler, rateLimit, isOperator)


### PR DESCRIPTION
## Summary

Adds an Executive-Lead-gated **Close Senate Vote** panel inside the Senate Vote section on `/project/[tokenId]` so the EB can advance a non-project proposal from Temperature Check → Voting (Member Vote) without leaving the site. Mirrors the Member Vote close pattern (`CloseAndTallyButton` + `/api/proposals/nonProjectVote`).

Today, closing a Senate vote requires manually invoking `Proposals.tallyVotes(mdp)` on-chain because the contract owner is the team's HSM wallet (`createHSMWallet()`), not any individual EOA. There was no in-app way to do it. With this PR an `OPERATORS`-listed wallet can click the button and the backend signs the call as the contract owner.

### Why
- MDP-249 (Executive Branch Q3 2026 proposal) reached senate quorum (6/7 voted, 6 in favor) and needs to advance to Member Vote. Today this requires hand-running `tallyVotes(249)` against Arbitrum from the HSM wallet — which is fine but not discoverable, and creates the same friction every cycle.
- Adds a clean parallel to the existing Member Vote close path so both halves of the non-project proposal lifecycle are accessible from the proposal page.

## Changes

- **New endpoint** `POST /api/proposals/closeSenate` (`ui/pages/api/proposals/closeSenate.ts`)
  - Gated by the existing `isOperator` middleware (so `OPERATORS` allowlist is enforced server-side, not just in the UI).
  - Pre-checks that the proposal is not already approved/failed and that `tempCheckVoteCount >= getQuorum()` before sending the tx (`tallyVotes` is a no-op below quorum on-chain).
  - Signs `Proposals.tallyVotes(mdp)` via `createHSMWallet()` (same pattern used by `nonProjectVote.ts`, `vote.ts`, `submit.ts`).
  - Reads use a local `readContractWithRetry` helper to absorb the buffer/decode race and "Block not found" gas-estimation race that thirdweb intermittently surfaces for Arbitrum view calls — same workaround as `vote.ts`.
  - Send loop retries on transient errors (4 attempts, exponential backoff) and bails immediately on real reverts.
  - Re-reads `tempCheckApproved`/`tempCheckFailed` post-tx and returns `{ mdp, passed, voteCount, approvalCount, quorum, txHash }` so the UI can render the actual outcome.
  - Error responses include a `details` field with the underlying viem/contract message (e.g. `OwnableUnauthorizedAccount`) so the UI can surface it instead of a generic "failed".

- **`ui/components/project/SenateVote.tsx`** — new `CloseSenateVoteButton` rendered inside the existing Senate Vote panel.
  - Visible only to wallets in `OPERATORS` (matches `CloseAndTallyButton`).
  - Reads `getQuorum()` from chain; disabled with subline `Quorum: N/M senators voted (N for · N against)` until quorum is reached.
  - Once quorum is met, shows a projection — *"Will pass — advances to Member Vote"* (≥2/3 approval) or *"Will fail — proposal cancelled"* — so the EB sees the outcome before signing.
  - Click POSTs to `/api/proposals/closeSenate`, toasts success/failure (toast surfaces `details` so contract reverts are diagnosable without server logs), then `router.replace(router.asPath)` to re-run `getServerSideProps`. That flips `proposalStatus` from `Temperature Check` → `Voting` (or `Cancelled`) and the page automatically swaps the Senate Vote section for the Member Vote section.

### Notes

- All on-chain calls in the new endpoint use **fully-qualified Solidity signatures** (e.g. `'function getQuorum() view returns (uint256)'`) instead of bare method names. The deployed Proposals contract on Arbitrum is the older `getQuorum()`-based source, while the JSON ABI shipped in `ui/const/abis/Proposals.json` is from a newer unreleased version that replaced it with `quorum()`/`threshold()` storage variables. Bare method names fail to resolve against the JSON ABI, so qualifying them bypasses the lookup. Worth a follow-up to re-sync the on-disk ABI with the deployed bytecode (or deploy the newer Proposals contract version).
- No changes to the on-chain contract or to the existing senate vote UI for senators — this is purely an additive control panel for Executive Leads.

## Test plan

- [ ] Deploy preview to Vercel (this branch); confirm the page renders for an unauthenticated visitor with no regression to the Senate Vote section.
- [ ] Connect pmoncada.eth (in `OPERATORS`) to `https://<preview>/project/249`. Verify:
  - Stat pills show `👍 6 · 👎 0 · 🗳️ 6 of 7`.
  - Executive Lead Controls panel renders with **Close Senate Vote** **enabled**, subline `Quorum: 6/5 senators voted (6 for · 0 against)`, projection *"Will pass — advances to Member Vote"*.
- [ ] Connect a non-OPERATORS wallet — verify the Executive Lead Controls panel does **not** render.
- [ ] Click **Close Senate Vote** as pmoncada.eth on the preview/prod build. Verify:
  - Tx succeeds; success toast: *"Senate vote closed — advancing to Member Vote."*
  - On-chain: `tempCheckApproved(249) = true`, `tempCheckApprovedTimestamp(249)` non-zero (verify with `cast call`).
  - Page re-renders into the Member Vote section (`<ProposalVotes>` quadratic Yes/No/Abstain) with `<CloseAndTallyButton>` showing a 5d countdown.
- [ ] Negative path: try clicking on a proposal that has not reached quorum — button is disabled with `Awaiting senate quorum` label. Try POSTing to the endpoint directly without a session — 401/403. Try POSTing as a non-OPERATOR — 403.
- [ ] Confirm the existing Member Vote close (`CloseAndTallyButton`) is unaffected.
