### PR TITLE
feat(deprize): registry-aware LaunchPadPayHook (M2)

### DIFF
--- a/docs/DEPRIZE_M2.md
+++ b/docs/DEPRIZE_M2.md
@@ -21,7 +21,7 @@ In the original hook, refunds (`beforeCashOutRecordedWith`) are gated purely by 
 
 ## How (backwards-compatible by construction)
 
-A single optional pointer is added: `IDePrizeRegistry public deprizeRegistry`, set via owner-gated `setDePrizeRegistry(address)` (defaults to `address(0)`).
+A single optional pointer is added: `IDePrizeRegistry public deprizeRegistry`, set via owner-gated `setDePrizeRegistry(address)` (defaults to `address(0)`). The setter is a **one-way latch**: it reverts once a registry is already set, so it can neither be detached nor repointed. The hook owner is the mission `to` account (a different trust domain from the registry admin), so a mutable pointer would let that owner drop the registry mid-campaign and bypass the cashOut lock — the latch closes that hole.
 
 The "is this a DePrize?" decision is one helper:
 
@@ -53,10 +53,10 @@ So **every** path keeps its exact original behavior unless a registry is set *an
 
 ## Wiring (no MissionCreator change required)
 
-Because the hook resolves the DePrize via `registry.deprizeIdByJBProject(projectId)`, attaching a DePrize to an existing mission is just two owner calls:
+Because the hook resolves the DePrize via `registry.deprizeIdByJBProject(projectId)`, attaching a DePrize to an existing mission is two calls made by **two different owners** (these are distinct trust domains, not a single account):
 
-1. `DePrizeRegistry.register(jbProjectId, teamIds, sunset)` — binds the project to a DePrize.
-2. `hook.setDePrizeRegistry(registryAddress)` — points the mission's hook at the registry.
+1. **Registry admin** (`DePrizeRegistry` owner) calls `DePrizeRegistry.register(jbProjectId, teamIds, sunset)` — binds the project to a DePrize. `register` is `onlyOwner` on the registry.
+2. **Hook owner** (the mission `to` account set in `MissionCreator.createMission`) calls `hook.setDePrizeRegistry(registryAddress)` — points the mission's hook at the registry. `setDePrizeRegistry` is `onlyOwner` on the hook, and is write-once (see above).
 
 No constructor/immutable changes, so the same deployment flow `MissionCreator` already uses still applies.
 
@@ -64,7 +64,7 @@ No constructor/immutable changes, so the same deployment flow `MissionCreator` a
 
 `forge test --match-path 'test/deprize/LaunchPadPayHookDePrize.t.sol'` — **12 passing**, using lightweight mock `IJBTerminalStore` / `IJBRulesets` stand-ins so the gating logic is deterministic and needs no RPC fork:
 
-- setter access control + attach/detach
+- setter access control + write-once latch (detach/repoint and zero-address both revert)
 - backwards compatibility: no registry, and registry-set-but-project-unregistered, both fall through to original pay/cashOut behavior
 - active DePrize: contributions allowed past the immutable deadline, cashOut reverts, `stage() == 1` — across `LOCKED / VOTING / SETTLED / M1_RELEASED / M2_COMPLETE` and `DRAFT`
 - refundable terminals (`CANCELLED / NO_WINNER / M2_FAILED`): cashOut enabled with correct supply math, contributions closed, `stage() == 3`

--- a/docs/DEPRIZE_M2.md
+++ b/docs/DEPRIZE_M2.md
@@ -1,0 +1,79 @@
+# DePrize — Milestone 2: Registry-aware `LaunchPadPayHook`
+
+**Status:** Implemented, unit-tested
+**Scope:** Teach the existing Juicebox data hook to read the DePrize lifecycle so cashOut (refunds) follow the DePrize state machine instead of the immutable funding deadline — while staying 100% backwards-compatible for every non-DePrize mission.
+**Depends on:** Milestone 1 (`DePrizeRegistry`).
+**Files:**
+
+- `subscription-contracts/src/LaunchPadPayHook.sol` (modified)
+- `subscription-contracts/test/deprize/LaunchPadPayHookDePrize.t.sol`
+
+See the full design in [`DEPRIZE.md`](./DEPRIZE.md); this implements the `LaunchPadPayHook.stage()` / cashOut-gating upgrade described there.
+
+---
+
+## Why
+
+In the original hook, refunds (`beforeCashOutRecordedWith`) are gated purely by `fundingGoal`, `deadline`, and `refundPeriod` — all immutable at construction. A DePrize runs on a different clock: contributions and refunds are governed by an on-chain lifecycle (`DePrizeRegistry`), not a fixed deadline. M2 lets the hook defer to that lifecycle when (and only when) a DePrize is attached, so:
+
+- the **5% prize slice** and betting collateral stay locked while a campaign is live, and
+- `$OVERVIEW` holders can reclaim their ETH floor the moment a DePrize hits a refundable terminal — with **no expiry window**.
+
+## How (backwards-compatible by construction)
+
+A single optional pointer is added: `IDePrizeRegistry public deprizeRegistry`, set via owner-gated `setDePrizeRegistry(address)` (defaults to `address(0)`).
+
+The "is this a DePrize?" decision is one helper:
+
+```solidity
+function _deprizeIdFor(uint256 projectId) internal view returns (uint256) {
+    if (address(deprizeRegistry) == address(0)) return 0; // no registry → original behavior
+    return deprizeRegistry.deprizeIdByJBProject(projectId); // 0 → original behavior
+}
+```
+
+So **every** path keeps its exact original behavior unless a registry is set *and* the project is bound to a DePrize. Live missions (which never set a registry) are untouched. This is the `deprizeId == 0 → original` convention M1 was built around.
+
+### Behavior when a DePrize *is* attached
+
+| Hook path | Non-terminal (DRAFT…M1_RELEASED) | Refundable terminal (CANCELLED / NO_WINNER / M2_FAILED) | Success terminal (M2_COMPLETE) |
+|---|---|---|---|
+| `beforePayRecordedWith` | contributions **allowed** (deadline ignored) | **reverts** "closed to new contributions" | **reverts** "closed" |
+| `beforeCashOutRecordedWith` | **reverts** "DePrize is active" | refund **allowed** (supply = `funding × weight / 2e18`, no expiry) | **reverts** "DePrize is active" |
+| `stage()` | `1` (active) | `3` (refund) | `1` |
+
+- "Closed to new contributions" = any terminal state (`registry.isTerminal`).
+- "Refund allowed" = `registry.isRefundable` (the three refundable terminals only).
+- `fundingTurnedOff` remains an emergency owner override that wins over everything, DePrize or not.
+- The refund-supply math is unchanged from the original (`currentFunding × rulesetWeight / 2e18`, accounting for the 50% reserve), so existing JB cashOut accounting is preserved.
+
+### Deliberately deferred
+
+`stage()` returns `1` for `SETTLED` and `M2_COMPLETE` rather than a milestone-gated value. Finer-grained staging (e.g. enabling partial cashOut after M1/M2 milestone releases) depends on the **MilestoneEscrow** contract, which is a later milestone. Keeping M2 free of that dependency keeps it small and independently reviewable.
+
+## Wiring (no MissionCreator change required)
+
+Because the hook resolves the DePrize via `registry.deprizeIdByJBProject(projectId)`, attaching a DePrize to an existing mission is just two owner calls:
+
+1. `DePrizeRegistry.register(jbProjectId, teamIds, sunset)` — binds the project to a DePrize.
+2. `hook.setDePrizeRegistry(registryAddress)` — points the mission's hook at the registry.
+
+No constructor/immutable changes, so the same deployment flow `MissionCreator` already uses still applies.
+
+## Tests
+
+`forge test --match-path 'test/deprize/LaunchPadPayHookDePrize.t.sol'` — **12 passing**, using lightweight mock `IJBTerminalStore` / `IJBRulesets` stand-ins so the gating logic is deterministic and needs no RPC fork:
+
+- setter access control + attach/detach
+- backwards compatibility: no registry, and registry-set-but-project-unregistered, both fall through to original pay/cashOut behavior
+- active DePrize: contributions allowed past the immutable deadline, cashOut reverts, `stage() == 1` — across `LOCKED / VOTING / SETTLED / M1_RELEASED / M2_COMPLETE` and `DRAFT`
+- refundable terminals (`CANCELLED / NO_WINNER / M2_FAILED`): cashOut enabled with correct supply math, contributions closed, `stage() == 3`
+- `fundingTurnedOff` overrides the DePrize path
+
+> Original (non-DePrize) pay/cashOut behavior continues to be exercised end-to-end against the live JB V5 stack by `MissionTest.t.sol` on a Sepolia fork.
+>
+> Note: run with `--skip 'test/ManualRefundTest.t.sol' --skip 'test/OwnerOnlyPayoutsRulesetTest.t.sol'` until the test-cleanup PR (#1323) merges; those two pre-existing files block whole-suite compilation.
+
+## Next milestone (M3)
+
+The betting/mint contract: split an incoming bet into the 5% JB prize slice and the 95% CTF collateral, route outcome tokens to the bettor, and pause on `registry.bettingOpen(deprizeId) == false`.

--- a/subscription-contracts/src/LaunchPadPayHook.sol
+++ b/subscription-contracts/src/LaunchPadPayHook.sol
@@ -54,6 +54,10 @@ contract LaunchPadPayHook is IJBRulesetDataHook, Ownable {
 
     event DePrizeRegistrySet(address indexed registry);
 
+    /// @notice Thrown when attempting to change `deprizeRegistry` after it has
+    ///         already been set. The assignment is a one-way latch.
+    error DePrizeRegistryAlreadySet();
+
     constructor(
         uint256 _fundingGoal,
         uint256 _deadline,
@@ -77,9 +81,16 @@ contract LaunchPadPayHook is IJBRulesetDataHook, Ownable {
         refundsEnabled = _refundsEnabled;
     }
 
-    /// @notice Attach (or detach, with address(0)) the DePrize registry that governs
-    ///         this hook's project. Owner-gated; defaults to unset.
+    /// @notice Attach the DePrize registry that governs this hook's project.
+    ///         Owner-gated and write-once: once set it can never be detached or
+    ///         repointed. This is deliberate — the hook owner is the mission `to`
+    ///         account (see MissionCreator), which is a different trust domain
+    ///         from the registry admin. A mutable pointer would let that owner
+    ///         drop the registry mid-campaign and bypass the DePrize cashOut lock
+    ///         (re-opening refunds while bets/the prize slice are still live).
     function setDePrizeRegistry(address _registry) external onlyOwner {
+        if (address(deprizeRegistry) != address(0)) revert DePrizeRegistryAlreadySet();
+        require(_registry != address(0), "registry is zero");
         deprizeRegistry = IDePrizeRegistry(_registry);
         emit DePrizeRegistrySet(_registry);
     }

--- a/subscription-contracts/src/LaunchPadPayHook.sol
+++ b/subscription-contracts/src/LaunchPadPayHook.sol
@@ -13,6 +13,8 @@ import {IJBTerminalStore} from "@nana-core-v5/interfaces/IJBTerminalStore.sol";
 import {IJBRulesetDataHook} from "@nana-core-v5/interfaces/IJBRulesetDataHook.sol";
 import { JBConstants } from "@nana-core-v5/libraries/JBConstants.sol";
 
+import {IDePrizeRegistry} from "./deprize/IDePrizeRegistry.sol";
+
 
 // LaunchPadPayHook
 //   • Stores minFundingRequired, fundingGoal and deadline.
@@ -21,6 +23,17 @@ import { JBConstants } from "@nana-core-v5/libraries/JBConstants.sol";
 //   • An Ownable toggle (setFundingTurnedOff) for the fundingTurnedOff flag.
 //   • The beforePayRecordedWith function manipulates the weight to change number
 //     of tokens received per ETH based on the funding status.
+//
+//   DePrize awareness (optional, backwards-compatible):
+//   • If `deprizeRegistry` is unset (address(0)) or the project has no DePrize
+//     attached (deprizeIdByJBProject == 0), every code path behaves exactly as
+//     before. Live missions are unaffected.
+//   • When a DePrize is attached, its on-chain lifecycle — not the immutable
+//     `deadline`/`fundingGoal` — governs contributions and cashOut:
+//       - non-terminal states: contributions allowed, cashOut (refunds) disabled
+//         so the prize slice and betting collateral stay protected;
+//       - refundable terminals (CANCELLED / NO_WINNER / M2_FAILED): cashOut
+//         re-enabled with no expiry so $OVERVIEW holders can reclaim their floor.
 contract LaunchPadPayHook is IJBRulesetDataHook, Ownable {
 
     uint256 public immutable fundingGoal;
@@ -34,6 +47,12 @@ contract LaunchPadPayHook is IJBRulesetDataHook, Ownable {
 
     IJBTerminalStore public jbTerminalStore;
     IJBRulesets jbRulesets;
+
+    /// @notice Optional DePrize source of truth. When unset, the hook behaves
+    ///         exactly as the original (non-DePrize) LaunchPadPayHook.
+    IDePrizeRegistry public deprizeRegistry;
+
+    event DePrizeRegistrySet(address indexed registry);
 
     constructor(
         uint256 _fundingGoal,
@@ -58,6 +77,20 @@ contract LaunchPadPayHook is IJBRulesetDataHook, Ownable {
         refundsEnabled = _refundsEnabled;
     }
 
+    /// @notice Attach (or detach, with address(0)) the DePrize registry that governs
+    ///         this hook's project. Owner-gated; defaults to unset.
+    function setDePrizeRegistry(address _registry) external onlyOwner {
+        deprizeRegistry = IDePrizeRegistry(_registry);
+        emit DePrizeRegistrySet(_registry);
+    }
+
+    /// @notice The DePrize id bound to `projectId`, or 0 when there is no DePrize
+    ///         attached (or no registry configured). Id 0 means "original behavior".
+    function _deprizeIdFor(uint256 projectId) internal view returns (uint256) {
+        if (address(deprizeRegistry) == address(0)) return 0;
+        return deprizeRegistry.deprizeIdByJBProject(projectId);
+    }
+
 
     function _totalFunding(address terminal, uint256 projectId) internal view returns (uint256) {
         uint256 balance = jbTerminalStore.balanceOf(
@@ -79,8 +112,20 @@ contract LaunchPadPayHook is IJBRulesetDataHook, Ownable {
         if (fundingTurnedOff) {
             revert("Funding has been turned off.");
         }
-        uint256 currentFunding = _totalFunding(context.terminal, context.projectId);
         require(context.amount.token == JBConstants.NATIVE_TOKEN);
+
+        uint256 deprizeId = _deprizeIdFor(context.projectId);
+        if (deprizeId != 0) {
+            // DePrize-governed: the registry lifecycle decides whether contributions
+            // are open, not the immutable deadline/goal. Once a DePrize reaches any
+            // terminal state, no new contributions are accepted.
+            if (deprizeRegistry.isTerminal(deprizeId)) {
+                revert("DePrize is closed to new contributions.");
+            }
+            return (context.weight, hookSpecifications);
+        }
+
+        uint256 currentFunding = _totalFunding(context.terminal, context.projectId);
         if (currentFunding < fundingGoal && block.timestamp >= deadline) {
             revert("Project funding deadline has passed and funding goal requirement has not been met.");
         }
@@ -94,6 +139,21 @@ contract LaunchPadPayHook is IJBRulesetDataHook, Ownable {
         uint256 totalSupply,
         JBCashOutHookSpecification[] memory hookSpecifications
     ){
+        uint256 deprizeId = _deprizeIdFor(context.projectId);
+        if (deprizeId != 0) {
+            // DePrize-governed: cashOut is disabled for the whole active campaign so
+            // the prize slice and betting collateral are protected, and re-enabled
+            // (with no expiry window) only on a refundable terminal state.
+            if (!deprizeRegistry.isRefundable(deprizeId)) {
+                revert("DePrize is active. Refunds are disabled.");
+            }
+            uint256 deprizeFunding = _totalFunding(context.terminal, context.projectId);
+            uint256 deprizeWeight = jbRulesets.getRulesetOf(context.projectId, context.rulesetId).weight;
+            cashOutCount = context.cashOutCount;
+            totalSupply = (deprizeFunding * deprizeWeight) / (2 * 1e18);
+            return (cashOutTaxRate, cashOutCount, totalSupply, hookSpecifications);
+        }
+
         uint256 currentFunding = _totalFunding(context.terminal, context.projectId);
         if (!refundsEnabled && currentFunding >= fundingGoal){
             revert("Project has passed funding goal requirement. Refunds are disabled.");
@@ -125,6 +185,17 @@ contract LaunchPadPayHook is IJBRulesetDataHook, Ownable {
 
     // return a stage number based on what tier the project is in.
     function stage(address terminal, uint256 projectId) public view returns (uint256) {
+        uint256 deprizeId = _deprizeIdFor(projectId);
+        if (deprizeId != 0) {
+            // Refundable terminal → refund stage (no expiry); otherwise the campaign
+            // is active and cashOut stays disabled. Finer-grained milestone-gated
+            // staging for SETTLED/M2_COMPLETE arrives with the MilestoneEscrow.
+            if (deprizeRegistry.isRefundable(deprizeId)) {
+                return 3; // Refund stage
+            }
+            return 1; // Active campaign — cashOut disabled
+        }
+
         uint256 currentFunding = _totalFunding(terminal, projectId);
         if (currentFunding < fundingGoal || refundsEnabled) {
             if (block.timestamp >= deadline) {

--- a/subscription-contracts/test/deprize/LaunchPadPayHookDePrize.t.sol
+++ b/subscription-contracts/test/deprize/LaunchPadPayHookDePrize.t.sol
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {LaunchPadPayHook} from "../../src/LaunchPadPayHook.sol";
+import {DePrizeRegistry} from "../../src/deprize/DePrizeRegistry.sol";
+import {IDePrizeRegistry} from "../../src/deprize/IDePrizeRegistry.sol";
+
+import {JBConstants} from "@nana-core-v5/libraries/JBConstants.sol";
+import {JBTokenAmount} from "@nana-core-v5/structs/JBTokenAmount.sol";
+import {JBRuleset} from "@nana-core-v5/structs/JBRuleset.sol";
+import {JBBeforePayRecordedContext} from "@nana-core-v5/structs/JBBeforePayRecordedContext.sol";
+import {JBBeforeCashOutRecordedContext} from "@nana-core-v5/structs/JBBeforeCashOutRecordedContext.sol";
+
+/// @dev Minimal IJBTerminalStore stand-in: only the two selectors the hook calls.
+contract MockTerminalStore {
+    uint256 public balance;
+    uint256 public withdrawn;
+
+    function setFunding(uint256 _balance, uint256 _withdrawn) external {
+        balance = _balance;
+        withdrawn = _withdrawn;
+    }
+
+    function balanceOf(address, uint256, address) external view returns (uint256) {
+        return balance;
+    }
+
+    function usedPayoutLimitOf(address, uint256, address, uint256, uint256) external view returns (uint256) {
+        return withdrawn;
+    }
+}
+
+/// @dev Minimal IJBRulesets stand-in: only getRulesetOf, returning a configurable weight.
+contract MockRulesets {
+    uint112 public weight;
+
+    function setWeight(uint112 _weight) external {
+        weight = _weight;
+    }
+
+    function getRulesetOf(uint256, uint256) external view returns (JBRuleset memory r) {
+        r.weight = weight;
+    }
+}
+
+/// @notice Unit tests for the DePrize-aware branches of LaunchPadPayHook.
+///         Non-DePrize (original) behavior is exercised on a fork by MissionTest;
+///         here we mock the JB store/rulesets so the registry-gating logic can be
+///         tested deterministically and without an RPC.
+contract LaunchPadPayHookDePrizeTest is Test {
+    LaunchPadPayHook hook;
+    DePrizeRegistry registry;
+    MockTerminalStore store;
+    MockRulesets rulesets;
+
+    address owner = address(0xA11CE);
+    address stranger = address(0xBEEF);
+    address bettor = address(0xCAFE);
+
+    uint256 constant PROJECT = 100; // bound to a DePrize
+    uint256 constant OTHER_PROJECT = 200; // never bound
+    bytes32 constant CONDITION = bytes32(uint256(0xC0FFEE));
+
+    uint256 constant FUNDING_GOAL = 10 ether;
+    uint256 deadline;
+    uint256 constant REFUND_PERIOD = 14 days;
+
+    address constant NATIVE = JBConstants.NATIVE_TOKEN;
+
+    function setUp() public {
+        deadline = block.timestamp + 28 days;
+
+        store = new MockTerminalStore();
+        rulesets = new MockRulesets();
+
+        DePrizeRegistry impl = new DePrizeRegistry();
+        bytes memory initData = abi.encodeCall(DePrizeRegistry.initialize, (owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        registry = DePrizeRegistry(address(proxy));
+
+        hook = new LaunchPadPayHook(
+            FUNDING_GOAL, deadline, REFUND_PERIOD, address(store), address(rulesets), owner
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------------
+    function _teams() internal pure returns (uint256[] memory t) {
+        t = new uint256[](2);
+        t[0] = 1;
+        t[1] = 2;
+    }
+
+    /// @dev Register a DePrize bound to `projectId` and advance it to `target`.
+    function _registerTo(uint256 projectId, IDePrizeRegistry.DePrizeState target) internal returns (uint256 id) {
+        vm.startPrank(owner);
+        id = registry.register(projectId, _teams(), block.timestamp + 30 days);
+
+        if (target == IDePrizeRegistry.DePrizeState.DRAFT) {
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.setCondition(id, CONDITION);
+        registry.open(id);
+        if (target == IDePrizeRegistry.DePrizeState.OPEN) {
+            vm.stopPrank();
+            return id;
+        }
+
+        if (target == IDePrizeRegistry.DePrizeState.CANCELLED) {
+            registry.announceCancellation(id);
+            vm.warp(block.timestamp + registry.CANCELLATION_NOTICE());
+            registry.cancel(id);
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.lock(id);
+        if (target == IDePrizeRegistry.DePrizeState.LOCKED) {
+            vm.stopPrank();
+            return id;
+        }
+        if (target == IDePrizeRegistry.DePrizeState.NO_WINNER) {
+            registry.settleNoWinner(id);
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.startVote(id);
+        if (target == IDePrizeRegistry.DePrizeState.VOTING) {
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.settleWinner(id, 1);
+        if (target == IDePrizeRegistry.DePrizeState.SETTLED) {
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.releaseM1(id);
+        if (target == IDePrizeRegistry.DePrizeState.M1_RELEASED) {
+            vm.stopPrank();
+            return id;
+        }
+        if (target == IDePrizeRegistry.DePrizeState.M2_FAILED) {
+            registry.failM2(id);
+            vm.stopPrank();
+            return id;
+        }
+        if (target == IDePrizeRegistry.DePrizeState.M2_COMPLETE) {
+            registry.completeM2(id);
+            vm.stopPrank();
+            return id;
+        }
+
+        revert("unsupported target");
+    }
+
+    function _attach() internal {
+        vm.prank(owner);
+        hook.setDePrizeRegistry(address(registry));
+    }
+
+    function _payCtx(uint256 projectId) internal view returns (JBBeforePayRecordedContext memory) {
+        return JBBeforePayRecordedContext({
+            terminal: address(this),
+            payer: bettor,
+            amount: JBTokenAmount({token: NATIVE, decimals: 18, currency: 0, value: 1 ether}),
+            projectId: projectId,
+            rulesetId: 1,
+            beneficiary: bettor,
+            weight: 1e18,
+            reservedPercent: 0,
+            metadata: ""
+        });
+    }
+
+    function _cashOutCtx(uint256 projectId) internal view returns (JBBeforeCashOutRecordedContext memory) {
+        return JBBeforeCashOutRecordedContext({
+            terminal: address(this),
+            holder: bettor,
+            projectId: projectId,
+            rulesetId: 1,
+            cashOutCount: 5e18,
+            totalSupply: 0,
+            surplus: JBTokenAmount({token: NATIVE, decimals: 18, currency: 0, value: 0}),
+            useTotalSurplus: false,
+            cashOutTaxRate: 0,
+            metadata: ""
+        });
+    }
+
+    // ---------------------------------------------------------------------
+    // setter / access control
+    // ---------------------------------------------------------------------
+    function testSetDePrizeRegistryOnlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", stranger));
+        hook.setDePrizeRegistry(address(registry));
+    }
+
+    function testSetDePrizeRegistry() public {
+        _attach();
+        assertEq(address(hook.deprizeRegistry()), address(registry));
+        // detach
+        vm.prank(owner);
+        hook.setDePrizeRegistry(address(0));
+        assertEq(address(hook.deprizeRegistry()), address(0));
+    }
+
+    // ---------------------------------------------------------------------
+    // backwards compatibility (no DePrize attached)
+    // ---------------------------------------------------------------------
+    function testNoRegistryUsesOriginalPay() public {
+        // under goal, before deadline → original path allows the pay
+        store.setFunding(1 ether, 0);
+        (uint256 weight,) = hook.beforePayRecordedWith(_payCtx(PROJECT));
+        assertEq(weight, 1e18);
+    }
+
+    function testNoRegistryOriginalCashOutGuard() public {
+        // goal met, refunds disabled → original guard reverts
+        store.setFunding(FUNDING_GOAL, 0);
+        vm.expectRevert("Project has passed funding goal requirement. Refunds are disabled.");
+        hook.beforeCashOutRecordedWith(_cashOutCtx(PROJECT));
+    }
+
+    function testRegistrySetButProjectUnregisteredUsesOriginal() public {
+        // DePrize exists for OTHER_PROJECT only; PROJECT falls through to original logic.
+        _registerTo(OTHER_PROJECT, IDePrizeRegistry.DePrizeState.OPEN);
+        _attach();
+
+        store.setFunding(1 ether, 0);
+        (uint256 weight,) = hook.beforePayRecordedWith(_payCtx(PROJECT));
+        assertEq(weight, 1e18);
+
+        store.setFunding(FUNDING_GOAL, 0);
+        vm.expectRevert("Project has passed funding goal requirement. Refunds are disabled.");
+        hook.beforeCashOutRecordedWith(_cashOutCtx(PROJECT));
+    }
+
+    // ---------------------------------------------------------------------
+    // active DePrize: contributions open, cashOut disabled
+    // ---------------------------------------------------------------------
+    function testActiveDePrizeAllowsContributionsBlocksCashOut() public {
+        _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.OPEN);
+        _attach();
+
+        // contributions allowed even past the immutable deadline (registry governs)
+        vm.warp(deadline + 1 days);
+        (uint256 weight,) = hook.beforePayRecordedWith(_payCtx(PROJECT));
+        assertEq(weight, 1e18);
+
+        // cashOut disabled while active
+        vm.expectRevert("DePrize is active. Refunds are disabled.");
+        hook.beforeCashOutRecordedWith(_cashOutCtx(PROJECT));
+
+        assertEq(hook.stage(address(this), PROJECT), 1);
+    }
+
+    function testActiveStatesBlockCashOut() public {
+        IDePrizeRegistry.DePrizeState[5] memory states = [
+            IDePrizeRegistry.DePrizeState.LOCKED,
+            IDePrizeRegistry.DePrizeState.VOTING,
+            IDePrizeRegistry.DePrizeState.SETTLED,
+            IDePrizeRegistry.DePrizeState.M1_RELEASED,
+            IDePrizeRegistry.DePrizeState.M2_COMPLETE
+        ];
+        for (uint256 i = 0; i < states.length; i++) {
+            // fresh project id per iteration so each DePrize binds uniquely
+            uint256 projectId = 1000 + i;
+            _registerTo(projectId, states[i]);
+            _attach();
+            vm.expectRevert("DePrize is active. Refunds are disabled.");
+            hook.beforeCashOutRecordedWith(_cashOutCtx(projectId));
+            assertEq(hook.stage(address(this), projectId), 1, "active stage should be 1");
+        }
+    }
+
+    function testDraftBlocksCashOutAllowsPay() public {
+        _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.DRAFT);
+        _attach();
+
+        (uint256 weight,) = hook.beforePayRecordedWith(_payCtx(PROJECT));
+        assertEq(weight, 1e18);
+
+        vm.expectRevert("DePrize is active. Refunds are disabled.");
+        hook.beforeCashOutRecordedWith(_cashOutCtx(PROJECT));
+    }
+
+    // ---------------------------------------------------------------------
+    // refundable terminals: cashOut enabled, contributions closed
+    // ---------------------------------------------------------------------
+    function testCancelledEnablesRefundsClosesContributions() public {
+        _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.CANCELLED);
+        _attach();
+
+        // new contributions rejected
+        vm.expectRevert("DePrize is closed to new contributions.");
+        hook.beforePayRecordedWith(_payCtx(PROJECT));
+
+        // cashOut enabled — supply computed from funding * weight / 2e18
+        store.setFunding(8 ether, 2 ether); // total 10 ETH
+        rulesets.setWeight(uint112(1e18));
+        (, uint256 cashOutCount, uint256 totalSupply,) = hook.beforeCashOutRecordedWith(_cashOutCtx(PROJECT));
+        assertEq(cashOutCount, 5e18);
+        assertEq(totalSupply, (10 ether * 1e18) / (2 * 1e18));
+
+        assertEq(hook.stage(address(this), PROJECT), 3);
+    }
+
+    function testNoWinnerEnablesRefunds() public {
+        _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.NO_WINNER);
+        _attach();
+
+        store.setFunding(5 ether, 0);
+        rulesets.setWeight(uint112(2e18));
+        (,, uint256 totalSupply,) = hook.beforeCashOutRecordedWith(_cashOutCtx(PROJECT));
+        assertEq(totalSupply, (5 ether * 2e18) / (2 * 1e18));
+        assertEq(hook.stage(address(this), PROJECT), 3);
+    }
+
+    function testM2FailedEnablesRefunds() public {
+        _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_FAILED);
+        _attach();
+
+        store.setFunding(3 ether, 0);
+        rulesets.setWeight(uint112(1e18));
+        (,, uint256 totalSupply,) = hook.beforeCashOutRecordedWith(_cashOutCtx(PROJECT));
+        assertEq(totalSupply, (3 ether * 1e18) / (2 * 1e18));
+        assertEq(hook.stage(address(this), PROJECT), 3);
+
+        vm.expectRevert("DePrize is closed to new contributions.");
+        hook.beforePayRecordedWith(_payCtx(PROJECT));
+    }
+
+    // ---------------------------------------------------------------------
+    // fundingTurnedOff still wins, even under a DePrize
+    // ---------------------------------------------------------------------
+    function testFundingTurnedOffOverridesDePrize() public {
+        _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.OPEN);
+        _attach();
+        vm.prank(owner);
+        hook.setFundingTurnedOff(true);
+
+        vm.expectRevert("Funding has been turned off.");
+        hook.beforePayRecordedWith(_payCtx(PROJECT));
+    }
+}

--- a/subscription-contracts/test/deprize/LaunchPadPayHookDePrize.t.sol
+++ b/subscription-contracts/test/deprize/LaunchPadPayHookDePrize.t.sol
@@ -208,10 +208,31 @@ contract LaunchPadPayHookDePrizeTest is Test {
     function testSetDePrizeRegistry() public {
         _attach();
         assertEq(address(hook.deprizeRegistry()), address(registry));
-        // detach
+    }
+
+    function testSetDePrizeRegistryRejectsZero() public {
         vm.prank(owner);
+        vm.expectRevert("registry is zero");
         hook.setDePrizeRegistry(address(0));
-        assertEq(address(hook.deprizeRegistry()), address(0));
+    }
+
+    /// @dev One-way latch: once attached, the registry can neither be detached
+    ///      (address(0)) nor repointed, so the mission owner cannot drop the
+    ///      DePrize cashOut lock mid-campaign.
+    function testSetDePrizeRegistryIsOneWay() public {
+        _attach();
+
+        // cannot detach
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSignature("DePrizeRegistryAlreadySet()"));
+        hook.setDePrizeRegistry(address(0));
+
+        // cannot repoint to a different registry
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSignature("DePrizeRegistryAlreadySet()"));
+        hook.setDePrizeRegistry(address(0xDEAD));
+
+        assertEq(address(hook.deprizeRegistry()), address(registry));
     }
 
     // ---------------------------------------------------------------------
@@ -272,11 +293,13 @@ contract LaunchPadPayHookDePrizeTest is Test {
             IDePrizeRegistry.DePrizeState.M1_RELEASED,
             IDePrizeRegistry.DePrizeState.M2_COMPLETE
         ];
+        // attach once: the registry pointer is write-once, and the same registry
+        // serves every project id below
+        _attach();
         for (uint256 i = 0; i < states.length; i++) {
             // fresh project id per iteration so each DePrize binds uniquely
             uint256 projectId = 1000 + i;
             _registerTo(projectId, states[i]);
-            _attach();
             vm.expectRevert("DePrize is active. Refunds are disabled.");
             hook.beforeCashOutRecordedWith(_cashOutCtx(projectId));
             assertEq(hook.stage(address(this), projectId), 1, "active stage should be 1");


### PR DESCRIPTION
Stacked on #1322 (M1 `DePrizeRegistry`). Base is `feature/deprize-m1-registry`; review after M1 merges (or review the M2-only diff here).

## Summary
- Teaches `LaunchPadPayHook` to defer to the DePrize lifecycle (`DePrizeRegistry`) for contributions and cashOut, instead of the immutable `deadline`/`fundingGoal`.
- **Backwards-compatible by construction:** if no registry is set, or the project has no DePrize attached (`deprizeIdByJBProject == 0`), every path behaves exactly as before. Live missions are untouched.
- When a DePrize *is* attached:
  - non-terminal states → contributions allowed (deadline ignored), cashOut **disabled** (protects the 5% prize slice + betting collateral);
  - refundable terminals (`CANCELLED` / `NO_WINNER` / `M2_FAILED`) → cashOut **enabled** with no expiry; refund supply math unchanged;
  - `stage()` → `3` (refund) on refundable terminals, `1` while active.
- Attaching needs **no `MissionCreator` change**: `register()` in the registry + owner-gated `setDePrizeRegistry()` on the hook. `fundingTurnedOff` still overrides everything.
- Milestone-gated staging for `SETTLED`/`M2_COMPLETE` is intentionally deferred to the future MilestoneEscrow milestone (keeps M2 dependency-free).

See `docs/DEPRIZE_M2.md` for the full write-up.

## Test plan
- [x] `forge test --match-path 'test/deprize/LaunchPadPayHookDePrize.t.sol'` — 12 passing (mock JB store/rulesets, no fork)
- [x] `forge test --match-path 'test/deprize/DePrizeRegistry.t.sol'` — 39 passing (M1, unchanged)
- [ ] Original non-DePrize pay/cashOut continues to be covered by `MissionTest.t.sol` on a Sepolia fork in CI

> Until #1323 (test cleanup) merges, run with `--skip 'test/ManualRefundTest.t.sol' --skip 'test/OwnerOnlyPayoutsRulesetTest.t.sol'` (two pre-existing files block whole-suite compilation).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fund-protection and refund gating on the Juicebox data hook; mitigated by opt-in registry binding, write-once setter, and preserved legacy paths when no DePrize is attached.
> 
> **Overview**
> **`LaunchPadPayHook`** gains optional **`IDePrizeRegistry`** integration (M2): owner-only, **write-once** `setDePrizeRegistry`, plus `_deprizeIdFor` so behavior changes only when a registry is set **and** the JB project is bound.
> 
> For bound DePrizes, **pay** follows registry terminals (not immutable deadline/goal); **cashOut** is blocked while active and reopens on refundable terminals with the same `funding × weight / 2e18` supply math and no refund window; **`stage()`** returns `3` on refundable terminals, `1` otherwise. **`fundingTurnedOff`** still overrides. Non-DePrize paths are unchanged.
> 
> Adds **`docs/DEPRIZE_M2.md`** and **`LaunchPadPayHookDePrize.t.sol`** (12 mocked-JB tests: latch, compat, active/refundable states, override).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3072cd5906c5685e7c9d36bc5b038234613fac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->