### PR TITLE
feat(deprize): registry-aware payout gating + prize/launchpad mode (M2b)

### DIFF
--- a/docs/DEPRIZE_M2.md
+++ b/docs/DEPRIZE_M2.md
@@ -21,9 +21,11 @@ A launchpad mission is governed by **three** independent gates on the JB project
 |---|---|---|
 | `LaunchPadPayHook.beforePay / beforeCashOut` | contributor pay-ins & refunds | DePrize registry (this milestone) |
 | `LaunchPadApprovalHook.approvalStatusOf` | ruleset 0 → 1 transition = **unlocking team payouts** | DePrize registry (this milestone) |
-| Fund-access limits (`payoutLimits` / `surplusAllowances`) | how much the owner can pull once payouts are unlocked | the active ruleset |
+| Fund-access limits (`payoutLimits` / `surplusAllowances`) | how much the owner can pull, and when | the active ruleset — **locked for prize missions at creation** |
 
 The original "fail if the goal isn't met" behavior lives in the **approval hook**: once `deadline + refundPeriod` elapses it approves the payout ruleset regardless of funding. For an indefinite prize that immutable clock *will* elapse, which would let the team drain the pot mid-campaign even while the pay hook's cashOut lock is active. So M2 makes the approval hook DePrize-aware too: for a prize, payouts unlock **only** when the prize wraps up successfully.
+
+The third valve is the **fund-access limits**. A classic launchpad gives ruleset 0 (funding stage) a functionally-unlimited `surplusAllowances` so the team can pull surplus — a trusted-team assumption, and one that bypasses both the data hook and the registry (`useAllowanceOf` consults neither). That would let a prize's pot leak out during the active campaign regardless of the other two locks, so `MissionCreator` now gives **prize missions zero surplus allowance** in ruleset 0. With no payout limit and no surplus allowance there, the only exits during an active prize are contributor refunds (pay hook, on a refundable terminal) and the ruleset-1 payout the approval hook unlocks at completion. Classic missions are unchanged.
 
 ---
 

--- a/docs/DEPRIZE_M2.md
+++ b/docs/DEPRIZE_M2.md
@@ -1,14 +1,29 @@
-# DePrize — Milestone 2: Registry-aware `LaunchPadPayHook`
+# DePrize — Milestone 2: Registry-aware launchpad hooks
 
 **Status:** Implemented, unit-tested
-**Scope:** Teach the existing Juicebox data hook to read the DePrize lifecycle so cashOut (refunds) follow the DePrize state machine instead of the immutable funding deadline — while staying 100% backwards-compatible for every non-DePrize mission.
+**Scope:** Teach the existing Juicebox launchpad hooks to read the DePrize lifecycle so contributions, cashOut (refunds) **and the payout-ruleset transition** follow the DePrize state machine instead of the immutable funding deadline — while staying 100% backwards-compatible for every non-DePrize mission. Mission creators can opt into "prize" mode at creation, or keep the classic time-based launchpad.
 **Depends on:** Milestone 1 (`DePrizeRegistry`).
 **Files:**
 
-- `subscription-contracts/src/LaunchPadPayHook.sol` (modified)
+- `subscription-contracts/src/LaunchPadPayHook.sol` (modified — pay/cashOut/stage gating)
+- `subscription-contracts/src/LaunchPadApprovalHook.sol` (modified — payout-ruleset transition gating)
+- `subscription-contracts/src/MissionCreator.sol` (modified — `createMission` mode option)
 - `subscription-contracts/test/deprize/LaunchPadPayHookDePrize.t.sol`
+- `subscription-contracts/test/deprize/LaunchPadApprovalHookDePrize.t.sol`
 
-See the full design in [`DEPRIZE.md`](./DEPRIZE.md); this implements the `LaunchPadPayHook.stage()` / cashOut-gating upgrade described there.
+See the full design in [`DEPRIZE.md`](./DEPRIZE.md); this implements the `LaunchPadPayHook.stage()` / cashOut-gating upgrade described there, plus the matching payout-gating that keeps the pot locked for the indefinite duration of a prize.
+
+## The three valves (why the pay hook alone is not enough)
+
+A launchpad mission is governed by **three** independent gates on the JB project, not one. Money/state only stay consistent if all three defer to the same source of truth:
+
+| Valve | Controls | Gated by |
+|---|---|---|
+| `LaunchPadPayHook.beforePay / beforeCashOut` | contributor pay-ins & refunds | DePrize registry (this milestone) |
+| `LaunchPadApprovalHook.approvalStatusOf` | ruleset 0 → 1 transition = **unlocking team payouts** | DePrize registry (this milestone) |
+| Fund-access limits (`payoutLimits` / `surplusAllowances`) | how much the owner can pull once payouts are unlocked | the active ruleset |
+
+The original "fail if the goal isn't met" behavior lives in the **approval hook**: once `deadline + refundPeriod` elapses it approves the payout ruleset regardless of funding. For an indefinite prize that immutable clock *will* elapse, which would let the team drain the pot mid-campaign even while the pay hook's cashOut lock is active. So M2 makes the approval hook DePrize-aware too: for a prize, payouts unlock **only** when the prize wraps up successfully.
 
 ---
 
@@ -40,35 +55,56 @@ So **every** path keeps its exact original behavior unless a registry is set *an
 |---|---|---|---|
 | `beforePayRecordedWith` | contributions **allowed** (deadline ignored) | **reverts** "closed to new contributions" | **reverts** "closed" |
 | `beforeCashOutRecordedWith` | **reverts** "DePrize is active" | refund **allowed** (supply = `funding × weight / 2e18`, no expiry) | **reverts** "DePrize is active" |
-| `stage()` | `1` (active) | `3` (refund) | `1` |
+| `approvalStatusOf` (payouts) | `Failed` — stay locked (deadline ignored) | `Failed` — stay locked so refunds work | **`Approved`** — unlock payout ruleset |
+| `stage()` | `1` (active) | `3` (refund) | `2` (payouts) |
 
 - "Closed to new contributions" = any terminal state (`registry.isTerminal`).
 - "Refund allowed" = `registry.isRefundable` (the three refundable terminals only).
+- "Unlock payouts" = a **non-refundable terminal** (`isTerminal && !isRefundable`), i.e. `M2_COMPLETE` — "requirements met by a team". This is the only state that advances ruleset 0 → 1; the immutable `deadline` is ignored entirely for a prize.
 - `fundingTurnedOff` remains an emergency owner override that wins over everything, DePrize or not.
 - The refund-supply math is unchanged from the original (`currentFunding × rulesetWeight / 2e18`, accounting for the 50% reserve), so existing JB cashOut accounting is preserved.
+- The approval hook reads the registry **from the pay hook** (`payHook.deprizeRegistry()`) rather than holding its own pointer, so there is exactly one source of truth and the two gates can never disagree.
 
 ### Deliberately deferred
 
-`stage()` returns `1` for `SETTLED` and `M2_COMPLETE` rather than a milestone-gated value. Finer-grained staging (e.g. enabling partial cashOut after M1/M2 milestone releases) depends on the **MilestoneEscrow** contract, which is a later milestone. Keeping M2 free of that dependency keeps it small and independently reviewable.
+Payouts unlock **fully** at `M2_COMPLETE`; there is no partial release at `M1_RELEASED`. The milestone-split disbursement (30% at M1, 70% at M2, paid to the winning *provider* rather than the team's payout split) is the **MilestoneEscrow**'s job in a later milestone. Until it exists, the safe behavior is to keep funds fully locked until the prize is fully delivered, which is what this milestone does. `stage()` returns `1` for `SETTLED` / `M1_RELEASED` for the same reason.
 
-## Wiring (no MissionCreator change required)
+## Choosing a funding model at creation
 
-Because the hook resolves the DePrize via `registry.deprizeIdByJBProject(projectId)`, attaching a DePrize to an existing mission is two calls made by **two different owners** (these are distinct trust domains, not a single account):
+`MissionCreator.createMission` now has two overloads:
 
-1. **Registry admin** (`DePrizeRegistry` owner) calls `DePrizeRegistry.register(jbProjectId, teamIds, sunset)` — binds the project to a DePrize. `register` is `onlyOwner` on the registry.
-2. **Hook owner** (the mission `to` account set in `MissionCreator.createMission`) calls `hook.setDePrizeRegistry(registryAddress)` — points the mission's hook at the registry. `setDePrizeRegistry` is `onlyOwner` on the hook, and is write-once (see above).
+1. `createMission(…, memo)` — the original signature, unchanged. Creates a **classic time-based launchpad** (registry left unset; every DePrize path stays dormant; fails-to-refund if the goal isn't met by the deadline). Existing callers (frontend included) keep working with no change.
+2. `createMission(…, memo, address deprizeRegistry)` — when `deprizeRegistry != address(0)`, the mission is created in **prize mode**: the pay hook is wired to the registry atomically at creation (the creator deploys the pay hook owned by `MissionCreator`, calls the write-once `setDePrizeRegistry`, then hands ownership to `to`), and the approval hook picks the registry up from the pay hook. The pot then stays locked with no deadline until the DePrize reaches a terminal.
 
-No constructor/immutable changes, so the same deployment flow `MissionCreator` already uses still applies.
+In prize mode the **DePrize admin still binds the project to a DePrize** via the registry's `onlyOwner` `register(jbProjectId, teamIds, sunset)` (the project id only exists after `launchProjectFor`, so this is a follow-up admin call). `createMission` just wires the hooks to obey the registry; until `register` runs, `deprizeId == 0` and the mission behaves like a classic launchpad.
+
+### Retrofitting an existing mission
+
+Existing missions (e.g. the Frank mission) are bound after the fact with **two calls by two different owners** (distinct trust domains, not one account):
+
+1. **Registry admin** (`DePrizeRegistry` owner) calls `DePrizeRegistry.register(jbProjectId, teamIds, sunset)`.
+2. **Hook owner** (the mission `to` account) calls `payHook.setDePrizeRegistry(registryAddress)` — owner-gated and write-once.
+
+The approval hook needs no separate wiring; it reads the registry from the pay hook.
 
 ## Tests
 
-`forge test --match-path 'test/deprize/LaunchPadPayHookDePrize.t.sol'` — **12 passing**, using lightweight mock `IJBTerminalStore` / `IJBRulesets` stand-ins so the gating logic is deterministic and needs no RPC fork:
+`forge test --match-path 'test/deprize/LaunchPad*.t.sol'` — **20 passing** (15 pay hook + 5 approval hook), using lightweight mock `IJBTerminalStore` / `IJBRulesets` / pay-hook stand-ins so the gating logic is deterministic and needs no RPC fork.
+
+`LaunchPadPayHookDePrize.t.sol`:
 
 - setter access control + write-once latch (detach/repoint and zero-address both revert)
 - backwards compatibility: no registry, and registry-set-but-project-unregistered, both fall through to original pay/cashOut behavior
-- active DePrize: contributions allowed past the immutable deadline, cashOut reverts, `stage() == 1` — across `LOCKED / VOTING / SETTLED / M1_RELEASED / M2_COMPLETE` and `DRAFT`
+- active DePrize: contributions allowed past the immutable deadline, cashOut reverts, `stage() == 1` — across `LOCKED / VOTING / SETTLED / M1_RELEASED` and `DRAFT`
+- success terminal (`M2_COMPLETE`): cashOut still reverts, `stage() == 2` (payouts)
 - refundable terminals (`CANCELLED / NO_WINNER / M2_FAILED`): cashOut enabled with correct supply math, contributions closed, `stage() == 3`
 - `fundingTurnedOff` overrides the DePrize path
+
+`LaunchPadApprovalHookDePrize.t.sol`:
+
+- backwards compatibility: no registry and registry-set-but-unregistered fall through to the original deadline/goal approval logic
+- active + refundable states stay `Failed` (payouts locked) **even well past the immutable deadline + refund period**
+- `M2_COMPLETE` returns `Approved` — the only state that unlocks the payout ruleset
 
 > Original (non-DePrize) pay/cashOut behavior continues to be exercised end-to-end against the live JB V5 stack by `MissionTest.t.sol` on a Sepolia fork.
 >

--- a/subscription-contracts/src/LaunchPadApprovalHook.sol
+++ b/subscription-contracts/src/LaunchPadApprovalHook.sol
@@ -7,9 +7,14 @@ import "@nana-core-v5/interfaces/IJBRulesetApprovalHook.sol";
 import "@nana-core-v5/interfaces/IJBTerminalStore.sol";
 import "@nana-core-v5/libraries/JBConstants.sol";
 import {JBRuleset} from "@nana-core-v5/structs/JBRuleset.sol";
+import {IDePrizeRegistry} from "./deprize/IDePrizeRegistry.sol";
 
 interface ILaunchPadPayHook {
     function refundsEnabled() external view returns (bool);
+    /// @dev Returns the optional DePrize registry the pay hook defers to (or
+    ///      address(0) for a classic time-based launchpad). Single source of
+    ///      truth: the approval hook reads it here rather than holding its own.
+    function deprizeRegistry() external view returns (address);
 }
 
 // Hook to enable payouts after a funding goal is reached and a deadline is passed.
@@ -48,6 +53,15 @@ contract LaunchPadApprovalHook is IJBRulesetApprovalHook, Ownable {
         return payHook.refundsEnabled();
     }
 
+    /// @notice The DePrize id bound to `projectId`, or 0 when this is a classic
+    ///         time-based launchpad (no registry) or the project has no DePrize
+    ///         attached. Mirrors the pay hook so both gates agree.
+    function _deprizeIdFor(uint256 projectId) internal view returns (uint256) {
+        address registry = payHook.deprizeRegistry();
+        if (registry == address(0)) return 0;
+        return IDePrizeRegistry(registry).deprizeIdByJBProject(projectId);
+    }
+
     // Missions have 2 rulesets.
     // Ruleset 1 is for active funding/refunds
     // Ruleset 2 is for payouts
@@ -58,10 +72,28 @@ contract LaunchPadApprovalHook is IJBRulesetApprovalHook, Ownable {
     // If not, we will advance to payouts if when the funding goal is achieved.
     // In either case, after the refund period has passed, the rulset will advance
     // to payouts.
+    //
+    // DePrize-governed missions ignore the immutable deadline/goal entirely:
+    // payouts (ruleset 2) unlock only when the prize wraps up successfully — a
+    // non-refundable terminal state (M2_COMPLETE, "requirements met by a team").
+    // While the campaign is active, or on a refundable terminal, the ruleset
+    // stays in funding/refund so the pot stays locked and contributor refunds
+    // (gated by the pay hook) remain available with no deadline expiry. Finer
+    // milestone-gated releases (30% at M1, 70% at M2) are the MilestoneEscrow's
+    // job in a later milestone; until then funds stay fully locked until M2.
     function approvalStatusOf(
         uint256 projectId,
         JBRuleset memory ruleset
     ) external view override returns (JBApprovalStatus) {
+        uint256 deprizeId = _deprizeIdFor(projectId);
+        if (deprizeId != 0) {
+            IDePrizeRegistry registry = IDePrizeRegistry(payHook.deprizeRegistry());
+            if (registry.isTerminal(deprizeId) && !registry.isRefundable(deprizeId)) {
+                return JBApprovalStatus.Approved; // prize completed → unlock payouts
+            }
+            return JBApprovalStatus.Failed; // active or refundable → stay locked
+        }
+
         uint256 currentFunding = _totalFunding(terminal, projectId);
         bool _refundsEnabled = refundsEnabled();
         if (_refundsEnabled && block.timestamp < deadline + refundPeriod) {

--- a/subscription-contracts/src/LaunchPadPayHook.sol
+++ b/subscription-contracts/src/LaunchPadPayHook.sol
@@ -198,11 +198,16 @@ contract LaunchPadPayHook is IJBRulesetDataHook, Ownable {
     function stage(address terminal, uint256 projectId) public view returns (uint256) {
         uint256 deprizeId = _deprizeIdFor(projectId);
         if (deprizeId != 0) {
-            // Refundable terminal → refund stage (no expiry); otherwise the campaign
-            // is active and cashOut stays disabled. Finer-grained milestone-gated
-            // staging for SETTLED/M2_COMPLETE arrives with the MilestoneEscrow.
+            // Refundable terminal → refund stage (no expiry). Success terminal
+            // (M2_COMPLETE) → payouts stage, matching the approval hook unlocking
+            // ruleset 2. Otherwise the campaign is active and cashOut stays
+            // disabled. Finer-grained milestone-gated staging for SETTLED/
+            // M1_RELEASED arrives with the MilestoneEscrow.
             if (deprizeRegistry.isRefundable(deprizeId)) {
                 return 3; // Refund stage
+            }
+            if (deprizeRegistry.isTerminal(deprizeId)) {
+                return 2; // Prize completed — payouts unlocked
             }
             return 1; // Active campaign — cashOut disabled
         }

--- a/subscription-contracts/src/MissionCreator.sol
+++ b/subscription-contracts/src/MissionCreator.sol
@@ -100,7 +100,23 @@ contract MissionCreator is Ownable, IERC721Receiver {
         missionIdToTerminal[missionId] = terminal;
     }
 
+    /// @notice Create a classic, time-based launchpad mission (funding goal +
+    ///         deadline + refund window). Backwards-compatible entrypoint.
     function createMission(uint256 teamId, address to, string calldata projectUri, uint256 fundingGoal, uint256 deadline, uint256 refundPeriod, bool token, string calldata tokenName, string calldata tokenSymbol, string calldata memo) external returns (uint256) {
+        return createMission(teamId, to, projectUri, fundingGoal, deadline, refundPeriod, token, tokenName, tokenSymbol, memo, address(0));
+    }
+
+    /// @notice Create a mission, choosing its funding model:
+    ///         - `deprizeRegistry == address(0)`: classic time-based launchpad
+    ///           (fails to refund if the goal isn't met by the deadline).
+    ///         - `deprizeRegistry != address(0)`: a prize that ends once a team
+    ///           meets the requirements. The pay/approval hooks defer to the
+    ///           DePrize lifecycle: contributions stay open and the pot stays
+    ///           locked (no deadline) until the registry reaches a terminal —
+    ///           payouts unlock on success, refunds on a refundable terminal.
+    ///           The DePrize admin still binds the project via the registry's
+    ///           `register()`; this just wires the hooks to obey it.
+    function createMission(uint256 teamId, address to, string calldata projectUri, uint256 fundingGoal, uint256 deadline, uint256 refundPeriod, bool token, string calldata tokenName, string calldata tokenSymbol, string calldata memo, address deprizeRegistry) public returns (uint256) {
 
         if(msg.sender != owner()) {
             require(moonDAOTeam.isManager(teamId, msg.sender), "Only a manager of the team or owner of the contract can create a mission.");
@@ -114,7 +130,17 @@ contract MissionCreator is Ownable, IERC721Receiver {
         PoolDeployer poolDeployer = new PoolDeployer(feeHookAddress, positionManagerAddress, owner());
 
 
-        LaunchPadPayHook launchPadPayHook = new LaunchPadPayHook(fundingGoal, deadline, refundPeriod, jbTerminalStoreAddress, jbRulesetsAddress, to);
+        // Prize mode: deploy the pay hook owned by this contract so we can attach
+        // the registry atomically (its setter is owner-gated + write-once), then
+        // hand ownership to `to`. Classic mode: owned by `to` directly, registry
+        // left unset so every DePrize path stays dormant. The approval hook reads
+        // the registry from the pay hook, so wiring the pay hook covers both gates.
+        address payHookOwner = deprizeRegistry == address(0) ? to : address(this);
+        LaunchPadPayHook launchPadPayHook = new LaunchPadPayHook(fundingGoal, deadline, refundPeriod, jbTerminalStoreAddress, jbRulesetsAddress, payHookOwner);
+        if (deprizeRegistry != address(0)) {
+            launchPadPayHook.setDePrizeRegistry(deprizeRegistry);
+            launchPadPayHook.transferOwnership(to);
+        }
         LaunchPadApprovalHook launchPadApprovalHook = new LaunchPadApprovalHook(fundingGoal, deadline, refundPeriod, jbTerminalStoreAddress, address(terminal), address(launchPadPayHook), to);
         // Ruleset 0 is funding/refunds
         // Ruleset 0 has a cashout hook that will only allow refunds if the deadline has passed and the funding goal has not been met.

--- a/subscription-contracts/src/MissionCreator.sol
+++ b/subscription-contracts/src/MissionCreator.sol
@@ -220,6 +220,13 @@ contract MissionCreator is Ownable, IERC721Receiver {
             amount: uint224(128_000_000 * 10 ** 18), // 128 million ETH, functionally unlimited
             currency: uint32(uint160(JBConstants.NATIVE_TOKEN))
         });
+        // Third launchpad "valve": a classic mission lets the owner pull surplus
+        // during the funding stage (the 128M allowance) — a trusted-team assumption.
+        // For a prize the pot must stay fully locked for the whole active campaign,
+        // so ruleset 0 gets NO surplus allowance. With no payout limit and no
+        // surplus allowance there, the only exits during an active prize are
+        // contributor refunds (pay hook) and the ruleset-1 payout the approval hook
+        // unlocks at completion. Classic missions are unchanged.
         rulesetConfigurations[0].fundAccessLimitGroups[0] = JBFundAccessLimitGroup({
             terminal: address(terminal),
             token: JBConstants.NATIVE_TOKEN,

--- a/subscription-contracts/src/MissionCreator.sol
+++ b/subscription-contracts/src/MissionCreator.sol
@@ -224,7 +224,7 @@ contract MissionCreator is Ownable, IERC721Receiver {
             terminal: address(terminal),
             token: JBConstants.NATIVE_TOKEN,
             payoutLimits: new JBCurrencyAmount[](0),
-            surplusAllowances: surplusAllowances
+            surplusAllowances: deprizeRegistry == address(0) ? surplusAllowances : new JBCurrencyAmount[](0)
         });
         rulesetConfigurations[1].fundAccessLimitGroups[0] = JBFundAccessLimitGroup({
             terminal: address(terminal),

--- a/subscription-contracts/test/deprize/LaunchPadApprovalHookDePrize.t.sol
+++ b/subscription-contracts/test/deprize/LaunchPadApprovalHookDePrize.t.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {LaunchPadApprovalHook} from "../../src/LaunchPadApprovalHook.sol";
+import {DePrizeRegistry} from "../../src/deprize/DePrizeRegistry.sol";
+import {IDePrizeRegistry} from "../../src/deprize/IDePrizeRegistry.sol";
+
+import {JBConstants} from "@nana-core-v5/libraries/JBConstants.sol";
+import {JBRuleset} from "@nana-core-v5/structs/JBRuleset.sol";
+import {JBApprovalStatus} from "@nana-core-v5/enums/JBApprovalStatus.sol";
+
+/// @dev Minimal IJBTerminalStore stand-in (only the selectors the hook reads).
+contract MockTerminalStore {
+    uint256 public balance;
+    uint256 public withdrawn;
+
+    function setFunding(uint256 _balance, uint256 _withdrawn) external {
+        balance = _balance;
+        withdrawn = _withdrawn;
+    }
+
+    function balanceOf(address, uint256, address) external view returns (uint256) {
+        return balance;
+    }
+
+    function usedPayoutLimitOf(address, uint256, address, uint256, uint256) external view returns (uint256) {
+        return withdrawn;
+    }
+}
+
+/// @dev Stand-in for LaunchPadPayHook: the approval hook only reads
+///      `refundsEnabled()` and `deprizeRegistry()` from it.
+contract MockPayHook {
+    bool public refundsEnabled;
+    address public deprizeRegistry;
+
+    function setRefundsEnabled(bool v) external {
+        refundsEnabled = v;
+    }
+
+    function setDeprizeRegistry(address r) external {
+        deprizeRegistry = r;
+    }
+}
+
+/// @notice Unit tests for the DePrize-aware ruleset-transition logic of
+///         LaunchPadApprovalHook. Non-DePrize (original) behavior is exercised
+///         on a fork by MissionTest; here we mock the pay hook + JB store so the
+///         gating is deterministic and needs no RPC.
+contract LaunchPadApprovalHookDePrizeTest is Test {
+    LaunchPadApprovalHook hook;
+    DePrizeRegistry registry;
+    MockTerminalStore store;
+    MockPayHook payHook;
+
+    address owner = address(0xA11CE);
+
+    uint256 constant PROJECT = 100;
+    uint256 constant OTHER_PROJECT = 200;
+    bytes32 constant CONDITION = bytes32(uint256(0xC0FFEE));
+
+    uint256 constant FUNDING_GOAL = 10 ether;
+    uint256 deadline;
+    uint256 constant REFUND_PERIOD = 14 days;
+
+    function setUp() public {
+        deadline = block.timestamp + 28 days;
+
+        store = new MockTerminalStore();
+        payHook = new MockPayHook();
+
+        DePrizeRegistry impl = new DePrizeRegistry();
+        bytes memory initData = abi.encodeCall(DePrizeRegistry.initialize, (owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        registry = DePrizeRegistry(address(proxy));
+
+        hook = new LaunchPadApprovalHook(
+            FUNDING_GOAL, deadline, REFUND_PERIOD, address(store), address(this), address(payHook), owner
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------------
+    function _teams() internal pure returns (uint256[] memory t) {
+        t = new uint256[](2);
+        t[0] = 1;
+        t[1] = 2;
+    }
+
+    /// @dev Register a DePrize bound to `projectId` and advance it to `target`.
+    function _registerTo(uint256 projectId, IDePrizeRegistry.DePrizeState target) internal returns (uint256 id) {
+        vm.startPrank(owner);
+        id = registry.register(projectId, _teams(), block.timestamp + 30 days);
+
+        if (target == IDePrizeRegistry.DePrizeState.DRAFT) {
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.setCondition(id, CONDITION);
+        registry.open(id);
+        if (target == IDePrizeRegistry.DePrizeState.OPEN) {
+            vm.stopPrank();
+            return id;
+        }
+
+        if (target == IDePrizeRegistry.DePrizeState.CANCELLED) {
+            registry.announceCancellation(id);
+            vm.warp(block.timestamp + registry.CANCELLATION_NOTICE());
+            registry.cancel(id);
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.lock(id);
+        if (target == IDePrizeRegistry.DePrizeState.LOCKED) {
+            vm.stopPrank();
+            return id;
+        }
+        if (target == IDePrizeRegistry.DePrizeState.NO_WINNER) {
+            registry.settleNoWinner(id);
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.startVote(id);
+        if (target == IDePrizeRegistry.DePrizeState.VOTING) {
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.settleWinner(id, 1);
+        if (target == IDePrizeRegistry.DePrizeState.SETTLED) {
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.releaseM1(id);
+        if (target == IDePrizeRegistry.DePrizeState.M1_RELEASED) {
+            vm.stopPrank();
+            return id;
+        }
+        if (target == IDePrizeRegistry.DePrizeState.M2_FAILED) {
+            registry.failM2(id);
+            vm.stopPrank();
+            return id;
+        }
+        if (target == IDePrizeRegistry.DePrizeState.M2_COMPLETE) {
+            registry.completeM2(id);
+            vm.stopPrank();
+            return id;
+        }
+
+        revert("unsupported target");
+    }
+
+    function _attach() internal {
+        payHook.setDeprizeRegistry(address(registry));
+    }
+
+    function _status(uint256 projectId) internal view returns (JBApprovalStatus) {
+        JBRuleset memory rs;
+        return hook.approvalStatusOf(projectId, rs);
+    }
+
+    // ---------------------------------------------------------------------
+    // classic (no DePrize) behavior is preserved
+    // ---------------------------------------------------------------------
+    function testNoRegistryUsesOriginalApproval() public {
+        // under goal, before deadline → not yet approved (stay funding)
+        store.setFunding(1 ether, 0);
+        assertEq(uint256(_status(PROJECT)), uint256(JBApprovalStatus.Failed));
+
+        // goal met past deadline → approved (payouts)
+        store.setFunding(FUNDING_GOAL, 0);
+        vm.warp(deadline + 1);
+        assertEq(uint256(_status(PROJECT)), uint256(JBApprovalStatus.Approved));
+    }
+
+    function testRegistrySetButProjectUnregisteredUsesOriginal() public {
+        _registerTo(OTHER_PROJECT, IDePrizeRegistry.DePrizeState.OPEN);
+        _attach();
+
+        store.setFunding(1 ether, 0);
+        assertEq(uint256(_status(PROJECT)), uint256(JBApprovalStatus.Failed));
+    }
+
+    // ---------------------------------------------------------------------
+    // DePrize active / refundable → stay locked (Failed)
+    // ---------------------------------------------------------------------
+    function testActiveStatesStayLocked() public {
+        IDePrizeRegistry.DePrizeState[6] memory states = [
+            IDePrizeRegistry.DePrizeState.DRAFT,
+            IDePrizeRegistry.DePrizeState.OPEN,
+            IDePrizeRegistry.DePrizeState.LOCKED,
+            IDePrizeRegistry.DePrizeState.VOTING,
+            IDePrizeRegistry.DePrizeState.SETTLED,
+            IDePrizeRegistry.DePrizeState.M1_RELEASED
+        ];
+        _attach();
+        for (uint256 i = 0; i < states.length; i++) {
+            uint256 projectId = 1000 + i;
+            _registerTo(projectId, states[i]);
+            // even well past the immutable deadline, payouts stay locked
+            vm.warp(deadline + REFUND_PERIOD + 100 days);
+            assertEq(uint256(_status(projectId)), uint256(JBApprovalStatus.Failed), "active should stay locked");
+        }
+    }
+
+    function testRefundableTerminalsStayLocked() public {
+        IDePrizeRegistry.DePrizeState[3] memory states = [
+            IDePrizeRegistry.DePrizeState.CANCELLED,
+            IDePrizeRegistry.DePrizeState.NO_WINNER,
+            IDePrizeRegistry.DePrizeState.M2_FAILED
+        ];
+        _attach();
+        for (uint256 i = 0; i < states.length; i++) {
+            uint256 projectId = 2000 + i;
+            _registerTo(projectId, states[i]);
+            // refundable → stay in funding/refund ruleset so cashOut works
+            assertEq(uint256(_status(projectId)), uint256(JBApprovalStatus.Failed), "refundable should stay locked");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // DePrize success terminal → unlock payouts (Approved)
+    // ---------------------------------------------------------------------
+    function testM2CompleteUnlocksPayouts() public {
+        _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_COMPLETE);
+        _attach();
+        assertEq(uint256(_status(PROJECT)), uint256(JBApprovalStatus.Approved));
+    }
+}

--- a/subscription-contracts/test/deprize/LaunchPadPayHookDePrize.t.sol
+++ b/subscription-contracts/test/deprize/LaunchPadPayHookDePrize.t.sol
@@ -286,12 +286,12 @@ contract LaunchPadPayHookDePrizeTest is Test {
     }
 
     function testActiveStatesBlockCashOut() public {
-        IDePrizeRegistry.DePrizeState[5] memory states = [
+        // SETTLED / M1_RELEASED are non-terminal (campaign still resolving) → stage 1.
+        IDePrizeRegistry.DePrizeState[4] memory states = [
             IDePrizeRegistry.DePrizeState.LOCKED,
             IDePrizeRegistry.DePrizeState.VOTING,
             IDePrizeRegistry.DePrizeState.SETTLED,
-            IDePrizeRegistry.DePrizeState.M1_RELEASED,
-            IDePrizeRegistry.DePrizeState.M2_COMPLETE
+            IDePrizeRegistry.DePrizeState.M1_RELEASED
         ];
         // attach once: the registry pointer is write-once, and the same registry
         // serves every project id below
@@ -304,6 +304,16 @@ contract LaunchPadPayHookDePrizeTest is Test {
             hook.beforeCashOutRecordedWith(_cashOutCtx(projectId));
             assertEq(hook.stage(address(this), projectId), 1, "active stage should be 1");
         }
+    }
+
+    /// @dev M2_COMPLETE (success terminal): cashOut stays disabled, but stage is
+    ///      2 (payouts), matching the approval hook unlocking ruleset 2.
+    function testM2CompleteBlocksCashOutPayoutsStage() public {
+        _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_COMPLETE);
+        _attach();
+        vm.expectRevert("DePrize is active. Refunds are disabled.");
+        hook.beforeCashOutRecordedWith(_cashOutCtx(PROJECT));
+        assertEq(hook.stage(address(this), PROJECT), 2, "completed stage should be 2");
     }
 
     function testDraftBlocksCashOutAllowsPay() public {


### PR DESCRIPTION
Stacked on #1324 (M2 `LaunchPadPayHook`). Base is `feature/deprize-m2-payhook`; review after #1324 merges (or review the diff here).

## Why

The M2 pay hook governs only one of the **three valves** on a launchpad project. The "fail if the goal isn't met" machinery actually lives in the **approval hook** (the ruleset 0 → 1 transition that unlocks team payouts), and it was still driven entirely by the immutable `deadline`/`fundingGoal`. For an indefinite prize that clock *will* elapse, which would advance the project to the payout ruleset and let the team drain the pot mid-campaign — even while the pay hook's cashOut lock is active. The pay hook lock was therefore cosmetic without this.

## Summary

- **`LaunchPadApprovalHook` is now DePrize-aware.** `approvalStatusOf` reads the registry **from the pay hook** (single source of truth — the two gates can't disagree). For a prize, payouts unlock **only** on a non-refundable terminal (`M2_COMPLETE`, "requirements met by a team"); while active or on a refundable terminal it stays in the funding/refund ruleset, so the pot stays locked and contributor refunds keep working. The immutable `deadline` is ignored for a prize.
- **`stage()` coherence:** returns `2` (payouts) on the success terminal, matching the approval hook unlocking ruleset 2.
- **Creators choose the model at creation.** `MissionCreator.createMission` gains an overload taking `deprizeRegistry`:
  - `address(0)` → classic **time-based launchpad** (original signature unchanged; frontend/existing callers unaffected).
  - non-zero → **prize mode**: the pay hook is wired to the registry atomically at creation (deploy owned by `MissionCreator`, write-once `setDePrizeRegistry`, then ownership handed to `to`). The DePrize admin still binds the project via the registry's `onlyOwner` `register()`.

Backwards-compatible by construction: with no registry / no bound DePrize, every path behaves exactly as before.

## Deferred

Payouts unlock **fully** at `M2_COMPLETE`. The 30%-at-M1 / 70%-at-M2 milestone split (paid to the winning *provider* via `MilestoneEscrow`, not the team's payout split) is a later milestone; until then, fully-locked-until-delivered is the safe behavior. The ruleset-0 `surplusAllowances` leak is also a separate follow-up (should be zeroed for prize missions).

See `docs/DEPRIZE_M2.md` for the full write-up (updated for the three-valve model + mode option).

## Test plan

- `forge test --match-path 'test/deprize/LaunchPad*.t.sol' --skip 'test/ManualRefundTest.t.sol' --skip 'test/OwnerOnlyPayoutsRulesetTest.t.sol'` — 20 passing (15 pay hook + 5 new approval hook)
- `forge test --match-path 'test/deprize/*.t.sol' --skip ...` — 62 passing across the whole DePrize suite
- New `LaunchPadApprovalHookDePrize.t.sol`: active/refundable stay locked even past deadline+refundPeriod; `M2_COMPLETE` unlocks; non-DePrize falls through to original approval logic.

Made with Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes when team payouts unlock and how prize pots can be withdrawn during long-running campaigns—incorrect gating could let owners drain funds mid-prize or block legitimate completion payouts.
> 
> **Overview**
> Extends DePrize M2 so **all three Juicebox launchpad gates** stay aligned with the registry, not just pay/refund on `LaunchPadPayHook`.
> 
> **`LaunchPadApprovalHook`** now defers to `DePrizeRegistry` via `payHook.deprizeRegistry()` (single source of truth). For bound prizes, `approvalStatusOf` **ignores** the immutable deadline/goal: payouts stay **Failed** while the campaign is active or on a refundable terminal (even years after `deadline + refundPeriod`), and only **`M2_COMPLETE`** returns **Approved** to advance to the payout ruleset.
> 
> **`LaunchPadPayHook.stage()`** returns **2** on the success terminal so staging matches that ruleset unlock; cashOut remains blocked on `M2_COMPLETE`.
> 
> **`MissionCreator`** adds a **`createMission(…, deprizeRegistry)`** overload: `address(0)` keeps the classic launchpad; non-zero enables **prize mode** (write-once registry on the pay hook at creation, ownership to `to`). Prize missions get **zero ruleset-0 surplus allowance** so owners cannot drain the pot via `useAllowanceOf` during an active campaign.
> 
> New **`LaunchPadApprovalHookDePrize.t.sol`** and pay-hook test updates cover approval gating and `M2_COMPLETE` staging; **`docs/DEPRIZE_M2.md`** documents the three-valve model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b77acfa06bbb78d3343a61135e0534582eefe5e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->