### PR TITLE
fix(onramp): don't block US users when geo header is absent (prod hotfix)

### DIFF
--- a/ui/pages/api/coinbase/create-order.ts
+++ b/ui/pages/api/coinbase/create-order.ts
@@ -50,14 +50,16 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       MOCK_ONRAMP
     )
 
-    // Detect country for region restrictions (Headless = US only). Coinbase
-    // determines the precise region itself from clientIp; we only gate here.
-    // Fail closed when no geo header is present (local dev, some proxies,
-    // direct calls) so the gate can't be bypassed by stripping headers —
-    // mirrors useOnrampRegion's non-US fallback on the client.
+    // Detect country for region restrictions (Headless = US only). This is a
+    // best-effort UX pre-filter: we only block on a POSITIVE non-US signal.
+    // When the geo header is absent (no Vercel/Cloudflare edge header, some
+    // proxies, local dev) we let the request through rather than blocking real
+    // US users — Coinbase performs the authoritative region determination from
+    // clientIp at order creation and rejects genuine non-US users there, so
+    // allowing "unknown" through never lets an ineligible user complete a buy.
     const country = getCountryFromHeaders(req)
 
-    if (!isRegionAllowed(country)) {
+    if (country && !isRegionAllowed(country)) {
       return res.status(400).json({
         error: 'Headless onramp is only available for US users',
         code: 'REGION_NOT_SUPPORTED',


### PR DESCRIPTION
## Problem
After #1320 merged, real **US users are being blocked** on production with `Headless onramp is only available for US users`.

The fail-closed region gate rejects the order whenever `getCountryFromHeaders` returns `null` — which happens any time the Vercel/Cloudflare geo header is absent (flaky edge header, proxy, etc.). Before #1320 a missing header defaulted to `US`; the fail-closed change removed that safety net.

## Fix
The server gate now blocks **only on a positive non-US signal** and lets *unknown* geo through:

```ts
const country = getCountryFromHeaders(req)
if (country && !isRegionAllowed(country)) { /* 400 */ }
```

This is safe because **Coinbase performs the authoritative `clientIp`-based region determination at order creation** and rejects genuine non-US users there. Our header check is only a best-effort UX pre-filter, so allowing "unknown" through never lets an ineligible user complete a purchase — it just stops blocking eligible ones.

## Testing
- 240 unit tests passing (`isRegionAllowed` pure-function tests unchanged).
- Restores pre-#1320 behavior for US users while keeping a positive non-US block.
