### PR TITLE
Guard member vote close against zero voting power fetch

### DIFF
--- a/ui/pages/api/proposals/nonProjectVote.ts
+++ b/ui/pages/api/proposals/nonProjectVote.ts
@@ -111,6 +111,23 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     votes as any,
     addressToQuadraticVotingPower
   )
+  const realVoteCount = votes.filter((vote: any) => {
+    if (typeof vote?.vote !== 'string') return true
+    try {
+      return JSON.parse(vote.vote)?.kind !== 'snapshot'
+    } catch {
+      return true
+    }
+  }).length
+  if (realVoteCount > 0 && tally.totalParticipationVP === 0) {
+    return res.status(503).json({
+      error:
+        'Resolved total voting power is 0 for non-snapshot votes. vMOONEY reads may have failed; retry once RPC/Engine reads recover.',
+      voterCount: realVoteCount,
+      vMOONEYs,
+      voteAddresses,
+    })
+  }
   const passed = tally.passed
   const active = passed ? PROJECT_ACTIVE : PROJECT_VOTE_FAILED
   const account = await createHSMWallet()


### PR DESCRIPTION
## Summary
- Adds a zero-voting-power guard to the Member Vote close-and-tally handler before any on-chain `active` update is prepared or sent.
- Returns `503` when real, non-snapshot vote rows exist but the resolved tally has `totalParticipationVP === 0`, which strongly indicates failed vMOONEY reads rather than a legitimate result.
- Excludes snapshot sentinel rows from the real-vote count so re-tally behavior remains compatible.

## Why
`fetchTotalVMOONEYs` catches chain/Engine read failures and returns an all-zero array. Without this guard, `nonProjectVote.ts` can compute `passed = false` and write `PROJECT_VOTE_FAILED` on-chain for a proposal that actually passed.

## Validation
- Not run locally; `node_modules` is not installed in this environment.
- Change is intentionally narrow and mirrors the existing zero-total-voting-power safety check in `ui/pages/api/proposals/vote.ts`.