### PR TITLE
Fix Weekly Check in

### DIFF
--- a/ui/components/tokens/WeeklyRewardPool.tsx
+++ b/ui/components/tokens/WeeklyRewardPool.tsx
@@ -7,7 +7,7 @@ import { FEE_HOOK_ADDRESSES } from 'const/config'
 import { BigNumber } from 'ethers'
 import { ethers } from 'ethers'
 import Link from 'next/link'
-import { useContext, useState, useEffect, useMemo } from 'react'
+import { useContext, useState, useEffect, useMemo, useCallback } from 'react'
 import toast from 'react-hot-toast'
 import { getContract, readContract, prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
@@ -184,16 +184,18 @@ export default function WeeklyRewardPool() {
     fetchEstimates()
   }, [address, chains, WEEK])
 
-  useEffect(() => {
+  // Reusable on-chain status loader. Exposed as a callback so it can be
+  // re-run after a check-in to reconcile the UI with the real on-chain state
+  // (the txs are already confirmed at that point, so lastCheckIn is updated).
+  const refreshFeeData = useCallback(async () => {
     if (!address) return
 
-    const fetchStatus = async () => {
-      // Each chain is fetched independently. A single chain failure (e.g.
-      // public RPC hiccup or rate limit) used to reject the whole Promise.all
-      // and leave `feeData` empty, which surfaced as "No fee data available"
-      // when the user tried to check in. Isolate failures per-chain so the
-      // remaining chains still populate.
-      const raw = await Promise.all(
+    // Each chain is fetched independently. A single chain failure (e.g.
+    // public RPC hiccup or rate limit) used to reject the whole Promise.all
+    // and leave `feeData` empty, which surfaced as "No fee data available"
+    // when the user tried to check in. Isolate failures per-chain so the
+    // remaining chains still populate.
+    const raw = await Promise.all(
         chains.map(async (chain) => {
           const slug = getChainSlug(chain)
           try {
@@ -323,10 +325,24 @@ export default function WeeklyRewardPool() {
 
       setCheckedInCount(totalCount)
       setIsCheckedIn(allChecked)
-    }
-
-    fetchStatus()
   }, [address, chains, WEEK])
+
+  useEffect(() => {
+    refreshFeeData()
+  }, [refreshFeeData])
+
+  // Keep the button's checked-in state in sync with feeData. This covers both
+  // the initial on-chain load and the optimistic update applied right after a
+  // successful check-in, so the button reliably flips to "Checked In ✓"
+  // without depending on the exact tx/skip counts inside handleCheckIn.
+  useEffect(() => {
+    if (!feeData || feeData.length === 0) return
+    const eligibleChains = feeData.filter((d) => d.hasVMooney)
+    const allChecked =
+      eligibleChains.length > 0 &&
+      eligibleChains.every((d) => d.checkedInOnChain)
+    setIsCheckedIn(allChecked)
+  }, [feeData])
 
   const handleCheckIn = async () => {
     try {
@@ -343,6 +359,13 @@ export default function WeeklyRewardPool() {
       let transactionsSent = 0
       let alreadyCheckedInCount = 0
       let eligibleChainsCount = 0
+      // Chains the user is confirmed checked in on after this run (either they
+      // already were, or we just submitted). Used to optimistically update
+      // feeData so re-clicking the button doesn't re-broadcast no-op txs.
+      const checkedInChainIds = new Set<number>()
+      // Capture the most useful failure reason so we can show the user what
+      // actually went wrong instead of a generic "please try again".
+      let lastError: string | null = null
 
       const waitForChainSwitch = async (targetChainId: number, maxWait = 5000) => {
         const startTime = Date.now()
@@ -353,6 +376,45 @@ export default function WeeklyRewardPool() {
           }
           await new Promise((resolve) => setTimeout(resolve, 100))
         }
+        return false
+      }
+
+      // Robustly switch the wallet to a target chain. Injected wallets (e.g.
+      // MetaMask) pop a confirmation the user has to approve, so we (a) give a
+      // generous window for that, (b) retry the request a couple of times, and
+      // (c) report WHY it failed (user rejected vs. timed out) so the toast is
+      // actionable. Returns true only once the wallet actually reports the
+      // target chain.
+      const switchToChain = async (chain: any): Promise<boolean> => {
+        const alreadyOn = () =>
+          +wallets[selectedWallet]?.chainId?.split(':')[1] === chain.id
+        if (alreadyOn()) return true
+
+        for (let attempt = 0; attempt < 2; attempt++) {
+          try {
+            await wallets[selectedWallet].switchChain(chain.id)
+            setSelectedChain(chain)
+          } catch (err: any) {
+            // 4001 / ACTION_REJECTED = user dismissed the wallet prompt.
+            if (
+              err?.code === 4001 ||
+              err?.code === 'ACTION_REJECTED' ||
+              err?.message?.toLowerCase().includes('reject') ||
+              err?.message?.toLowerCase().includes('denied')
+            ) {
+              lastError = `You declined the network switch to ${chain.name}. Approve it in your wallet to check in there.`
+              return false
+            }
+            console.warn(`switchChain to ${chain.name} threw:`, err)
+          }
+          // Wait up to 20s for the wallet to report the new chain (covers the
+          // time the user spends approving the MetaMask popup).
+          if (await waitForChainSwitch(chain.id, 20000)) {
+            await new Promise((resolve) => setTimeout(resolve, 500))
+            return true
+          }
+        }
+        lastError = `Could not switch your wallet to ${chain.name}. Open your wallet, switch to ${chain.name} manually, then press Check In again.`
         return false
       }
 
@@ -383,21 +445,14 @@ export default function WeeklyRewardPool() {
         eligibleChainsCount++
         if (data.checkedInOnChain) {
           alreadyCheckedInCount++
+          checkedInChainIds.add(data.chain.id)
           continue
         }
 
         const walletChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
         if (walletChainId !== data.chain.id) {
-          await wallets[selectedWallet].switchChain(data.chain.id)
-          setSelectedChain(data.chain)
-
-          const switched = await waitForChainSwitch(data.chain.id)
-          if (!switched) {
-            console.warn(`Chain switch to ${data.chain.id} may not have completed`)
-            continue
-          }
-
-          await new Promise((resolve) => setTimeout(resolve, 500))
+          const switched = await switchToChain(data.chain)
+          if (!switched) continue
         }
 
         const slug = getChainSlug(data.chain)
@@ -425,7 +480,35 @@ export default function WeeklyRewardPool() {
         // the `underlying network changed` error on check-in.
         let txAccount = await getAccountForChain()
 
+        // The ONLY source of truth for "did the check-in happen" is the
+        // on-chain state: lastCheckIn[address] === weekStart. Never trust the
+        // tx promise (or a nonce collision) on its own — a tx that looked
+        // confirmed but never landed previously produced a false "checked in"
+        // toast while nothing changed on-chain.
+        const verifyCheckedIn = async () => {
+          for (let i = 0; i < 3; i++) {
+            try {
+              const [ws, lc] = await Promise.all([
+                readContract({ contract, method: 'weekStart', params: [] }),
+                readContract({
+                  contract,
+                  method: 'lastCheckIn',
+                  params: [address],
+                }),
+              ])
+              if (ws != null && lc != null) {
+                return BigInt(lc as any) === BigInt(ws as any)
+              }
+            } catch (err) {
+              console.warn(`verify lastCheckIn failed for ${slug}:`, err)
+            }
+            await new Promise((r) => setTimeout(r, 800))
+          }
+          return false
+        }
+
         while (retries > 0 && !success) {
+          retries--
           try {
             const tx = prepareContractCall({
               contract,
@@ -437,44 +520,74 @@ export default function WeeklyRewardPool() {
               transaction: tx,
               account: txAccount,
             })
-
-            success = true
-            transactionsSent++
           } catch (error: any) {
-            if (
+            const isNonceUsed =
+              error?.code === 'NONCE_EXPIRED' ||
+              error?.message?.includes('nonce has already been used') ||
+              error?.message?.includes('nonce too low')
+            const isNetworkChanged =
               error?.code === 'NETWORK_ERROR' ||
               error?.message?.includes('underlying network changed') ||
               error?.message?.includes('network changed')
-            ) {
-              retries--
-              if (retries > 0) {
-                await new Promise((resolve) => setTimeout(resolve, 1000))
 
-                const verifyChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
-                if (verifyChainId !== data.chain.id) {
-                  throw new Error(
-                    `Network mismatch: expected ${data.chain.id}, got ${verifyChainId}`
-                  )
-                }
-
-                contract = getContract({
-                  client,
-                  address: hookAddress,
-                  abi: FeeHook.abi as any,
-                  chain: data.chain,
-                })
-
-                // Rebuild the account too so its provider re-detects the
-                // (now correct) network instead of reusing the stale one.
-                txAccount = await getAccountForChain()
-              } else {
-                throw error
+            // For a nonce collision we don't retry the send — instead we fall
+            // through to on-chain verification below, which decides whether it
+            // actually counts. For a network-changed error we rebuild the
+            // contract/account and let the while loop re-send.
+            if (isNetworkChanged && retries > 0) {
+              await new Promise((resolve) => setTimeout(resolve, 1000))
+              const verifyChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
+              if (verifyChainId !== data.chain.id) {
+                console.warn(
+                  `Network mismatch on ${slug}: expected ${data.chain.id}, got ${verifyChainId}`
+                )
+                break
               }
-            } else {
-              throw error
+              contract = getContract({
+                client,
+                address: hookAddress,
+                abi: FeeHook.abi as any,
+                chain: data.chain,
+              })
+              txAccount = await getAccountForChain()
+            } else if (!isNonceUsed && !isNetworkChanged) {
+              // Genuine, unexpected failure on this chain. Don't abort the
+              // whole loop — move on so other chains still get a chance.
+              console.error(`Check-in failed for ${slug}:`, error)
+              lastError =
+                error?.shortMessage || error?.message || 'Transaction failed'
+              break
             }
           }
+
+          // Regardless of what the send did, only a verified on-chain state
+          // counts as a successful check-in.
+          if (await verifyCheckedIn()) {
+            success = true
+            transactionsSent++
+            checkedInChainIds.add(data.chain.id)
+            lastError = null
+          } else if (retries === 0 && !lastError) {
+            // The send didn't throw, but the on-chain state never flipped.
+            // This usually means the tx silently failed or was sent on the
+            // wrong network. Record it so the user sees something actionable.
+            lastError = `Your ${data.chain.name} check-in transaction did not register on-chain. Make sure your wallet is on ${data.chain.name} and try again.`
+          }
         }
+      }
+
+      // Optimistically mark the chains we just checked in on so the button
+      // disables and a second click doesn't re-broadcast no-op transactions
+      // (the on-chain checkIn() is idempotent, so re-sending only produces a
+      // "No changes" wallet prompt that confuses users).
+      if (checkedInChainIds.size > 0) {
+        setFeeData((prev) =>
+          prev.map((d) =>
+            checkedInChainIds.has(d.chain.id)
+              ? { ...d, checkedInOnChain: true }
+              : d
+          )
+        )
       }
 
       const finalWalletChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
@@ -511,14 +624,24 @@ export default function WeeklyRewardPool() {
         )
         setIsCheckedIn(true)
       } else {
-        toast.error('No check-ins were submitted. Please try again.', {
-          style: toastStyle,
-        })
+        toast.error(
+          lastError
+            ? `Error checking in: ${lastError}`
+            : 'No check-ins were submitted. Please try again.',
+          { style: toastStyle }
+        )
       }
     } catch (error) {
       console.error('Error checking in:', error)
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred'
       toast.error(`Error checking in: ${errorMessage}`, { style: toastStyle })
+    } finally {
+      // Reconcile the UI with the real on-chain state. The check-in txs are
+      // confirmed by this point, so lastCheckIn is updated on-chain. A short
+      // delay gives the RPC a moment to propagate before we re-read.
+      setTimeout(() => {
+        refreshFeeData()
+      }, 1500)
     }
   }
 

--- a/ui/components/tokens/WeeklyRewardPool.tsx
+++ b/ui/components/tokens/WeeklyRewardPool.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { useContext, useState, useEffect, useMemo } from 'react'
 import toast from 'react-hot-toast'
 import { getContract, readContract, prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
+import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
 import { useActiveAccount } from 'thirdweb/react'
 import {
   arbitrum,
@@ -355,6 +356,26 @@ export default function WeeklyRewardPool() {
         return false
       }
 
+      // Build a thirdweb account from the Privy wallet's CURRENT ethers
+      // provider. The `account` returned by useActiveAccount() is bound (via
+      // ethers5Adapter) to whatever chain was selected when the component
+      // rendered. Reusing it after switching chains makes ethers v5 throw
+      // `underlying network changed` because the signer's cached network no
+      // longer matches the wallet's actual chain. Re-deriving the signer (and
+      // therefore its provider) after every switch keeps them in lockstep.
+      const getAccountForChain = async () => {
+        try {
+          const wallet = wallets[selectedWallet]
+          const provider = await wallet?.getEthersProvider()
+          const signer = provider?.getSigner()
+          if (!signer) return account
+          return await ethers5Adapter.signer.fromEthers({ signer })
+        } catch (err) {
+          console.warn('Failed to derive fresh account, falling back to active account:', err)
+          return account
+        }
+      }
+
       for (const data of feeData) {
         if (!data.vMooneyBalance || data.vMooneyBalance === BigInt(0)) {
           continue
@@ -399,6 +420,11 @@ export default function WeeklyRewardPool() {
         let retries = 3
         let success = false
 
+        // Derive an account whose underlying ethers provider is on the chain
+        // we just switched to. Using the stale `account` here is what produced
+        // the `underlying network changed` error on check-in.
+        let txAccount = await getAccountForChain()
+
         while (retries > 0 && !success) {
           try {
             const tx = prepareContractCall({
@@ -409,7 +435,7 @@ export default function WeeklyRewardPool() {
 
             await sendAndConfirmTransaction({
               transaction: tx,
-              account,
+              account: txAccount,
             })
 
             success = true
@@ -437,6 +463,10 @@ export default function WeeklyRewardPool() {
                   abi: FeeHook.abi as any,
                   chain: data.chain,
                 })
+
+                // Rebuild the account too so its provider re-detects the
+                // (now correct) network instead of reusing the stale one.
+                txAccount = await getAccountForChain()
               } else {
                 throw error
               }

--- a/ui/components/tokens/WeeklyRewardPool.tsx
+++ b/ui/components/tokens/WeeklyRewardPool.tsx
@@ -12,17 +12,10 @@ import toast from 'react-hot-toast'
 import { getContract, readContract, prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
 import { useActiveAccount } from 'thirdweb/react'
-import {
-  arbitrum,
-  base,
-  ethereum,
-  sepolia,
-  arbitrumSepolia,
-  Chain,
-} from '@/lib/rpc/chains'
 import toastStyle from '../../lib/marketplace/marketplace-utils/toastConfig'
 import useETHPrice from '@/lib/etherscan/useETHPrice'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
+import { arbitrum, base, ethereum, sepolia, arbitrumSepolia, Chain } from '@/lib/rpc/chains'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
 import client from '@/lib/thirdweb/client'
@@ -54,8 +47,7 @@ async function safeRead<T>(
     } catch (err: any) {
       const isLast = attempt === retries
       const isBufferDecodeError =
-        err?.message?.includes("reading 'buffer'") ||
-        err?.message?.includes('decodeAbiParameters')
+        err?.message?.includes("reading 'buffer'") || err?.message?.includes('decodeAbiParameters')
       if (!isLast && isBufferDecodeError) {
         await sleep(baseDelay * Math.pow(2, attempt))
         continue
@@ -196,135 +188,124 @@ export default function WeeklyRewardPool() {
     // when the user tried to check in. Isolate failures per-chain so the
     // remaining chains still populate.
     const raw = await Promise.all(
-        chains.map(async (chain) => {
-          const slug = getChainSlug(chain)
-          try {
-            const hookAddress = FEE_HOOK_ADDRESSES[slug]
-            if (!hookAddress) return null
+      chains.map(async (chain) => {
+        const slug = getChainSlug(chain)
+        try {
+          const hookAddress = FEE_HOOK_ADDRESSES[slug]
+          if (!hookAddress) return null
 
-            const contract = getContract({
-              client,
-              address: hookAddress,
-              abi: FeeHook.abi as any,
-              chain,
-            })
+          const contract = getContract({
+            client,
+            address: hookAddress,
+            abi: FeeHook.abi as any,
+            chain,
+          })
 
-            const [start, last, count, vMooneyAddress] = await Promise.all([
-              safeRead(
-                () => readContract({ contract, method: 'weekStart', params: [] }),
-                `${slug}.weekStart`
-              ),
-              safeRead(
-                () =>
-                  readContract({
-                    contract,
-                    method: 'lastCheckIn',
-                    params: [address],
-                  }),
-                `${slug}.lastCheckIn`
-              ),
-              safeRead(
-                () =>
-                  readContract({
-                    contract,
-                    method: 'getCheckedInCount',
-                    params: [],
-                  }),
-                `${slug}.getCheckedInCount`
-              ),
-              safeRead(
-                () =>
-                  readContract({
-                    contract,
-                    method: 'vMooneyAddress',
-                    params: [],
-                  }),
-                `${slug}.vMooneyAddress`
-              ),
-            ])
-
-            // Drop the chain only if the truly required reads are missing
-            // after retries. Previously a single rejected read would null
-            // out the whole chain, which is what was making Arbitrum's
-            // check-in count silently disappear.
-            if (start == null || vMooneyAddress == null) {
-              console.warn(
-                `Skipping ${slug}: missing required FeeHook reads (start=${start}, vMooneyAddress=${vMooneyAddress})`
-              )
-              return null
-            }
-
-            const vMooneyContract = getContract({
-              client,
-              address: vMooneyAddress as `0x${string}`,
-              abi: ERC20ABI as any,
-              chain,
-            })
-
-            const vMooneyBalance = await safeRead(
+          const [start, last, count, vMooneyAddress] = await Promise.all([
+            safeRead(
+              () => readContract({ contract, method: 'weekStart', params: [] }),
+              `${slug}.weekStart`
+            ),
+            safeRead(
               () =>
                 readContract({
-                  contract: vMooneyContract,
-                  method: 'balanceOf',
+                  contract,
+                  method: 'lastCheckIn',
                   params: [address],
                 }),
-              `${slug}.balanceOf`
+              `${slug}.lastCheckIn`
+            ),
+            safeRead(
+              () =>
+                readContract({
+                  contract,
+                  method: 'getCheckedInCount',
+                  params: [],
+                }),
+              `${slug}.getCheckedInCount`
+            ),
+            safeRead(
+              () =>
+                readContract({
+                  contract,
+                  method: 'vMooneyAddress',
+                  params: [],
+                }),
+              `${slug}.vMooneyAddress`
+            ),
+          ])
+
+          // Drop the chain only if the truly required reads are missing
+          // after retries. Previously a single rejected read would null
+          // out the whole chain, which is what was making Arbitrum's
+          // check-in count silently disappear.
+          if (start == null || vMooneyAddress == null) {
+            console.warn(
+              `Skipping ${slug}: missing required FeeHook reads (start=${start}, vMooneyAddress=${vMooneyAddress})`
             )
-
-            const balance = (vMooneyBalance as bigint | null) ?? BigInt(0)
-            const safeLast = (last as bigint | null) ?? BigInt(0)
-            const safeCount = (count as bigint | null) ?? BigInt(0)
-            const hasVMooney = balance > BigInt(0)
-
-            return {
-              chain,
-              slug,
-              contract,
-              start: start as bigint,
-              last: safeLast,
-              count: safeCount,
-              vMooneyBalance: balance,
-              hasVMooney,
-              checkedInOnChain: safeLast === (start as bigint),
-            }
-          } catch (err) {
-            console.error(`Error fetching check-in status for ${slug}:`, err)
             return null
           }
-        })
-      )
 
-      const results = raw.filter((r) => r) as Array<{
-        chain: any
-        slug: string
-        contract: any
-        start: bigint
-        last: bigint
-        count: bigint
-        vMooneyBalance: bigint
-        hasVMooney: boolean
-        checkedInOnChain: boolean
-      }>
+          const vMooneyContract = getContract({
+            client,
+            address: vMooneyAddress as `0x${string}`,
+            abi: ERC20ABI as any,
+            chain,
+          })
 
-      setFeeData(results)
+          const vMooneyBalance = await safeRead(
+            () =>
+              readContract({
+                contract: vMooneyContract,
+                method: 'balanceOf',
+                params: [address],
+              }),
+            `${slug}.balanceOf`
+          )
 
-      // Only chains where the user actually holds vMOONEY are eligible for
-      // check-in (the FeeHook reverts otherwise). The "checked in" state
-      // should therefore only consider those chains; otherwise a user who
-      // has vMOONEY on one chain (e.g. Arbitrum) and is already checked in
-      // there would be incorrectly shown as "not checked in" because they
-      // have a 0 balance on the other chains.
-      const eligibleChains = results.filter((r) => r.hasVMooney)
-      const totalCount = results.reduce(
-        (acc, { count }) => acc + Number(count || BigInt(0)),
-        0
-      )
-      const allChecked =
-        eligibleChains.length > 0 &&
-        eligibleChains.every(({ checkedInOnChain }) => checkedInOnChain)
+          const balance = (vMooneyBalance as bigint | null) ?? BigInt(0)
+          const safeLast = (last as bigint | null) ?? BigInt(0)
+          const safeCount = (count as bigint | null) ?? BigInt(0)
+          const hasVMooney = balance > BigInt(0)
 
-      setCheckedInCount(totalCount)
-      setIsCheckedIn(allChecked)
+          return {
+            chain,
+            slug,
+            contract,
+            start: start as bigint,
+            last: safeLast,
+            count: safeCount,
+            vMooneyBalance: balance,
+            hasVMooney,
+            checkedInOnChain: safeLast === (start as bigint),
+          }
+        } catch (err) {
+          console.error(`Error fetching check-in status for ${slug}:`, err)
+          return null
+        }
+      })
+    )
+
+    const results = raw.filter((r) => r) as Array<{
+      chain: any
+      slug: string
+      contract: any
+      start: bigint
+      last: bigint
+      count: bigint
+      vMooneyBalance: bigint
+      hasVMooney: boolean
+      checkedInOnChain: boolean
+    }>
+
+    setFeeData(results)
+
+    // checkedInCount is the only thing derived here now. The button's
+    // isCheckedIn state is derived from feeData in a dedicated effect below,
+    // giving a single source of truth that also covers the optimistic
+    // update applied right after a check-in.
+    const totalCount = results.reduce((acc, { count }) => acc + Number(count || BigInt(0)), 0)
+    setCheckedInCount(totalCount)
   }, [address, chains, WEEK])
 
   useEffect(() => {
@@ -338,9 +319,7 @@ export default function WeeklyRewardPool() {
   useEffect(() => {
     if (!feeData || feeData.length === 0) return
     const eligibleChains = feeData.filter((d) => d.hasVMooney)
-    const allChecked =
-      eligibleChains.length > 0 &&
-      eligibleChains.every((d) => d.checkedInOnChain)
+    const allChecked = eligibleChains.length > 0 && eligibleChains.every((d) => d.checkedInOnChain)
     setIsCheckedIn(allChecked)
   }, [feeData])
 
@@ -386,8 +365,7 @@ export default function WeeklyRewardPool() {
       // actionable. Returns true only once the wallet actually reports the
       // target chain.
       const switchToChain = async (chain: any): Promise<boolean> => {
-        const alreadyOn = () =>
-          +wallets[selectedWallet]?.chainId?.split(':')[1] === chain.id
+        const alreadyOn = () => +wallets[selectedWallet]?.chainId?.split(':')[1] === chain.id
         if (alreadyOn()) return true
 
         for (let attempt = 0; attempt < 2; attempt++) {
@@ -497,7 +475,12 @@ export default function WeeklyRewardPool() {
                 }),
               ])
               if (ws != null && lc != null) {
-                return BigInt(lc as any) === BigInt(ws as any)
+                // weekStart === 0 means the hook is uninitialized / the RPC
+                // returned an empty read. Treating 0 === 0 as "checked in"
+                // would reintroduce the phantom-success bug, so require a
+                // real (non-zero) week boundary before trusting the match.
+                const wsBig = BigInt(ws as any)
+                return wsBig !== BigInt(0) && BigInt(lc as any) === wsBig
               }
             } catch (err) {
               console.warn(`verify lastCheckIn failed for ${slug}:`, err)
@@ -554,8 +537,7 @@ export default function WeeklyRewardPool() {
               // Genuine, unexpected failure on this chain. Don't abort the
               // whole loop — move on so other chains still get a chance.
               console.error(`Check-in failed for ${slug}:`, error)
-              lastError =
-                error?.shortMessage || error?.message || 'Transaction failed'
+              lastError = error?.shortMessage || error?.message || 'Transaction failed'
               break
             }
           }
@@ -583,9 +565,7 @@ export default function WeeklyRewardPool() {
       if (checkedInChainIds.size > 0) {
         setFeeData((prev) =>
           prev.map((d) =>
-            checkedInChainIds.has(d.chain.id)
-              ? { ...d, checkedInOnChain: true }
-              : d
+            checkedInChainIds.has(d.chain.id) ? { ...d, checkedInOnChain: true } : d
           )
         )
       }
@@ -733,7 +713,12 @@ export default function WeeklyRewardPool() {
               >
                 <span>Learn about rewards</span>
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
                 </svg>
               </Link>
               <div

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -20,25 +20,13 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import React, { useState, useEffect, useContext, useMemo, useCallback } from 'react'
 import toast from 'react-hot-toast'
-import {
-  prepareContractCall,
-  sendAndConfirmTransaction,
-  readContract,
-  getContract,
-} from 'thirdweb'
+import { prepareContractCall, sendAndConfirmTransaction, readContract, getContract } from 'thirdweb'
 import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
 import { useActiveAccount } from 'thirdweb/react'
-import {
-  arbitrum,
-  base,
-  ethereum,
-  sepolia,
-  arbitrumSepolia,
-  Chain,
-} from '@/lib/rpc/chains'
 import toastStyle from '../lib/marketplace/marketplace-utils/toastConfig'
 import useETHPrice from '@/lib/etherscan/useETHPrice'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
+import { arbitrum, base, ethereum, sepolia, arbitrumSepolia, Chain } from '@/lib/rpc/chains'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
 import client from '@/lib/thirdweb/client'
@@ -89,8 +77,7 @@ async function safeRead<T>(
     } catch (err: any) {
       const isLast = attempt === retries
       const isBufferDecodeError =
-        err?.message?.includes("reading 'buffer'") ||
-        err?.message?.includes('decodeAbiParameters')
+        err?.message?.includes("reading 'buffer'") || err?.message?.includes('decodeAbiParameters')
       if (!isLast && isBufferDecodeError) {
         await sleep(baseDelay * Math.pow(2, attempt))
         continue
@@ -156,12 +143,8 @@ function StatCard({
           </div>
         ) : (
           <>
-            <div className="text-white font-GoodTimes text-xl sm:text-2xl break-words">
-              {value}
-            </div>
-            {subValue && (
-              <div className="text-gray-400 text-xs sm:text-sm mt-1">{subValue}</div>
-            )}
+            <div className="text-white font-GoodTimes text-xl sm:text-2xl break-words">{value}</div>
+            {subValue && <div className="text-gray-400 text-xs sm:text-sm mt-1">{subValue}</div>}
           </>
         )}
       </div>
@@ -260,15 +243,9 @@ export default function Fees() {
                 const result = data?.result
                 // Guard against malformed responses like '0x' or non-hex strings
                 // that would otherwise throw inside BigNumber.from.
-                if (
-                  typeof result !== 'string' ||
-                  !/^0x[0-9a-fA-F]+$/.test(result)
-                ) {
+                if (typeof result !== 'string' || !/^0x[0-9a-fA-F]+$/.test(result)) {
                   if (result !== undefined && result !== null) {
-                    console.error(
-                      `Invalid eth_getBalance result for ${slug}:`,
-                      result
-                    )
+                    console.error(`Invalid eth_getBalance result for ${slug}:`, result)
                   }
                   return BigNumber.from(0)
                 }
@@ -355,128 +332,118 @@ export default function Fees() {
     // user tried to check in. Isolate failures per-chain so the remaining
     // chains still populate.
     const raw = await Promise.all(
-        chains.map(async (chain) => {
-          const slug = getChainSlug(chain)
-          try {
-            const hookAddress = FEE_HOOK_ADDRESSES[slug]
-            if (!hookAddress) return null
+      chains.map(async (chain) => {
+        const slug = getChainSlug(chain)
+        try {
+          const hookAddress = FEE_HOOK_ADDRESSES[slug]
+          if (!hookAddress) return null
 
-            const contract = getContract({
-              client,
-              address: hookAddress,
-              abi: FeeHook.abi as any,
-              chain,
-            })
+          const contract = getContract({
+            client,
+            address: hookAddress,
+            abi: FeeHook.abi as any,
+            chain,
+          })
 
-            // Read each method independently with retry. Previously these
-            // were batched in `Promise.all`; if any single read failed (the
-            // recurring `decodeAbiParameters → buffer` error from a flaky
-            // RPC batch), the whole chain row was dropped from `feeData`,
-            // which surfaced as Arbitrum data going missing.
-            const [start, last, count, vMooneyAddress] = await Promise.all([
-              safeRead(
-                () => readContract({ contract, method: 'weekStart', params: [] }),
-                `${slug}.weekStart`
-              ),
-              safeRead(
-                () =>
-                  readContract({
-                    contract,
-                    method: 'lastCheckIn',
-                    params: [address],
-                  }),
-                `${slug}.lastCheckIn`
-              ),
-              safeRead(
-                () =>
-                  readContract({
-                    contract,
-                    method: 'getCheckedInCount',
-                    params: [],
-                  }),
-                `${slug}.getCheckedInCount`
-              ),
-              safeRead(
-                () =>
-                  readContract({
-                    contract,
-                    method: 'vMooneyAddress',
-                    params: [],
-                  }),
-                `${slug}.vMooneyAddress`
-              ),
-            ])
-
-            // We need at least the week boundaries + vMooney address to do
-            // anything useful. If those are missing the chain is unusable
-            // for this render, but we still don't want to throw — other
-            // chains should keep populating.
-            if (start == null || vMooneyAddress == null) {
-              console.warn(
-                `Skipping ${slug}: missing required FeeHook reads (start=${start}, vMooneyAddress=${vMooneyAddress})`
-              )
-              return null
-            }
-
-            const vMooneyContract = getContract({
-              client,
-              address: vMooneyAddress as `0x${string}`,
-              abi: ERC20ABI as any,
-              chain,
-            })
-
-            const vMooneyBalance = await safeRead(
+          // Read each method independently with retry. Previously these
+          // were batched in `Promise.all`; if any single read failed (the
+          // recurring `decodeAbiParameters → buffer` error from a flaky
+          // RPC batch), the whole chain row was dropped from `feeData`,
+          // which surfaced as Arbitrum data going missing.
+          const [start, last, count, vMooneyAddress] = await Promise.all([
+            safeRead(
+              () => readContract({ contract, method: 'weekStart', params: [] }),
+              `${slug}.weekStart`
+            ),
+            safeRead(
               () =>
                 readContract({
-                  contract: vMooneyContract,
-                  method: 'balanceOf',
+                  contract,
+                  method: 'lastCheckIn',
                   params: [address],
                 }),
-              `${slug}.balanceOf`
+              `${slug}.lastCheckIn`
+            ),
+            safeRead(
+              () =>
+                readContract({
+                  contract,
+                  method: 'getCheckedInCount',
+                  params: [],
+                }),
+              `${slug}.getCheckedInCount`
+            ),
+            safeRead(
+              () =>
+                readContract({
+                  contract,
+                  method: 'vMooneyAddress',
+                  params: [],
+                }),
+              `${slug}.vMooneyAddress`
+            ),
+          ])
+
+          // We need at least the week boundaries + vMooney address to do
+          // anything useful. If those are missing the chain is unusable
+          // for this render, but we still don't want to throw — other
+          // chains should keep populating.
+          if (start == null || vMooneyAddress == null) {
+            console.warn(
+              `Skipping ${slug}: missing required FeeHook reads (start=${start}, vMooneyAddress=${vMooneyAddress})`
             )
-
-            const balance = (vMooneyBalance as bigint | null) ?? BigInt(0)
-            const safeLast = (last as bigint | null) ?? BigInt(0)
-            const safeCount = (count as bigint | null) ?? BigInt(0)
-            const hasVMooney = balance > BigInt(0)
-
-            return {
-              chain,
-              slug,
-              contract,
-              start: start as bigint,
-              last: safeLast,
-              count: safeCount,
-              vMooneyBalance: balance,
-              hasVMooney,
-              checkedInOnChain: safeLast === (start as bigint),
-            }
-          } catch (err) {
-            console.error(`Error fetching check-in status for ${slug}:`, err)
             return null
           }
-        })
-      )
 
-      const results = raw.filter((r) => r !== null) as FeeChainData[]
-      setFeeData(results)
+          const vMooneyContract = getContract({
+            client,
+            address: vMooneyAddress as `0x${string}`,
+            abi: ERC20ABI as any,
+            chain,
+          })
 
-      // Only chains where the user actually holds vMOONEY are eligible to
-      // check in (the FeeHook reverts otherwise). Aggregating "checked in"
-      // across all chains regardless of balance would mean a user with
-      // vMOONEY only on Arbitrum is forever shown as "not checked in"
-      // because they can never check in on Ethereum / Base.
-      const eligibleChains = results.filter((r) => r.hasVMooney)
-      const totalCount = results.reduce(
-        (acc, { count }) => acc + Number(count || BigInt(0)),
-        0
-      )
-      const allChecked =
-        eligibleChains.length > 0 &&
-        eligibleChains.every(({ checkedInOnChain }) => checkedInOnChain)
+          const vMooneyBalance = await safeRead(
+            () =>
+              readContract({
+                contract: vMooneyContract,
+                method: 'balanceOf',
+                params: [address],
+              }),
+            `${slug}.balanceOf`
+          )
 
-      setCheckedInCount(totalCount)
-      setIsCheckedIn(allChecked)
+          const balance = (vMooneyBalance as bigint | null) ?? BigInt(0)
+          const safeLast = (last as bigint | null) ?? BigInt(0)
+          const safeCount = (count as bigint | null) ?? BigInt(0)
+          const hasVMooney = balance > BigInt(0)
+
+          return {
+            chain,
+            slug,
+            contract,
+            start: start as bigint,
+            last: safeLast,
+            count: safeCount,
+            vMooneyBalance: balance,
+            hasVMooney,
+            checkedInOnChain: safeLast === (start as bigint),
+          }
+        } catch (err) {
+          console.error(`Error fetching check-in status for ${slug}:`, err)
+          return null
+        }
+      })
+    )
+
+    const results = raw.filter((r) => r !== null) as FeeChainData[]
+    setFeeData(results)
+
+    // checkedInCount is the only thing derived here now. The button's
+    // isCheckedIn state is derived from feeData in a dedicated effect below,
+    // giving a single source of truth that also covers the optimistic
+    // update applied right after a check-in.
+    const totalCount = results.reduce((acc, { count }) => acc + Number(count || BigInt(0)), 0)
+    setCheckedInCount(totalCount)
   }, [address, chains])
 
   useEffect(() => {
@@ -490,8 +457,7 @@ export default function Fees() {
   useEffect(() => {
     if (!feeData || feeData.length === 0) return
     const eligible = feeData.filter((d) => d.hasVMooney)
-    const allChecked =
-      eligible.length > 0 && eligible.every((d) => d.checkedInOnChain)
+    const allChecked = eligible.length > 0 && eligible.every((d) => d.checkedInOnChain)
     setIsCheckedIn(allChecked)
   }, [feeData])
 
@@ -535,8 +501,7 @@ export default function Fees() {
       // actionable. Returns true only once the wallet actually reports the
       // target chain.
       const switchToChain = async (chain: any): Promise<boolean> => {
-        const alreadyOn = () =>
-          +wallets[selectedWallet]?.chainId?.split(':')[1] === chain.id
+        const alreadyOn = () => +wallets[selectedWallet]?.chainId?.split(':')[1] === chain.id
         if (alreadyOn()) return true
 
         for (let attempt = 0; attempt < 2; attempt++) {
@@ -582,10 +547,7 @@ export default function Fees() {
           if (!signer) return account
           return await ethers5Adapter.signer.fromEthers({ signer })
         } catch (err) {
-          console.warn(
-            'Failed to derive fresh account, falling back to active account:',
-            err
-          )
+          console.warn('Failed to derive fresh account, falling back to active account:', err)
           return account
         }
       }
@@ -639,7 +601,12 @@ export default function Fees() {
                 }),
               ])
               if (ws != null && lc != null) {
-                return BigInt(lc as any) === BigInt(ws as any)
+                // weekStart === 0 means the hook is uninitialized / the RPC
+                // returned an empty read. Treating 0 === 0 as "checked in"
+                // would reintroduce the phantom-success bug, so require a
+                // real (non-zero) week boundary before trusting the match.
+                const wsBig = BigInt(ws as any)
+                return wsBig !== BigInt(0) && BigInt(lc as any) === wsBig
               }
             } catch (err) {
               console.warn(`verify lastCheckIn failed for ${data.slug}:`, err)
@@ -663,8 +630,7 @@ export default function Fees() {
             error?.message?.includes('nonce too low') ||
             error?.message?.includes('underlying network changed') ||
             error?.message?.includes('network changed')
-          lastError =
-            error?.shortMessage || error?.message || 'Transaction failed'
+          lastError = error?.shortMessage || error?.message || 'Transaction failed'
           if (!isRecoverable) {
             console.error(`Check-in failed for ${data.slug}:`, error)
             continue
@@ -691,9 +657,7 @@ export default function Fees() {
       if (checkedInChainIds.size > 0) {
         setFeeData((prev) =>
           prev.map((d) =>
-            checkedInChainIds.has(d.chain.id)
-              ? { ...d, checkedInOnChain: true }
-              : d
+            checkedInChainIds.has(d.chain.id) ? { ...d, checkedInOnChain: true } : d
           )
         )
       }
@@ -741,8 +705,7 @@ export default function Fees() {
       }
     } catch (error) {
       console.error('Error checking in:', error)
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error occurred'
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred'
       toast.error(`Check-in failed: ${errorMessage}`, { style: toastStyle })
     } finally {
       // Reconcile the UI with the real on-chain state. The check-in txs are
@@ -786,7 +749,7 @@ export default function Fees() {
               //   on a *child* span normally wins, but we still mark it to
               //   be safe.
               // - Layered text-shadows + a subtle backdrop pill give the
-                //   white type guaranteed contrast over the dark gradient
+              //   white type guaranteed contrast over the dark gradient
               //   regardless of what scrolls behind it.
               <div className="pt-24 md:pt-28 lg:pt-20 pb-2 flex flex-col gap-3 sm:gap-4 max-w-3xl">
                 <h1
@@ -808,8 +771,7 @@ export default function Fees() {
                     textShadow: '0 1px 4px rgba(0,0,0,0.7)',
                   }}
                 >
-                  Earn a share of MoonDAO&apos;s weekly trading-fee reward
-                  pool by checking in.
+                  Earn a share of MoonDAO&apos;s weekly trading-fee reward pool by checking in.
                 </p>
               </div>
             }
@@ -839,11 +801,10 @@ export default function Fees() {
                       How Liquidity Rewards Work
                     </h2>
                     <p className="mt-2 text-sm sm:text-base text-gray-300 leading-relaxed">
-                      MoonDAO captures trading fees from MOONEY/ETH liquidity
-                      pools on Ethereum, Arbitrum, and Base. Each week the
-                      collected ETH is split pro-rata among vMOONEY holders
-                      who checked in for that week — your share is proportional
-                      to your vMOONEY balance.
+                      MoonDAO captures trading fees from MOONEY/ETH liquidity pools on Ethereum,
+                      Arbitrum, and Base. Each week the collected ETH is split pro-rata among
+                      vMOONEY holders who checked in for that week — your share is proportional to
+                      your vMOONEY balance.
                     </p>
                   </div>
 
@@ -871,9 +832,7 @@ export default function Fees() {
                   <div className="mt-2 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-xs sm:text-sm text-gray-400 border-t border-white/10 pt-4">
                     <div className="flex items-center gap-2">
                       <ClockIcon className="w-4 h-4" />
-                      <span>
-                        Distribution runs every Thursday at 1pm Pacific
-                      </span>
+                      <span>Distribution runs every Thursday at 1pm Pacific</span>
                     </div>
                     <Link
                       href="https://docs.moondao.com"
@@ -910,20 +869,14 @@ export default function Fees() {
                       ? `${yourEth} ETH`
                       : 'Calculating...'
                   }
-                  subValue={
-                    address && hasVMooney && yourUsd ? `~$${yourUsd}` : undefined
-                  }
+                  subValue={address && hasVMooney && yourUsd ? `~$${yourUsd}` : undefined}
                   loading={!!address && hasVMooney && estimatedFees === null}
                   accent="bg-gradient-to-br from-purple-500/40 to-pink-600/40"
                 />
                 <StatCard
                   icon={<UserGroupIcon className="w-5 h-5 text-white" />}
                   label="Participants This Week"
-                  value={
-                    checkedInCount === null
-                      ? 'Loading...'
-                      : checkedInCount.toLocaleString()
-                  }
+                  value={checkedInCount === null ? 'Loading...' : checkedInCount.toLocaleString()}
                   subValue={
                     checkedInCount !== null
                       ? checkedInCount === 1
@@ -967,8 +920,8 @@ export default function Fees() {
                         Connect your wallet to check in
                       </h2>
                       <p className="mt-1 text-sm text-gray-300">
-                        You need a connected wallet with vMOONEY to participate
-                        in this week's reward pool.
+                        You need a connected wallet with vMOONEY to participate in this week's
+                        reward pool.
                       </p>
                     </div>
                     <PrivyWeb3Button
@@ -986,8 +939,8 @@ export default function Fees() {
                         Lock MOONEY to start earning
                       </h2>
                       <p className="mt-1 text-sm text-gray-300">
-                        Only vMOONEY holders qualify for the weekly reward pool.
-                        Lock MOONEY to receive vMOONEY.
+                        Only vMOONEY holders qualify for the weekly reward pool. Lock MOONEY to
+                        receive vMOONEY.
                       </p>
                     </div>
                     <PrivyWeb3Button
@@ -1002,9 +955,7 @@ export default function Fees() {
                   <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                     <div className="flex-1">
                       <h2 className="font-GoodTimes text-white text-base sm:text-lg">
-                        {isCheckedIn
-                          ? "You're checked in for this week"
-                          : 'Check in for this week'}
+                        {isCheckedIn ? "You're checked in for this week" : 'Check in for this week'}
                       </h2>
                       <p className="mt-1 text-sm text-gray-300">
                         {isCheckedIn
@@ -1070,10 +1021,7 @@ export default function Fees() {
                             )
                           }
                           return (
-                            <tr
-                              key={d.slug}
-                              className="border-b border-white/5 last:border-b-0"
-                            >
+                            <tr key={d.slug} className="border-b border-white/5 last:border-b-0">
                               <td className="px-3 py-3 text-white capitalize">
                                 {d.chain.name ?? d.slug}
                               </td>
@@ -1091,9 +1039,8 @@ export default function Fees() {
                     </table>
                   </div>
                   <p className="mt-3 text-xs text-gray-500">
-                    A check-in transaction is required on each chain where you
-                    hold vMOONEY. Chains where you have a 0 balance are skipped
-                    automatically.
+                    A check-in transaction is required on each chain where you hold vMOONEY. Chains
+                    where you have a 0 balance are skipped automatically.
                   </p>
                 </div>
               )}

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -26,6 +26,7 @@ import {
   readContract,
   getContract,
 } from 'thirdweb'
+import { ethers5Adapter } from 'thirdweb/adapters/ethers5'
 import { useActiveAccount } from 'thirdweb/react'
 import {
   arbitrum,
@@ -505,6 +506,27 @@ export default function Fees() {
         return false
       }
 
+      // Build a thirdweb account from the Privy wallet's CURRENT ethers
+      // provider. The `account` from useActiveAccount() is bound (via
+      // ethers5Adapter) to the chain selected at render time; reusing it after
+      // switching chains makes ethers v5 throw `underlying network changed`
+      // because the signer's cached network no longer matches the wallet.
+      const getAccountForChain = async () => {
+        try {
+          const wallet = wallets[selectedWallet]
+          const provider = await wallet?.getEthersProvider()
+          const signer = provider?.getSigner()
+          if (!signer) return account
+          return await ethers5Adapter.signer.fromEthers({ signer })
+        } catch (err) {
+          console.warn(
+            'Failed to derive fresh account, falling back to active account:',
+            err
+          )
+          return account
+        }
+      }
+
       for (const data of feeData) {
         if (!data.hasVMooney) continue
         eligibleChainsCount++
@@ -527,7 +549,8 @@ export default function Fees() {
           method: 'checkIn' as string,
           params: [],
         })
-        await sendAndConfirmTransaction({ transaction: tx, account })
+        const txAccount = await getAccountForChain()
+        await sendAndConfirmTransaction({ transaction: tx, account: txAccount })
         transactionsSent++
       }
 

--- a/ui/pages/fees.tsx
+++ b/ui/pages/fees.tsx
@@ -18,7 +18,7 @@ import { BigNumber } from 'ethers'
 import { ethers } from 'ethers'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import React, { useState, useEffect, useContext, useMemo } from 'react'
+import React, { useState, useEffect, useContext, useMemo, useCallback } from 'react'
 import toast from 'react-hot-toast'
 import {
   prepareContractCall,
@@ -343,16 +343,18 @@ export default function Fees() {
     fetchEstimates()
   }, [address, chains])
 
-  useEffect(() => {
+  // Reusable on-chain status loader. Exposed as a callback so it can be
+  // re-run after a check-in to reconcile the UI with the real on-chain state
+  // (the txs are already confirmed at that point, so lastCheckIn is updated).
+  const refreshFeeData = useCallback(async () => {
     if (!address) return
 
-    const fetchStatus = async () => {
-      // Each chain is fetched independently. A single chain failure (RPC
-      // hiccup, rate limit, etc.) used to reject the whole Promise.all and
-      // leave `feeData` empty, surfacing as "No fee data available" when the
-      // user tried to check in. Isolate failures per-chain so the remaining
-      // chains still populate.
-      const raw = await Promise.all(
+    // Each chain is fetched independently. A single chain failure (RPC
+    // hiccup, rate limit, etc.) used to reject the whole Promise.all and
+    // leave `feeData` empty, surfacing as "No fee data available" when the
+    // user tried to check in. Isolate failures per-chain so the remaining
+    // chains still populate.
+    const raw = await Promise.all(
         chains.map(async (chain) => {
           const slug = getChainSlug(chain)
           try {
@@ -475,10 +477,23 @@ export default function Fees() {
 
       setCheckedInCount(totalCount)
       setIsCheckedIn(allChecked)
-    }
-
-    fetchStatus()
   }, [address, chains])
+
+  useEffect(() => {
+    refreshFeeData()
+  }, [refreshFeeData])
+
+  // Keep the button's checked-in state in sync with feeData. This covers both
+  // the initial on-chain load and the optimistic update applied right after a
+  // successful check-in, so the button reliably flips to "Checked In" without
+  // depending on the exact tx/skip counts inside handleCheckIn.
+  useEffect(() => {
+    if (!feeData || feeData.length === 0) return
+    const eligible = feeData.filter((d) => d.hasVMooney)
+    const allChecked =
+      eligible.length > 0 && eligible.every((d) => d.checkedInOnChain)
+    setIsCheckedIn(allChecked)
+  }, [feeData])
 
   const handleCheckIn = async () => {
     try {
@@ -495,6 +510,13 @@ export default function Fees() {
       let transactionsSent = 0
       let alreadyCheckedInCount = 0
       let eligibleChainsCount = 0
+      // Chains the user is confirmed checked in on after this run. Used to
+      // optimistically update feeData so re-clicking the button doesn't
+      // re-broadcast no-op transactions.
+      const checkedInChainIds = new Set<number>()
+      // Capture the most useful failure reason so we can show the user what
+      // actually went wrong instead of a generic "please try again".
+      let lastError: string | null = null
 
       const waitForChainSwitch = async (targetChainId: number, maxWait = 5000) => {
         const startTime = Date.now()
@@ -503,6 +525,47 @@ export default function Fees() {
           if (walletChainId === targetChainId) return true
           await new Promise((resolve) => setTimeout(resolve, 100))
         }
+        return false
+      }
+
+      // Robustly switch the wallet to a target chain. Injected wallets (e.g.
+      // MetaMask) pop a confirmation the user has to approve, so we (a) give a
+      // generous window for that, (b) retry the request a couple of times, and
+      // (c) report WHY it failed (user rejected vs. timed out) so the toast is
+      // actionable. Returns true only once the wallet actually reports the
+      // target chain.
+      const switchToChain = async (chain: any): Promise<boolean> => {
+        const alreadyOn = () =>
+          +wallets[selectedWallet]?.chainId?.split(':')[1] === chain.id
+        if (alreadyOn()) return true
+
+        for (let attempt = 0; attempt < 2; attempt++) {
+          try {
+            await wallets[selectedWallet].switchChain(chain.id)
+            setSelectedChain(chain)
+          } catch (err: any) {
+            // 4001 / ACTION_REJECTED = user dismissed the wallet prompt.
+            if (
+              err?.code === 4001 ||
+              err?.code === 'ACTION_REJECTED' ||
+              err?.message?.toLowerCase().includes('reject') ||
+              err?.message?.toLowerCase().includes('denied')
+            ) {
+              lastError = `You declined the network switch to ${chain.name}. Approve it in your wallet to check in there.`
+              return false
+            }
+            console.warn(`switchChain to ${chain.name} threw:`, err)
+          }
+          // Wait up to 20s for the wallet to report the new chain (covers the
+          // time the user spends approving the MetaMask popup).
+          if (await waitForChainSwitch(chain.id, 20000)) {
+            // Small settle delay so the provider's network is fully updated
+            // before we build a signer / send the tx.
+            await new Promise((resolve) => setTimeout(resolve, 500))
+            return true
+          }
+        }
+        lastError = `Could not switch your wallet to ${chain.name}. Open your wallet, switch to ${chain.name} manually, then press Check In again.`
         return false
       }
 
@@ -532,16 +595,14 @@ export default function Fees() {
         eligibleChainsCount++
         if (data.checkedInOnChain) {
           alreadyCheckedInCount++
+          checkedInChainIds.add(data.chain.id)
           continue
         }
 
         const walletChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
         if (walletChainId !== data.chain.id) {
-          await wallets[selectedWallet].switchChain(data.chain.id)
-          setSelectedChain(data.chain)
-          const switched = await waitForChainSwitch(data.chain.id)
+          const switched = await switchToChain(data.chain)
           if (!switched) continue
-          await new Promise((resolve) => setTimeout(resolve, 500))
         }
 
         const tx = prepareContractCall({
@@ -550,8 +611,91 @@ export default function Fees() {
           params: [],
         })
         const txAccount = await getAccountForChain()
-        await sendAndConfirmTransaction({ transaction: tx, account: txAccount })
-        transactionsSent++
+
+        // The ONLY source of truth for "did the check-in happen" is the
+        // on-chain state: lastCheckIn[address] === weekStart. Never trust the
+        // tx promise (or a nonce collision) on its own — a tx that looked
+        // confirmed but never landed previously produced a false "checked in"
+        // toast while nothing changed on-chain.
+        const verifyCheckedIn = async () => {
+          const verifyContract = getContract({
+            client,
+            address: FEE_HOOK_ADDRESSES[data.slug],
+            abi: FeeHook.abi as any,
+            chain: data.chain,
+          })
+          for (let i = 0; i < 3; i++) {
+            try {
+              const [ws, lc] = await Promise.all([
+                readContract({
+                  contract: verifyContract,
+                  method: 'weekStart',
+                  params: [],
+                }),
+                readContract({
+                  contract: verifyContract,
+                  method: 'lastCheckIn',
+                  params: [address],
+                }),
+              ])
+              if (ws != null && lc != null) {
+                return BigInt(lc as any) === BigInt(ws as any)
+              }
+            } catch (err) {
+              console.warn(`verify lastCheckIn failed for ${data.slug}:`, err)
+            }
+            await new Promise((r) => setTimeout(r, 800))
+          }
+          return false
+        }
+
+        try {
+          await sendAndConfirmTransaction({ transaction: tx, account: txAccount })
+        } catch (error: any) {
+          // Nonce collisions / network-changed errors don't necessarily mean
+          // failure — fall through to on-chain verification, which decides.
+          // Any other error is a genuine failure for this chain, but we don't
+          // abort the whole loop so other chains still get a chance.
+          const isRecoverable =
+            error?.code === 'NONCE_EXPIRED' ||
+            error?.code === 'NETWORK_ERROR' ||
+            error?.message?.includes('nonce has already been used') ||
+            error?.message?.includes('nonce too low') ||
+            error?.message?.includes('underlying network changed') ||
+            error?.message?.includes('network changed')
+          lastError =
+            error?.shortMessage || error?.message || 'Transaction failed'
+          if (!isRecoverable) {
+            console.error(`Check-in failed for ${data.slug}:`, error)
+            continue
+          }
+        }
+
+        // Only a verified on-chain state counts as a successful check-in.
+        if (await verifyCheckedIn()) {
+          transactionsSent++
+          checkedInChainIds.add(data.chain.id)
+          lastError = null
+        } else if (!lastError) {
+          // The send didn't throw, but the on-chain state never flipped. This
+          // usually means the tx silently failed or was sent on the wrong
+          // network. Record it so the user sees something actionable.
+          lastError = `Your ${data.chain.name} check-in transaction did not register on-chain. Make sure your wallet is on ${data.chain.name} and try again.`
+        }
+      }
+
+      // Optimistically mark the chains we just checked in on so the button
+      // disables and a second click doesn't re-broadcast no-op transactions
+      // (on-chain checkIn() is idempotent, so re-sending only produces a
+      // "No changes" wallet prompt that confuses users).
+      if (checkedInChainIds.size > 0) {
+        setFeeData((prev) =>
+          prev.map((d) =>
+            checkedInChainIds.has(d.chain.id)
+              ? { ...d, checkedInOnChain: true }
+              : d
+          )
+        )
       }
 
       const finalWalletChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
@@ -588,15 +732,25 @@ export default function Fees() {
         )
         setIsCheckedIn(true)
       } else {
-        toast.error('No check-ins were submitted. Please try again.', {
-          style: toastStyle,
-        })
+        toast.error(
+          lastError
+            ? `Check-in failed: ${lastError}`
+            : 'No check-ins were submitted. Please try again.',
+          { style: toastStyle }
+        )
       }
     } catch (error) {
       console.error('Error checking in:', error)
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error occurred'
       toast.error(`Check-in failed: ${errorMessage}`, { style: toastStyle })
+    } finally {
+      // Reconcile the UI with the real on-chain state. The check-in txs are
+      // confirmed by this point, so lastCheckIn is updated on-chain. A short
+      // delay gives the RPC a moment to propagate before we re-read.
+      setTimeout(() => {
+        refreshFeeData()
+      }, 1500)
     }
   }
 

--- a/ui/scripts/check-checkin-status.mjs
+++ b/ui/scripts/check-checkin-status.mjs
@@ -1,0 +1,96 @@
+// Quick diagnostic: is `address` actually checked in on each chain this week?
+//
+// Usage:
+//   node ui/scripts/check-checkin-status.mjs 0xYOURADDRESS
+//
+// Reads weekStart, lastCheckIn[address] and vMOONEY balance directly from the
+// public RPC for Ethereum, Arbitrum and Base, then tells you per-chain:
+//   - whether you hold vMOONEY (i.e. you're eligible to check in there)
+//   - whether your lastCheckIn == weekStart (i.e. you ARE checked in there)
+
+const CHAINS = [
+  {
+    name: 'ethereum',
+    rpc: 'https://ethereum-rpc.publicnode.com',
+    feeHook: '0x1b9f3544dC4915E0C08882d1C3F39B6E464E4844',
+    vMooney: '0xCc71C80d803381FD6Ee984FAff408f8501DB1740',
+  },
+  {
+    name: 'arbitrum',
+    rpc: 'https://arb1.arbitrum.io/rpc',
+    feeHook: '0x6D9C97c94c88a67d1A93BBC8ccAe3a5322208844',
+    vMooney: '0xB255c74F8576f18357cE6184DA033c6d93C71899',
+  },
+  {
+    name: 'base',
+    rpc: 'https://mainnet.base.org',
+    feeHook: '0x3F74A92F6D68a0638802d32D40a1Cb63C49b0844',
+    vMooney: '0x7f8f1B45c3FD6Be4F467520Fc1Cf030d5CaBACF5',
+  },
+]
+
+// 4-byte selectors (verified via ethers.utils.id):
+//   weekStart()           -> 0x3b698348
+//   lastCheckIn(address)  -> 0xef6fdb1c
+//   balanceOf(address)    -> 0x70a08231
+const WEEK_START = '0x3b698348'
+const LAST_CHECK_IN = '0xef6fdb1c'
+const BALANCE_OF = '0x70a08231'
+
+function pad(addr) {
+  return addr.toLowerCase().replace('0x', '').padStart(64, '0')
+}
+
+async function call(rpc, to, data) {
+  const res = await fetch(rpc, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_call',
+      params: [{ to, data }, 'latest'],
+    }),
+  })
+  const json = await res.json()
+  if (json.error) throw new Error(json.error.message)
+  return json.result
+}
+
+async function main() {
+  const address = process.argv[2]
+  if (!address || !/^0x[0-9a-fA-F]{40}$/.test(address)) {
+    console.error('Usage: node check-checkin-status.mjs 0xYOURADDRESS')
+    process.exit(1)
+  }
+
+  console.log(`\nChecking weekly check-in status for ${address}\n`)
+
+  for (const c of CHAINS) {
+    try {
+      const weekStartHex = await call(c.rpc, c.feeHook, WEEK_START)
+      const lastHex = await call(c.rpc, c.feeHook, LAST_CHECK_IN + pad(address))
+      const balHex = await call(c.rpc, c.vMooney, BALANCE_OF + pad(address))
+
+      const weekStart = BigInt(weekStartHex)
+      const last = BigInt(lastHex)
+      const bal = BigInt(balHex)
+
+      const eligible = bal > 0n
+      const checkedIn = last === weekStart && weekStart !== 0n
+
+      console.log(`── ${c.name} ──────────────────────────────`)
+      console.log(`  vMOONEY balance : ${bal} ${eligible ? '(eligible)' : '(0 — not eligible)'}`)
+      console.log(`  weekStart       : ${weekStart}`)
+      console.log(`  lastCheckIn     : ${last}`)
+      console.log(`  CHECKED IN?     : ${checkedIn ? '✅ YES' : '❌ NO'}`)
+      console.log('')
+    } catch (err) {
+      console.log(`── ${c.name} ──────────────────────────────`)
+      console.log(`  ⚠️  read failed: ${err.message}`)
+      console.log('')
+    }
+  }
+}
+
+main()

--- a/ui/scripts/check-checkin-status.mjs
+++ b/ui/scripts/check-checkin-status.mjs
@@ -8,6 +8,11 @@
 //   - whether you hold vMOONEY (i.e. you're eligible to check in there)
 //   - whether your lastCheckIn == weekStart (i.e. you ARE checked in there)
 
+// NOTE: These FeeHook / vMOONEY addresses are duplicated from the app config
+// (FEE_HOOK_ADDRESSES in ui/const/config.ts, sourced from
+// contracts/deployments/<chain>.json, and the vMOONEY config). They are
+// hardcoded here only so this stays a zero-dependency standalone .mjs you can
+// run with plain `node`. If a FeeHook is ever redeployed, update both places.
 const CHAINS = [
   {
     name: 'ethereum',


### PR DESCRIPTION
## Summary

Makes the weekly liquidity-reward **check-in** flow reliable across Ethereum, Arbitrum, and Base. Previously users could see a green "successfully checked in" toast while **nothing actually changed on-chain**, the button stayed stuck on "Check In", and repeated presses re-prompted the wallet with no-op transactions.

Affects both the dashboard widget (`ui/components/tokens/WeeklyRewardPool.tsx`) and the standalone fees page (`ui/pages/fees.tsx`).

## Root causes & fixes

1. **`underlying network changed` (ethers v5)**
   The thirdweb `account` from `useActiveAccount()` is bound to the chain selected at render time. After switching chains mid-loop, ethers' cached network no longer matched the wallet. → Re-derive the account from the wallet's **current** ethers provider after every switch.

2. **`nonce has already been used` shown as a hard error, then as fake success**
   Treating nonce collisions as blind success masked real failures. → Success is now gated **solely** on on-chain verification: `lastCheckIn[address] === weekStart` (with short retries for RPC propagation). A transaction that doesn't land can no longer report success.

3. **Failed automatic chain switch (e.g. to Ethereum)**
   The old 5s wait + unguarded `switchChain` was too fragile for injected wallets (MetaMask requires user approval). → New `switchToChain()` helper: retries, a 20s approval window, settle delay, and user-reject detection.

4. **Stale button / repeated wallet prompts**
   `isCheckedIn` is now derived from `feeData`, and on-chain status is refreshed after check-in, so the button reliably flips to "Checked In ✓" and stops re-prompting. Eligible chains are also optimistically marked to prevent no-op re-sends.

5. **Unhelpful "No check-ins were submitted" message**
   The real per-chain failure reason (revert/RPC message, user-declined switch, or "did not register on-chain") now surfaces in the toast.

## Diagnostic tooling

Adds `ui/scripts/check-checkin-status.mjs` — reads `weekStart`, `lastCheckIn[address]`, and vMOONEY balance directly from public RPCs to confirm real on-chain check-in status per chain. Standalone script, not imported anywhere (no build/bundle impact).

```bash
node ui/scripts/check-checkin-status.mjs 0xYOURADDRESS
```

## Testing

Verified end-to-end against mainnet with a real wallet:
- Arbitrum check-in registered on-chain (`lastCheckIn === weekStart` ✅).
- Ethereum auto-switch + check-in registered on-chain ✅.
- Base correctly skipped (0 vMOONEY balance).
- Button flips to "Checked In ✓" once all eligible chains are verified; no more phantom successes or repeat prompts.

## Notes

- No gas overrides are set anywhere; wallets use standard network estimates.
- `checkIn()` is a storage-only call, so wallets show "No changes" in the asset-diff preview — this is expected and not an error.
