### PR TITLE
Member Vote UX: right-rail voting, network enforcement, tabs, Abstain

### DIFF
--- a/ui/components/nance/NewVoteButton.tsx
+++ b/ui/components/nance/NewVoteButton.tsx
@@ -84,7 +84,6 @@ export default function NewVoteButton({
           votes={votes}
           project={project}
           address={address}
-          spaceHideAbstain={true}
           totalVMOONEY={totalVMOONEY}
         />
       )}

--- a/ui/components/nance/VotingModal.tsx
+++ b/ui/components/nance/VotingModal.tsx
@@ -178,18 +178,22 @@ export default function VotingModal({
   }
 
   const renderVoteButton = () => {
-    // PrivyWeb3Button owns the wallet/network state machine: it flips its
-    // own label/handler to "Sign In" when unauthenticated and to
+    // PrivyWeb3Button owns the wallet/network state machine: it flips
+    // its own label/handler to "Sign In" when unauthenticated and to
     // "Switch Network" when the connected chain doesn't match
-    // `requiredChain`. We only need to drive the *action* button label
-    // (state 2) and disable it when the form isn't submittable yet.
+    // `requiredChain`. We only need to drive the *action* button
+    // label (state 2). `actionDisabled` (vs `isDisabled`) is
+    // important here: blocking the whole button would also block
+    // the Switch Network affordance, leaving wrong-network users
+    // unable to resolve their network *before* the form considers
+    // itself submittable.
     let canVote = false
     let actionLabel = 'Submit vote'
 
     if (!SUPPORTED_VOTING_TYPES.includes(proposalType)) {
       actionLabel = 'Not supported'
     } else if (choice === undefined) {
-      actionLabel = 'You need to select a choice'
+      actionLabel = 'Select a choice'
     } else if (vp <= 0) {
       actionLabel = 'No voting power'
     } else if (submitting) {
@@ -205,7 +209,7 @@ export default function VotingModal({
         loadingLabel="Submitting..."
         action={handleSubmit}
         requiredChain={DEFAULT_CHAIN_V5}
-        isDisabled={!canVote}
+        actionDisabled={!canVote}
         noGradient
         noPadding
         className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 disabled:from-gray-600 disabled:to-gray-700 disabled:cursor-not-allowed !text-white py-3 px-4 rounded-lg font-semibold transition-all duration-200 transform hover:scale-105 disabled:hover:scale-100 shadow-lg disabled:opacity-50 !text-base"

--- a/ui/components/nance/VotingModal.tsx
+++ b/ui/components/nance/VotingModal.tsx
@@ -26,7 +26,6 @@ interface VotingProps {
   modalIsOpen: boolean
   closeModal: () => void
   address: string | undefined
-  spaceHideAbstain: boolean
   project: Project
   votes: any[]
   totalVMOONEY: any
@@ -38,7 +37,6 @@ export default function VotingModal({
   modalIsOpen,
   closeModal,
   address,
-  spaceHideAbstain,
   project,
   votes,
   totalVMOONEY,
@@ -334,7 +332,6 @@ export default function VotingModal({
                                 value={choice}
                                 setValue={setChoice}
                                 choices={choices}
-                                hideAbstain={spaceHideAbstain}
                               />
                             )}
                           </div>
@@ -391,16 +388,12 @@ function SingleClickChoiceSelector({
   value,
   setValue,
   choices,
-  hideAbstain = false,
 }: Omit<SelectorProps, 'value'> & {
   value: { [key: string]: number } | undefined
-  hideAbstain?: boolean
 }) {
   const visibleChoices = useMemo(() => {
-    return choices
-      .map((label, index) => ({ label, key: String(index + 1) }))
-      .filter((c) => !(hideAbstain && c.label.toLowerCase() === 'abstain'))
-  }, [choices, hideAbstain])
+    return choices.map((label, index) => ({ label, key: String(index + 1) }))
+  }, [choices])
 
   // Argmax over the existing distribution. Single-click votes are
   // always 100/0/0 so this resolves trivially; it also gracefully

--- a/ui/components/nance/VotingModal.tsx
+++ b/ui/components/nance/VotingModal.tsx
@@ -261,12 +261,9 @@ export default function VotingModal({
                             <div className="w-1.5 h-1.5 bg-blue-600 rounded-full"></div>
                           </div>
                         </div>
-                        <div>
-                          <h2 className="text-lg font-bold text-white">Vote on Proposal</h2>
-                          <p className="text-gray-300 text-xs">
-                            Cast your vote and make your voice heard
-                          </p>
-                        </div>
+                        <h2 className="text-lg font-bold text-white">
+                          Vote on Proposal
+                        </h2>
                       </div>
 
                       {/* Proposal Name */}
@@ -342,34 +339,21 @@ export default function VotingModal({
                             )}
                           </div>
 
-                          {/* Wrong-network banner — shows before the user
-                              even clicks. The submit button itself will
-                              also flip to "Switch Network" via
-                              PrivyWeb3Button, but a banner makes the
-                              cause unambiguous (MetaMask on Ethereum vs.
-                              Arbitrum was the previous failure mode). */}
+                          {/* Wrong-network indicator. The PrivyWeb3Button
+                              below already swaps its label to "Switch
+                              Network" — this just names the destination
+                              so the user doesn't have to guess which
+                              network. */}
                           {isWrongNetwork && (
-                            <div className="rounded-lg border border-yellow-400/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-100">
-                              <p className="font-semibold mb-0.5">
-                                Wrong network detected
-                              </p>
-                              <p className="text-yellow-100/80">
-                                Your wallet is connected to chain{' '}
-                                <code className="text-yellow-50">
-                                  {connectedChainId}
-                                </code>
-                                . MoonDAO proposals live on{' '}
-                                <span className="font-medium">
-                                  {DEFAULT_CHAIN_V5.name ?? 'Arbitrum One'}
-                                </span>{' '}
-                                (chain id {requiredChainId}). Click{' '}
-                                <span className="font-medium">
-                                  Switch Network
-                                </span>{' '}
-                                below — your wallet will prompt you and
-                                the button will then become{' '}
-                                <span className="font-medium">Submit vote</span>.
-                              </p>
+                            <div className="rounded-lg border border-yellow-400/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-100 flex items-center gap-2">
+                              <span className="font-semibold">
+                                Wrong network.
+                              </span>
+                              <span className="text-yellow-100/80">
+                                Switch to{' '}
+                                {DEFAULT_CHAIN_V5.name ?? 'Arbitrum One'} to
+                                vote.
+                              </span>
                             </div>
                           )}
 

--- a/ui/components/nance/VotingModal.tsx
+++ b/ui/components/nance/VotingModal.tsx
@@ -1,10 +1,15 @@
-import { Dialog, RadioGroup, Transition } from '@headlessui/react'
-import { XMarkIcon } from '@heroicons/react/24/solid'
+import { Dialog, Transition } from '@headlessui/react'
+import {
+  CheckCircleIcon,
+  MinusCircleIcon,
+  XCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/solid'
 import { useWallets } from '@privy-io/react-auth'
+import confetti from 'canvas-confetti'
 import NonProjectProposalABI from 'const/abis/NonProjectProposal.json'
 import { DEFAULT_CHAIN_V5, NON_PROJECT_PROPOSAL_ADDRESSES } from 'const/config'
 import { useState, Fragment, useEffect, useMemo } from 'react'
-import { useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
 import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
@@ -145,7 +150,21 @@ export default function VotingModal({
         { label: 'senate-vote-notification' }
       )
 
+      // Celebrate + dismiss. Same confetti palette the SenateVote
+      // component uses on a successful approve so the visual language
+      // stays consistent across both vote stages. Closing the modal
+      // here means the user lands back on the proposal page (where
+      // the right-rail sidebar reflects their vote on the next
+      // getServerSideProps refresh) without having to hunt for the X.
+      confetti({
+        particleCount: 150,
+        spread: 100,
+        origin: { y: 0.6 },
+        shapes: ['circle', 'star'],
+        colors: ['#22c55e', '#4ade80', '#86efac', '#ffffff', '#FFD700'],
+      })
       setSubmitting(false)
+      closeModal()
     } catch (error) {
       console.error('Error submitting distribution:', error)
       toast.error('Error submitting distribution. Please try again.', {
@@ -290,31 +309,35 @@ export default function VotingModal({
                         </h3>
 
                         <form className="space-y-4">
-                          {/* Option selector */}
+                          {/* Option selector. Quadratic is what every
+                              non-project proposal actually uses today,
+                              and the old WeightedChoiceSelector forced
+                              voters to type a percentage per choice
+                              (which routinely failed the
+                              "must equal 100%" guard and felt like
+                              busywork for a yes/no question). The new
+                              SingleClickChoiceSelector encodes a single
+                              choice as `{ "<index>": 100 }`, the exact
+                              shape `runQuadraticVoting` already
+                              expects, so the on-chain tally stays
+                              compatible with every prior vote — but
+                              the user just clicks once. */}
                           <div>
                             <h4 className="text-gray-300 font-medium text-xs uppercase tracking-wide mb-3">
                               Select Your Choice
                             </h4>
-                            {(proposalType == 'single-choice' || proposalType == 'basic') && (
-                              <BasicChoiceSelector
-                                value={choice}
-                                setValue={setChoice}
-                                choices={choices}
-                              />
-                            )}
-                            {proposalType == 'weighted' ||
-                              (proposalType == 'quadratic' && (
-                                <WeightedChoiceSelector
-                                  value={choice}
-                                  setValue={setChoice}
-                                  choices={choices}
-                                />
-                              ))}
-                            {proposalType == 'ranked-choice' && (
+                            {proposalType == 'ranked-choice' ? (
                               <RankedChoiceSelector
                                 value={choice || []}
                                 setValue={setChoice}
                                 choices={choices}
+                              />
+                            ) : (
+                              <SingleClickChoiceSelector
+                                value={choice}
+                                setValue={setChoice}
+                                choices={choices}
+                                hideAbstain={spaceHideAbstain}
                               />
                             )}
                           </div>
@@ -372,95 +395,105 @@ interface SelectorProps {
   choices: string[]
 }
 
-function BasicChoiceSelector({ value, setValue, choices }: SelectorProps) {
-  return (
-    <RadioGroup value={value} onChange={setValue}>
-      <div className="grid grid-cols-3 gap-3">
-        {choices.map((choice, index) => (
-          <RadioGroup.Option
-            as="div"
-            key={choice}
-            value={index + 1}
-            className={({ active, checked }) =>
-              classNames(
-                'relative block cursor-pointer rounded-lg p-3 transition-all duration-200 text-center',
-                checked
-                  ? 'bg-blue-500/20 border-2 border-blue-500/50 shadow-lg'
-                  : 'bg-black/20 border border-white/10 hover:bg-black/30 hover:border-white/20',
-                active ? 'ring-2 ring-blue-500/50' : ''
-              )
-            }
-          >
-            {({ active, checked }) => (
-              <>
-                <div className="flex items-center justify-center">
-                  <RadioGroup.Label as="p" className="text-sm font-medium text-white">
-                    {choice}
-                  </RadioGroup.Label>
-                </div>
-              </>
-            )}
-          </RadioGroup.Option>
-        ))}
-      </div>
-    </RadioGroup>
-  )
-}
-
-function WeightedChoiceSelector({
+// Single-click yes/no/abstain selector. Encodes the picked option as
+// `{ "<index+1>": 100 }` — the same shape the on-chain
+// NonProjectProposal table stores and `runQuadraticVoting` expects, so
+// the tally code is unchanged. Shown for `quadratic` / `weighted` /
+// `basic` / `single-choice` proposal types now that the underlying
+// vote is binary in practice. Edit mode highlights whichever choice
+// has the largest weight in the existing distribution (argmax) so
+// re-opening a previously cast vote shows the user's prior pick.
+function SingleClickChoiceSelector({
   value,
   setValue,
   choices,
+  hideAbstain = false,
 }: Omit<SelectorProps, 'value'> & {
   value: { [key: string]: number } | undefined
+  hideAbstain?: boolean
 }) {
-  const { register, getValues, watch } = useForm()
+  const visibleChoices = useMemo(() => {
+    return choices
+      .map((label, index) => ({ label, key: String(index + 1) }))
+      .filter((c) => !(hideAbstain && c.label.toLowerCase() === 'abstain'))
+  }, [choices, hideAbstain])
 
-  useEffect(() => {
-    // sync form state
-    const subscription = watch((_) => {
-      const values = getValues()
-      const newValue: { [key: string]: any } = {}
-      // remove empty values
-      for (const key in values) {
-        const val = values[key]
-        if (!isNaN(val) && val > 0) {
-          newValue[key] = val
-        }
-      }
-      setValue(newValue)
-    })
+  // Argmax over the existing distribution. Single-click votes are
+  // always 100/0/0 so this resolves trivially; it also gracefully
+  // highlights the dominant choice for legacy split votes.
+  const selectedKey = useMemo(() => {
+    if (!value) return null
+    let best: [string, number] | null = null
+    for (const [k, v] of Object.entries(value)) {
+      const n = Number(v)
+      if (!Number.isFinite(n)) continue
+      if (best === null || n > best[1]) best = [k, n]
+    }
+    return best && best[1] > 0 ? best[0] : null
+  }, [value])
 
-    return () => subscription.unsubscribe()
-  }, [watch])
+  const styleFor = (label: string, isSelected: boolean) => {
+    const base =
+      'group flex flex-col items-center justify-center gap-2 rounded-xl border-2 p-4 transition-all duration-200 cursor-pointer select-none focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black/20'
+    if (label.toLowerCase() === 'yes' || label.toLowerCase() === 'for') {
+      return classNames(
+        base,
+        isSelected
+          ? 'bg-green-500/25 border-green-400 shadow-lg shadow-green-500/20 scale-[1.02]'
+          : 'bg-green-500/5 border-green-500/20 hover:bg-green-500/15 hover:border-green-400/60'
+      )
+    }
+    if (label.toLowerCase() === 'no' || label.toLowerCase() === 'against') {
+      return classNames(
+        base,
+        isSelected
+          ? 'bg-red-500/25 border-red-400 shadow-lg shadow-red-500/20 scale-[1.02]'
+          : 'bg-red-500/5 border-red-500/20 hover:bg-red-500/15 hover:border-red-400/60'
+      )
+    }
+    return classNames(
+      base,
+      isSelected
+        ? 'bg-gray-500/25 border-gray-300 shadow-lg shadow-gray-500/20 scale-[1.02]'
+        : 'bg-gray-500/5 border-gray-500/20 hover:bg-gray-500/15 hover:border-gray-300/60'
+    )
+  }
 
-  const totalUnits = Object.values(value ?? {}).reduce((a, b) => a + b, 0)
+  const iconFor = (label: string, isSelected: boolean) => {
+    const cls = isSelected ? 'w-7 h-7' : 'w-7 h-7 opacity-70 group-hover:opacity-100'
+    if (label.toLowerCase() === 'yes' || label.toLowerCase() === 'for') {
+      return <CheckCircleIcon className={`${cls} text-green-400`} />
+    }
+    if (label.toLowerCase() === 'no' || label.toLowerCase() === 'against') {
+      return <XCircleIcon className={`${cls} text-red-400`} />
+    }
+    return <MinusCircleIcon className={`${cls} text-gray-300`} />
+  }
 
   return (
-    <div className="space-y-3">
-      {choices.map((choice, index) => (
-        <div
-          key={choice}
-          className="bg-black/20 border border-white/10 rounded-lg p-4 hover:bg-black/30 hover:border-white/20 transition-all duration-200"
-        >
-          <div className="flex items-center gap-4">
-            <label className="flex-1 text-white font-medium">{choice}</label>
-            <input
-              className="w-24 bg-black/30 border border-white/20 rounded-lg px-3 py-2 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-all duration-200"
-              type="number"
-              placeholder="0"
-              min={0}
-              step={1}
-              defaultValue={value ? value[index + 1] : 0}
-              {...register((index + 1).toString(), {
-                shouldUnregister: true,
-                valueAsNumber: true,
-              })}
-            />
-            <span className="w-16 text-right text-gray-300 text-sm">%</span>
-          </div>
-        </div>
-      ))}
+    <div
+      className={classNames(
+        'grid gap-3',
+        visibleChoices.length === 2 ? 'grid-cols-2' : 'grid-cols-3'
+      )}
+      role="radiogroup"
+    >
+      {visibleChoices.map(({ label, key }) => {
+        const isSelected = selectedKey === key
+        return (
+          <button
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            key={key}
+            onClick={() => setValue({ [key]: 100 })}
+            className={styleFor(label, isSelected)}
+          >
+            {iconFor(label, isSelected)}
+            <span className="text-sm font-semibold text-white">{label}</span>
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/ui/components/nance/VotingModal.tsx
+++ b/ui/components/nance/VotingModal.tsx
@@ -9,10 +9,11 @@ import { useWallets } from '@privy-io/react-auth'
 import confetti from 'canvas-confetti'
 import NonProjectProposalABI from 'const/abis/NonProjectProposal.json'
 import { DEFAULT_CHAIN_V5, NON_PROJECT_PROPOSAL_ADDRESSES } from 'const/config'
-import { useState, Fragment, useEffect, useMemo } from 'react'
+import { useState, Fragment, useEffect, useMemo, useContext } from 'react'
 import toast from 'react-hot-toast'
 import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
+import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import { formatNumberUSStyle } from '@/lib/nance'
 import { sendOnchainNotification } from '@/lib/notifications/sendOnchainNotification'
@@ -78,13 +79,20 @@ export default function VotingModal({
   // first-class banner inside the modal so the user sees it *before*
   // signing, in addition to the Submit button auto-flipping to a "Switch
   // Network" CTA via PrivyWeb3Button.
+  // Read the chainId from the *same* wallet PrivyWeb3Button will sign
+  // with (selectedWallet via PrivyWalletContext). Earlier this read
+  // wallets?.[0] which silently disagreed with the button when the
+  // user had multiple wallets connected and a non-zero one selected
+  // — the banner could green-light a Submit while the button was
+  // still showing "Switch Network", or vice versa.
   const { wallets } = useWallets()
+  const { selectedWallet } = useContext(PrivyWalletContext)
   const connectedChainId = useMemo(() => {
-    const raw = wallets?.[0]?.chainId
+    const raw = wallets?.[selectedWallet]?.chainId
     if (!raw) return undefined
     const parts = String(raw).split(':')
     return Number(parts[parts.length - 1]) || undefined
-  }, [wallets])
+  }, [wallets, selectedWallet])
   const requiredChainId = DEFAULT_CHAIN_V5.id
   const isWrongNetwork =
     Boolean(address) &&
@@ -451,21 +459,30 @@ function SingleClickChoiceSelector({
     return <MinusCircleIcon className={`${cls} text-gray-300`} />
   }
 
+  // Plain <button>s with aria-pressed, grouped by `role="group"`
+  // and the form's existing `id="options-heading"` label. We avoid
+  // claiming `role="radiogroup"` / `role="radio"` because the full
+  // ARIA radio pattern (roving tabIndex, arrow-key navigation,
+  // Home/End handling) isn't implemented here — and a half-spec'd
+  // radio group is worse for screen readers than a plain button
+  // group with toggle state. Tab still walks each button, Space /
+  // Enter activates them via native button keyboard handling.
   return (
     <div
       className={classNames(
         'grid gap-3',
         visibleChoices.length === 2 ? 'grid-cols-2' : 'grid-cols-3'
       )}
-      role="radiogroup"
+      role="group"
+      aria-labelledby="options-heading"
     >
       {visibleChoices.map(({ label, key }) => {
         const isSelected = selectedKey === key
         return (
           <button
             type="button"
-            role="radio"
-            aria-checked={isSelected}
+            aria-pressed={isSelected}
+            aria-label={label}
             key={key}
             onClick={() => setValue({ [key]: 100 })}
             className={styleFor(label, isSelected)}

--- a/ui/components/nance/VotingModal.tsx
+++ b/ui/components/nance/VotingModal.tsx
@@ -1,8 +1,9 @@
 import { Dialog, RadioGroup, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/solid'
+import { useWallets } from '@privy-io/react-auth'
 import NonProjectProposalABI from 'const/abis/NonProjectProposal.json'
 import { DEFAULT_CHAIN_V5, NON_PROJECT_PROPOSAL_ADDRESSES } from 'const/config'
-import { useState, Fragment, useEffect } from 'react'
+import { useState, Fragment, useEffect, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
 import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
@@ -14,6 +15,7 @@ import { Project } from '@/lib/project/useProjectData'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
 import { classNames } from '@/lib/utils/tailwind'
+import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
 
 interface VotingProps {
   modalIsOpen: boolean
@@ -65,6 +67,26 @@ export default function VotingModal({
   const choices = ['Yes', 'No', 'Abstain'] // could make this dynamic in the future
   // external
   const vp = Math.sqrt(totalVMOONEY) || 0
+
+  // The previous voter to hit `nonce has already been used` was on the wrong
+  // network — MetaMask was on Ethereum, vote was sent against the
+  // NonProjectProposal contract that only exists on Arbitrum, and the
+  // signed tx ended up at a stale nonce. Surface the chain mismatch as a
+  // first-class banner inside the modal so the user sees it *before*
+  // signing, in addition to the Submit button auto-flipping to a "Switch
+  // Network" CTA via PrivyWeb3Button.
+  const { wallets } = useWallets()
+  const connectedChainId = useMemo(() => {
+    const raw = wallets?.[0]?.chainId
+    if (!raw) return undefined
+    const parts = String(raw).split(':')
+    return Number(parts[parts.length - 1]) || undefined
+  }, [wallets])
+  const requiredChainId = DEFAULT_CHAIN_V5.id
+  const isWrongNetwork =
+    Boolean(address) &&
+    Boolean(connectedChainId) &&
+    connectedChainId !== requiredChainId
 
   const handleSubmit = async () => {
     if (!choice) {
@@ -139,35 +161,38 @@ export default function VotingModal({
   }
 
   const renderVoteButton = () => {
+    // PrivyWeb3Button owns the wallet/network state machine: it flips its
+    // own label/handler to "Sign In" when unauthenticated and to
+    // "Switch Network" when the connected chain doesn't match
+    // `requiredChain`. We only need to drive the *action* button label
+    // (state 2) and disable it when the form isn't submittable yet.
     let canVote = false
-    let label = 'Close'
+    let actionLabel = 'Submit vote'
 
-    if (address == '') {
-      label = 'Wallet not connected'
-    } else if (!SUPPORTED_VOTING_TYPES.includes(proposalType)) {
-      label = 'Not supported'
+    if (!SUPPORTED_VOTING_TYPES.includes(proposalType)) {
+      actionLabel = 'Not supported'
     } else if (choice === undefined) {
-      label = 'You need to select a choice'
-    } else if (vp > 0) {
-      if (submitting) {
-        label = 'Submitting...'
-      } else {
-        label = 'Submit vote'
-        canVote = true
-      }
+      actionLabel = 'You need to select a choice'
+    } else if (vp <= 0) {
+      actionLabel = 'No voting power'
+    } else if (submitting) {
+      actionLabel = 'Submitting...'
     } else {
-      label = 'Close'
+      canVote = true
+      actionLabel = 'Submit vote'
     }
 
     return (
-      <button
-        type="button"
-        disabled={!canVote}
-        onClick={canVote ? handleSubmit : closeModal}
-        className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 disabled:from-gray-600 disabled:to-gray-700 disabled:cursor-not-allowed text-white py-3 px-4 rounded-lg font-semibold transition-all duration-200 transform hover:scale-105 disabled:hover:scale-100 shadow-lg disabled:opacity-50"
-      >
-        {label}
-      </button>
+      <PrivyWeb3Button
+        label={actionLabel}
+        loadingLabel="Submitting..."
+        action={handleSubmit}
+        requiredChain={DEFAULT_CHAIN_V5}
+        isDisabled={!canVote}
+        noGradient
+        noPadding
+        className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 disabled:from-gray-600 disabled:to-gray-700 disabled:cursor-not-allowed !text-white py-3 px-4 rounded-lg font-semibold transition-all duration-200 transform hover:scale-105 disabled:hover:scale-100 shadow-lg disabled:opacity-50 !text-base"
+      />
     )
   }
 
@@ -293,6 +318,37 @@ export default function VotingModal({
                               />
                             )}
                           </div>
+
+                          {/* Wrong-network banner — shows before the user
+                              even clicks. The submit button itself will
+                              also flip to "Switch Network" via
+                              PrivyWeb3Button, but a banner makes the
+                              cause unambiguous (MetaMask on Ethereum vs.
+                              Arbitrum was the previous failure mode). */}
+                          {isWrongNetwork && (
+                            <div className="rounded-lg border border-yellow-400/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-100">
+                              <p className="font-semibold mb-0.5">
+                                Wrong network detected
+                              </p>
+                              <p className="text-yellow-100/80">
+                                Your wallet is connected to chain{' '}
+                                <code className="text-yellow-50">
+                                  {connectedChainId}
+                                </code>
+                                . MoonDAO proposals live on{' '}
+                                <span className="font-medium">
+                                  {DEFAULT_CHAIN_V5.name ?? 'Arbitrum One'}
+                                </span>{' '}
+                                (chain id {requiredChainId}). Click{' '}
+                                <span className="font-medium">
+                                  Switch Network
+                                </span>{' '}
+                                below — your wallet will prompt you and
+                                the button will then become{' '}
+                                <span className="font-medium">Submit vote</span>.
+                              </p>
+                            </div>
+                          )}
 
                           {/* Vote button */}
                           <div className="pt-2">{renderVoteButton()}</div>

--- a/ui/components/privy/PrivyWeb3Button.tsx
+++ b/ui/components/privy/PrivyWeb3Button.tsx
@@ -20,7 +20,17 @@ type PrivyWeb3BtnProps = {
   label: any
   type?: string
   action: Function
+  /** Disables every state of the button (Connect / Switch Network /
+   *  Action). Use sparingly — usually only for hard "this whole
+   *  surface is read-only" cases, since it also blocks the
+   *  Switch Network affordance for wrong-network users. For
+   *  per-form validation prefer `actionDisabled`. */
   isDisabled?: boolean
+  /** Disables only the Action state (state 2). Connect Wallet
+   *  and Switch Network remain clickable so a wrong-network user
+   *  can still resolve their network *before* the form is
+   *  considered submittable. */
+  actionDisabled?: boolean
   className?: string
   onSuccess?: Function
   onError?: Function
@@ -68,6 +78,7 @@ export function PrivyWeb3Button({
   type = 'button',
   action,
   isDisabled = false,
+  actionDisabled = false,
   className = '',
   onSuccess,
   onError,
@@ -264,7 +275,9 @@ export function PrivyWeb3Button({
               isProcessingRef.current = false
             }
           }}
-          isDisabled={isDisabled || isLoading || isProcessing}
+          isDisabled={
+            isDisabled || actionDisabled || isLoading || isProcessing
+          }
           noPadding={noPadding}
           noGradient={noGradient}
         >

--- a/ui/components/project/CloseAndTallyButton.tsx
+++ b/ui/components/project/CloseAndTallyButton.tsx
@@ -113,10 +113,6 @@ export default function CloseAndTallyButton({
       {remainingLabel && (
         <p className="text-[11px] text-white/60">{remainingLabel}</p>
       )}
-      <p className="text-[11px] text-white/50">
-        Runs the quadratic vMOONEY tally on the NonProjectProposal table and
-        flips this proposal's status on-chain.
-      </p>
     </div>
   )
 }

--- a/ui/components/project/MemberVoteSidebar.tsx
+++ b/ui/components/project/MemberVoteSidebar.tsx
@@ -135,6 +135,16 @@ export default function MemberVoteSidebar({
   // both sidebar cards read as peers.
   const isActive = mode === 'voting'
 
+  // Reveal the per-choice tally and per-voter pick only after the
+  // vote has closed. While voting is open we show *who* has voted
+  // and their voting power but never *what* they voted for —
+  // surfacing the running tally lets late voters bandwagon or vote
+  // strategically against a known leader. The on-chain Tableland
+  // rows are still public, so this isn't a confidentiality
+  // guarantee — just a UI-level discouragement of bandwagoning that
+  // matches the legacy Nance flow.
+  const revealResults = mode === 'closed'
+
   return (
     <aside
       className={
@@ -184,8 +194,11 @@ export default function MemberVoteSidebar({
         </>
       )}
 
-      {/* Headline tally — total VP and per-choice breakdown. Mirrors the
-          old Nance "Total VP" stat strip. */}
+      {/* Participation summary — voter count + total committed VP.
+          Visible at every phase: how *many* people have weighed in
+          and *how much* voting power has shown up so far is fair to
+          surface even mid-vote (it nudges turnout without revealing
+          which side is winning). */}
       <div className="grid grid-cols-2 gap-2 text-center">
         <div className="rounded-lg bg-white/5 px-2 py-2 border border-white/10">
           <p className="text-[10px] uppercase tracking-wider text-white/50">
@@ -205,28 +218,44 @@ export default function MemberVoteSidebar({
         </div>
       </div>
 
-      <div className="flex flex-col gap-1.5 text-[11px]">
-        <div className="flex items-center justify-between">
-          <span className="text-green-300">For</span>
-          <span className="text-white/80 font-mono">
-            {formatNumberUSStyle(tally.For, true)} VP
-          </span>
-        </div>
-        <div className="flex items-center justify-between">
-          <span className="text-red-300">Against</span>
-          <span className="text-white/80 font-mono">
-            {formatNumberUSStyle(tally.Against, true)} VP
-          </span>
-        </div>
-        {tally.Abstain > 0 && (
+      {/* Per-choice tally — only after the vote has closed.
+          Suppressed mid-vote to avoid bandwagoning. */}
+      {revealResults && (
+        <div className="flex flex-col gap-1.5 text-[11px]">
           <div className="flex items-center justify-between">
-            <span className="text-gray-300">Abstain</span>
+            <span className="text-green-300">For</span>
             <span className="text-white/80 font-mono">
-              {formatNumberUSStyle(tally.Abstain, true)} VP
+              {formatNumberUSStyle(tally.For, true)} VP
             </span>
           </div>
-        )}
-      </div>
+          <div className="flex items-center justify-between">
+            <span className="text-red-300">Against</span>
+            <span className="text-white/80 font-mono">
+              {formatNumberUSStyle(tally.Against, true)} VP
+            </span>
+          </div>
+          {tally.Abstain > 0 && (
+            <div className="flex items-center justify-between">
+              <span className="text-gray-300">Abstain</span>
+              <span className="text-white/80 font-mono">
+                {formatNumberUSStyle(tally.Abstain, true)} VP
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!revealResults && enriched.length > 0 && (
+        <div className="rounded-lg border border-white/10 bg-white/5 px-3 py-2">
+          <p className="text-[11px] text-white/70">
+            Results are hidden until voting closes
+          </p>
+          <p className="text-[10px] text-white/40 mt-0.5">
+            You can see who has voted, but not how, while voting is
+            open — discourages bandwagoning.
+          </p>
+        </div>
+      )}
 
       {/* Voter list */}
       <div className="border-t border-white/10 pt-3">
@@ -265,7 +294,16 @@ export default function MemberVoteSidebar({
                       <AddressLink address={v.address} />
                     </span>
                   )}
-                  <ChoicePill label={v.choice} />
+                  {revealResults ? (
+                    <ChoicePill label={v.choice} />
+                  ) : (
+                    <span
+                      className="inline-flex items-center text-[11px] font-medium px-2 py-0.5 rounded-full border bg-white/5 text-white/40 border-white/10"
+                      title="Choice hidden while voting is open"
+                    >
+                      Voted
+                    </span>
+                  )}
                 </div>
                 <span className="text-white/70 font-mono whitespace-nowrap">
                   {formatNumberUSStyle(v.vp, true)} VP

--- a/ui/components/project/MemberVoteSidebar.tsx
+++ b/ui/components/project/MemberVoteSidebar.tsx
@@ -154,20 +154,15 @@ export default function MemberVoteSidebar({
       }
     >
       <div className="flex items-start justify-between gap-2">
-        <div>
-          <h3
-            className={
-              isActive
-                ? 'font-GoodTimes text-base text-white'
-                : 'font-GoodTimes text-base text-white/90'
-            }
-          >
-            Member Vote
-          </h3>
-          <p className="text-[11px] text-white/60 mt-1">
-            Quadratic vMOONEY voting (vp = √vMOONEY at close).
-          </p>
-        </div>
+        <h3
+          className={
+            isActive
+              ? 'font-GoodTimes text-base text-white'
+              : 'font-GoodTimes text-base text-white/90'
+          }
+        >
+          Member Vote
+        </h3>
         {isActive && (
           <span className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-blue-400/50 bg-blue-500/15 text-[10px] font-semibold uppercase tracking-wider text-blue-100">
             <span className="relative flex h-1.5 w-1.5">
@@ -180,18 +175,11 @@ export default function MemberVoteSidebar({
       </div>
 
       {isActive && (
-        <>
-          <p className="text-xs text-blue-100/80">
-            This is the primary action right now — the Senate has
-            approved this proposal and members must weigh in. Click
-            below to cast your vote.
-          </p>
-          <NewVoteButton
-            proposalStatus={proposalStatus}
-            votes={votes}
-            project={project}
-          />
-        </>
+        <NewVoteButton
+          proposalStatus={proposalStatus}
+          votes={votes}
+          project={project}
+        />
       )}
 
       {/* Participation summary — voter count + total committed VP.
@@ -245,17 +233,6 @@ export default function MemberVoteSidebar({
         </div>
       )}
 
-      {!revealResults && enriched.length > 0 && (
-        <div className="rounded-lg border border-white/10 bg-white/5 px-3 py-2">
-          <p className="text-[11px] text-white/70">
-            Results are hidden until voting closes
-          </p>
-          <p className="text-[10px] text-white/40 mt-0.5">
-            You can see who has voted, but not how, while voting is
-            open — discourages bandwagoning.
-          </p>
-        </div>
-      )}
 
       {/* Voter list */}
       <div className="border-t border-white/10 pt-3">

--- a/ui/components/project/MemberVoteSidebar.tsx
+++ b/ui/components/project/MemberVoteSidebar.tsx
@@ -128,22 +128,60 @@ export default function MemberVoteSidebar({
     return acc
   }, [enriched])
 
+  // While the Member Vote is the active step, elevate the card so
+  // users can't miss the primary action: a tinted background, a
+  // gradient ring, and a pulsing "Active — Vote now" pill. Once
+  // voting has closed (or hasn't opened yet), strip the emphasis so
+  // both sidebar cards read as peers.
+  const isActive = mode === 'voting'
+
   return (
-    <aside className="w-full bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-5 flex flex-col gap-4">
-      <div>
-        <h3 className="font-GoodTimes text-base text-white/90">Member Vote</h3>
-        <p className="text-[11px] text-white/50 mt-1">
-          Quadratic vMOONEY voting (vp = √vMOONEY at close).
-        </p>
+    <aside
+      className={
+        isActive
+          ? 'relative w-full rounded-[20px] p-4 sm:p-5 flex flex-col gap-4 bg-gradient-to-br from-blue-950/60 via-darkest-cool to-purple-950/40 border border-blue-400/40 shadow-[0_0_0_1px_rgba(59,130,246,0.25),0_8px_30px_-12px_rgba(59,130,246,0.45)]'
+          : 'w-full bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-5 flex flex-col gap-4'
+      }
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3
+            className={
+              isActive
+                ? 'font-GoodTimes text-base text-white'
+                : 'font-GoodTimes text-base text-white/90'
+            }
+          >
+            Member Vote
+          </h3>
+          <p className="text-[11px] text-white/60 mt-1">
+            Quadratic vMOONEY voting (vp = √vMOONEY at close).
+          </p>
+        </div>
+        {isActive && (
+          <span className="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-blue-400/50 bg-blue-500/15 text-[10px] font-semibold uppercase tracking-wider text-blue-100">
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-300 opacity-75" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-blue-300" />
+            </span>
+            Vote now
+          </span>
+        )}
       </div>
 
-      {mode === 'voting' && (
-        <NewVoteButton
-          proposalStatus={proposalStatus}
-          votes={votes}
-          project={project}
-          isSmall
-        />
+      {isActive && (
+        <>
+          <p className="text-xs text-blue-100/80">
+            This is the primary action right now — the Senate has
+            approved this proposal and members must weigh in. Click
+            below to cast your vote.
+          </p>
+          <NewVoteButton
+            proposalStatus={proposalStatus}
+            votes={votes}
+            project={project}
+          />
+        </>
       )}
 
       {/* Headline tally — total VP and per-choice breakdown. Mirrors the

--- a/ui/components/project/MemberVoteSidebar.tsx
+++ b/ui/components/project/MemberVoteSidebar.tsx
@@ -129,7 +129,7 @@ export default function MemberVoteSidebar({
   }, [enriched])
 
   return (
-    <aside className="w-full bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-5 flex flex-col gap-4 lg:sticky lg:top-24">
+    <aside className="w-full bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-5 flex flex-col gap-4">
       <div>
         <h3 className="font-GoodTimes text-base text-white/90">Member Vote</h3>
         <p className="text-[11px] text-white/50 mt-1">

--- a/ui/components/project/MemberVoteSidebar.tsx
+++ b/ui/components/project/MemberVoteSidebar.tsx
@@ -1,0 +1,244 @@
+// Right-rail sidebar that mirrors the layout of the legacy Nance proposal
+// page (pages/proposal/[proposal].tsx) for non-project proposals: a vote
+// CTA at the top, then a list of every voter with their dominant choice
+// and quadratic voting power running down the right side of the proposal.
+//
+// Three rendering modes derived from the proposal lifecycle:
+//   - 'voting'  — Vote button + voter list. Used while members can still cast.
+//   - 'closed'  — Voter list only (no CTA), shown after the vote tallied.
+//   - 'inactive' — No voters yet (Senate hasn't approved or no rows).
+//
+// Voting power per voter = sqrt(vMOONEY at the voting-window close) and
+// is computed server-side in `pages/project/[tokenId].tsx` so this
+// component just renders it (same number used for the on-chain tally).
+import { CITIZEN_TABLE_NAMES, DEFAULT_CHAIN_V5 } from 'const/config'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { formatNumberUSStyle } from '@/lib/nance'
+import { ProposalStatus } from '@/lib/nance/useProposalStatus'
+import { Project } from '@/lib/project/useProjectData'
+import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
+import { useTablelandQuery } from '@/lib/swr/useTablelandQuery'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import NewVoteButton from '@/components/nance/NewVoteButton'
+import { AddressLink } from '@/components/nance/AddressLink'
+
+const CHOICE_LABELS: Record<string, string> = {
+  '1': 'For',
+  '2': 'Against',
+  '3': 'Abstain',
+}
+
+// Map a quadratic vote distribution like { '1': 70, '2': 30 } to a single
+// label by picking the choice with the highest weight. Single-click votes
+// (after task 4) are always 100/0/0 so this collapses to the obvious
+// answer; older split votes still render sensibly.
+function dominantChoice(vote: Record<string, number> | undefined): string {
+  if (!vote) return 'Unknown'
+  let best: [string, number] | null = null
+  for (const [k, v] of Object.entries(vote)) {
+    const n = Number(v)
+    if (!Number.isFinite(n)) continue
+    if (best === null || n > best[1]) best = [k, n]
+  }
+  if (!best || best[1] <= 0) return 'Unknown'
+  return CHOICE_LABELS[best[0]] ?? `Choice ${best[0]}`
+}
+
+function ChoicePill({ label }: { label: string }) {
+  const cls =
+    label === 'For'
+      ? 'bg-green-500/20 text-green-300 border-green-500/30'
+      : label === 'Against'
+      ? 'bg-red-500/20 text-red-300 border-red-500/30'
+      : label === 'Abstain'
+      ? 'bg-gray-500/20 text-gray-300 border-gray-500/30'
+      : 'bg-white/5 text-white/60 border-white/10'
+  return (
+    <span
+      className={`inline-flex items-center text-[11px] font-medium px-2 py-0.5 rounded-full border ${cls}`}
+    >
+      {label}
+    </span>
+  )
+}
+
+export type MemberVoteSidebarProps = {
+  project: Project
+  votes: any[]
+  addressToVotingPower: { [address: string]: number }
+  proposalStatus: ProposalStatus
+  // 'voting' enables the Vote button (and Close & Tally for operators
+  // via the parent). 'closed' renders read-only.
+  mode: 'voting' | 'closed' | 'inactive'
+  // Children slot for the operator-only Close & Tally button so the
+  // parent stays in charge of when it shows.
+  footer?: React.ReactNode
+}
+
+export default function MemberVoteSidebar({
+  project,
+  votes,
+  addressToVotingPower,
+  proposalStatus,
+  mode,
+  footer,
+}: MemberVoteSidebarProps) {
+  const chainSlug = getChainSlug(DEFAULT_CHAIN_V5)
+
+  // Resolve voter addresses to citizen names so the list reads like the
+  // Snapshot/Nance UI rather than a wall of 0x… hashes.
+  const citizenStatement = useMemo(() => {
+    if (!votes || votes.length === 0) return null
+    return `SELECT id, name, owner FROM ${CITIZEN_TABLE_NAMES[chainSlug]} WHERE owner IN (${votes
+      .map((v) => `'${String(v.address).toLowerCase()}'`)
+      .join(',')})`
+  }, [votes, chainSlug])
+
+  const { data: votingCitizens = [] } = useTablelandQuery(citizenStatement, {
+    revalidateOnFocus: false,
+  })
+
+  const enriched = useMemo(() => {
+    return (votes ?? [])
+      .map((v) => {
+        const addr = String(v.address || '').toLowerCase()
+        const vp = addressToVotingPower?.[v.address] ?? addressToVotingPower?.[addr] ?? 0
+        const choice = dominantChoice(v.vote)
+        const citizen = votingCitizens?.find?.(
+          (c: any) => String(c.owner).toLowerCase() === addr
+        )
+        return { ...v, vp, choice, citizen }
+      })
+      .sort((a, b) => (b.vp || 0) - (a.vp || 0))
+  }, [votes, addressToVotingPower, votingCitizens])
+
+  const totalVP = useMemo(
+    () => enriched.reduce((acc, v) => acc + (v.vp || 0), 0),
+    [enriched]
+  )
+
+  const tally = useMemo(() => {
+    const acc = { For: 0, Against: 0, Abstain: 0 }
+    for (const v of enriched) {
+      if (v.choice === 'For') acc.For += v.vp
+      else if (v.choice === 'Against') acc.Against += v.vp
+      else if (v.choice === 'Abstain') acc.Abstain += v.vp
+    }
+    return acc
+  }, [enriched])
+
+  return (
+    <aside className="w-full bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-5 flex flex-col gap-4 lg:sticky lg:top-24">
+      <div>
+        <h3 className="font-GoodTimes text-base text-white/90">Member Vote</h3>
+        <p className="text-[11px] text-white/50 mt-1">
+          Quadratic vMOONEY voting (vp = √vMOONEY at close).
+        </p>
+      </div>
+
+      {mode === 'voting' && (
+        <NewVoteButton
+          proposalStatus={proposalStatus}
+          votes={votes}
+          project={project}
+          isSmall
+        />
+      )}
+
+      {/* Headline tally — total VP and per-choice breakdown. Mirrors the
+          old Nance "Total VP" stat strip. */}
+      <div className="grid grid-cols-2 gap-2 text-center">
+        <div className="rounded-lg bg-white/5 px-2 py-2 border border-white/10">
+          <p className="text-[10px] uppercase tracking-wider text-white/50">
+            Voters
+          </p>
+          <p className="text-sm font-semibold text-white">
+            {enriched.length}
+          </p>
+        </div>
+        <div className="rounded-lg bg-white/5 px-2 py-2 border border-white/10">
+          <p className="text-[10px] uppercase tracking-wider text-white/50">
+            Total VP
+          </p>
+          <p className="text-sm font-semibold text-white">
+            {formatNumberUSStyle(totalVP, true)}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5 text-[11px]">
+        <div className="flex items-center justify-between">
+          <span className="text-green-300">For</span>
+          <span className="text-white/80 font-mono">
+            {formatNumberUSStyle(tally.For, true)} VP
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-red-300">Against</span>
+          <span className="text-white/80 font-mono">
+            {formatNumberUSStyle(tally.Against, true)} VP
+          </span>
+        </div>
+        {tally.Abstain > 0 && (
+          <div className="flex items-center justify-between">
+            <span className="text-gray-300">Abstain</span>
+            <span className="text-white/80 font-mono">
+              {formatNumberUSStyle(tally.Abstain, true)} VP
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Voter list */}
+      <div className="border-t border-white/10 pt-3">
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-[10px] uppercase tracking-wider text-white/50">
+            Votes ({enriched.length})
+          </p>
+          <p className="text-[10px] text-white/40">sorted by VP</p>
+        </div>
+        {enriched.length === 0 ? (
+          <p className="text-xs text-white/50 italic">
+            {mode === 'inactive'
+              ? 'Voting has not opened yet.'
+              : 'No votes cast yet — be the first.'}
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2 max-h-[420px] overflow-y-auto pr-1">
+            {enriched.map((v) => (
+              <li
+                key={v.id ?? v.address}
+                className="flex items-center justify-between gap-2 text-xs"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  {v.citizen ? (
+                    <Link
+                      href={`/citizen/${generatePrettyLinkWithId(
+                        v.citizen.name,
+                        v.citizen.id
+                      )}`}
+                      className="text-white/90 hover:underline truncate"
+                    >
+                      {v.citizen.name}
+                    </Link>
+                  ) : (
+                    <span className="text-white/80 font-mono truncate">
+                      <AddressLink address={v.address} />
+                    </span>
+                  )}
+                  <ChoicePill label={v.choice} />
+                </div>
+                <span className="text-white/70 font-mono whitespace-nowrap">
+                  {formatNumberUSStyle(v.vp, true)} VP
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {footer && <div className="border-t border-white/10 pt-3">{footer}</div>}
+    </aside>
+  )
+}

--- a/ui/components/project/SenateVote.tsx
+++ b/ui/components/project/SenateVote.tsx
@@ -360,11 +360,6 @@ function CloseSenateVoteButton({
       {projectedOutcome && (
         <p className="text-[11px] text-white/50">{projectedOutcome}</p>
       )}
-      <p className="text-[11px] text-white/40">
-        Signs{' '}
-        <code className="text-white/60">Proposals.tallyVotes({mdp})</code>{' '}
-        with the HSM owner wallet. Approval threshold is 2/3 of votes cast.
-      </p>
     </div>
   )
 }

--- a/ui/components/project/SenateVote.tsx
+++ b/ui/components/project/SenateVote.tsx
@@ -445,7 +445,20 @@ function SenatorPill({
   )
 }
 
-export default function SenateVote({ mdp }: { mdp: number }) {
+export default function SenateVote({
+  mdp,
+  // When true, render as a historical results card: hide the cast-vote
+  // CTA, the "only senators can vote" copy, and the operator close
+  // control. The on-chain `voteTempCheck` reverts after the senate has
+  // tallied anyway, but showing those affordances post-tally is
+  // confusing — the voter doesn't know why their click does nothing.
+  // Used by the proposal page to keep the senate breakdown visible
+  // through the Voting and Approved/Cancelled phases.
+  readOnly = false,
+}: {
+  mdp: number
+  readOnly?: boolean
+}) {
   const chain = DEFAULT_CHAIN_V5
   const chainSlug = getChainSlug(chain)
   const account = useActiveAccount()
@@ -484,14 +497,49 @@ export default function SenateVote({ mdp }: { mdp: number }) {
       ? Number(proposalData?.tempCheckVoteCount || 0)
       : 0
   const rejectionCount = Math.max(totalVoteCount - approvalCount, 0)
+  const tempCheckApproved = Boolean(
+    'tempCheckApproved' in proposalData && proposalData?.tempCheckApproved
+  )
+  const tempCheckFailed = Boolean(
+    'tempCheckFailed' in proposalData && proposalData?.tempCheckFailed
+  )
 
   const votedCount = senatorVotes.filter((s) => s.hasVoted).length
   const senatorTotal = senatorVotes.length
 
-  const canVote = isSenator && Boolean(account) && authenticated
+  const canVote = isSenator && Boolean(account) && authenticated && !readOnly
+
+  // Outcome badge — only meaningful in read-only mode (post-tally).
+  // `tempCheckApproved` and `tempCheckFailed` are mutually exclusive on
+  // chain; if neither is set the senate just hasn't tallied yet.
+  const outcomeBadge = readOnly
+    ? tempCheckApproved
+      ? {
+          label: 'Approved by Senate',
+          className: 'bg-green-500/15 border-green-500/40 text-green-200',
+        }
+      : tempCheckFailed
+      ? {
+          label: 'Rejected by Senate',
+          className: 'bg-red-500/15 border-red-500/40 text-red-200',
+        }
+      : {
+          label: 'Senate vote closed',
+          className: 'bg-slate-500/15 border-slate-500/40 text-slate-200',
+        }
+    : null
 
   return (
     <div className="flex flex-col gap-6">
+      {outcomeBadge && (
+        <div
+          className={`inline-flex self-start items-center gap-2 px-3 py-1.5 rounded-full border text-xs font-semibold ${outcomeBadge.className}`}
+        >
+          <span className="w-1.5 h-1.5 rounded-full bg-current" />
+          {outcomeBadge.label}
+        </div>
+      )}
+
       {/* Summary stats — equal-width cards on every screen */}
       <div className="grid grid-cols-3 gap-3">
         <StatPill emoji="👍" label="For" count={approvalCount} tone="positive" />
@@ -509,46 +557,55 @@ export default function SenateVote({ mdp }: { mdp: number }) {
         />
       </div>
 
-      {/* Action row — buttons for senators, status note for everyone else */}
-      <div className="flex flex-col items-center gap-3">
-        {isSenatorLoading ? (
-          <LoadingSpinner width="w-5" height="h-5" />
-        ) : canVote ? (
-          <>
-            <p className="text-xs uppercase tracking-wider text-white/60">
-              Cast your senate vote
+      {/* Action row — buttons for senators, status note for everyone
+          else. Hidden in read-only mode (post-tally) — voting is
+          impossible at that point and showing dead buttons is
+          misleading. */}
+      {!readOnly && (
+        <div className="flex flex-col items-center gap-3">
+          {isSenatorLoading ? (
+            <LoadingSpinner width="w-5" height="h-5" />
+          ) : canVote ? (
+            <>
+              <p className="text-xs uppercase tracking-wider text-white/60">
+                Cast your senate vote
+              </p>
+              <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto sm:max-w-md">
+                <PrivyWeb3Button
+                  action={handleVote(true)}
+                  requiredChain={DEFAULT_CHAIN_V5}
+                  className="flex-1 !px-6 !py-3 rounded-lg bg-gradient-to-r from-green-600 to-green-700 hover:from-green-500 hover:to-green-600 text-white font-semibold text-base transition-all shadow-lg"
+                  label="👍 Approve"
+                />
+                <PrivyWeb3Button
+                  action={handleVote(false)}
+                  requiredChain={DEFAULT_CHAIN_V5}
+                  className="flex-1 !px-6 !py-3 rounded-lg bg-gradient-to-r from-red-600 to-red-700 hover:from-red-500 hover:to-red-600 text-white font-semibold text-base transition-all shadow-lg"
+                  label="👎 Reject"
+                />
+              </div>
+            </>
+          ) : (
+            <p className="text-xs text-white/50">
+              Only senators can cast a vote at this stage.
             </p>
-            <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto sm:max-w-md">
-              <PrivyWeb3Button
-                action={handleVote(true)}
-                requiredChain={DEFAULT_CHAIN_V5}
-                className="flex-1 !px-6 !py-3 rounded-lg bg-gradient-to-r from-green-600 to-green-700 hover:from-green-500 hover:to-green-600 text-white font-semibold text-base transition-all shadow-lg"
-                label="👍 Approve"
-              />
-              <PrivyWeb3Button
-                action={handleVote(false)}
-                requiredChain={DEFAULT_CHAIN_V5}
-                className="flex-1 !px-6 !py-3 rounded-lg bg-gradient-to-r from-red-600 to-red-700 hover:from-red-500 hover:to-red-600 text-white font-semibold text-base transition-all shadow-lg"
-                label="👎 Reject"
-              />
-            </div>
-          </>
-        ) : (
-          <p className="text-xs text-white/50">
-            Only senators can cast a vote at this stage.
-          </p>
-        )}
-      </div>
+          )}
+        </div>
+      )}
 
-      {/* Owner controls — close the senate vote and advance the state machine. */}
-      <CloseSenateVoteButton
-        mdp={mdp}
-        proposalContract={proposalContract}
-        votedCount={votedCount}
-        approvalCount={approvalCount}
-        rejectionCount={rejectionCount}
-        onClosed={refetch}
-      />
+      {/* Owner controls — close the senate vote and advance the state
+          machine. Pointless once the vote has already closed, so we
+          skip it in read-only mode. */}
+      {!readOnly && (
+        <CloseSenateVoteButton
+          mdp={mdp}
+          proposalContract={proposalContract}
+          votedCount={votedCount}
+          approvalCount={approvalCount}
+          rejectionCount={rejectionCount}
+          onClosed={refetch}
+        />
+      )}
 
       {/* Senator roster */}
       {senatorTotal > 0 && (

--- a/ui/components/project/SenateVoteSidebar.tsx
+++ b/ui/components/project/SenateVoteSidebar.tsx
@@ -15,7 +15,17 @@ import useProposalData from '@/lib/project/useProposalData'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
 
-export default function SenateVoteSidebar({ mdp }: { mdp: number }) {
+export default function SenateVoteSidebar({
+  mdp,
+  // When `true`, render dimmed/quieter — the Member Vote above is the
+  // active step and this card should fade into reference territory so
+  // the eye lands on the primary CTA. The breakdown is still fully
+  // legible at hover/focus.
+  secondary = false,
+}: {
+  mdp: number
+  secondary?: boolean
+}) {
   const chain = DEFAULT_CHAIN_V5
   const chainSlug = getChainSlug(chain)
 
@@ -67,14 +77,22 @@ export default function SenateVoteSidebar({ mdp }: { mdp: number }) {
       }
 
   return (
-    <aside className="w-full bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-5 flex flex-col gap-4">
+    <aside
+      className={
+        secondary
+          ? 'w-full bg-dark-cool lg:bg-darkest-cool/60 rounded-[20px] p-4 sm:p-5 flex flex-col gap-4 border border-white/5 opacity-80 hover:opacity-100 focus-within:opacity-100 transition-opacity'
+          : 'w-full bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-5 flex flex-col gap-4'
+      }
+    >
       <div className="flex items-start justify-between gap-2">
         <div>
-          <h3 className="font-GoodTimes text-base text-white/90">
+          <h3 className="font-GoodTimes text-base text-white/80">
             Senate Vote
           </h3>
           <p className="text-[11px] text-white/50 mt-1">
-            On-chain vote of MoonDAO senators.
+            {secondary
+              ? 'Completed — required before Member Vote could open.'
+              : 'On-chain vote of MoonDAO senators.'}
           </p>
         </div>
         <span

--- a/ui/components/project/SenateVoteSidebar.tsx
+++ b/ui/components/project/SenateVoteSidebar.tsx
@@ -1,0 +1,169 @@
+// Compact, right-rail variant of the Senate Vote breakdown that lives
+// alongside `MemberVoteSidebar`. Always read-only — the interactive
+// 👍/👎 buttons (for senators) and the operator Close Senate Vote
+// control stay in the main-column SectionCard during Temperature Check
+// because they need more breathing room than the rail allows. The
+// sidebar's job is to be the persistent reference card members can
+// glance at to see how the proposal got past the Senate (or whether
+// it has).
+//
+// Reads the same on-chain state as the full `SenateVote` component
+// via `useProposalData` so the two views can never disagree.
+import ProposalsABI from 'const/abis/Proposals.json'
+import { DEFAULT_CHAIN_V5, PROPOSALS_ADDRESSES } from 'const/config'
+import useProposalData from '@/lib/project/useProposalData'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import useContract from '@/lib/thirdweb/hooks/useContract'
+
+export default function SenateVoteSidebar({ mdp }: { mdp: number }) {
+  const chain = DEFAULT_CHAIN_V5
+  const chainSlug = getChainSlug(chain)
+
+  const proposalContract = useContract({
+    address: PROPOSALS_ADDRESSES[chainSlug],
+    chain,
+    abi: ProposalsABI.abi as any,
+  })
+
+  const { proposalData, senatorVotes, isLoading } = useProposalData(
+    proposalContract,
+    mdp
+  )
+
+  const approvalCount =
+    'tempCheckApprovalCount' in proposalData
+      ? Number(proposalData?.tempCheckApprovalCount || 0)
+      : 0
+  const totalVoteCount =
+    'tempCheckVoteCount' in proposalData
+      ? Number(proposalData?.tempCheckVoteCount || 0)
+      : 0
+  const rejectionCount = Math.max(totalVoteCount - approvalCount, 0)
+  const tempCheckApproved = Boolean(
+    'tempCheckApproved' in proposalData && proposalData?.tempCheckApproved
+  )
+  const tempCheckFailed = Boolean(
+    'tempCheckFailed' in proposalData && proposalData?.tempCheckFailed
+  )
+  const senatorTotal = senatorVotes.length
+  const votedCount = senatorVotes.filter((s) => s.hasVoted).length
+
+  // Three states: approved (green), failed (red), in-progress (slate).
+  // `tempCheckApproved` and `tempCheckFailed` are mutually exclusive on
+  // chain so the cascade below is unambiguous.
+  const outcome = tempCheckApproved
+    ? {
+        label: 'Approved by Senate',
+        className: 'bg-green-500/15 border-green-500/40 text-green-200',
+      }
+    : tempCheckFailed
+    ? {
+        label: 'Rejected by Senate',
+        className: 'bg-red-500/15 border-red-500/40 text-red-200',
+      }
+    : {
+        label: 'Senate vote in progress',
+        className: 'bg-slate-500/15 border-slate-500/40 text-slate-200',
+      }
+
+  return (
+    <aside className="w-full bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-5 flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="font-GoodTimes text-base text-white/90">
+            Senate Vote
+          </h3>
+          <p className="text-[11px] text-white/50 mt-1">
+            On-chain vote of MoonDAO senators.
+          </p>
+        </div>
+        <span
+          className={`shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[10px] font-semibold uppercase tracking-wider ${outcome.className}`}
+        >
+          <span className="w-1.5 h-1.5 rounded-full bg-current" />
+          {outcome.label}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div className="rounded-lg bg-green-500/10 border border-green-500/20 px-2 py-2 text-center">
+          <p className="text-[10px] uppercase tracking-wider text-green-300/80">
+            For
+          </p>
+          <p className="text-base font-semibold text-green-200">
+            {approvalCount}
+          </p>
+        </div>
+        <div className="rounded-lg bg-red-500/10 border border-red-500/20 px-2 py-2 text-center">
+          <p className="text-[10px] uppercase tracking-wider text-red-300/80">
+            Against
+          </p>
+          <p className="text-base font-semibold text-red-200">
+            {rejectionCount}
+          </p>
+        </div>
+        <div className="rounded-lg bg-white/5 border border-white/10 px-2 py-2 text-center">
+          <p className="text-[10px] uppercase tracking-wider text-white/50">
+            Voted
+          </p>
+          <p className="text-base font-semibold text-white">
+            {votedCount}/{senatorTotal}
+          </p>
+        </div>
+      </div>
+
+      {senatorTotal > 0 && (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-baseline justify-between">
+            <h4 className="text-[10px] uppercase tracking-wider text-white/50">
+              Senators
+            </h4>
+            <span className="text-[10px] text-white/40">
+              {votedCount}/{senatorTotal}
+            </span>
+          </div>
+          <div
+            className={`flex flex-wrap gap-1.5 ${
+              isLoading ? 'opacity-60' : ''
+            }`}
+          >
+            {senatorVotes.map((s) => {
+              const tone = !s.hasVoted
+                ? 'bg-slate-700/40 border-white/10 text-white/50'
+                : s.votedApprove
+                ? 'bg-green-500/20 border-green-500/40 text-green-200'
+                : s.votedDeny
+                ? 'bg-red-500/20 border-red-500/40 text-red-200'
+                : 'bg-slate-700/40 border-white/10 text-white/70'
+              const icon = !s.hasVoted
+                ? '○'
+                : s.votedApprove
+                ? '✓'
+                : s.votedDeny
+                ? '✗'
+                : '•'
+              return (
+                <span
+                  key={s.address}
+                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-[10px] ${tone}`}
+                  title={`${s.name}${
+                    s.hasVoted
+                      ? s.votedApprove
+                        ? ' approved'
+                        : s.votedDeny
+                        ? ' rejected'
+                        : ' voted'
+                      : ' has not voted yet'
+                  }`}
+                >
+                  <span>{icon}</span>
+                  <span className="font-medium">{s.name}</span>
+                </span>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/ui/components/project/SenateVoteSidebar.tsx
+++ b/ui/components/project/SenateVoteSidebar.tsx
@@ -85,16 +85,9 @@ export default function SenateVoteSidebar({
       }
     >
       <div className="flex items-start justify-between gap-2">
-        <div>
-          <h3 className="font-GoodTimes text-base text-white/80">
-            Senate Vote
-          </h3>
-          <p className="text-[11px] text-white/50 mt-1">
-            {secondary
-              ? 'Completed — required before Member Vote could open.'
-              : 'On-chain vote of MoonDAO senators.'}
-          </p>
-        </div>
+        <h3 className="font-GoodTimes text-base text-white/80">
+          Senate Vote
+        </h3>
         <span
           className={`shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[10px] font-semibold uppercase tracking-wider ${outcome.className}`}
         >

--- a/ui/components/subscription/TeamTreasury.tsx
+++ b/ui/components/subscription/TeamTreasury.tsx
@@ -18,6 +18,55 @@ type TeamTreasuryProps = {
   multisigAddress: string
   safeOwners: string[]
   projectActive?: number
+  // Drop the inner "Treasury" title row when the parent already
+  // provides one (e.g. a SectionCard on the proposal page). Keeps
+  // the multisig address pill and action buttons so the call sites
+  // on the team page — which wrap us in a plain styled `<div>` and
+  // need our own title — are unaffected.
+  hideHeader?: boolean
+}
+
+// The multisig address + Safe link + copy button. Pulled out so the
+// hideHeader / default render paths share one source of truth, and so
+// the markup doesn't shift around at the responsive breakpoints.
+function MultisigAddressPill({ address }: { address: string }) {
+  const safePrefix =
+    process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? 'arb1' : 'sep'
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <a
+        href={`https://app.safe.global/home?safe=${safePrefix}:${address}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs sm:text-sm text-blue-400 hover:text-blue-300 transition-colors font-mono truncate"
+      >
+        {`${address.slice(0, 6)}...${address.slice(-4)}`}
+      </a>
+      <button
+        type="button"
+        className="text-slate-500 hover:text-slate-300 transition-colors bg-transparent border-0 p-0 cursor-pointer flex-shrink-0"
+        aria-label="Copy treasury address"
+        onClick={() => {
+          navigator.clipboard.writeText(address)
+          toast.success('Treasury address copied to clipboard!')
+        }}
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+          />
+        </svg>
+      </button>
+    </div>
+  )
 }
 
 function SignerAddress({ address }: { address: string }) {
@@ -37,7 +86,14 @@ function SignerAddress({ address }: { address: string }) {
   )
 }
 
-export default function TeamTreasury({ isSigner, safeData, multisigAddress, safeOwners, projectActive }: TeamTreasuryProps) {
+export default function TeamTreasury({
+  isSigner,
+  safeData,
+  multisigAddress,
+  safeOwners,
+  projectActive,
+  hideHeader = false,
+}: TeamTreasuryProps) {
   const account = useActiveAccount()
   const address = account?.address
   const [safeModalEnabled, setSafeModalEnabled] = useState(false)
@@ -71,10 +127,10 @@ export default function TeamTreasury({ isSigner, safeData, multisigAddress, safe
           setEnabled={setSafeSendModalEnabled}
         />
       )}
-      <div className="w-full flex flex-col gap-4 sm:gap-5 p-0 sm:p-6">
+      <div className="w-full flex flex-col gap-4 sm:gap-5 p-4 sm:p-6">
         {safeOwners.length < 5 && projectActive === PROJECT_PENDING && (
-          <div className="p-4 bg-yellow-900/30 border border-yellow-500/40 rounded-xl">
-            <div className="flex items-start gap-3">
+          <div className="p-3 sm:p-4 bg-yellow-900/30 border border-yellow-500/40 rounded-xl">
+            <div className="flex items-start gap-2 sm:gap-3">
               <svg
                 className="w-5 h-5 text-yellow-400 mt-0.5 flex-shrink-0"
                 fill="none"
@@ -88,7 +144,7 @@ export default function TeamTreasury({ isSigner, safeData, multisigAddress, safe
                   d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
                 />
               </svg>
-              <div>
+              <div className="min-w-0">
                 <p className="text-sm text-yellow-200 font-medium">
                   Multisig Setup Required
                 </p>
@@ -101,50 +157,48 @@ export default function TeamTreasury({ isSigner, safeData, multisigAddress, safe
             </div>
           </div>
         )}
-        <div className="flex flex-col gap-4 lg:flex-row lg:gap-5 lg:justify-between lg:items-center">
-          <div className="flex flex-col sm:flex-row gap-3 sm:gap-5 sm:items-center">
-            <div className="flex gap-3 sm:gap-5 items-center">
-              <Image
-                src="/assets/icon-star.svg"
-                alt="Treasury icon"
-                width={30}
-                height={30}
-                className="opacity-70"
-              />
-              <h2 className="font-GoodTimes text-xl sm:text-2xl text-white">Treasury</h2>
-            </div>
-            {multisigAddress && (
-              <div className="flex items-center gap-2">
-                <a
-                  href={`https://app.safe.global/home?safe=${
-                    process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? 'arb1' : 'sep'
-                  }:${multisigAddress}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-xs sm:text-sm text-blue-400 hover:text-blue-300 transition-colors font-mono"
-                >
-                  {`${multisigAddress.slice(0, 6)}...${multisigAddress.slice(-4)}`}
-                </a>
-                <button
-                  type="button"
-                  className="text-slate-500 hover:text-slate-300 transition-colors bg-transparent border-0 p-0 cursor-pointer"
-                  aria-label="Copy treasury address"
-                  onClick={() => {
-                    navigator.clipboard.writeText(multisigAddress)
-                    toast.success('Treasury address copied to clipboard!')
-                  }}
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                  </svg>
-                </button>
+        {/* Header row layout strategy:
+            - Mobile (default): everything stacks. Title on one line,
+              multisig pill on the next, then a 3-up button grid.
+            - sm (640+): title and multisig pill share a row; buttons
+              still wrap below as a flex row.
+            - xl (1280+): the entire header collapses to one row with
+              `justify-between`. We stop short of `lg` because at the
+              lg breakpoint this card is sometimes mounted in a
+              ~600px-wide grid column (e.g. col-span-2 of 3 on the
+              proposal page) where a horizontal layout fights for
+              space with the action buttons. `flex-wrap` is on the
+              row so even when xl kicks in, narrow viewports still
+              wrap gracefully instead of overflowing. */}
+        <div className="flex flex-col gap-3 xl:flex-row xl:flex-wrap xl:items-center xl:justify-between xl:gap-5">
+          {!hideHeader && (
+            <div className="flex flex-col sm:flex-row gap-3 sm:gap-5 sm:items-center min-w-0">
+              <div className="flex gap-3 sm:gap-5 items-center min-w-0">
+                <Image
+                  src="/assets/icon-star.svg"
+                  alt="Treasury icon"
+                  width={30}
+                  height={30}
+                  className="opacity-70 flex-shrink-0"
+                />
+                <h2 className="font-GoodTimes text-xl sm:text-2xl text-white truncate">
+                  Treasury
+                </h2>
               </div>
-            )}
-          </div>
+              {multisigAddress && (
+                <MultisigAddressPill address={multisigAddress} />
+              )}
+            </div>
+          )}
+          {hideHeader && multisigAddress && (
+            <div className="flex items-center min-w-0">
+              <MultisigAddressPill address={multisigAddress} />
+            </div>
+          )}
           {safeData && isSigner && (
-            <div className="flex flex-col sm:flex-row gap-3">
+            <div className="grid grid-cols-3 gap-2 sm:flex sm:flex-wrap sm:gap-3">
               <StandardButton
-                className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white rounded-xl py-2 px-5 text-sm font-semibold transition-all duration-200 hover:scale-105"
+                className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white rounded-xl py-2 px-3 sm:px-5 text-xs sm:text-sm font-semibold transition-all duration-200 hover:scale-105"
                 onClick={() => {
                   setSafeSendModalEnabled(true)
                 }}
@@ -152,7 +206,7 @@ export default function TeamTreasury({ isSigner, safeData, multisigAddress, safe
                 {'Send'}
               </StandardButton>
               <StandardButton
-                className="bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 text-white rounded-xl py-2 px-5 text-sm font-semibold transition-all duration-200 hover:scale-105"
+                className="w-full sm:w-auto bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 text-white rounded-xl py-2 px-3 sm:px-5 text-xs sm:text-sm font-semibold transition-all duration-200 hover:scale-105"
                 onClick={() => {
                   setSafeReceiveModalEnabled(true)
                 }}
@@ -160,7 +214,7 @@ export default function TeamTreasury({ isSigner, safeData, multisigAddress, safe
                 {'Receive'}
               </StandardButton>
               <StandardButton
-                className="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white rounded-xl py-2 px-5 text-sm font-semibold transition-all duration-200 hover:scale-105"
+                className="w-full sm:w-auto bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white rounded-xl py-2 px-3 sm:px-5 text-xs sm:text-sm font-semibold transition-all duration-200 hover:scale-105"
                 onClick={() => {
                   setSafeModalEnabled(true)
                 }}

--- a/ui/pages/api/proposals/vote-notification.ts
+++ b/ui/pages/api/proposals/vote-notification.ts
@@ -207,7 +207,12 @@ async function handler(req: any, res: any) {
       content = `## 🗳️ **${voterDisplay}** ${verb} **${proposalLabel}**`
 
       if (proposalMDP != null && Number.isFinite(proposalMDP)) {
-        linkUrl = `${DEPLOYED_ORIGIN}/proposal/${proposalMDP}`
+        // `/proposal/<MDP>` is the legacy Nance-only viewer; the
+        // canonical surface is `/project/<MDP>` (the full proposal
+        // page with the right-rail vote sidebar). Sending the
+        // legacy link from a Discord notification is a dead end —
+        // the vote action is on `/project/...`.
+        linkUrl = `${DEPLOYED_ORIGIN}/project/${proposalMDP}`
         content += `\n\n[View proposal →](${linkUrl})`
       }
     } else {

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -311,10 +311,6 @@ export default function ProjectProfile({
                     iconSrc="/assets/icon-star.svg"
                   >
                     <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-6">
-                      <p className="text-sm text-white/70 mb-5">
-                        Senators must approve this proposal before it can
-                        advance to the next stage.
-                      </p>
                       <SenateVote mdp={project.MDP} />
                     </div>
                   </SectionCard>

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -45,12 +45,12 @@ import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import SectionCard from '@/components/layout/SectionCard'
 import SlidingCardMenu from '@/components/layout/SlidingCardMenu'
 import MarkdownWithTOC from '@/components/nance/MarkdownWithTOC'
-import ProposalVotes from '@/components/nance/ProposalVotes'
 
 import VotingResults from '@/components/nance/VotingResults'
 import ProposalEditSection from '@/components/nance/ProposalEditSection'
 import AuthorCitizenLink from '@/components/project/AuthorCitizenLink'
 import CloseAndTallyButton from '@/components/project/CloseAndTallyButton'
+import MemberVoteSidebar from '@/components/project/MemberVoteSidebar'
 import SenateVote from '@/components/project/SenateVote'
 import TeamManageMembers from '@/components/subscription/TeamManageMembers'
 import TeamMembers from '@/components/subscription/TeamMembers'
@@ -85,6 +85,11 @@ type ProjectProfileProps = {
   votes: any[]
   voteOutcome: any
   proposalStatus: any
+  // address (lowercased or checksummed — we look up both) -> quadratic
+  // voting power (sqrt of vMOONEY at the voting-window close).
+  // Empty object when the proposal has no votes yet or isn't a
+  // non-project proposal.
+  addressToVotingPower: { [address: string]: number }
   tempCheckApprovedTimestamp?: string
   pending?: boolean
 }
@@ -98,6 +103,7 @@ export default function ProjectProfile({
   votes,
   voteOutcome,
   proposalStatus,
+  addressToVotingPower,
   tempCheckApprovedTimestamp,
   pending,
 }: ProjectProfileProps) {
@@ -262,129 +268,184 @@ export default function ProjectProfile({
           />
         }
       >
-        <div id="page-container" className="flex flex-col gap-4 sm:gap-6 pt-2 sm:pt-3 md:pt-4 pb-4 sm:pb-6 md:pb-8">
-          {finalReportMarkdown && (
-            <SectionCard header="Final Report" iconSrc="/assets/icon-star.svg">
-              <div className="prose prose-invert max-w-none">
-                <MarkdownWithTOC body={finalReportMarkdown} />
-              </div>
-            </SectionCard>
-          )}
-          {/* Senate Vote Section — pending proposals in Temperature Check.
-              Senators see interactive 👍/👎 buttons; everyone sees the
-              running counts and the per-senator voted/pending status. */}
-          {project.active === PROJECT_PENDING &&
-            proposalStatus === 'Temperature Check' && (
-              <SectionCard header="Senate Vote" iconSrc="/assets/icon-star.svg">
-                <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-6">
-                  <p className="text-sm text-white/70 mb-5">
-                    Senators must approve this proposal before it can advance
-                    to the next stage.
-                  </p>
-                  <SenateVote mdp={project.MDP} />
-                </div>
-              </SectionCard>
-            )}
+        {(() => {
+          // Non-project proposals get the Snapshot/Nance-style two-column
+          // layout: proposal body on the left, a sticky vote sidebar
+          // running down the right with the live voter list and quadratic
+          // voting power. Project proposals fall back to a single column.
+          const showVoteSidebar = Boolean(proposalJSON?.nonProjectProposal)
+          const sidebarMode: 'voting' | 'closed' | 'inactive' =
+            project.active === PROJECT_PENDING && proposalStatus === 'Voting'
+              ? 'voting'
+              : project.active !== PROJECT_PENDING
+              ? 'closed'
+              : 'inactive'
 
-          {/* Member Vote Section — non-project proposals after senate approval. */}
-          {project.active === PROJECT_PENDING &&
-            proposalStatus === 'Voting' &&
-            proposalJSON?.nonProjectProposal && (
-              <SectionCard header="Member Vote" iconSrc="/assets/icon-star.svg">
-                <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-5">
-                  <p className="text-sm text-white/70 mb-4">
-                    This proposal passed the Senate vote. Lock $MOONEY to vote
-                    quadratically with vMOONEY-weighted Yes / No / Abstain.
-                  </p>
-                  <ProposalVotes
-                    project={project}
-                    votes={votes}
-                    proposalStatus={proposalStatus}
-                    showContainer
-                  />
-                  <CloseAndTallyButton
-                    mdp={project.MDP}
-                    tempCheckApprovedTimestamp={tempCheckApprovedTimestamp}
-                  />
-                </div>
-              </SectionCard>
-            )}
+          const mainColumn = (
+            <div className="flex flex-col gap-4 sm:gap-6 min-w-0">
+              {finalReportMarkdown && (
+                <SectionCard
+                  header="Final Report"
+                  iconSrc="/assets/icon-star.svg"
+                >
+                  <div className="prose prose-invert max-w-none">
+                    <MarkdownWithTOC body={finalReportMarkdown} />
+                  </div>
+                </SectionCard>
+              )}
 
-          {/* Project Overview */}
-          <SectionCard
-            header="Proposal"
-            iconSrc="/assets/icon-star.svg"
-            className=""
-          >
-            <div className="mb-6 sm:mt-4 sm:mb-10 px-0 sm:px-4 md:px-8 w-full">
-              <div className="prose prose-base prose-invert max-w-none">
-                <MarkdownWithTOC body={(() => {
-                  const full = proposalJSON.body || ''
-                  const idx = full.search(/^#{1,6}\s*Abstract/im)
-                  if (idx !== -1) return full.slice(idx)
-                  const plainIdx = full.search(/^\*{0,2}Abstract\*{0,2}\s*$/im)
-                  if (plainIdx !== -1) return full.slice(plainIdx)
-                  return full
-                })()} />
-              </div>
-            </div>
-          </SectionCard>
-
-          {/* Voting Results Section - Only show for completed proposals */}
-          {project.active !== PROJECT_PENDING && proposalJSON?.nonProjectProposal && (
-            <SectionCard
-              header="Voting Results"
-              iconSrc="/assets/icon-star.svg"
-            >
-              <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-5">
-                <VotingResults voteOutcome={voteOutcome} votes={votes} threshold={0} />
-              </div>
-            </SectionCard>
-          )}
-
-          <SectionCard
-            header="Meet the Team"
-            iconSrc="/assets/icon-team.svg"
-            action={
-              isManager && (
-                <div className="flex flex-col md:flex-row justify-start items-center gap-2">
-                  <TeamManageMembers
-                    account={account}
-                    hats={hats}
-                    hatsContract={hatsContract}
-                    teamContract={projectContract}
-                    teamId={tokenId}
-                    selectedChain={selectedChain}
-                    multisigAddress={safeAddress}
-                    adminHatId={adminHatId}
-                    managerHatId={managerHatId}
-                  />
-                </div>
-              )
-            }
-          >
-            <SlidingCardMenu>
-              <div className="flex gap-2 md:gap-4">
-                {hats?.[0].id && (
-                  <TeamMembers
-                    hats={hats}
-                    hatsContract={hatsContract}
-                    citizenContract={citizenContract}
-                  />
+              {/* Senate Vote Section — pending proposals in Temperature
+                  Check. Senators see interactive 👍/👎 buttons; everyone
+                  sees the running counts and the per-senator
+                  voted/pending status. */}
+              {project.active === PROJECT_PENDING &&
+                proposalStatus === 'Temperature Check' && (
+                  <SectionCard
+                    header="Senate Vote"
+                    iconSrc="/assets/icon-star.svg"
+                  >
+                    <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-6">
+                      <p className="text-sm text-white/70 mb-5">
+                        Senators must approve this proposal before it can
+                        advance to the next stage.
+                      </p>
+                      <SenateVote mdp={project.MDP} />
+                    </div>
+                  </SectionCard>
                 )}
+
+              {/* Project Overview */}
+              <SectionCard
+                header="Proposal"
+                iconSrc="/assets/icon-star.svg"
+                className=""
+              >
+                <div className="mb-6 sm:mt-4 sm:mb-10 px-0 sm:px-4 md:px-8 w-full">
+                  <div className="prose prose-base prose-invert max-w-none">
+                    <MarkdownWithTOC
+                      body={(() => {
+                        const full = proposalJSON.body || ''
+                        const idx = full.search(/^#{1,6}\s*Abstract/im)
+                        if (idx !== -1) return full.slice(idx)
+                        const plainIdx = full.search(
+                          /^\*{0,2}Abstract\*{0,2}\s*$/im
+                        )
+                        if (plainIdx !== -1) return full.slice(plainIdx)
+                        return full
+                      })()}
+                    />
+                  </div>
+                </div>
+              </SectionCard>
+
+              {/* Voting Results Section - Only show for completed
+                  proposals. Aggregate verdict card; the right rail still
+                  carries the per-voter detail. */}
+              {project.active !== PROJECT_PENDING &&
+                proposalJSON?.nonProjectProposal && (
+                  <SectionCard
+                    header="Voting Results"
+                    iconSrc="/assets/icon-star.svg"
+                  >
+                    <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-5">
+                      <VotingResults
+                        voteOutcome={voteOutcome}
+                        votes={votes}
+                        threshold={0}
+                      />
+                    </div>
+                  </SectionCard>
+                )}
+
+              <SectionCard
+                header="Meet the Team"
+                iconSrc="/assets/icon-team.svg"
+                action={
+                  isManager && (
+                    <div className="flex flex-col md:flex-row justify-start items-center gap-2">
+                      <TeamManageMembers
+                        account={account}
+                        hats={hats}
+                        hatsContract={hatsContract}
+                        teamContract={projectContract}
+                        teamId={tokenId}
+                        selectedChain={selectedChain}
+                        multisigAddress={safeAddress}
+                        adminHatId={adminHatId}
+                        managerHatId={managerHatId}
+                      />
+                    </div>
+                  )
+                }
+              >
+                <SlidingCardMenu>
+                  <div className="flex gap-2 md:gap-4">
+                    {hats?.[0].id && (
+                      <TeamMembers
+                        hats={hats}
+                        hatsContract={hatsContract}
+                        citizenContract={citizenContract}
+                      />
+                    )}
+                  </div>
+                </SlidingCardMenu>
+              </SectionCard>
+              <SectionCard
+                header="Treasury"
+                iconSrc="/assets/icon-treasury.svg"
+              >
+                <TeamTreasury
+                  isSigner={isSigner}
+                  safeData={safeData}
+                  multisigAddress={safeAddress}
+                  safeOwners={safeOwners}
+                  projectActive={project.active}
+                />
+              </SectionCard>
+            </div>
+          )
+
+          if (!showVoteSidebar) {
+            return (
+              <div
+                id="page-container"
+                className="pt-2 sm:pt-3 md:pt-4 pb-4 sm:pb-6 md:pb-8"
+              >
+                {mainColumn}
               </div>
-            </SlidingCardMenu>
-          </SectionCard>
-          <SectionCard header="Treasury" iconSrc="/assets/icon-treasury.svg">
-            <TeamTreasury
-              isSigner={isSigner}
-              safeData={safeData}
-              multisigAddress={safeAddress}
-              safeOwners={safeOwners}
-              projectActive={project.active}
-            />
-          </SectionCard>
-        </div>
+            )
+          }
+
+          // The sidebar appears *first* in source order so on mobile the
+          // active CTA (Vote button) is above the proposal body — same
+          // reasoning as Snapshot's mobile layout. On lg+ the grid
+          // rebalances it to the right column.
+          return (
+            <div
+              id="page-container"
+              className="pt-2 sm:pt-3 md:pt-4 pb-4 sm:pb-6 md:pb-8 grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6"
+            >
+              <div className="lg:order-2 lg:col-span-1">
+                <MemberVoteSidebar
+                  project={project}
+                  votes={votes}
+                  addressToVotingPower={addressToVotingPower}
+                  proposalStatus={proposalStatus}
+                  mode={sidebarMode}
+                  footer={
+                    sidebarMode === 'voting' ? (
+                      <CloseAndTallyButton
+                        mdp={project.MDP}
+                        tempCheckApprovedTimestamp={tempCheckApprovedTimestamp}
+                      />
+                    ) : null
+                  }
+                />
+              </div>
+              <div className="lg:order-1 lg:col-span-2">{mainColumn}</div>
+            </div>
+          )
+        })()}
       </ContentLayout>
     </Container>
   )
@@ -536,6 +597,12 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query: pa
 
     let votes: DistributionVote[] = []
     let voteOutcome = {}
+    // address -> quadratic voting power (sqrt of vMOONEY at the voting
+    // window close). Same number we'd use to tally on-chain, so the
+    // sidebar list stays consistent with the eventual outcome. Empty
+    // object when there are no voters yet (or this is a project
+    // proposal that doesn't carry vote rows).
+    let addressToVotingPower: { [address: string]: number } = {}
     if (proposalJSON?.nonProjectProposal) {
       try {
         const voteStatement = `SELECT * FROM ${NON_PROJECT_PROPOSAL_TABLE_NAMES[chainSlug]} WHERE MDP = ${mdp}`
@@ -548,11 +615,11 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query: pa
 
         if (voteAddresses.length > 0) {
           const vMOONEYs = await fetchTotalVMOONEYs(voteAddresses, votingPeriodClosedTimestamp)
-          const addressToQuadraticVotingPower = Object.fromEntries(
+          addressToVotingPower = Object.fromEntries(
             voteAddresses.map((address, index) => [address, Math.sqrt(vMOONEYs[index])])
           )
           const SUM_TO_ONE_HUNDRED = 100
-          voteOutcome = runQuadraticVoting(votes, addressToQuadraticVotingPower, SUM_TO_ONE_HUNDRED)
+          voteOutcome = runQuadraticVoting(votes, addressToVotingPower, SUM_TO_ONE_HUNDRED)
         }
       } catch (error) {
         console.error('Error fetching votes:', error)
@@ -604,6 +671,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query: pa
         proposalStatus,
         proposalJSON,
         voteOutcome,
+        addressToVotingPower,
         tempCheckApprovedTimestamp: tempCheckApprovedTimestamp
           ? tempCheckApprovedTimestamp.toString()
           : '0',

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -45,6 +45,7 @@ import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import SectionCard from '@/components/layout/SectionCard'
 import SlidingCardMenu from '@/components/layout/SlidingCardMenu'
 import MarkdownWithTOC from '@/components/nance/MarkdownWithTOC'
+import Tab from '@/components/layout/Tab'
 
 import VotingResults from '@/components/nance/VotingResults'
 import ProposalEditSection from '@/components/nance/ProposalEditSection'
@@ -159,6 +160,48 @@ export default function ProjectProfile({
     }, 5000)
     return () => clearTimeout(timer)
   }, [pending, tokenId, router])
+
+  // Tabbed main column. The right rail (Senate + Member vote
+  // sidebars) is intentionally outside the tab system so the
+  // primary action stays visible across all three tabs.
+  type ProjectTab = 'proposal' | 'treasury' | 'team'
+  const [tab, setTab] = useState<ProjectTab>('proposal')
+
+  // Hydrate from `?tab=` so deep links land on the right tab and
+  // browser back/forward navigates between tabs the user has
+  // already visited.
+  useEffect(() => {
+    const urlTab = router.query.tab
+    if (
+      typeof urlTab === 'string' &&
+      (urlTab === 'proposal' ||
+        urlTab === 'treasury' ||
+        urlTab === 'team')
+    ) {
+      setTab(urlTab)
+    }
+  }, [router.query.tab])
+
+  const handleTabChange = (next: string) => {
+    const nextTab = next as ProjectTab
+    setTab(nextTab)
+    // `shallow + scroll: false`: don't re-run getServerSideProps
+    // and don't yank the user back to the top of the page when
+    // they're switching tabs — the rail is sticky and the tab
+    // strip itself sits inside the main column.
+    const { tab: _omit, ...restQuery } = router.query
+    router.replace(
+      {
+        pathname: router.pathname,
+        query:
+          nextTab === 'proposal'
+            ? restQuery
+            : { ...restQuery, tab: nextTab },
+      },
+      undefined,
+      { shallow: true, scroll: false }
+    )
+  }
 
   if (pending) {
     return (
@@ -282,7 +325,11 @@ export default function ProjectProfile({
               ? 'closed'
               : 'inactive'
 
-          const mainColumn = (
+          // Proposal tab — proposal-lifecycle content. Final Report
+          // (post-completion), Senate Vote interactive section
+          // (Temperature Check only), the proposal body itself, and
+          // Voting Results (post-tally, non-project proposals only).
+          const proposalPane = (
             <div className="flex flex-col gap-4 sm:gap-6 min-w-0">
               {finalReportMarkdown && (
                 <SectionCard
@@ -316,13 +363,12 @@ export default function ProjectProfile({
                   </SectionCard>
                 )}
 
-              {/* Project Overview */}
-              <SectionCard
-                header="Proposal"
-                iconSrc="/assets/icon-star.svg"
-                className=""
-              >
-                <div className="mb-6 sm:mt-4 sm:mb-10 px-0 sm:px-4 md:px-8 w-full">
+              {/* Proposal body. The "Proposal" tab is the navigation;
+                  no need for a duplicate `Proposal` SectionCard
+                  header inside it. Just render the markdown on the
+                  same SectionCard surface for visual continuity. */}
+              <div className="md:bg-gradient-to-br md:from-slate-700/20 md:to-slate-800/30 md:backdrop-blur-xl md:border md:border-white/10 md:rounded-xl px-4 py-3 md:p-6 md:shadow-lg w-full">
+                <div className="px-0 sm:px-4 md:px-8 w-full">
                   <div className="prose prose-base prose-invert max-w-none">
                     <MarkdownWithTOC
                       body={(() => {
@@ -338,11 +384,11 @@ export default function ProjectProfile({
                     />
                   </div>
                 </div>
-              </SectionCard>
+              </div>
 
               {/* Voting Results Section - Only show for completed
-                  proposals. Aggregate verdict card; the right rail still
-                  carries the per-voter detail. */}
+                  proposals. Aggregate verdict card; the right rail
+                  still carries the per-voter detail. */}
               {project.active !== PROJECT_PENDING &&
                 proposalJSON?.nonProjectProposal && (
                   <SectionCard
@@ -358,56 +404,100 @@ export default function ProjectProfile({
                     </div>
                   </SectionCard>
                 )}
+            </div>
+          )
 
-              <SectionCard
-                header="Meet the Team"
-                iconSrc="/assets/icon-team.svg"
-                action={
-                  isManager && (
-                    <div className="flex flex-col md:flex-row justify-start items-center gap-2">
-                      <TeamManageMembers
-                        account={account}
-                        hats={hats}
-                        hatsContract={hatsContract}
-                        teamContract={projectContract}
-                        teamId={tokenId}
-                        selectedChain={selectedChain}
-                        multisigAddress={safeAddress}
-                        adminHatId={adminHatId}
-                        managerHatId={managerHatId}
-                      />
-                    </div>
-                  )
-                }
-              >
-                <SlidingCardMenu>
-                  <div className="flex gap-2 md:gap-4">
-                    {hats?.[0].id && (
-                      <TeamMembers
-                        hats={hats}
-                        hatsContract={hatsContract}
-                        citizenContract={citizenContract}
-                      />
-                    )}
-                  </div>
-                </SlidingCardMenu>
-              </SectionCard>
-              <SectionCard
-                header="Treasury"
-                iconSrc="/assets/icon-treasury.svg"
-              >
-                {/* `hideHeader`: SectionCard already renders the
-                    "Treasury" title, so suppress the inner h2 + icon
-                    to avoid the double-title look. */}
-                <TeamTreasury
-                  isSigner={isSigner}
-                  safeData={safeData}
-                  multisigAddress={safeAddress}
-                  safeOwners={safeOwners}
-                  projectActive={project.active}
-                  hideHeader
-                />
-              </SectionCard>
+          // Treasury tab — drop the SectionCard wrapper so the tab
+          // (already labelled "Treasury") is the only title, then
+          // re-create the SectionCard surface inline. `hideHeader`
+          // keeps TeamTreasury from rendering its own internal h2.
+          const treasuryPane = (
+            <div className="md:bg-gradient-to-br md:from-slate-700/20 md:to-slate-800/30 md:backdrop-blur-xl md:border md:border-white/10 md:rounded-xl md:shadow-lg w-full">
+              <TeamTreasury
+                isSigner={isSigner}
+                safeData={safeData}
+                multisigAddress={safeAddress}
+                safeOwners={safeOwners}
+                projectActive={project.active}
+                hideHeader
+              />
+            </div>
+          )
+
+          // Team tab — same pattern. The Manage Members button (only
+          // visible to managers) stays anchored to the top-right of
+          // the card so it doesn't get lost without a SectionCard
+          // header to host it.
+          const teamPane = (
+            <div className="md:bg-gradient-to-br md:from-slate-700/20 md:to-slate-800/30 md:backdrop-blur-xl md:border md:border-white/10 md:rounded-xl px-4 py-3 md:p-6 md:shadow-lg w-full">
+              {isManager && (
+                <div className="flex justify-end mb-3 md:mb-5">
+                  <TeamManageMembers
+                    account={account}
+                    hats={hats}
+                    hatsContract={hatsContract}
+                    teamContract={projectContract}
+                    teamId={tokenId}
+                    selectedChain={selectedChain}
+                    multisigAddress={safeAddress}
+                    adminHatId={adminHatId}
+                    managerHatId={managerHatId}
+                  />
+                </div>
+              )}
+              <SlidingCardMenu>
+                <div className="flex gap-2 md:gap-4">
+                  {hats?.[0].id && (
+                    <TeamMembers
+                      hats={hats}
+                      hatsContract={hatsContract}
+                      citizenContract={citizenContract}
+                    />
+                  )}
+                </div>
+              </SlidingCardMenu>
+            </div>
+          )
+
+          const mainColumn = (
+            <div className="flex flex-col gap-4 sm:gap-6 min-w-0">
+              {/* Tab strip. Sticky at small viewports too, but on
+                  mobile it sits *below* the right-rail vote cards
+                  (which are themselves source-ordered first via
+                  `lg:order-2` on the rail wrapper) so the primary
+                  vote action stays above the navigation. */}
+              <div className="bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 p-1.5 self-start">
+                <div className="flex text-sm gap-1">
+                  <Tab
+                    tab="proposal"
+                    currentTab={tab}
+                    setTab={handleTabChange}
+                    icon="/assets/icon-star.svg"
+                  >
+                    Proposal
+                  </Tab>
+                  <Tab
+                    tab="treasury"
+                    currentTab={tab}
+                    setTab={handleTabChange}
+                    icon="/assets/icon-treasury.svg"
+                  >
+                    Treasury
+                  </Tab>
+                  <Tab
+                    tab="team"
+                    currentTab={tab}
+                    setTab={handleTabChange}
+                    icon="/assets/icon-team.svg"
+                  >
+                    Team
+                  </Tab>
+                </div>
+              </div>
+
+              {tab === 'proposal' && proposalPane}
+              {tab === 'treasury' && treasuryPane}
+              {tab === 'team' && teamPane}
             </div>
           )
 

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -45,7 +45,6 @@ import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import SectionCard from '@/components/layout/SectionCard'
 import SlidingCardMenu from '@/components/layout/SlidingCardMenu'
 import MarkdownWithTOC from '@/components/nance/MarkdownWithTOC'
-import Tab from '@/components/layout/Tab'
 
 import VotingResults from '@/components/nance/VotingResults'
 import ProposalEditSection from '@/components/nance/ProposalEditSection'
@@ -459,40 +458,38 @@ export default function ProjectProfile({
             </div>
           )
 
+          // Underline-style tab bar matching the Mission/Launchpad
+          // pattern (`MissionInfo.tsx`): text-only, gray-500
+          // inactive, white + 2px indigo underline active, sitting
+          // on a thin `border-b`. `overflow-x-auto` keeps it
+          // single-row on phones.
+          const tabButton = (key: ProjectTab, label: string) => {
+            const isActive = tab === key
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => handleTabChange(key)}
+                className={`relative px-5 py-3 text-base md:text-lg font-semibold tracking-wide whitespace-nowrap transition-all duration-200 ${
+                  isActive
+                    ? 'text-white'
+                    : 'text-gray-500 hover:text-gray-300'
+                }`}
+              >
+                {label}
+                {isActive && (
+                  <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-3/4 h-[2px] bg-indigo-400 rounded-full" />
+                )}
+              </button>
+            )
+          }
+
           const mainColumn = (
             <div className="flex flex-col gap-4 sm:gap-6 min-w-0">
-              {/* Tab strip. Sticky at small viewports too, but on
-                  mobile it sits *below* the right-rail vote cards
-                  (which are themselves source-ordered first via
-                  `lg:order-2` on the rail wrapper) so the primary
-                  vote action stays above the navigation. */}
-              <div className="bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 p-1.5 self-start">
-                <div className="flex text-sm gap-1">
-                  <Tab
-                    tab="proposal"
-                    currentTab={tab}
-                    setTab={handleTabChange}
-                    icon="/assets/icon-star.svg"
-                  >
-                    Proposal
-                  </Tab>
-                  <Tab
-                    tab="treasury"
-                    currentTab={tab}
-                    setTab={handleTabChange}
-                    icon="/assets/icon-treasury.svg"
-                  >
-                    Treasury
-                  </Tab>
-                  <Tab
-                    tab="team"
-                    currentTab={tab}
-                    setTab={handleTabChange}
-                    icon="/assets/icon-team.svg"
-                  >
-                    Team
-                  </Tab>
-                </div>
+              <div className="flex items-center gap-1 border-b border-white/[0.08] overflow-x-auto max-w-full -mx-1 px-1">
+                {tabButton('proposal', 'Proposal')}
+                {tabButton('treasury', 'Treasury')}
+                {tabButton('team', 'Team')}
               </div>
 
               {tab === 'proposal' && proposalPane}

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -52,6 +52,7 @@ import AuthorCitizenLink from '@/components/project/AuthorCitizenLink'
 import CloseAndTallyButton from '@/components/project/CloseAndTallyButton'
 import MemberVoteSidebar from '@/components/project/MemberVoteSidebar'
 import SenateVote from '@/components/project/SenateVote'
+import SenateVoteSidebar from '@/components/project/SenateVoteSidebar'
 import TeamManageMembers from '@/components/subscription/TeamManageMembers'
 import TeamMembers from '@/components/subscription/TeamMembers'
 import TeamTreasury from '@/components/subscription/TeamTreasury'
@@ -294,21 +295,15 @@ export default function ProjectProfile({
                 </SectionCard>
               )}
 
-              {/* Senate Vote Section.
-                  - During Temperature Check: senators see interactive
-                    👍/👎 buttons; everyone sees the running counts and
-                    the per-senator voted/pending grid; OPERATORS see
-                    the Close Senate Vote control.
-                  - After Temperature Check (Voting / Approved /
-                    Cancelled): the same panel renders read-only with a
-                    "Approved by Senate" / "Rejected by Senate" outcome
-                    badge so the senate breakdown stays visible across
-                    the rest of the proposal lifecycle. The on-chain
-                    `voteTempCheck` reverts post-tally so the cast-vote
-                    affordances are hidden — they would only confuse.
-                  Project proposals (which don't carry the on-chain
-                  Senate vote in the same way) are excluded post-TC to
-                  avoid showing zeros for a vote that never happened. */}
+              {/* Senate Vote Section — only renders during Temperature
+                  Check, when senators still need the interactive 👍/👎
+                  buttons and OPERATORS need the Close Senate Vote
+                  control. Once the senate has tallied, the read-only
+                  breakdown lives in the right-rail `SenateVoteSidebar`
+                  (so it's persistent across Voting / Approved /
+                  Cancelled without consuming main-column real estate).
+                  Project proposals don't carry the on-chain Senate
+                  vote in the same way, so they're excluded. */}
               {project.active === PROJECT_PENDING &&
                 proposalStatus === 'Temperature Check' && (
                   <SectionCard
@@ -321,23 +316,6 @@ export default function ProjectProfile({
                         advance to the next stage.
                       </p>
                       <SenateVote mdp={project.MDP} />
-                    </div>
-                  </SectionCard>
-                )}
-
-              {proposalStatus !== 'Temperature Check' &&
-                proposalJSON?.nonProjectProposal && (
-                  <SectionCard
-                    header="Senate Vote Results"
-                    iconSrc="/assets/icon-star.svg"
-                  >
-                    <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-6">
-                      <p className="text-sm text-white/70 mb-5">
-                        Senate verdict for this proposal — the breakdown
-                        and per-senator votes that decided whether it
-                        advanced to the Member Vote.
-                      </p>
-                      <SenateVote mdp={project.MDP} readOnly />
                     </div>
                   </SectionCard>
                 )}
@@ -447,13 +425,17 @@ export default function ProjectProfile({
           // The sidebar appears *first* in source order so on mobile the
           // active CTA (Vote button) is above the proposal body — same
           // reasoning as Snapshot's mobile layout. On lg+ the grid
-          // rebalances it to the right column.
+          // rebalances it to the right column. The Senate and Member
+          // Vote cards stack inside one sticky wrapper so they scroll
+          // together as a single unit (two independent `position:
+          // sticky` siblings would race each other for `top: 24px`).
           return (
             <div
               id="page-container"
               className="pt-2 sm:pt-3 md:pt-4 pb-4 sm:pb-6 md:pb-8 grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6"
             >
-              <div className="lg:order-2 lg:col-span-1">
+              <div className="lg:order-2 lg:col-span-1 lg:sticky lg:top-24 lg:self-start flex flex-col gap-4">
+                <SenateVoteSidebar mdp={project.MDP} />
                 <MemberVoteSidebar
                   project={project}
                   votes={votes}

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -294,10 +294,21 @@ export default function ProjectProfile({
                 </SectionCard>
               )}
 
-              {/* Senate Vote Section — pending proposals in Temperature
-                  Check. Senators see interactive 👍/👎 buttons; everyone
-                  sees the running counts and the per-senator
-                  voted/pending status. */}
+              {/* Senate Vote Section.
+                  - During Temperature Check: senators see interactive
+                    👍/👎 buttons; everyone sees the running counts and
+                    the per-senator voted/pending grid; OPERATORS see
+                    the Close Senate Vote control.
+                  - After Temperature Check (Voting / Approved /
+                    Cancelled): the same panel renders read-only with a
+                    "Approved by Senate" / "Rejected by Senate" outcome
+                    badge so the senate breakdown stays visible across
+                    the rest of the proposal lifecycle. The on-chain
+                    `voteTempCheck` reverts post-tally so the cast-vote
+                    affordances are hidden — they would only confuse.
+                  Project proposals (which don't carry the on-chain
+                  Senate vote in the same way) are excluded post-TC to
+                  avoid showing zeros for a vote that never happened. */}
               {project.active === PROJECT_PENDING &&
                 proposalStatus === 'Temperature Check' && (
                   <SectionCard
@@ -310,6 +321,23 @@ export default function ProjectProfile({
                         advance to the next stage.
                       </p>
                       <SenateVote mdp={project.MDP} />
+                    </div>
+                  </SectionCard>
+                )}
+
+              {proposalStatus !== 'Temperature Check' &&
+                proposalJSON?.nonProjectProposal && (
+                  <SectionCard
+                    header="Senate Vote Results"
+                    iconSrc="/assets/icon-star.svg"
+                  >
+                    <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-4 sm:p-6">
+                      <p className="text-sm text-white/70 mb-5">
+                        Senate verdict for this proposal — the breakdown
+                        and per-senator votes that decided whether it
+                        advanced to the Member Vote.
+                      </p>
+                      <SenateVote mdp={project.MDP} readOnly />
                     </div>
                   </SectionCard>
                 )}

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -400,12 +400,16 @@ export default function ProjectProfile({
                 header="Treasury"
                 iconSrc="/assets/icon-treasury.svg"
               >
+                {/* `hideHeader`: SectionCard already renders the
+                    "Treasury" title, so suppress the inner h2 + icon
+                    to avoid the double-title look. */}
                 <TeamTreasury
                   isSigner={isSigner}
                   safeData={safeData}
                   multisigAddress={safeAddress}
                   safeOwners={safeOwners}
                   projectActive={project.active}
+                  hideHeader
                 />
               </SectionCard>
             </div>

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -435,7 +435,14 @@ export default function ProjectProfile({
               className="pt-2 sm:pt-3 md:pt-4 pb-4 sm:pb-6 md:pb-8 grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6"
             >
               <div className="lg:order-2 lg:col-span-1 lg:sticky lg:top-24 lg:self-start flex flex-col gap-4">
-                <SenateVoteSidebar mdp={project.MDP} />
+                {/* Member Vote sits on top while it's the active step
+                    — that's the primary action members can take right
+                    now, so it gets the eye-catching styling. The
+                    Senate Vote slot below renders as a "completed"
+                    reference card so members can still see how the
+                    proposal got past senate approval. Once voting is
+                    closed, the emphasis lifts and both panels render
+                    as peers. */}
                 <MemberVoteSidebar
                   project={project}
                   votes={votes}
@@ -450,6 +457,10 @@ export default function ProjectProfile({
                       />
                     ) : null
                   }
+                />
+                <SenateVoteSidebar
+                  mdp={project.MDP}
+                  secondary={sidebarMode === 'voting'}
                 />
               </div>
               <div className="lg:order-1 lg:col-span-2">{mainColumn}</div>


### PR DESCRIPTION
## Summary

Reworks the proposal page voting experience, end-to-end, in response to a user hitting `NONCE_EXPIRED` while on the wrong network and feedback that the Senate / Member vote affordances were buried below the proposal body.

### Network enforcement
- Vote modal now uses `PrivyWeb3Button` with `requiredChain={DEFAULT_CHAIN_V5}` so wrong-network users get a "Switch Network" affordance instead of a stuck `eth_sendTransaction` call.
- Inline yellow banner names the destination network so the user does not have to guess.

### Right-rail vote layout
- Two-column grid on `lg+`: proposal body left, sticky right rail with **Member Vote** stacked over **Senate Vote** results.
- Member Vote card is the visual primary action while voting is open (gradient surface, glowing border, pulsing pill); Senate Vote card dims to a reference card.
- Per-voter voting power computed server-side (`sqrt(vMOONEY)`) so the rail can show who voted and how much VP they swung.
- Senate Vote results persist across Voting / Approved / Cancelled — they no longer disappear after Temperature Check closes.

### Member Vote: single-click + result hiding
- Replaced the multi-input `WeightedChoiceSelector` with `SingleClickChoiceSelector`: Yes / No / Abstain in a 3-column grid, one click submits.
- On-chain encoding unchanged (`{ "<index+1>": 100 }`), so `runQuadraticVoting` and existing tally logic keep working.
- Confetti + auto-close on successful submit.
- Per-choice tally is hidden in the rail until voting closes (anti-bandwagoning); voters list still shows who voted with their VP.

### Senate vote ops
- Executive Lead button to manually close + tally a Senate vote on-chain (HSM-signed via `/api/proposals/closeSenate`), with retry on transient RPC errors.
- Discord notification link points at `/project/<MDP>` (was `/proposal/<MDP>`).

### Proposal page tabs
- Main column is now tabbed: **Proposal** / **Treasury** / **Team**, matching the Mission/Launchpad underline-style tab pattern.
- Tab state syncs with `?tab=` for shareable deep links and back/forward; right-rail vote sidebars stay outside the tab system so the primary action is visible regardless of tab.
- Treasury responsive layout cleaned up across `sm` / `lg` / `xl` breakpoints.

### Copy
- Trimmed explanatory paragraphs across the proposal/vote UI — let the affordances speak for themselves.

## Files changed

- `ui/pages/project/[tokenId].tsx` — grid layout, tabs, server-side VP calc
- `ui/pages/api/proposals/vote-notification.ts` — `/project/` link
- `ui/components/project/MemberVoteSidebar.tsx` — new
- `ui/components/project/SenateVoteSidebar.tsx` — new
- `ui/components/project/SenateVote.tsx` — `readOnly` prop, Close vote button
- `ui/components/project/CloseAndTallyButton.tsx` — copy trim
- `ui/components/nance/VotingModal.tsx` — network enforcement, single-click selector, Abstain, confetti
- `ui/components/nance/NewVoteButton.tsx` — drop `spaceHideAbstain`
- `ui/components/subscription/TeamTreasury.tsx` — responsive cleanup, `hideHeader` prop

## Test plan

- [ ] On a Temperature Check proposal, senators see the interactive Senate Vote section + 👍/👎 buttons; non-senators see read-only outcome.
- [ ] Executive Lead can click "Close Senate Vote" once quorum is reached; tx confirms and proposal advances to Member Voting.
- [ ] Senate vote results stay visible in the right rail across Voting / Approved / Cancelled states.
- [ ] Member on the wrong network: vote modal shows "Switch Network" + yellow banner; clicking switches to Arbitrum One.
- [ ] Member on the right network: clicking Yes / No / Abstain submits in one click, confetti fires, modal auto-closes.
- [ ] During Member Vote, the right rail shows voters + their VP but hides the Yes/No/Abstain breakdown until close.
- [ ] After Close & Tally, the Voting Results aggregate card and per-choice breakdown both render.
- [ ] Discord notifications for Senate vote events link to `/project/<MDP>`.
- [ ] Proposal / Treasury / Team tabs each render their content; `?tab=treasury` deep-links work; back/forward navigates between tabs.
- [ ] Treasury layout looks right on mobile, `lg`, and `xl`.


Made with [Cursor](https://cursor.com)