### PR TITLE
fix(image-gen): supply Juggernaut checkpoint to comfy.icu via files map

### DIFF
--- a/ui/pages/api/image-gen/citizen-image.ts
+++ b/ui/pages/api/image-gen/citizen-image.ts
@@ -8,6 +8,15 @@ const COMFY_WORKFLOW_URL =
 // plenty of time before we abort the request.
 const COMFY_REQUEST_TIMEOUT_MS = 45_000
 
+// The comfy.icu API workers don't have the Juggernaut Lightning checkpoint
+// pre-installed, so we supply it via the `files` map. The worker downloads it on
+// first use and caches it for subsequent runs. Public, ungated HF repo (no token
+// required); the destination filename below must match node 4's `ckpt_name`.
+const JUGGERNAUT_CHECKPOINT_PATH =
+  '/models/checkpoints/juggernautXL_v9Rdphoto2Lighting.safetensors'
+const JUGGERNAUT_CHECKPOINT_URL =
+  'https://huggingface.co/RunDiffusion/Juggernaut-XL-Lightning/resolve/main/Juggernaut_RunDiffusionPhoto2_Lightning_4Steps.safetensors?download=true'
+
 async function fetchComfy(
   init: RequestInit & { method: 'POST' | 'GET' }
 ): Promise<Response> {
@@ -49,6 +58,7 @@ export default async function handler(
     const uuid = v4()
     const files: { [key: string]: string } = {}
     files[`/input/${uuid}.jpg`] = url
+    files[JUGGERNAUT_CHECKPOINT_PATH] = JUGGERNAUT_CHECKPOINT_URL
 
     // generate a random 15 digit number
     let seed = ''


### PR DESCRIPTION
The comfy.icu API workers lack the juggernautXL_v9Rdphoto2Lighting checkpoint, causing a "Value not in list" validation error. Provide the checkpoint through the files map (downloaded from the public RunDiffusion HF repo and cached by the worker) so ckpt_name resolves on API runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to the image-gen API payload with no auth or data-model impact; main operational risk is reliance on an external HF download URL for first-run checkpoint fetch.
> 
> **Overview**
> Fixes citizen image generation on **comfy.icu** when workers reject the workflow’s `ckpt_name` because the **Juggernaut XL Lightning** checkpoint isn’t installed locally.
> 
> The API route now registers that checkpoint in the existing **`files`** map (same pattern as the user photo URL), pointing workers at a **public Hugging Face** download whose on-disk path matches **`juggernautXL_v9Rdphoto2Lighting.safetensors`** in the Comfy prompt. Workers fetch and cache the weights on first run; the workflow graph itself is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45afbc8d8f9e3b2ec6174c9057dde70f672b5a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->