### PR TITLE
Member-vote UX: Voting Results tab, top-of-rail tally, voted-state polish

### DIFF
--- a/ui/components/nance/NewVoteButton.tsx
+++ b/ui/components/nance/NewVoteButton.tsx
@@ -24,12 +24,30 @@ const VOTE_CHOICE_LABELS: Record<string, string> = {
 // the only nonzero key; legacy split votes still resolve to whichever
 // side got the most weight, matching the dominantChoice logic in the
 // sidebar so "You voted" and the per-voter pill always agree.
+//
+// Accepts both shapes a vote row can arrive as: an already-parsed
+// object (Tableland gateway path) and a JSON-encoded string (some
+// adapter paths and the legacy `distribution` column). Without the
+// string fallback, `Object.entries(stringVote)` would iterate the
+// JSON literal's characters and produce a nonsense label. Mirrors
+// `parseVote` in `lib/proposals/computeMemberProposalTally`.
 function dominantVoteLabel(
-  vote: Record<string, number> | undefined
+  vote: Record<string, number> | string | undefined | null
 ): string | null {
-  if (!vote) return null
+  if (vote == null) return null
+  let dist: Record<string, number> = {}
+  if (typeof vote === 'string') {
+    try {
+      const parsed = JSON.parse(vote)
+      if (parsed && typeof parsed === 'object') dist = parsed
+    } catch {
+      return null
+    }
+  } else {
+    dist = vote
+  }
   let best: [string, number] | null = null
-  for (const [k, v] of Object.entries(vote)) {
+  for (const [k, v] of Object.entries(dist)) {
     const n = Number(v)
     if (!Number.isFinite(n)) continue
     if (best === null || n > best[1]) best = [k, n]

--- a/ui/components/nance/NewVoteButton.tsx
+++ b/ui/components/nance/NewVoteButton.tsx
@@ -1,5 +1,5 @@
 import { usePrivy } from '@privy-io/react-auth'
-import { useState, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { ProposalStatus, STATUS_DISPLAY_LABELS } from '@/lib/nance/useProposalStatus'
 import { Project } from '@/lib/project/useProjectData'
 import useAccountAddress from '../../lib/nance/useAccountAddress'
@@ -7,6 +7,36 @@ import { classNames } from '../../lib/utils/tailwind'
 import { useTotalLockedMooney } from '@/lib/tokens/hooks/useTotalLockedMooney'
 import { useTotalVMOONEY } from '@/lib/tokens/hooks/useTotalVMOONEY'
 import VotingModal from './VotingModal'
+
+// Same '1' / '2' / '3' choice keys VotingModal writes into the
+// NonProjectProposal_* table. Kept inline rather than importing from
+// MemberVoteSidebar so this component stays usable on the legacy
+// /proposal/[id] route too (where ProposalVotes still renders it).
+const VOTE_CHOICE_LABELS: Record<string, string> = {
+  '1': 'For',
+  '2': 'Against',
+  '3': 'Abstain',
+}
+
+// Map a quadratic distribution like { '1': 70, '2': 30 } back to the
+// dominant label. Single-click votes (the default since the
+// SingleClickChoiceSelector landed) are always 100/0/0 so this picks
+// the only nonzero key; legacy split votes still resolve to whichever
+// side got the most weight, matching the dominantChoice logic in the
+// sidebar so "You voted" and the per-voter pill always agree.
+function dominantVoteLabel(
+  vote: Record<string, number> | undefined
+): string | null {
+  if (!vote) return null
+  let best: [string, number] | null = null
+  for (const [k, v] of Object.entries(vote)) {
+    const n = Number(v)
+    if (!Number.isFinite(n)) continue
+    if (best === null || n > best[1]) best = [k, n]
+  }
+  if (!best || best[1] <= 0) return null
+  return VOTE_CHOICE_LABELS[best[0]] ?? `Choice ${best[0]}`
+}
 
 export default function NewVoteButton({
   votes,
@@ -22,20 +52,32 @@ export default function NewVoteButton({
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const { address, isConnected } = useAccountAddress()
   const { connectWallet: openConnectModal } = usePrivy()
-  const [edit, setEdit] = useState(false)
   const { breakdown: lockedMooneyBreakdown } = useTotalLockedMooney(address)
   const { totalVMOONEY } = useTotalVMOONEY(address, lockedMooneyBreakdown)
 
-  useEffect(() => {
-    if (votes && address) {
-      for (const v of votes) {
-        if (v.address.toLowerCase() === address.toLowerCase()) {
-          setEdit(true)
-          break
-        }
+  // Find the connected wallet's vote row in `votes` (if any). Drives
+  // both the "Edit Vote" / "Vote" label switch and the new "You voted"
+  // pill that surfaces the actual choice the user already cast — fixing
+  // the previous UX where a returning voter saw "Edit Vote" with no
+  // hint of what they'd voted for.
+  const myVote = useMemo(() => {
+    if (!votes || !address) return null
+    const lower = address.toLowerCase()
+    for (const v of votes) {
+      if (
+        v &&
+        typeof v.address === 'string' &&
+        v.address.toLowerCase() === lower
+      ) {
+        return v
       }
     }
-  }, [address, votes])
+    return null
+  }, [votes, address])
+
+  const myChoice = useMemo(() => dominantVoteLabel(myVote?.vote), [myVote])
+
+  const edit = Boolean(myVote)
 
   let buttonLabel = 'Vote'
   if (proposalStatus === undefined) {
@@ -54,10 +96,31 @@ export default function NewVoteButton({
   } else {
     buttonLabel = 'Connect Wallet'
   }
-  console.log('new vote button')
+
+  // Tone for the "You voted" pill. Mirrors the per-voter ChoicePill
+  // colors in MemberVoteSidebar so the "your vote" pill and the
+  // matching row in the sidebar always read as the same color.
+  const myChoiceCls =
+    myChoice === 'For'
+      ? 'bg-green-500/15 text-green-300 border-green-500/30'
+      : myChoice === 'Against'
+      ? 'bg-red-500/15 text-red-300 border-red-500/30'
+      : myChoice === 'Abstain'
+      ? 'bg-gray-500/15 text-gray-300 border-gray-500/30'
+      : 'bg-white/5 text-white/60 border-white/10'
 
   return (
     <div className={isSmall ? '' : 'my-4'}>
+      {edit && myChoice && (
+        <div className="mb-2 flex items-center justify-center gap-2 text-[11px] text-white/70">
+          <span>You voted</span>
+          <span
+            className={`inline-flex items-center font-medium px-2 py-0.5 rounded-full border ${myChoiceCls}`}
+          >
+            {myChoice}
+          </span>
+        </div>
+      )}
       <button
         id="vote"
         className={classNames(

--- a/ui/components/nance/ProposalEditSection.tsx
+++ b/ui/components/nance/ProposalEditSection.tsx
@@ -14,17 +14,24 @@ import {
   InformationCircleIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
+import { ProposalStatus } from '@/lib/nance/useProposalStatus'
 
 interface ProposalEditSectionProps {
   proposalJSON: any
   projectName: string
   mdp: number
+  // Lifecycle gate. Editing a proposal post-approval would let the
+  // author rewrite the text members already voted on, so we lock it
+  // once `proposalStatus === 'Approved'`. Optional so legacy callers
+  // (and tests) keep working without a status feed.
+  proposalStatus?: ProposalStatus
 }
 
 export default function ProposalEditSection({
   proposalJSON,
   projectName,
   mdp,
+  proposalStatus,
 }: ProposalEditSectionProps) {
   const router = useRouter()
   const account = useActiveAccount()
@@ -44,6 +51,7 @@ export default function ProposalEditSection({
     address.toLowerCase() === proposalJSON.authorAddress.toLowerCase()
 
   if (!isAuthor) return null
+  if (proposalStatus === 'Approved') return null
 
   const handleSetMarkdown = (markdown: string) => {
     setNewBody(markdown)

--- a/ui/components/project/MemberVoteSidebar.tsx
+++ b/ui/components/project/MemberVoteSidebar.tsx
@@ -29,14 +29,46 @@ const CHOICE_LABELS: Record<string, string> = {
   '3': 'Abstain',
 }
 
-// Map a quadratic vote distribution like { '1': 70, '2': 30 } to a single
-// label by picking the choice with the highest weight. Single-click votes
-// (after task 4) are always 100/0/0 so this collapses to the obvious
-// answer; older split votes still render sensibly.
-function dominantChoice(vote: Record<string, number> | undefined): string {
-  if (!vote) return 'Unknown'
+const FOR_KEY = '1'
+const AGAINST_KEY = '2'
+const ABSTAIN_KEY = '3'
+
+// Mirrors `parseVote` in `lib/proposals/computeMemberProposalTally`:
+// the Tableland row's `vote` field can come back as either an already-
+// parsed object (Tableland gateway path) or a JSON-encoded string
+// (some adapter paths and the legacy `distribution` column). Without
+// this fallback, `Object.entries(stringVote)` would iterate the
+// characters of the JSON literal and produce nonsense numbers — which
+// would silently disagree with the on-chain tally for any caller that
+// happens to pass a string-form row.
+function parseVoteDist(
+  raw: Record<string, number> | string | undefined | null
+): Record<string, number> {
+  if (raw == null) return {}
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw)
+      return parsed && typeof parsed === 'object' ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+  return raw
+}
+
+// Map a quadratic vote distribution like { '1': 70, '2': 30 } to a
+// single label by picking the choice with the highest weight. Used
+// only for the per-voter ChoicePill in the voter list — the *tally*
+// (For/Against/Abstain VP totals) is intentionally computed by
+// weighting each voter's VP by their allocation pct (see the
+// useMemo below) so it still agrees with the canonical
+// `computeMemberProposalTally` for legacy split votes.
+function dominantChoice(
+  vote: Record<string, number> | string | undefined
+): string {
+  const dist = parseVoteDist(vote)
   let best: [string, number] | null = null
-  for (const [k, v] of Object.entries(vote)) {
+  for (const [k, v] of Object.entries(dist)) {
     const n = Number(v)
     if (!Number.isFinite(n)) continue
     if (best === null || n > best[1]) best = [k, n]
@@ -132,30 +164,51 @@ export default function MemberVoteSidebar({
     [enriched]
   )
 
+  // VP-weighted tally — mirrors `computeMemberProposalTally` line-for-
+  // line so the rendered sidebar breakdown can never diverge from the
+  // server-side outcome or the on-chain decision. Each voter's VP is
+  // distributed across For/Against/Abstain by the same pct allocation
+  // they wrote into the Tableland row (split votes preserve their
+  // weighting; single-click votes collapse to 100/0/0 and behave as
+  // expected). `totalParticipationVP` counts each voter's *full* VP
+  // when they allocated to any choice, which is the denominator used
+  // for `abstainShareOfTurnout` — same convention as the helper.
   const tally = useMemo(() => {
-    const acc = { For: 0, Against: 0, Abstain: 0 }
+    let forVP = 0
+    let againstVP = 0
+    let abstainVP = 0
+    let totalParticipationVP = 0
     for (const v of enriched) {
-      if (v.choice === 'For') acc.For += v.vp
-      else if (v.choice === 'Against') acc.Against += v.vp
-      else if (v.choice === 'Abstain') acc.Abstain += v.vp
+      const power = Number(v.vp) || 0
+      if (power <= 0) continue
+      const dist = parseVoteDist(v.vote)
+      const pctFor = Number(dist[FOR_KEY]) || 0
+      const pctAgainst = Number(dist[AGAINST_KEY]) || 0
+      const pctAbstain = Number(dist[ABSTAIN_KEY]) || 0
+      forVP += (power * pctFor) / 100
+      againstVP += (power * pctAgainst) / 100
+      abstainVP += (power * pctAbstain) / 100
+      if (pctFor > 0 || pctAgainst > 0 || pctAbstain > 0) {
+        totalParticipationVP += power
+      }
     }
-    return acc
+    return { For: forVP, Against: againstVP, Abstain: abstainVP, totalParticipationVP }
   }, [enriched])
 
-  // Percentages match `computeMemberProposalTally` exactly: For/
-  // Against are shares of *decided* VP (excluding Abstain — that's
-  // what the on-chain supermajority test uses), Abstain is shown as
-  // a share of *total turnout* so members can still see how much VP
-  // declined to take a side. Keeping the math here in lockstep with
-  // the server-side helper means the sidebar breakdown can never
-  // disagree with the Voting Results tab or the on-chain decision.
+  // Percentages match `computeMemberProposalTally`: For/Against are
+  // shares of decided VP (Abstain excluded — what the on-chain
+  // supermajority test uses), Abstain is reported as % of total
+  // participation VP so members can still see how much VP declined
+  // to take a side.
   const tallyPercents = useMemo(() => {
     const decided = tally.For + tally.Against
-    const turnout = decided + tally.Abstain
     return {
       forPctOfDecided: decided > 0 ? (tally.For / decided) * 100 : 0,
       againstPctOfDecided: decided > 0 ? (tally.Against / decided) * 100 : 0,
-      abstainPctOfTurnout: turnout > 0 ? (tally.Abstain / turnout) * 100 : 0,
+      abstainPctOfTurnout:
+        tally.totalParticipationVP > 0
+          ? (tally.Abstain / tally.totalParticipationVP) * 100
+          : 0,
     }
   }, [tally])
 
@@ -284,19 +337,30 @@ export default function MemberVoteSidebar({
           {/* Single proportional bar visualizes For vs Against —
               Abstain is intentionally omitted from the bar since the
               decision math also excludes it (matches the
-              VotingResults ColorBar in the Voting Results tab). The
-              [&>div]:transition-all keeps width changes smooth if
-              snapshot data lands after first paint. */}
-          <div className="h-1.5 w-full rounded-full bg-white/10 overflow-hidden flex">
+              VotingResults ColorBar in the Voting Results tab).
+              `role="img"` + a combined `aria-label` on the wrapper
+              makes the bar legible to screen readers as one unit;
+              the segment <div>s themselves are decorative
+              (`aria-hidden`) since their textual percentages are
+              already rendered in the grid above. Putting aria-labels
+              on the inner divs would not be announced reliably —
+              they have no semantic role of their own. */}
+          <div
+            role="img"
+            aria-label={`For ${tallyPercents.forPctOfDecided.toFixed(
+              1
+            )}%, Against ${tallyPercents.againstPctOfDecided.toFixed(1)}%`}
+            className="h-1.5 w-full rounded-full bg-white/10 overflow-hidden flex"
+          >
             <div
+              aria-hidden="true"
               className="h-full bg-green-500/70"
               style={{ width: `${tallyPercents.forPctOfDecided}%` }}
-              aria-label={`For ${tallyPercents.forPctOfDecided.toFixed(1)}%`}
             />
             <div
+              aria-hidden="true"
               className="h-full bg-red-500/70"
               style={{ width: `${tallyPercents.againstPctOfDecided}%` }}
-              aria-label={`Against ${tallyPercents.againstPctOfDecided.toFixed(1)}%`}
             />
           </div>
         </div>

--- a/ui/components/project/MemberVoteSidebar.tsx
+++ b/ui/components/project/MemberVoteSidebar.tsx
@@ -142,6 +142,23 @@ export default function MemberVoteSidebar({
     return acc
   }, [enriched])
 
+  // Percentages match `computeMemberProposalTally` exactly: For/
+  // Against are shares of *decided* VP (excluding Abstain — that's
+  // what the on-chain supermajority test uses), Abstain is shown as
+  // a share of *total turnout* so members can still see how much VP
+  // declined to take a side. Keeping the math here in lockstep with
+  // the server-side helper means the sidebar breakdown can never
+  // disagree with the Voting Results tab or the on-chain decision.
+  const tallyPercents = useMemo(() => {
+    const decided = tally.For + tally.Against
+    const turnout = decided + tally.Abstain
+    return {
+      forPctOfDecided: decided > 0 ? (tally.For / decided) * 100 : 0,
+      againstPctOfDecided: decided > 0 ? (tally.Against / decided) * 100 : 0,
+      abstainPctOfTurnout: turnout > 0 ? (tally.Abstain / turnout) * 100 : 0,
+    }
+  }, [tally])
+
   // While the Member Vote is the active step, elevate the card so
   // users can't miss the primary action: a tinted background, a
   // gradient ring, and a pulsing "Active — Vote now" pill. Once
@@ -220,6 +237,71 @@ export default function MemberVoteSidebar({
           </div>
         )}
 
+      {/* Final tally breakdown — pinned to the top of the card so
+          it's the first thing readers see post-close. Three labeled
+          percentages (For/Against of decided VP, Abstain of turnout)
+          over a single proportional bar. Suppressed mid-vote since
+          revealing the running split mid-window invites bandwagoning
+          (same reason the per-voter Choice pill is gated on
+          `revealResults`). */}
+      {revealResults && enriched.length > 0 && (
+        <div className="rounded-lg border border-white/10 bg-white/5 p-3 flex flex-col gap-2">
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div>
+              <p className="text-[10px] uppercase tracking-wider text-green-300/80">
+                For
+              </p>
+              <p className="text-sm font-semibold text-green-300">
+                {tallyPercents.forPctOfDecided.toFixed(1)}%
+              </p>
+              <p className="text-[10px] text-white/50 font-mono">
+                {formatNumberUSStyle(tally.For, true)} VP
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] uppercase tracking-wider text-red-300/80">
+                Against
+              </p>
+              <p className="text-sm font-semibold text-red-300">
+                {tallyPercents.againstPctOfDecided.toFixed(1)}%
+              </p>
+              <p className="text-[10px] text-white/50 font-mono">
+                {formatNumberUSStyle(tally.Against, true)} VP
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] uppercase tracking-wider text-gray-300/80">
+                Abstain
+              </p>
+              <p className="text-sm font-semibold text-gray-300">
+                {tallyPercents.abstainPctOfTurnout.toFixed(1)}%
+              </p>
+              <p className="text-[10px] text-white/50 font-mono">
+                {formatNumberUSStyle(tally.Abstain, true)} VP
+              </p>
+            </div>
+          </div>
+          {/* Single proportional bar visualizes For vs Against —
+              Abstain is intentionally omitted from the bar since the
+              decision math also excludes it (matches the
+              VotingResults ColorBar in the Voting Results tab). The
+              [&>div]:transition-all keeps width changes smooth if
+              snapshot data lands after first paint. */}
+          <div className="h-1.5 w-full rounded-full bg-white/10 overflow-hidden flex">
+            <div
+              className="h-full bg-green-500/70"
+              style={{ width: `${tallyPercents.forPctOfDecided}%` }}
+              aria-label={`For ${tallyPercents.forPctOfDecided.toFixed(1)}%`}
+            />
+            <div
+              className="h-full bg-red-500/70"
+              style={{ width: `${tallyPercents.againstPctOfDecided}%` }}
+              aria-label={`Against ${tallyPercents.againstPctOfDecided.toFixed(1)}%`}
+            />
+          </div>
+        </div>
+      )}
+
       {isActive && (
         <NewVoteButton
           proposalStatus={proposalStatus}
@@ -252,33 +334,10 @@ export default function MemberVoteSidebar({
         </div>
       </div>
 
-      {/* Per-choice tally — only after the vote has closed.
-          Suppressed mid-vote to avoid bandwagoning. */}
-      {revealResults && (
-        <div className="flex flex-col gap-1.5 text-[11px]">
-          <div className="flex items-center justify-between">
-            <span className="text-green-300">For</span>
-            <span className="text-white/80 font-mono">
-              {formatNumberUSStyle(tally.For, true)} VP
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-red-300">Against</span>
-            <span className="text-white/80 font-mono">
-              {formatNumberUSStyle(tally.Against, true)} VP
-            </span>
-          </div>
-          {tally.Abstain > 0 && (
-            <div className="flex items-center justify-between">
-              <span className="text-gray-300">Abstain</span>
-              <span className="text-white/80 font-mono">
-                {formatNumberUSStyle(tally.Abstain, true)} VP
-              </span>
-            </div>
-          )}
-        </div>
-      )}
-
+      {/* Per-choice tally has moved to the top of the card (pinned
+          right after the provenance pill) — keeping the absolute VPs
+          there with the % breakdown so the post-close summary stays
+          in one place rather than splitting across the card. */}
 
       {/* Voter list */}
       <div className="border-t border-white/10 pt-3">
@@ -317,16 +376,11 @@ export default function MemberVoteSidebar({
                       <AddressLink address={v.address} />
                     </span>
                   )}
-                  {revealResults ? (
-                    <ChoicePill label={v.choice} />
-                  ) : (
-                    <span
-                      className="inline-flex items-center text-[11px] font-medium px-2 py-0.5 rounded-full border bg-white/5 text-white/40 border-white/10"
-                      title="Choice hidden while voting is open"
-                    >
-                      Voted
-                    </span>
-                  )}
+                  {/* Choice pill is only rendered once results are
+                      unlocked. Mid-vote, the row is just name + VP —
+                      the section header already says "Votes" so a
+                      per-row "Voted" pill was redundant noise. */}
+                  {revealResults && <ChoicePill label={v.choice} />}
                 </div>
                 <span className="text-white/70 font-mono whitespace-nowrap">
                   {formatNumberUSStyle(v.vp, true)} VP

--- a/ui/pages/project/[tokenId].tsx
+++ b/ui/pages/project/[tokenId].tsx
@@ -271,8 +271,8 @@ export default function ProjectProfile({
 
   // Tabbed main column. The right rail (Senate + Member vote
   // sidebars) is intentionally outside the tab system so the
-  // primary action stays visible across all three tabs.
-  type ProjectTab = 'proposal' | 'treasury' | 'team'
+  // primary action stays visible across all four tabs.
+  type ProjectTab = 'proposal' | 'results' | 'treasury' | 'team'
   const [tab, setTab] = useState<ProjectTab>('proposal')
 
   // Hydrate from `?tab=` so deep links land on the right tab and
@@ -283,6 +283,7 @@ export default function ProjectProfile({
     if (
       typeof urlTab === 'string' &&
       (urlTab === 'proposal' ||
+        urlTab === 'results' ||
         urlTab === 'treasury' ||
         urlTab === 'team')
     ) {
@@ -400,6 +401,7 @@ export default function ProjectProfile({
                 proposalJSON={proposalJSON}
                 projectName={project.name}
                 mdp={project.MDP}
+                proposalStatus={proposalStatus}
               />
             </div>
           </div>
@@ -493,27 +495,28 @@ export default function ProjectProfile({
                   </div>
                 </div>
               </div>
-
-              {/* Voting Results Section - Only show for completed
-                  proposals. Aggregate verdict card; the right rail
-                  still carries the per-voter detail. */}
-              {project.active !== PROJECT_PENDING &&
-                proposalJSON?.nonProjectProposal && (
-                  <SectionCard
-                    header="Voting Results"
-                    iconSrc="/assets/icon-star.svg"
-                  >
-                    <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-5 flex flex-col gap-3">
-                      <TallyProvenanceTag meta={voteSnapshotMeta} />
-                      <VotingResults
-                        voteOutcome={voteOutcome}
-                        votes={votes}
-                      />
-                    </div>
-                  </SectionCard>
-                )}
             </div>
           )
+
+          // Voting Results tab — only meaningful for non-project
+          // proposals that have actually closed. Aggregate verdict
+          // card; the right rail still carries the per-voter detail
+          // so members can correlate their own vote against the
+          // tally.
+          const hasVotingResults =
+            project.active !== PROJECT_PENDING &&
+            Boolean(proposalJSON?.nonProjectProposal)
+          const resultsPane = hasVotingResults ? (
+            <div className="md:bg-gradient-to-br md:from-slate-700/20 md:to-slate-800/30 md:backdrop-blur-xl md:border md:border-white/10 md:rounded-xl px-4 py-3 md:p-6 md:shadow-lg w-full">
+              <div className="bg-dark-cool lg:bg-darkest-cool rounded-[20px] p-5 flex flex-col gap-3">
+                <TallyProvenanceTag meta={voteSnapshotMeta} />
+                <VotingResults
+                  voteOutcome={voteOutcome}
+                  votes={votes}
+                />
+              </div>
+            </div>
+          ) : null
 
           // Treasury tab — drop the SectionCard wrapper so the tab
           // (already labelled "Treasury") is the only title, then
@@ -567,13 +570,25 @@ export default function ProjectProfile({
             </div>
           )
 
+          // The Voting Results tab only appears once there's
+          // something to show — i.e. the proposal has tallied. While
+          // the vote is still in-flight, we don't surface a ghost tab
+          // that would just render an empty card.
+          const showResultsTab = hasVotingResults
+
+          // If the user deep-links to ?tab=results on a proposal that
+          // doesn't (yet) have results, fall back to the proposal tab
+          // rather than rendering blank content.
+          const effectiveTab: ProjectTab =
+            tab === 'results' && !showResultsTab ? 'proposal' : tab
+
           // Underline-style tab bar matching the Mission/Launchpad
           // pattern (`MissionInfo.tsx`): text-only, gray-500
           // inactive, white + 2px indigo underline active, sitting
           // on a thin `border-b`. `overflow-x-auto` keeps it
           // single-row on phones.
           const tabButton = (key: ProjectTab, label: string) => {
-            const isActive = tab === key
+            const isActive = effectiveTab === key
             return (
               <button
                 key={key}
@@ -597,13 +612,15 @@ export default function ProjectProfile({
             <div className="flex flex-col gap-4 sm:gap-6 min-w-0">
               <div className="flex items-center gap-1 border-b border-white/[0.08] overflow-x-auto max-w-full -mx-1 px-1">
                 {tabButton('proposal', 'Proposal')}
+                {showResultsTab && tabButton('results', 'Voting Results')}
                 {tabButton('treasury', 'Treasury')}
                 {tabButton('team', 'Team')}
               </div>
 
-              {tab === 'proposal' && proposalPane}
-              {tab === 'treasury' && treasuryPane}
-              {tab === 'team' && teamPane}
+              {effectiveTab === 'proposal' && proposalPane}
+              {effectiveTab === 'results' && resultsPane}
+              {effectiveTab === 'treasury' && treasuryPane}
+              {effectiveTab === 'team' && teamPane}
             </div>
           )
 
@@ -630,7 +647,15 @@ export default function ProjectProfile({
               id="page-container"
               className="pt-2 sm:pt-3 md:pt-4 pb-4 sm:pb-6 md:pb-8 grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6"
             >
-              <div className="lg:order-2 lg:col-span-1 lg:sticky lg:top-24 lg:self-start flex flex-col gap-4">
+              {/* `lg:mt-[77px]` shifts the rail down on desktop so its
+                  top edge lines up with the start of the proposal
+                  pane (i.e. *below* the tab strip in the main column),
+                  not the tab strip itself. Math: tab button height
+                  `py-3 text-lg` ≈ 52px + 1px `border-b` + 24px
+                  `gap-6` between tab strip and pane = 77px. Mobile
+                  keeps the rail on top so the Vote CTA stays above
+                  the fold. */}
+              <div className="lg:order-2 lg:col-span-1 lg:mt-[77px] lg:sticky lg:top-24 lg:self-start flex flex-col gap-4">
                 {/* Member Vote sits on top while it's the active step
                     — that's the primary action members can take right
                     now, so it gets the eye-catching styling. The


### PR DESCRIPTION
## Summary

Bundle of small follow-ups to #1312 / #1313, all targeting the post-close Member Vote experience using MDP-249 as the live test case. Each change is small and isolated; together they tighten the Member Vote UI around the canonical `computeMemberProposalTally` outcome (For/Against as % of decided VP, Abstain as % of turnout — same math as the on-chain supermajority test).

### What changed

1. **Voting Results tab.** Promoted the aggregate post-close tally to its own top-level tab on `/project/[tokenId]`, alongside Proposal / Treasury / Team. Tab is conditional — only appears when there's something to render (non-project proposal, `project.active !== PROJECT_PENDING`) — and `?tab=results` deep-links on a still-in-flight proposal fall back to the Proposal tab instead of an empty pane. Tab underline tracks the resolved tab so the highlight always matches what's rendered.

2. **Tally breakdown pinned to the top of the Member Vote sidebar.** Three-column For / Against / Abstain block with percentages over a single proportional bar, sitting right after the title row. Replaces the lower per-choice list (which only showed VPs and was easy to miss). Mid-vote the breakdown stays suppressed for the same anti-bandwagoning reason as the per-voter ChoicePill.

3. **Dropped redundant "Voted" placeholder pill** from each voter row in the sidebar. The section header `Votes (N)` already conveys that the listed addresses have voted; the per-row pill mid-vote was noise. Post-close, the real ChoicePill (For/Against/Abstain, color-coded) takes its place.

4. **"You voted" pill on the Vote button** (`NewVoteButton.tsx`). A returning voter previously saw `Edit Vote` with no hint of what they'd voted for. Now the dominant choice renders above the button as a small color-matched pill (same colors as the per-voter ChoicePill in the sidebar so the user's pill and their row read identically). Refactored the `useEffect + setEdit` into a `useMemo`-derived `myVote` lookup and dropped a stray `console.log('new vote button')`.

5. **Hide "Edit Proposal" once `proposalStatus === 'Approved'`** (`ProposalEditSection.tsx`). Editing post-approval would let the author rewrite text members already voted on. Other in-flight states (Temperature Check / Voting / Cancelled / Archived) keep the current behavior. New optional `proposalStatus` prop so legacy callers and tests keep working.

6. **Right-rail vertical alignment.** Added `lg:mt-[77px]` to the rail wrapper so on `lg+` the Member Vote card top aligns with the start of the proposal pane (tab height ~52px + `border-b` 1px + flex `gap-6` 24px). Mobile keeps the rail on top so the Vote CTA stays above the fold (Snapshot-style).

## Test plan

- [x] `localhost:3000/project/249` renders 200 and shows the new top-of-card tally breakdown with `For 91.1% / Against 8.9% / Abstain 61.0%` — matches `forPctOfDecided: 91.139…` from the MDP-249 sentinel snapshot row exactly.
- [x] Voting Results tab button renders for MDP-249, `?tab=results` deep-link drives the underline + content correctly, and the existing in-pane VotingResults card renders without `ReferenceError` (the threshold ref was already fixed in #1313).
- [x] No "Voted" placeholder pill in voter rows mid-vote; ChoicePill color appears once `revealResults` flips on.
- [x] No linter errors on the four modified files.
- [ ] After merge: confirm rail aligns with proposal pane on a `lg+` viewport (the 77px math is calculated, not measured — easy to swap for a phantom-spacer if any drift on real fonts).
- [ ] After merge: confirm "You voted" pill renders for an authenticated voter, and "Edit Proposal" is hidden on MDP-249 (`Approved`) but still visible on a Temperature-Check or Voting proposal for the author.
