### PR TITLE
Hotfix: /project/[mdp] 500 from undefined threshold in VotingResults

### DIFF
--- a/ui/components/nance/VotingResults.tsx
+++ b/ui/components/nance/VotingResults.tsx
@@ -178,7 +178,7 @@ export default function VotingResults({
             <ColorBar
               greenScore={forPctNum}
               redScore={againstPctNum}
-              threshold={threshold}
+              threshold={0}
               noTooltip={false}
               backgroundColor="bg-slate-600"
             />


### PR DESCRIPTION
## Summary

Production /project/249 has been returning 500 since #1312 merged. Cause: my `aeed31bc` commit removed VotingResults' `threshold` prop from the signature/destructure, but missed a remaining `threshold={threshold}` reference forwarded to `<ColorBar>` (line 181). It only fired once the structured-tally branch actually rendered — which happened the instant the auto-snapshot row landed for MDP-249. SSR threw `ReferenceError: threshold is not defined` → Next.js fell back to its 500 page for the whole proposal route.

Fix: restore the previous call-site value (`threshold={0}`). ColorBar visual is unchanged from pre-#1312 behavior, and pass/fail UX is already driven by the structured `passed` flag from `computeMemberProposalTally` upstream.

The auto-snapshot itself worked correctly — sentinel row in `NonProjectProposal_42161_154` for MDP-249 has valid `closeBlocks` on all 4 chains and the locked tally is 91.14% For of decided VP (passed). Once this lands, the page will render that frozen tally with the "Final tally" provenance pill.

## Test plan

- [x] Reproduced 500 on `localhost:3000/project/249` (mainnet config) before the fix — server log showed `ReferenceError: threshold is not defined at VotingResults`.
- [x] Verified `localhost:3000/project/249` returns 200 after the fix.
- [ ] After merge: confirm `https://www.moondao.com/project/249` returns 200 and renders the locked tally with the "Final tally" pill.
