### PR TITLE
fix(image-gen): supply Juggernaut checkpoint to comfy.icu via files map

### DIFF
--- a/ui/pages/api/image-gen/citizen-image.ts
+++ b/ui/pages/api/image-gen/citizen-image.ts
@@ -8,6 +8,15 @@ const COMFY_WORKFLOW_URL =
 // plenty of time before we abort the request.
 const COMFY_REQUEST_TIMEOUT_MS = 45_000
 
+// The comfy.icu API workers don't have the Juggernaut Lightning checkpoint
+// pre-installed, so we supply it via the `files` map. The worker downloads it on
+// first use and caches it for subsequent runs. Public, ungated HF repo (no token
+// required); the destination filename below must match node 4's `ckpt_name`.
+const JUGGERNAUT_CHECKPOINT_PATH =
+  '/models/checkpoints/juggernautXL_v9Rdphoto2Lighting.safetensors'
+const JUGGERNAUT_CHECKPOINT_URL =
+  'https://huggingface.co/RunDiffusion/Juggernaut-XL-Lightning/resolve/main/Juggernaut_RunDiffusionPhoto2_Lightning_4Steps.safetensors?download=true'
+
 async function fetchComfy(
   init: RequestInit & { method: 'POST' | 'GET' }
 ): Promise<Response> {
@@ -49,6 +58,7 @@ export default async function handler(
     const uuid = v4()
     const files: { [key: string]: string } = {}
     files[`/input/${uuid}.jpg`] = url
+    files[JUGGERNAUT_CHECKPOINT_PATH] = JUGGERNAUT_CHECKPOINT_URL
 
     // generate a random 15 digit number
     let seed = ''


### PR DESCRIPTION
## Summary
Follow-up to #1335. That PR switched the citizen image pipeline to `juggernautXL_v9Rdphoto2Lighting.safetensors`, but the comfy.icu API workers do not have that checkpoint installed, so API runs fail with:

```
CheckpointLoaderSimple: Value not in list: ckpt_name: 'juggernautXL_v9Rdphoto2Lighting.safetensors' not in [...]
```

This change supplies the checkpoint via the comfy.icu `files` map (the same mechanism already used for the input image). The worker downloads it from the public, ungated RunDiffusion Hugging Face repo and caches it for subsequent runs. The destination filename matches node 4's `ckpt_name`, so no other changes are needed.

## Notes
- First generation after deploy will be slower (~7 GB download); subsequent runs use the cached file.
- The download happens during the async run, not during job creation, so it does not affect the POST request timeout.
- Source: `RunDiffusion/Juggernaut-XL-Lightning` on Hugging Face (token-free). Can be swapped for a CivitAI link if preferred.

## Test plan
- [ ] Trigger a citizen image generation and confirm the `Value not in list` error is gone.
- [ ] Confirm the worker successfully downloads the checkpoint (watch for download/network errors on the first run).
- [ ] Verify generated output matches the dashboard-validated Juggernaut Lightning results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single API route change for missing remote assets; no auth, data model, or payment logic touched.
> 
> **Overview**
> Fixes citizen image generation on comfy.icu after the workflow was pointed at **`juggernautXL_v9Rdphoto2Lighting.safetensors`**, which API workers do not ship—runs were failing with a checkpoint “not in list” error.
> 
> The **`citizen-image`** POST handler now registers that checkpoint in the comfy.icu **`files`** map (same pattern as the input photo): a worker-local path aligned with node 4’s **`ckpt_name`**, backed by a public Hugging Face download URL. Workers fetch and cache the weights on first use; no workflow or timeout changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e3bd6747a388c169055b52d7404ab0225d1982b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->