### PR TITLE
feat(deprize): DePrizeMilestoneEscrow (M3) — registry-gated prize disbursement

### DIFF
--- a/docs/DEPRIZE_M3.md
+++ b/docs/DEPRIZE_M3.md
@@ -1,0 +1,65 @@
+# DePrize — Milestone 3: `DePrizeMilestoneEscrow`
+
+**Status:** Implemented, unit-tested
+**Scope:** Custody the prize pool after settlement and release it to the winning provider in two milestones (30% at M1, 70% at M2), gated entirely by the `DePrizeRegistry` lifecycle. Handles the failure/refund terminals too.
+**Depends on:** Milestone 1 (`DePrizeRegistry`). Complements the M2 launchpad-hook work (the hooks keep the JB-side pot locked during a prize; this contract is *where the prize goes* once it resolves).
+**Files:**
+
+- `subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol`
+- `subscription-contracts/test/deprize/DePrizeMilestoneEscrow.t.sol`
+
+See the full design in [`DEPRIZE.md`](./DEPRIZE.md) §Settlement.
+
+---
+
+## Why
+
+The M2 hooks make a prize mission's JB pot stay locked until the registry reaches a terminal, and unlock the payout ruleset on success. But the standard launchpad payout splits send funds to the *team* (90%) — wrong for a prize, where the pool belongs to the **winning provider** and must be released in step with **actual delivery**, not just capability. `DePrizeMilestoneEscrow` is the destination for a prize's pool:
+
+- **M1 (capability demonstrated):** 30% released, so a winning provider has liquid funds for prep (insurance, training, hardware, filings).
+- **M2 (mission delivered):** the remaining 70% — the carrot that's contingent on actually flying.
+
+This addresses the "provider walks away after winning" gap.
+
+## Lifecycle (gated by the registry)
+
+| Escrow call | Registry state required | Effect |
+|---|---|---|
+| `releaseM1` | `M1_RELEASED` | pay 30% of deposited to the provider recipient |
+| `releaseM2` | `M2_COMPLETE` | pay the remaining balance to the provider recipient (finalize) |
+| `returnToTreasury` | `M2_FAILED` | send the un-released remainder to the MoonDAO treasury for `$OVERVIEW`-governed re-allocation (the 30% paid at M1 is not clawed back) |
+| `refundToJB` | `CANCELLED` or `NO_WINNER` | return the balance to the JB project via `addToBalanceOf`, raising `$OVERVIEW` cashOut value |
+
+- Releases are **permissionless** (keeper-friendly): gated by registry state + the admin-set recipient, so anyone can trigger once the state is right, but the destination is never attacker-controlled.
+- `setProviderRecipient` is owner-only, requires a declared winner (`registry.winningTeamId != 0`), and is locked once M1 has released — a release can never be redirected after the fact.
+- Per-DePrize accounting (`deposited` / `released` / `finalized`) lets one escrow serve many DePrizes. `deposited - released = pendingBalance`.
+- UUPS-upgradeable + `ReentrancyGuard`, matching `DePrizeRegistry`. Checks-effects-interactions on every payout.
+
+## Funding boundary (integration point)
+
+This contract releases percentages of its **own per-DePrize ETH balance**. It is deliberately agnostic about *where* the ETH came from, which keeps it independently reviewable and testable. The settlement process funds it via `deposit(deprizeId)` before `releaseM1`:
+
+- the JB project's prize pool (routed out of the project as a payout/surplus to the escrow), plus
+- swap-fee accrual from the future `DePrizePrizeEscrow`.
+
+Wiring a prize mission's **ruleset-1 payout to this escrow** (instead of the team's 90% split) is the remaining integration step and is intentionally **not** included here — it needs JB split/permission design and should land with the betting/mint + PrizeEscrow milestone. Until then the escrow works standalone with explicit `deposit()` calls, and the M2 hooks keep the JB pot locked so nothing leaks in the meantime.
+
+`receive()` reverts: every wei must be attributed to a DePrize via `deposit(deprizeId)`.
+
+## Tests
+
+`forge test --match-path 'test/deprize/DePrizeMilestoneEscrow.t.sol'` — **23 passing**, using the real `DePrizeRegistry` (proxy) + a mock JB terminal:
+
+- init / re-init guard / owner-only setters
+- deposit credits per-DePrize balance; unknown / zero / post-finalized deposits revert; `receive()` reverts
+- `setProviderRecipient` requires a declared winner, owner-only, locked after M1
+- `releaseM1` pays exactly 30%; reverts on wrong state, missing recipient, or double release
+- `releaseM2` pays the remainder after M1, or the full balance if M1 was skipped; finalize guard
+- `returnToTreasury` sends the remainder on `M2_FAILED` (M1's 30% not clawed back)
+- `refundToJB` calls `addToBalanceOf` with the full balance on `CANCELLED` / `NO_WINNER`; wrong-state guard
+
+## Next
+
+- Route a prize mission's ruleset-1 payout into this escrow (JB split/permission wiring).
+- `DePrizePrizeEscrow` (swap-fee accrual) forwarding into this escrow at settlement.
+- Optional M2 deadline enforcement (18 months + extension) as an on-chain trigger for `returnToTreasury`.

--- a/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
+++ b/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
@@ -204,18 +204,23 @@ contract DePrizeMilestoneEscrow is Initializable, OwnableUpgradeable, UUPSUpgrad
             revert WrongState(deprizeId, s);
         }
         if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
-        address recipient = providerRecipient[deprizeId];
-        if (recipient == address(0)) revert RecipientNotSet(deprizeId);
 
         // Finalizers must always be able to finalize, even with a zero balance,
         // so a fully-resolved prize never gets stuck un-finalized (consistent
-        // with refundToJB). _sendETH no-ops on zero. (releaseM1 keeps its zero
-        // guard because it is intermediate, not a finalizer: a zero-amount M1
-        // would prematurely lock the recipient with nothing paid.)
+        // with refundToJB and returnToTreasury). Only check recipient when
+        // there's an amount to pay — this allows zero-balance finalization
+        // without a recipient set. (releaseM1 keeps its zero guard because it is
+        // intermediate, not a finalizer: a zero-amount M1 would prematurely lock
+        // the recipient with nothing paid.)
         uint256 amount = deposited[deprizeId] - released[deprizeId];
         finalized[deprizeId] = true;
         released[deprizeId] = deposited[deprizeId];
-        _sendETH(recipient, amount);
+
+        address recipient = providerRecipient[deprizeId];
+        if (amount > 0) {
+            if (recipient == address(0)) revert RecipientNotSet(deprizeId);
+            _sendETH(recipient, amount);
+        }
         emit M2Released(deprizeId, recipient, amount);
     }
 

--- a/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
+++ b/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
@@ -221,7 +221,9 @@ contract DePrizeMilestoneEscrow is Initializable, OwnableUpgradeable, UUPSUpgrad
 
     /// @notice Return the un-released remainder to the MoonDAO treasury when a
     ///         prize fails after M1 (`M2_FAILED`) for $OVERVIEW-governed
-    ///         re-allocation. The 30% already paid at M1 is not clawed back.
+    ///         re-allocation. The provider's 30% M1 tranche is never clawed back:
+    ///         if a keeper never called releaseM1 before failM2, it is paid out
+    ///         here first and only the remaining 70% goes to the treasury.
     function returnToTreasury(uint256 deprizeId) external nonReentrant {
         IDePrizeRegistry.DePrizeState s = registry.state(deprizeId);
         if (s != IDePrizeRegistry.DePrizeState.M2_FAILED) {
@@ -232,8 +234,26 @@ contract DePrizeMilestoneEscrow is Initializable, OwnableUpgradeable, UUPSUpgrad
         // Finalize gracefully even with a zero balance (matches refundToJB), so an
         // M2_FAILED prize with no escrow deposits can't be left permanently
         // un-finalized — which would otherwise keep accepting stray deposits.
-        uint256 amount = deposited[deprizeId] - released[deprizeId];
         finalized[deprizeId] = true;
+
+        // The registry only reaches M2_FAILED from M1_RELEASED, so the provider
+        // earned their 30% M1 tranche regardless of whether a keeper actually
+        // called releaseM1 first. Pay it here if it was skipped so the tranche is
+        // never clawed back to the treasury. (If there were no deposits, m1 is 0
+        // and we skip it — keeping zero-balance finalization recipient-agnostic.)
+        if (!m1Released[deprizeId]) {
+            uint256 m1 = (deposited[deprizeId] * M1_BPS) / BPS_DENOMINATOR;
+            if (m1 > 0) {
+                address recipient = providerRecipient[deprizeId];
+                if (recipient == address(0)) revert RecipientNotSet(deprizeId);
+                m1Released[deprizeId] = true;
+                released[deprizeId] += m1;
+                _sendETH(recipient, m1);
+                emit M1Released(deprizeId, recipient, m1);
+            }
+        }
+
+        uint256 amount = deposited[deprizeId] - released[deprizeId];
         released[deprizeId] = deposited[deprizeId];
         _sendETH(moonDAOTreasury, amount);
         emit ReturnedToTreasury(deprizeId, moonDAOTreasury, amount);

--- a/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
+++ b/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
@@ -206,6 +206,7 @@ contract DePrizeMilestoneEscrow is
         if (recipient == address(0)) revert RecipientNotSet(deprizeId);
 
         uint256 amount = deposited[deprizeId] - released[deprizeId];
+        if (amount == 0) revert ZeroAmount();
         finalized[deprizeId] = true;
         released[deprizeId] = deposited[deprizeId];
         _sendETH(recipient, amount);
@@ -223,6 +224,7 @@ contract DePrizeMilestoneEscrow is
         if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
 
         uint256 amount = deposited[deprizeId] - released[deprizeId];
+        if (amount == 0) revert ZeroAmount();
         finalized[deprizeId] = true;
         released[deprizeId] = deposited[deprizeId];
         _sendETH(moonDAOTreasury, amount);

--- a/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
+++ b/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
@@ -178,14 +178,16 @@ contract DePrizeMilestoneEscrow is
     /// @notice Release the 30% M1 tranche to the winning provider once the
     ///         registry reports `M1_RELEASED`.
     function releaseM1(uint256 deprizeId) external nonReentrant {
-        if (registry.state(deprizeId) != IDePrizeRegistry.DePrizeState.M1_RELEASED) {
-            revert WrongState(deprizeId, registry.state(deprizeId));
+        IDePrizeRegistry.DePrizeState s = registry.state(deprizeId);
+        if (s != IDePrizeRegistry.DePrizeState.M1_RELEASED) {
+            revert WrongState(deprizeId, s);
         }
         if (m1Released[deprizeId]) revert AlreadyReleasedM1(deprizeId);
         address recipient = providerRecipient[deprizeId];
         if (recipient == address(0)) revert RecipientNotSet(deprizeId);
 
         uint256 amount = (deposited[deprizeId] * M1_BPS) / BPS_DENOMINATOR;
+        if (amount == 0) revert ZeroAmount();
         m1Released[deprizeId] = true;
         released[deprizeId] += amount;
         _sendETH(recipient, amount);
@@ -195,8 +197,9 @@ contract DePrizeMilestoneEscrow is
     /// @notice Release the remaining balance to the winning provider once the
     ///         registry reports `M2_COMPLETE`.
     function releaseM2(uint256 deprizeId) external nonReentrant {
-        if (registry.state(deprizeId) != IDePrizeRegistry.DePrizeState.M2_COMPLETE) {
-            revert WrongState(deprizeId, registry.state(deprizeId));
+        IDePrizeRegistry.DePrizeState s = registry.state(deprizeId);
+        if (s != IDePrizeRegistry.DePrizeState.M2_COMPLETE) {
+            revert WrongState(deprizeId, s);
         }
         if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
         address recipient = providerRecipient[deprizeId];
@@ -213,8 +216,9 @@ contract DePrizeMilestoneEscrow is
     ///         prize fails after M1 (`M2_FAILED`) for $OVERVIEW-governed
     ///         re-allocation. The 30% already paid at M1 is not clawed back.
     function returnToTreasury(uint256 deprizeId) external nonReentrant {
-        if (registry.state(deprizeId) != IDePrizeRegistry.DePrizeState.M2_FAILED) {
-            revert WrongState(deprizeId, registry.state(deprizeId));
+        IDePrizeRegistry.DePrizeState s = registry.state(deprizeId);
+        if (s != IDePrizeRegistry.DePrizeState.M2_FAILED) {
+            revert WrongState(deprizeId, s);
         }
         if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
 

--- a/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
+++ b/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
@@ -40,12 +40,7 @@ import {JBConstants} from "@nana-core-v5/libraries/JBConstants.sol";
 ///      destination is never attacker-controlled. Admin (the same Safe that owns
 ///      the registry, in v1) sets the provider recipient, JB terminal, and
 ///      treasury. UUPS-upgradeable to match `DePrizeRegistry`.
-contract DePrizeMilestoneEscrow is
-    Initializable,
-    OwnableUpgradeable,
-    UUPSUpgradeable,
-    ReentrancyGuardUpgradeable
-{
+contract DePrizeMilestoneEscrow is Initializable, OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuardUpgradeable {
     /// @notice Basis points released at M1 (capability demonstrated).
     uint256 public constant M1_BPS = 3_000; // 30%
     uint256 public constant BPS_DENOMINATOR = 10_000;
@@ -144,6 +139,7 @@ contract DePrizeMilestoneEscrow is
     ///         released (so a release can never be redirected after the fact).
     function setProviderRecipient(uint256 deprizeId, address recipient) external onlyOwner {
         if (recipient == address(0)) revert ZeroAddress();
+        if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
         if (m1Released[deprizeId]) revert AlreadyReleasedM1(deprizeId);
         if (registry.winningTeamId(deprizeId) == 0) revert NoWinnerDeclared(deprizeId);
         providerRecipient[deprizeId] = recipient;

--- a/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
+++ b/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
@@ -207,8 +207,12 @@ contract DePrizeMilestoneEscrow is Initializable, OwnableUpgradeable, UUPSUpgrad
         address recipient = providerRecipient[deprizeId];
         if (recipient == address(0)) revert RecipientNotSet(deprizeId);
 
+        // Finalizers must always be able to finalize, even with a zero balance,
+        // so a fully-resolved prize never gets stuck un-finalized (consistent
+        // with refundToJB). _sendETH no-ops on zero. (releaseM1 keeps its zero
+        // guard because it is intermediate, not a finalizer: a zero-amount M1
+        // would prematurely lock the recipient with nothing paid.)
         uint256 amount = deposited[deprizeId] - released[deprizeId];
-        if (amount == 0) revert ZeroAmount();
         finalized[deprizeId] = true;
         released[deprizeId] = deposited[deprizeId];
         _sendETH(recipient, amount);
@@ -225,8 +229,10 @@ contract DePrizeMilestoneEscrow is Initializable, OwnableUpgradeable, UUPSUpgrad
         }
         if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
 
+        // Finalize gracefully even with a zero balance (matches refundToJB), so an
+        // M2_FAILED prize with no escrow deposits can't be left permanently
+        // un-finalized — which would otherwise keep accepting stray deposits.
         uint256 amount = deposited[deprizeId] - released[deprizeId];
-        if (amount == 0) revert ZeroAmount();
         finalized[deprizeId] = true;
         released[deprizeId] = deposited[deprizeId];
         _sendETH(moonDAOTreasury, amount);

--- a/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
+++ b/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+
+import {IDePrizeRegistry} from "./IDePrizeRegistry.sol";
+import {IJBTerminal} from "@nana-core-v5/interfaces/IJBTerminal.sol";
+import {JBConstants} from "@nana-core-v5/libraries/JBConstants.sol";
+
+/// @title DePrizeMilestoneEscrow
+/// @notice Holds a DePrize's prize pool after settlement and releases it to the
+///         winning provider in two milestones, gated entirely by the
+///         `DePrizeRegistry` lifecycle:
+///
+///           - `releaseM1`  (state == M1_RELEASED):  pays 30% to the provider.
+///           - `releaseM2`  (state == M2_COMPLETE):  pays the remainder to the provider.
+///           - `returnToTreasury` (state == M2_FAILED): the un-released remainder
+///             goes to the MoonDAO treasury for $OVERVIEW-governed re-allocation.
+///           - `refundToJB` (state == CANCELLED | NO_WINNER): the balance is
+///             returned to the JB project so $OVERVIEW holders can cash out.
+///
+///         The 30/70 split aligns the provider's incentive with actual delivery
+///         (M1 = capability demonstrated, M2 = mission flown). See `DEPRIZE.md`.
+///
+/// @dev Funding boundary (integration point): this contract releases percentages
+///      of its **own per-DePrize ETH balance**. The settlement process is
+///      responsible for funding it first — the JB project's prize pool plus any
+///      swap-fee accrual (the future `DePrizePrizeEscrow`) are deposited via
+///      `deposit(deprizeId)` before `releaseM1` is called. Keeping the escrow
+///      agnostic about *where* the ETH came from makes it independently
+///      reviewable and testable; the JB payout-routing that funds it is wired
+///      separately (a prize mission's ruleset-1 payout, or a manual deposit).
+///
+///      Release functions are permissionless (keeper-friendly): they are gated
+///      by the registry state and the admin-set provider recipient, so anyone
+///      can trigger a release once the registry reaches the right state, but the
+///      destination is never attacker-controlled. Admin (the same Safe that owns
+///      the registry, in v1) sets the provider recipient, JB terminal, and
+///      treasury. UUPS-upgradeable to match `DePrizeRegistry`.
+contract DePrizeMilestoneEscrow is
+    Initializable,
+    OwnableUpgradeable,
+    UUPSUpgradeable,
+    ReentrancyGuardUpgradeable
+{
+    /// @notice Basis points released at M1 (capability demonstrated).
+    uint256 public constant M1_BPS = 3_000; // 30%
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @notice The DePrize lifecycle source of truth.
+    IDePrizeRegistry public registry;
+
+    /// @notice JB multi-terminal used to return funds to a project on refund.
+    IJBTerminal public jbTerminal;
+
+    /// @notice Recipient of forfeited M2 funds when a prize fails post-M1.
+    address public moonDAOTreasury;
+
+    /// @notice Total ETH funded into the escrow for a DePrize.
+    mapping(uint256 => uint256) public deposited;
+
+    /// @notice Cumulative ETH already paid out for a DePrize.
+    mapping(uint256 => uint256) public released;
+
+    /// @notice Winning provider payout address (admin-set once a winner exists).
+    mapping(uint256 => address) public providerRecipient;
+
+    /// @notice Whether the M1 (30%) tranche has been released.
+    mapping(uint256 => bool) public m1Released;
+
+    /// @notice Whether the DePrize's escrow has reached a final state
+    ///         (M2 released / returned to treasury / refunded to JB).
+    mapping(uint256 => bool) public finalized;
+
+    event RegistrySet(address indexed registry);
+    event JBTerminalSet(address indexed terminal);
+    event MoonDAOTreasurySet(address indexed treasury);
+    event ProviderRecipientSet(uint256 indexed deprizeId, address indexed recipient);
+    event Deposited(uint256 indexed deprizeId, address indexed from, uint256 amount);
+    event M1Released(uint256 indexed deprizeId, address indexed recipient, uint256 amount);
+    event M2Released(uint256 indexed deprizeId, address indexed recipient, uint256 amount);
+    event ReturnedToTreasury(uint256 indexed deprizeId, address indexed treasury, uint256 amount);
+    event RefundedToJB(uint256 indexed deprizeId, uint256 indexed jbProjectId, uint256 amount);
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error UnknownDePrize(uint256 deprizeId);
+    error AlreadyFinalized(uint256 deprizeId);
+    error WrongState(uint256 deprizeId, IDePrizeRegistry.DePrizeState state);
+    error NoWinnerDeclared(uint256 deprizeId);
+    error RecipientNotSet(uint256 deprizeId);
+    error AlreadyReleasedM1(uint256 deprizeId);
+    error TransferFailed();
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address owner_, address registry_, address jbTerminal_, address treasury_)
+        external
+        initializer
+    {
+        if (owner_ == address(0) || registry_ == address(0) || jbTerminal_ == address(0) || treasury_ == address(0)) {
+            revert ZeroAddress();
+        }
+        __Ownable_init(owner_);
+        __UUPSUpgradeable_init();
+        __ReentrancyGuard_init();
+        registry = IDePrizeRegistry(registry_);
+        jbTerminal = IJBTerminal(jbTerminal_);
+        moonDAOTreasury = treasury_;
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    // ---------------------------------------------------------------------
+    // Admin configuration
+    // ---------------------------------------------------------------------
+
+    function setRegistry(address registry_) external onlyOwner {
+        if (registry_ == address(0)) revert ZeroAddress();
+        registry = IDePrizeRegistry(registry_);
+        emit RegistrySet(registry_);
+    }
+
+    function setJBTerminal(address terminal_) external onlyOwner {
+        if (terminal_ == address(0)) revert ZeroAddress();
+        jbTerminal = IJBTerminal(terminal_);
+        emit JBTerminalSet(terminal_);
+    }
+
+    function setMoonDAOTreasury(address treasury_) external onlyOwner {
+        if (treasury_ == address(0)) revert ZeroAddress();
+        moonDAOTreasury = treasury_;
+        emit MoonDAOTreasurySet(treasury_);
+    }
+
+    /// @notice Set the winning provider's payout address. Only valid once a winner
+    ///         has been declared in the registry, and only before M1 has been
+    ///         released (so a release can never be redirected after the fact).
+    function setProviderRecipient(uint256 deprizeId, address recipient) external onlyOwner {
+        if (recipient == address(0)) revert ZeroAddress();
+        if (m1Released[deprizeId]) revert AlreadyReleasedM1(deprizeId);
+        if (registry.winningTeamId(deprizeId) == 0) revert NoWinnerDeclared(deprizeId);
+        providerRecipient[deprizeId] = recipient;
+        emit ProviderRecipientSet(deprizeId, recipient);
+    }
+
+    // ---------------------------------------------------------------------
+    // Funding
+    // ---------------------------------------------------------------------
+
+    /// @notice Fund the escrow for a specific DePrize. Anyone may deposit (the
+    ///         settlement flow, the future PrizeEscrow, or a JB payout routed
+    ///         here). Reverts for unknown or already-finalized DePrizes so ETH is
+    ///         never stranded under an unreleasable id.
+    function deposit(uint256 deprizeId) external payable {
+        if (msg.value == 0) revert ZeroAmount();
+        if (registry.state(deprizeId) == IDePrizeRegistry.DePrizeState.NONE) revert UnknownDePrize(deprizeId);
+        if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
+        deposited[deprizeId] += msg.value;
+        emit Deposited(deprizeId, msg.sender, msg.value);
+    }
+
+    /// @dev Reject unattributed ETH so every wei is tied to a DePrize.
+    receive() external payable {
+        revert("use deposit(deprizeId)");
+    }
+
+    // ---------------------------------------------------------------------
+    // Releases (gated by registry state; permissionless / keeper-friendly)
+    // ---------------------------------------------------------------------
+
+    /// @notice Release the 30% M1 tranche to the winning provider once the
+    ///         registry reports `M1_RELEASED`.
+    function releaseM1(uint256 deprizeId) external nonReentrant {
+        if (registry.state(deprizeId) != IDePrizeRegistry.DePrizeState.M1_RELEASED) {
+            revert WrongState(deprizeId, registry.state(deprizeId));
+        }
+        if (m1Released[deprizeId]) revert AlreadyReleasedM1(deprizeId);
+        address recipient = providerRecipient[deprizeId];
+        if (recipient == address(0)) revert RecipientNotSet(deprizeId);
+
+        uint256 amount = (deposited[deprizeId] * M1_BPS) / BPS_DENOMINATOR;
+        m1Released[deprizeId] = true;
+        released[deprizeId] += amount;
+        _sendETH(recipient, amount);
+        emit M1Released(deprizeId, recipient, amount);
+    }
+
+    /// @notice Release the remaining balance to the winning provider once the
+    ///         registry reports `M2_COMPLETE`.
+    function releaseM2(uint256 deprizeId) external nonReentrant {
+        if (registry.state(deprizeId) != IDePrizeRegistry.DePrizeState.M2_COMPLETE) {
+            revert WrongState(deprizeId, registry.state(deprizeId));
+        }
+        if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
+        address recipient = providerRecipient[deprizeId];
+        if (recipient == address(0)) revert RecipientNotSet(deprizeId);
+
+        uint256 amount = deposited[deprizeId] - released[deprizeId];
+        finalized[deprizeId] = true;
+        released[deprizeId] = deposited[deprizeId];
+        _sendETH(recipient, amount);
+        emit M2Released(deprizeId, recipient, amount);
+    }
+
+    /// @notice Return the un-released remainder to the MoonDAO treasury when a
+    ///         prize fails after M1 (`M2_FAILED`) for $OVERVIEW-governed
+    ///         re-allocation. The 30% already paid at M1 is not clawed back.
+    function returnToTreasury(uint256 deprizeId) external nonReentrant {
+        if (registry.state(deprizeId) != IDePrizeRegistry.DePrizeState.M2_FAILED) {
+            revert WrongState(deprizeId, registry.state(deprizeId));
+        }
+        if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
+
+        uint256 amount = deposited[deprizeId] - released[deprizeId];
+        finalized[deprizeId] = true;
+        released[deprizeId] = deposited[deprizeId];
+        _sendETH(moonDAOTreasury, amount);
+        emit ReturnedToTreasury(deprizeId, moonDAOTreasury, amount);
+    }
+
+    /// @notice Return the escrow balance to the JB project on a refundable,
+    ///         pre-provider terminal (`CANCELLED` or `NO_WINNER`), raising the
+    ///         $OVERVIEW cashOut value so contributors can reclaim their floor.
+    function refundToJB(uint256 deprizeId) external nonReentrant {
+        IDePrizeRegistry.DePrizeState s = registry.state(deprizeId);
+        if (s != IDePrizeRegistry.DePrizeState.CANCELLED && s != IDePrizeRegistry.DePrizeState.NO_WINNER) {
+            revert WrongState(deprizeId, s);
+        }
+        if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
+
+        uint256 projectId = registry.getDePrize(deprizeId).jbProjectId;
+        uint256 amount = deposited[deprizeId] - released[deprizeId];
+        finalized[deprizeId] = true;
+        released[deprizeId] = deposited[deprizeId];
+
+        if (amount > 0) {
+            jbTerminal.addToBalanceOf{value: amount}(
+                projectId, JBConstants.NATIVE_TOKEN, amount, false, "DePrize refund", bytes("")
+            );
+        }
+        emit RefundedToJB(deprizeId, projectId, amount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice ETH still held by the escrow for a DePrize (deposited − released).
+    function pendingBalance(uint256 deprizeId) external view returns (uint256) {
+        return deposited[deprizeId] - released[deprizeId];
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal
+    // ---------------------------------------------------------------------
+
+    function _sendETH(address to, uint256 amount) private {
+        if (amount == 0) return;
+        (bool ok,) = payable(to).call{value: amount}("");
+        if (!ok) revert TransferFailed();
+    }
+}

--- a/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
+++ b/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
@@ -154,10 +154,16 @@ contract DePrizeMilestoneEscrow is Initializable, OwnableUpgradeable, UUPSUpgrad
     ///         settlement flow, the future PrizeEscrow, or a JB payout routed
     ///         here). Reverts for unknown or already-finalized DePrizes so ETH is
     ///         never stranded under an unreleasable id.
+    /// @dev Deposits must land before the M1 tranche is released: the 30/70 split
+    ///      is computed from `deposited` at `releaseM1` time, so ETH arriving
+    ///      afterwards would skip the M1 treatment entirely and silently distort
+    ///      the per-prize accounting. Once `m1Released` is set, the prize is
+    ///      considered fully funded and further deposits are rejected.
     function deposit(uint256 deprizeId) external payable {
         if (msg.value == 0) revert ZeroAmount();
         if (registry.state(deprizeId) == IDePrizeRegistry.DePrizeState.NONE) revert UnknownDePrize(deprizeId);
         if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
+        if (m1Released[deprizeId]) revert AlreadyReleasedM1(deprizeId);
         deposited[deprizeId] += msg.value;
         emit Deposited(deprizeId, msg.sender, msg.value);
     }

--- a/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
+++ b/subscription-contracts/src/deprize/DePrizeMilestoneEscrow.sol
@@ -262,6 +262,8 @@ contract DePrizeMilestoneEscrow is Initializable, OwnableUpgradeable, UUPSUpgrad
     /// @notice Return the escrow balance to the JB project on a refundable,
     ///         pre-provider terminal (`CANCELLED` or `NO_WINNER`), raising the
     ///         $OVERVIEW cashOut value so contributors can reclaim their floor.
+    ///         If a winner was declared (meaning M1 was earned), the provider's
+    ///         30% M1 tranche is paid first and only the remainder is refunded.
     function refundToJB(uint256 deprizeId) external nonReentrant {
         IDePrizeRegistry.DePrizeState s = registry.state(deprizeId);
         if (s != IDePrizeRegistry.DePrizeState.CANCELLED && s != IDePrizeRegistry.DePrizeState.NO_WINNER) {
@@ -269,9 +271,22 @@ contract DePrizeMilestoneEscrow is Initializable, OwnableUpgradeable, UUPSUpgrad
         }
         if (finalized[deprizeId]) revert AlreadyFinalized(deprizeId);
 
+        finalized[deprizeId] = true;
+
+        if (!m1Released[deprizeId]) {
+            uint256 m1 = (deposited[deprizeId] * M1_BPS) / BPS_DENOMINATOR;
+            if (m1 > 0 && registry.winningTeamId(deprizeId) != 0) {
+                address recipient = providerRecipient[deprizeId];
+                if (recipient == address(0)) revert RecipientNotSet(deprizeId);
+                m1Released[deprizeId] = true;
+                released[deprizeId] += m1;
+                _sendETH(recipient, m1);
+                emit M1Released(deprizeId, recipient, m1);
+            }
+        }
+
         uint256 projectId = registry.getDePrize(deprizeId).jbProjectId;
         uint256 amount = deposited[deprizeId] - released[deprizeId];
-        finalized[deprizeId] = true;
         released[deprizeId] = deposited[deprizeId];
 
         if (amount > 0) {

--- a/subscription-contracts/test/deprize/DePrizeMilestoneEscrow.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeMilestoneEscrow.t.sol
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {DePrizeMilestoneEscrow} from "../../src/deprize/DePrizeMilestoneEscrow.sol";
+import {DePrizeRegistry} from "../../src/deprize/DePrizeRegistry.sol";
+import {IDePrizeRegistry} from "../../src/deprize/IDePrizeRegistry.sol";
+import {JBConstants} from "@nana-core-v5/libraries/JBConstants.sol";
+
+/// @dev Records addToBalanceOf calls; only the selector the escrow uses is real.
+contract MockJBTerminal {
+    uint256 public lastProjectId;
+    uint256 public lastAmount;
+    uint256 public received;
+
+    function addToBalanceOf(
+        uint256 projectId,
+        address,
+        uint256 amount,
+        bool,
+        string calldata,
+        bytes calldata
+    ) external payable {
+        lastProjectId = projectId;
+        lastAmount = amount;
+        received += msg.value;
+    }
+}
+
+contract DePrizeMilestoneEscrowTest is Test {
+    DePrizeMilestoneEscrow escrow;
+    DePrizeRegistry registry;
+    MockJBTerminal terminal;
+
+    address owner = address(0xA11CE);
+    address stranger = address(0xBEEF);
+    address provider = address(0x9F0);
+    address treasury = address(0x7EA);
+
+    uint256 constant PROJECT = 100;
+    bytes32 constant CONDITION = bytes32(uint256(0xC0FFEE));
+    uint256 constant DEPOSIT = 10 ether;
+
+    function setUp() public {
+        DePrizeRegistry rImpl = new DePrizeRegistry();
+        ERC1967Proxy rProxy = new ERC1967Proxy(address(rImpl), abi.encodeCall(DePrizeRegistry.initialize, (owner)));
+        registry = DePrizeRegistry(address(rProxy));
+
+        terminal = new MockJBTerminal();
+
+        DePrizeMilestoneEscrow eImpl = new DePrizeMilestoneEscrow();
+        ERC1967Proxy eProxy = new ERC1967Proxy(
+            address(eImpl),
+            abi.encodeCall(DePrizeMilestoneEscrow.initialize, (owner, address(registry), address(terminal), treasury))
+        );
+        escrow = DePrizeMilestoneEscrow(payable(address(eProxy)));
+
+        vm.deal(address(this), 1_000 ether);
+    }
+
+    // ---------------------------------------------------------------------
+    // lifecycle helper (mirrors the registry tests)
+    // ---------------------------------------------------------------------
+    function _teams() internal pure returns (uint256[] memory t) {
+        t = new uint256[](2);
+        t[0] = 1;
+        t[1] = 2;
+    }
+
+    function _registerTo(uint256 projectId, IDePrizeRegistry.DePrizeState target) internal returns (uint256 id) {
+        vm.startPrank(owner);
+        id = registry.register(projectId, _teams(), block.timestamp + 30 days);
+
+        if (target == IDePrizeRegistry.DePrizeState.DRAFT) {
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.setCondition(id, CONDITION);
+        registry.open(id);
+        if (target == IDePrizeRegistry.DePrizeState.OPEN) {
+            vm.stopPrank();
+            return id;
+        }
+
+        if (target == IDePrizeRegistry.DePrizeState.CANCELLED) {
+            registry.announceCancellation(id);
+            vm.warp(block.timestamp + registry.CANCELLATION_NOTICE());
+            registry.cancel(id);
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.lock(id);
+        if (target == IDePrizeRegistry.DePrizeState.LOCKED) {
+            vm.stopPrank();
+            return id;
+        }
+        if (target == IDePrizeRegistry.DePrizeState.NO_WINNER) {
+            registry.settleNoWinner(id);
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.settleWinner(id, 1);
+        if (target == IDePrizeRegistry.DePrizeState.SETTLED) {
+            vm.stopPrank();
+            return id;
+        }
+
+        registry.releaseM1(id);
+        if (target == IDePrizeRegistry.DePrizeState.M1_RELEASED) {
+            vm.stopPrank();
+            return id;
+        }
+        if (target == IDePrizeRegistry.DePrizeState.M2_FAILED) {
+            registry.failM2(id);
+            vm.stopPrank();
+            return id;
+        }
+        if (target == IDePrizeRegistry.DePrizeState.M2_COMPLETE) {
+            registry.completeM2(id);
+            vm.stopPrank();
+            return id;
+        }
+
+        revert("unsupported target");
+    }
+
+    function _setRecipient(uint256 id, address r) internal {
+        vm.prank(owner);
+        escrow.setProviderRecipient(id, r);
+    }
+
+    // ---------------------------------------------------------------------
+    // init / config
+    // ---------------------------------------------------------------------
+    function testInitialState() public view {
+        assertEq(address(escrow.registry()), address(registry));
+        assertEq(address(escrow.jbTerminal()), address(terminal));
+        assertEq(escrow.moonDAOTreasury(), treasury);
+        assertEq(escrow.owner(), owner);
+        assertEq(escrow.M1_BPS(), 3_000);
+    }
+
+    function testCannotReinitialize() public {
+        vm.expectRevert();
+        escrow.initialize(owner, address(registry), address(terminal), treasury);
+    }
+
+    function testSettersOnlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", stranger));
+        escrow.setMoonDAOTreasury(address(0x1234));
+
+        vm.prank(owner);
+        escrow.setMoonDAOTreasury(address(0x1234));
+        assertEq(escrow.moonDAOTreasury(), address(0x1234));
+    }
+
+    // ---------------------------------------------------------------------
+    // deposit
+    // ---------------------------------------------------------------------
+    function testDepositCreditsBalance() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.OPEN);
+        escrow.deposit{value: DEPOSIT}(id);
+        assertEq(escrow.deposited(id), DEPOSIT);
+        assertEq(escrow.pendingBalance(id), DEPOSIT);
+        assertEq(address(escrow).balance, DEPOSIT);
+    }
+
+    function testDepositUnknownReverts() public {
+        vm.expectRevert(abi.encodeWithSignature("UnknownDePrize(uint256)", uint256(999)));
+        escrow.deposit{value: 1 ether}(999);
+    }
+
+    function testDepositZeroReverts() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.OPEN);
+        vm.expectRevert(abi.encodeWithSignature("ZeroAmount()"));
+        escrow.deposit{value: 0}(id);
+    }
+
+    function testReceiveReverts() public {
+        (bool ok,) = address(escrow).call{value: 1 ether}("");
+        assertFalse(ok);
+    }
+
+    // ---------------------------------------------------------------------
+    // provider recipient
+    // ---------------------------------------------------------------------
+    function testSetProviderRecipientRequiresWinner() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.OPEN);
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSignature("NoWinnerDeclared(uint256)", id));
+        escrow.setProviderRecipient(id, provider);
+    }
+
+    function testSetProviderRecipientOnlyOwner() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.SETTLED);
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", stranger));
+        escrow.setProviderRecipient(id, provider);
+    }
+
+    // ---------------------------------------------------------------------
+    // releaseM1 (30%)
+    // ---------------------------------------------------------------------
+    function testReleaseM1Pays30Percent() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M1_RELEASED);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id);
+
+        escrow.releaseM1(id);
+
+        assertEq(provider.balance, 3 ether);
+        assertEq(escrow.released(id), 3 ether);
+        assertEq(escrow.pendingBalance(id), 7 ether);
+        assertTrue(escrow.m1Released(id));
+    }
+
+    function testReleaseM1WrongStateReverts() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.SETTLED);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id);
+        vm.expectRevert();
+        escrow.releaseM1(id);
+    }
+
+    function testReleaseM1NoRecipientReverts() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M1_RELEASED);
+        escrow.deposit{value: DEPOSIT}(id);
+        vm.expectRevert(abi.encodeWithSignature("RecipientNotSet(uint256)", id));
+        escrow.releaseM1(id);
+    }
+
+    function testReleaseM1Twice() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M1_RELEASED);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id);
+        escrow.releaseM1(id);
+        vm.expectRevert(abi.encodeWithSignature("AlreadyReleasedM1(uint256)", id));
+        escrow.releaseM1(id);
+    }
+
+    function testSetRecipientAfterM1Reverts() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M1_RELEASED);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id);
+        escrow.releaseM1(id);
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSignature("AlreadyReleasedM1(uint256)", id));
+        escrow.setProviderRecipient(id, stranger);
+    }
+
+    // ---------------------------------------------------------------------
+    // releaseM2 (remainder)
+    // ---------------------------------------------------------------------
+    function testReleaseM2PaysRemainderAfterM1() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M1_RELEASED);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id);
+        escrow.releaseM1(id);
+
+        vm.prank(owner);
+        registry.completeM2(id);
+        escrow.releaseM2(id);
+
+        assertEq(provider.balance, DEPOSIT); // 3 + 7
+        assertEq(escrow.pendingBalance(id), 0);
+        assertTrue(escrow.finalized(id));
+    }
+
+    function testReleaseM2WithoutM1PaysAll() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_COMPLETE);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id);
+
+        escrow.releaseM2(id);
+
+        assertEq(provider.balance, DEPOSIT);
+        assertEq(escrow.pendingBalance(id), 0);
+    }
+
+    function testReleaseM2Finalized() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_COMPLETE);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id);
+        escrow.releaseM2(id);
+        vm.expectRevert(abi.encodeWithSignature("AlreadyFinalized(uint256)", id));
+        escrow.releaseM2(id);
+    }
+
+    // ---------------------------------------------------------------------
+    // M2_FAILED -> treasury
+    // ---------------------------------------------------------------------
+    function testReturnToTreasuryOnM2Failed() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M1_RELEASED);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id);
+        escrow.releaseM1(id); // provider gets 3 ETH
+
+        vm.prank(owner);
+        registry.failM2(id);
+        escrow.returnToTreasury(id);
+
+        assertEq(provider.balance, 3 ether);
+        assertEq(treasury.balance, 7 ether);
+        assertEq(escrow.pendingBalance(id), 0);
+        assertTrue(escrow.finalized(id));
+    }
+
+    function testReturnToTreasuryWrongStateReverts() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_COMPLETE);
+        escrow.deposit{value: DEPOSIT}(id);
+        vm.expectRevert();
+        escrow.returnToTreasury(id);
+    }
+
+    // ---------------------------------------------------------------------
+    // refundToJB on CANCELLED / NO_WINNER
+    // ---------------------------------------------------------------------
+    function testRefundToJBOnCancelled() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.CANCELLED);
+        escrow.deposit{value: DEPOSIT}(id);
+
+        escrow.refundToJB(id);
+
+        assertEq(terminal.received(), DEPOSIT);
+        assertEq(terminal.lastProjectId(), PROJECT);
+        assertEq(terminal.lastAmount(), DEPOSIT);
+        assertEq(escrow.pendingBalance(id), 0);
+        assertTrue(escrow.finalized(id));
+    }
+
+    function testRefundToJBOnNoWinner() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.NO_WINNER);
+        escrow.deposit{value: DEPOSIT}(id);
+        escrow.refundToJB(id);
+        assertEq(terminal.received(), DEPOSIT);
+        assertEq(terminal.lastProjectId(), PROJECT);
+    }
+
+    function testRefundToJBWrongStateReverts() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_COMPLETE);
+        escrow.deposit{value: DEPOSIT}(id);
+        vm.expectRevert();
+        escrow.refundToJB(id);
+    }
+
+    function testDepositAfterFinalizedReverts() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.CANCELLED);
+        escrow.deposit{value: DEPOSIT}(id);
+        escrow.refundToJB(id);
+        vm.expectRevert(abi.encodeWithSignature("AlreadyFinalized(uint256)", id));
+        escrow.deposit{value: 1 ether}(id);
+    }
+}

--- a/subscription-contracts/test/deprize/DePrizeMilestoneEscrow.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeMilestoneEscrow.t.sol
@@ -322,6 +322,20 @@ contract DePrizeMilestoneEscrowTest is Test {
         assertTrue(escrow.finalized(id));
     }
 
+    /// @dev If the registry reaches M2_FAILED but a keeper never called releaseM1,
+    ///      the provider still earned their 30% — returnToTreasury must pay it
+    ///      rather than send 100% to the treasury.
+    function testReturnToTreasuryPaysSkippedM1() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_FAILED);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id); // 10 ETH, releaseM1 never called
+        escrow.returnToTreasury(id);
+        assertEq(provider.balance, (DEPOSIT * 3000) / 10000); // 30%
+        assertEq(treasury.balance, DEPOSIT - (DEPOSIT * 3000) / 10000); // 70%
+        assertTrue(escrow.finalized(id));
+        assertTrue(escrow.m1Released(id));
+    }
+
     /// @dev A finalizer must be able to finalize a zero-balance prize so it can't
     ///      get stuck (and keep silently accepting stray deposits).
     function testReturnToTreasuryZeroBalanceFinalizes() public {

--- a/subscription-contracts/test/deprize/DePrizeMilestoneEscrow.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeMilestoneEscrow.t.sol
@@ -187,6 +187,17 @@ contract DePrizeMilestoneEscrowTest is Test {
         assertFalse(ok);
     }
 
+    /// @dev Deposits must land before M1 releases, or the 30/70 split (computed
+    ///      from `deposited` at releaseM1 time) would be silently distorted.
+    function testDepositAfterM1Reverts() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M1_RELEASED);
+        _setRecipient(id, provider);
+        escrow.deposit{value: DEPOSIT}(id);
+        escrow.releaseM1(id);
+        vm.expectRevert(abi.encodeWithSignature("AlreadyReleasedM1(uint256)", id));
+        escrow.deposit{value: 1 ether}(id);
+    }
+
     // ---------------------------------------------------------------------
     // provider recipient
     // ---------------------------------------------------------------------

--- a/subscription-contracts/test/deprize/DePrizeMilestoneEscrow.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeMilestoneEscrow.t.sol
@@ -322,6 +322,23 @@ contract DePrizeMilestoneEscrowTest is Test {
         assertTrue(escrow.finalized(id));
     }
 
+    /// @dev A finalizer must be able to finalize a zero-balance prize so it can't
+    ///      get stuck (and keep silently accepting stray deposits).
+    function testReturnToTreasuryZeroBalanceFinalizes() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_FAILED);
+        escrow.returnToTreasury(id); // no deposits, no recipient
+        assertTrue(escrow.finalized(id));
+        assertEq(treasury.balance, 0);
+    }
+
+    function testReleaseM2ZeroBalanceFinalizes() public {
+        uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_COMPLETE);
+        _setRecipient(id, provider);
+        escrow.releaseM2(id); // no deposits
+        assertTrue(escrow.finalized(id));
+        assertEq(provider.balance, 0);
+    }
+
     function testReturnToTreasuryWrongStateReverts() public {
         uint256 id = _registerTo(PROJECT, IDePrizeRegistry.DePrizeState.M2_COMPLETE);
         escrow.deposit{value: DEPOSIT}(id);


### PR DESCRIPTION
Stacked on #1329 (M2 payout gating + prize mode), which is stacked on #1324 (M2 pay hook). Base is `feature/deprize-m2-approval-hook`; review after the M2 PRs merge (or review the M3-only diff here).

## Summary

`DePrizeMilestoneEscrow` is *where a prize's pool goes* once it resolves. The M2 hooks keep the JB-side pot locked during an active prize; this contract custodies the prize pool after settlement and releases it to the **winning provider** in step with delivery, gated entirely by the `DePrizeRegistry` lifecycle.

| Escrow call | Registry state | Effect |
|---|---|---|
| `releaseM1` | `M1_RELEASED` | pay **30%** to the provider recipient |
| `releaseM2` | `M2_COMPLETE` | pay the **remainder** to the provider, finalize |
| `returnToTreasury` | `M2_FAILED` | un-released remainder → MoonDAO treasury for `$OVERVIEW`-governed re-allocation (M1's 30% not clawed back) |
| `refundToJB` | `CANCELLED` / `NO_WINNER` | return the balance to the JB project via `addToBalanceOf`, raising `$OVERVIEW` cashOut value |

## Design

- **Releases are permissionless** (keeper-friendly) but gated by registry state **and** an admin-set provider recipient that **locks once M1 releases** — a payout can never be redirected after the fact.
- `setProviderRecipient` is owner-only and requires a declared winner (`registry.winningTeamId != 0`).
- **Per-DePrize accounting** (`deposited` / `released` / `finalized`) lets one escrow serve many DePrizes; `pendingBalance = deposited − released`.
- **UUPS-upgradeable + `ReentrancyGuard`**, checks-effects-interactions on every payout, matching `DePrizeRegistry` conventions.
- `receive()` reverts — every wei must be attributed via `deposit(deprizeId)`.

## Funding boundary (intentionally not in this PR)

The escrow releases percentages of its **own per-DePrize ETH balance** and is agnostic about the source; the settlement flow funds it via `deposit(deprizeId)`. Routing a prize mission's **ruleset-1 payout into the escrow** (instead of the team's 90% split) needs JB split/permission design and is left to the betting/mint + `DePrizePrizeEscrow` milestone. Until then the escrow works standalone and the M2 hooks keep the JB pot locked, so nothing leaks in the meantime.

## Test plan

- `forge test --match-path 'test/deprize/DePrizeMilestoneEscrow.t.sol' --skip 'test/ManualRefundTest.t.sol' --skip 'test/OwnerOnlyPayoutsRulesetTest.t.sol'` — 23 passing (real `DePrizeRegistry` proxy + mock JB terminal)
- `forge test --match-path 'test/deprize/*.t.sol' --skip ...` — 85 passing across the whole DePrize suite
- Covers: init/re-init guard, owner-only setters, deposit accounting + guards, recipient rules, exact 30% M1, remainder/full M2, treasury return on M2_FAILED, refund-to-JB on CANCELLED/NO_WINNER, and wrong-state/finalize reverts.

See `docs/DEPRIZE_M3.md` for the full write-up.

Made with Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New on-chain custody and ETH disbursement tied to registry lifecycle and Juicebox refunds; misconfiguration or state-gating bugs could misroute prize pools.
> 
> **Overview**
> Adds **`DePrizeMilestoneEscrow`**, a UUPS upgradeable escrow that holds per-DePrize ETH after settlement and pays the winning provider **30% at M1** and the **remainder at M2**, with all payout paths gated on **`DePrizeRegistry`** state. Permissionless `releaseM1` / `releaseM2` require the right registry state and an owner-set `providerRecipient` (locked after M1); `returnToTreasury` and `refundToJB` handle `M2_FAILED` and `CANCELLED` / `NO_WINNER`, including paying a skipped M1 tranche before sending the rest to treasury or Juicebox via `addToBalanceOf`.
> 
> Funding is explicit via `deposit(deprizeId)` (plain `receive` reverts); deposits are blocked after M1 or finalization so the 30/70 split cannot be distorted. Owner configures registry, JB terminal, and MoonDAO treasury. **`docs/DEPRIZE_M3.md`** documents scope and notes JB ruleset routing into the escrow is **out of scope** for this PR.
> 
> **23 Forge tests** exercise the escrow against a real registry proxy and a mock JB terminal (splits, finalization, treasury/refund paths, guards).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd493abd3ca983c63ff91ff7abfea6b18fcbe72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->