### PR TITLE
feat(image-gen): clearer wait UX for citizen AI image generation

### DIFF
--- a/ui/components/onboarding/CitizenImageGenerator.tsx
+++ b/ui/components/onboarding/CitizenImageGenerator.tsx
@@ -1,6 +1,8 @@
 import Image from 'next/image'
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import useImageGenerator, { GenerationPhase } from '@/lib/image-generator/useImageGenerator'
+import useImageGenerator, {
+  type GenerationPhase,
+} from '@/lib/image-generator/useImageGenerator'
 import { cropImageWithCoordinates } from '@/lib/utils/images'
 import FileInput from '../layout/FileInput'
 import IPFSRenderer from '../layout/IPFSRenderer'

--- a/ui/components/onboarding/CitizenImageGenerator.tsx
+++ b/ui/components/onboarding/CitizenImageGenerator.tsx
@@ -1,8 +1,6 @@
 import Image from 'next/image'
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import useImageGenerator, {
-  GenerationPhase,
-} from '@/lib/image-generator/useImageGenerator'
+import useImageGenerator, { GenerationPhase } from '@/lib/image-generator/useImageGenerator'
 import { cropImageWithCoordinates } from '@/lib/utils/images'
 import FileInput from '../layout/FileInput'
 import IPFSRenderer from '../layout/IPFSRenderer'
@@ -73,10 +71,7 @@ export function ImageGenerator({
     }
     const start = Date.now()
     const elapsedTimer = setInterval(() => setElapsedMs(Date.now() - start), 250)
-    const tipTimer = setInterval(
-      () => setTipIndex((i) => (i + 1) % GENERATION_TIPS.length),
-      4000
-    )
+    const tipTimer = setInterval(() => setTipIndex((i) => (i + 1) % GENERATION_TIPS.length), 4000)
     return () => {
       clearInterval(elapsedTimer)
       clearInterval(tipTimer)
@@ -88,7 +83,7 @@ export function ImageGenerator({
   const progressPct = useMemo(() => {
     if (phase === 'done') return 100
     const eased = Math.round((1 - Math.exp(-elapsedMs / 22000)) * 100)
-    if (phase === 'finishing') return Math.max(92, eased)
+    if (phase === 'finishing') return Math.min(98, Math.max(92, eased))
     return Math.min(90, Math.max(5, eased))
   }, [phase, elapsedMs])
 
@@ -122,7 +117,7 @@ export function ImageGenerator({
         inputImage,
         cropArea.x,
         cropArea.y,
-        cropArea.size
+        cropArea.size,
       )
 
       // Store the cropped image for fallback
@@ -307,7 +302,7 @@ export function ImageGenerator({
           case 'nw':
             newSize = Math.max(
               50,
-              Math.min(prev.x + prev.size - imageX, prev.y + prev.size - imageY)
+              Math.min(prev.x + prev.size - imageX, prev.y + prev.size - imageY),
             )
             newX = prev.x + prev.size - newSize
             newY = prev.y + prev.size - newSize
@@ -355,7 +350,7 @@ export function ImageGenerator({
       displayedImageSize.height,
       displayedImageSize.offsetX,
       displayedImageSize.offsetY,
-    ]
+    ],
   )
 
   const handleMouseMove = useCallback(
@@ -400,7 +395,7 @@ export function ImageGenerator({
       resizeHandle,
       isDragging,
       handleResize,
-    ]
+    ],
   )
 
   const handleMouseUp = useCallback(() => {
@@ -433,7 +428,7 @@ export function ImageGenerator({
           inputImage,
           cropArea.x,
           cropArea.y,
-          cropArea.size
+          cropArea.size,
         )
         setImage(croppedFile)
       } catch (error) {
@@ -452,7 +447,7 @@ export function ImageGenerator({
         inputImage,
         cropArea.x,
         cropArea.y,
-        cropArea.size
+        cropArea.size,
       )
 
       // Set the cropped image as the final image
@@ -493,10 +488,10 @@ export function ImageGenerator({
               {generating
                 ? 'Generating your AI photo…'
                 : inputImage && !image
-                ? 'Drag to reposition crop · Handles to resize'
-                : image
-                ? 'Your photo'
-                : 'Current image'}
+                  ? 'Drag to reposition crop · Handles to resize'
+                  : image
+                    ? 'Your photo'
+                    : 'Current image'}
             </p>
             {inputImage && (
               <button
@@ -511,7 +506,12 @@ export function ImageGenerator({
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-white/10 hover:bg-white/20 border border-white/10 rounded-lg transition-all duration-200"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
                 </svg>
                 Change Photo
               </button>
@@ -577,9 +577,7 @@ export function ImageGenerator({
                               style={{ width: `${progressPct}%` }}
                             />
                           </div>
-                          <p className="text-xs text-slate-500">
-                            Usually takes 30–60 seconds
-                          </p>
+                          <p className="text-xs text-slate-500">Usually takes 30–60 seconds</p>
                         </div>
                         <p className="min-h-[1rem] text-xs text-slate-400 transition-opacity duration-300">
                           {GENERATION_TIPS[tipIndex]}
@@ -632,19 +630,9 @@ export function ImageGenerator({
                                 className="resize-handle absolute w-3 h-3 bg-indigo-400 border-2 border-white rounded-full shadow-lg"
                                 data-handle={handle}
                                 style={{
-                                  top:
-                                    handle === 'n'
-                                      ? -6
-                                      : handle === 's'
-                                      ? undefined
-                                      : '50%',
+                                  top: handle === 'n' ? -6 : handle === 's' ? undefined : '50%',
                                   bottom: handle === 's' ? -6 : undefined,
-                                  left:
-                                    handle === 'w'
-                                      ? -6
-                                      : handle === 'e'
-                                      ? undefined
-                                      : '50%',
+                                  left: handle === 'w' ? -6 : handle === 'e' ? undefined : '50%',
                                   right: handle === 'e' ? -6 : undefined,
                                   transform:
                                     handle === 'n' || handle === 's'
@@ -671,8 +659,7 @@ export function ImageGenerator({
                             <div
                               className="absolute bg-black/60"
                               style={{
-                                left:
-                                  (cropArea.x + cropArea.size) * cropScale + cropOffsetX,
+                                left: (cropArea.x + cropArea.size) * cropScale + cropOffsetX,
                                 top: 0,
                                 width:
                                   displayedImageSize.width -
@@ -693,8 +680,7 @@ export function ImageGenerator({
                               className="absolute bg-black/60"
                               style={{
                                 left: cropArea.x * cropScale + cropOffsetX,
-                                top:
-                                  (cropArea.y + cropArea.size) * cropScale + cropOffsetY,
+                                top: (cropArea.y + cropArea.size) * cropScale + cropOffsetY,
                                 width: cropArea.size * cropScale,
                                 height:
                                   displayedImageSize.height -
@@ -716,8 +702,7 @@ export function ImageGenerator({
             <div className="px-1">
               <p className="text-sm text-red-400/80">{generateError}</p>
               <p className="text-xs text-slate-500 mt-1">
-                We&apos;ve kept your cropped photo so you can continue, or try
-                generating again.
+                We&apos;ve kept your cropped photo so you can continue, or try generating again.
               </p>
             </div>
           )}

--- a/ui/components/onboarding/CitizenImageGenerator.tsx
+++ b/ui/components/onboarding/CitizenImageGenerator.tsx
@@ -1,11 +1,38 @@
 import Image from 'next/image'
-import { useEffect, useState, useRef, useCallback } from 'react'
-import useImageGenerator from '@/lib/image-generator/useImageGenerator'
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
+import useImageGenerator, {
+  GenerationPhase,
+} from '@/lib/image-generator/useImageGenerator'
 import { cropImageWithCoordinates } from '@/lib/utils/images'
 import FileInput from '../layout/FileInput'
 import IPFSRenderer from '../layout/IPFSRenderer'
 
 type ResizeHandle = 'nw' | 'ne' | 'sw' | 'se' | 'n' | 's' | 'e' | 'w' | null
+
+const PHASE_LABELS: Record<GenerationPhase, string> = {
+  idle: 'Preparing…',
+  uploading: 'Uploading your photo…',
+  queued: 'Waiting in line…',
+  generating: 'Generating your portrait…',
+  finishing: 'Finishing up…',
+  done: 'Done!',
+  error: 'Something went wrong…',
+}
+
+// Rotating messages shown during the wait to keep things feeling alive.
+const GENERATION_TIPS = [
+  'Crafting your MoonDAO astronaut portrait…',
+  'Tip: a clear, front-facing photo gives the best results.',
+  'Adding some cosmic flair to your image…',
+  'Hang tight — great art takes a few seconds.',
+]
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
 
 export function ImageGenerator({
   currImage,
@@ -31,7 +58,41 @@ export function ImageGenerator({
     generateImage,
     isLoading: generating,
     error: generateError,
+    phase,
   } = useImageGenerator('/api/image-gen/citizen-image', inputImage, setImage)
+
+  // Progress UX while the (cold-start heavy) generation runs.
+  const [elapsedMs, setElapsedMs] = useState(0)
+  const [tipIndex, setTipIndex] = useState(0)
+
+  useEffect(() => {
+    if (!generating) {
+      setElapsedMs(0)
+      setTipIndex(0)
+      return
+    }
+    const start = Date.now()
+    const elapsedTimer = setInterval(() => setElapsedMs(Date.now() - start), 250)
+    const tipTimer = setInterval(
+      () => setTipIndex((i) => (i + 1) % GENERATION_TIPS.length),
+      4000
+    )
+    return () => {
+      clearInterval(elapsedTimer)
+      clearInterval(tipTimer)
+    }
+  }, [generating])
+
+  // Eased progress bar: approaches ~90% over ~45s, with phase-based floors so it
+  // never looks stuck and snaps forward when we hit the final stages.
+  const progressPct = useMemo(() => {
+    if (phase === 'done') return 100
+    const eased = Math.round((1 - Math.exp(-elapsedMs / 22000)) * 100)
+    if (phase === 'finishing') return Math.max(92, eased)
+    return Math.min(90, Math.max(5, eased))
+  }, [phase, elapsedMs])
+
+  const phaseLabel = PHASE_LABELS[phase] ?? 'Creating your AI image…'
 
   // Store original image when first uploaded
   useEffect(() => {
@@ -481,21 +542,49 @@ export function ImageGenerator({
                   {image && !generating && generatedImageUrl ? (
                     <img
                       src={generatedImageUrl}
-                      className="absolute inset-0 w-full h-full object-contain"
+                      className="animate-fadeIn absolute inset-0 w-full h-full object-contain"
                       alt="Generated photo"
                     />
                   ) : generating ? (
-                    <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-slate-900/80">
-                      <Image
-                        src="/assets/MoonDAO-Loading-Animation.svg"
-                        width={96}
-                        height={96}
-                        className="animate-pulse"
-                        alt="Generating"
-                      />
-                      <p className="text-sm text-slate-400 animate-pulse">
-                        Creating your AI image…
-                      </p>
+                    <div className="absolute inset-0">
+                      {/* Show the user's photo underneath so the frame never looks empty */}
+                      {inputImageUrl && (
+                        <img
+                          src={inputImageUrl}
+                          className="absolute inset-0 w-full h-full object-contain opacity-30 blur-[2px]"
+                          alt=""
+                          aria-hidden="true"
+                        />
+                      )}
+                      <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-slate-900/70 px-6 text-center">
+                        <Image
+                          src="/assets/MoonDAO-Loading-Animation.svg"
+                          width={72}
+                          height={72}
+                          className="animate-pulse"
+                          alt="Generating"
+                        />
+                        <div className="flex w-full max-w-[260px] flex-col gap-2">
+                          <div className="flex items-center justify-between text-xs text-slate-300">
+                            <span>{phaseLabel}</span>
+                            <span className="tabular-nums text-slate-400">
+                              {formatElapsed(elapsedMs)}
+                            </span>
+                          </div>
+                          <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+                            <div
+                              className="h-full rounded-full bg-indigo-400 transition-all duration-700 ease-out"
+                              style={{ width: `${progressPct}%` }}
+                            />
+                          </div>
+                          <p className="text-xs text-slate-500">
+                            Usually takes 30–60 seconds
+                          </p>
+                        </div>
+                        <p className="min-h-[1rem] text-xs text-slate-400 transition-opacity duration-300">
+                          {GENERATION_TIPS[tipIndex]}
+                        </p>
+                      </div>
                     </div>
                   ) : inputImageUrl ? (
                     <>
@@ -624,34 +713,45 @@ export function ImageGenerator({
 
           {/* Error message */}
           {showError && generateError && (
-            <p className="text-sm text-red-400/80 px-1">{generateError}</p>
+            <div className="px-1">
+              <p className="text-sm text-red-400/80">{generateError}</p>
+              <p className="text-xs text-slate-500 mt-1">
+                We&apos;ve kept your cropped photo so you can continue, or try
+                generating again.
+              </p>
+            </div>
           )}
         </div>
       )}
 
       {/* Action buttons */}
       {inputImage && !image && !generating && (
-        <div className="flex flex-col sm:flex-row gap-3">
-          <button
-            className="flex-1 py-3 px-6 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2"
-            onClick={handleGenerateImage}
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-              />
-            </svg>
-            Generate AI Photo
-          </button>
-          <button
-            className="flex-1 py-3 px-6 bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.1] hover:border-white/[0.2] transition-all duration-200 rounded-2xl font-semibold text-white text-sm"
-            onClick={handleUseCroppedImage}
-          >
-            Use Cropped Image
-          </button>
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col sm:flex-row gap-3">
+            <button
+              className="flex-1 py-3 px-6 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2"
+              onClick={handleGenerateImage}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+                />
+              </svg>
+              Generate AI Photo
+            </button>
+            <button
+              className="flex-1 py-3 px-6 bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.1] hover:border-white/[0.2] transition-all duration-200 rounded-2xl font-semibold text-white text-sm"
+              onClick={handleUseCroppedImage}
+            >
+              Use Cropped Image
+            </button>
+          </div>
+          <p className="text-xs text-slate-500 px-1 text-center sm:text-left">
+            AI generation usually takes 30–60 seconds.
+          </p>
         </div>
       )}
 

--- a/ui/lib/image-generator/useImageGenerator.tsx
+++ b/ui/lib/image-generator/useImageGenerator.tsx
@@ -8,12 +8,26 @@ import { compressImageForUpload, fitImage } from '../utils/images'
 // would otherwise have completed successfully.
 const CREATE_JOB_TIMEOUT_MS = 45_000 // POST /api/image-gen/<route>
 const CREATE_JOB_MAX_RETRIES = 2 // 1 initial attempt + this many retries
-const POLL_INTERVAL_MS = 5_000
-const POLL_MAX_ATTEMPTS = 90 // ≈ 7.5 minutes
+// A shorter poll interval makes the UI notice completion sooner (the generation
+// itself is the slow part, not our polling). Attempts are bumped to keep the
+// overall ceiling at ~7.5 minutes.
+const POLL_INTERVAL_MS = 3_000
+const POLL_MAX_ATTEMPTS = 150 // ≈ 7.5 minutes
 const POLL_TRANSIENT_ERROR_LIMIT = 6 // consecutive failed polls before giving up
 const GET_IMAGE_MAX_RETRIES = 3
 
 const PENDING_STATUSES = new Set(['QUEUED', 'STARTED', 'INIT', 'PENDING'])
+
+// Coarse, user-facing phases of the generation pipeline so the UI can show
+// meaningful progress and set expectations during the (cold-start heavy) wait.
+export type GenerationPhase =
+  | 'idle'
+  | 'uploading'
+  | 'queued'
+  | 'generating'
+  | 'finishing'
+  | 'done'
+  | 'error'
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -40,6 +54,7 @@ export default function useImageGenerator(
 ) {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string>()
+  const [phase, setPhase] = useState<GenerationPhase>('idle')
 
   // Upload image to Google Cloud Storage. Retries on transient errors
   // (network blips / 5xx) but bails immediately on auth/validation failures.
@@ -202,6 +217,7 @@ export default function useImageGenerator(
 
     setError(undefined)
     setIsLoading(true)
+    setPhase('uploading')
     let uploadedFilename: string | null = null
 
     try {
@@ -209,10 +225,12 @@ export default function useImageGenerator(
       const { url, filename } = await uploadToGoogleStorage(sourceImage)
       uploadedFilename = filename
 
+      setPhase('queued')
       const jobId = await createJob(url)
       await checkJobStatus(jobId, uploadedFilename, sourceImage)
     } catch (err: any) {
       console.error('Image generation failed:', err)
+      setPhase('error')
 
       // Clean up uploaded file on error
       if (uploadedFilename) {
@@ -288,6 +306,7 @@ export default function useImageGenerator(
         }
 
         if (PENDING_STATUSES.has(job.status)) {
+          setPhase(job.status === 'STARTED' ? 'generating' : 'queued')
           await sleep(POLL_INTERVAL_MS)
           continue
         }
@@ -306,6 +325,7 @@ export default function useImageGenerator(
           throw new Error('Job completed without an output image')
         }
 
+        setPhase('finishing')
         let lastErr: any
         for (let attempt = 0; attempt < GET_IMAGE_MAX_RETRIES; attempt++) {
           try {
@@ -325,6 +345,7 @@ export default function useImageGenerator(
             const fileName = `image_${jobId}.png`
             const file = new File([blob], fileName, { type: blob.type })
             setImage(file)
+            setPhase('done')
             return
           } catch (err) {
             lastErr = err
@@ -346,10 +367,12 @@ export default function useImageGenerator(
         )
       }
 
+      setPhase('error')
       const fittedImage = await fitImage(sourceImage, 1024, 1024)
       setImage(fittedImage)
     } catch (err: any) {
       console.error('Image generation polling failed:', err)
+      setPhase('error')
       setError('Unable to generate an image, please try again later.')
       try {
         const fittedImage = await fitImage(sourceImage, 1024, 1024)
@@ -363,5 +386,5 @@ export default function useImageGenerator(
     }
   }
 
-  return { generateImage, isLoading, error }
+  return { generateImage, isLoading, error, phase }
 }

--- a/ui/lib/image-generator/useImageGenerator.tsx
+++ b/ui/lib/image-generator/useImageGenerator.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { compressImageForUpload, fitImage } from '../utils/images'
 
 // Tunables for the comfy.icu polling pipeline. These default to fairly generous
@@ -52,9 +52,36 @@ export default function useImageGenerator(
   inputImage: File | undefined,
   setImage: Function
 ) {
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string>()
-  const [phase, setPhase] = useState<GenerationPhase>('idle')
+  const [isLoading, _setIsLoading] = useState(false)
+  const [error, _setError] = useState<string>()
+  const [phase, _setPhase] = useState<GenerationPhase>('idle')
+
+  // The onboarding "generate in background" flow can advance (and unmount this
+  // hook's owner) while a job is still uploading/polling. Guard our internal
+  // state setters so they no-op after unmount, while leaving `setImage` (the
+  // parent-provided callback) free to deliver the result.
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  const setIsLoading = (value: boolean) => {
+    if (isMountedRef.current) _setIsLoading(value)
+  }
+  const setError = (value?: string) => {
+    if (isMountedRef.current) _setError(value)
+  }
+  // Only re-render when the phase actually changes. Polling calls this on every
+  // tick (often with the same value), and the functional updater lets React
+  // bail out of a render when the value is unchanged.
+  const setPhase = (value: GenerationPhase) => {
+    if (isMountedRef.current) {
+      _setPhase((prev) => (prev === value ? prev : value))
+    }
+  }
 
   // Upload image to Google Cloud Storage. Retries on transient errors
   // (network blips / 5xx) but bails immediately on auth/validation failures.


### PR DESCRIPTION
## Summary
Improves the UX of the citizen AI image generation so the (cold-start heavy) 30–60s wait feels intentional instead of clunky, and sets clear expectations. Applies to **both** the onboarding flow and the **edit/regenerate** flow, since `CitizenMetadataModal` reuses the same `ImageGenerator` component.

### Hook (`useImageGenerator`)
- Exposes a coarse `phase` of the pipeline: `uploading → queued → generating → finishing → done` (and `error`), mapped from the upload step and comfy.icu job statuses.
- Tightens the poll interval `5s → 3s` (with attempts bumped to keep the ~7.5 min ceiling) so completion is detected sooner.

### Component (`CitizenImageGenerator` / `ImageGenerator`)
- Staged status label tied to `phase`, an elapsed timer, and an eased progress bar that approaches ~90% over ~45s with phase-based floors (never looks stuck, snaps forward at the end).
- "Usually takes 30–60 seconds" expectation note near the Generate button and in the loading state.
- Shows the user's photo (dimmed/blurred) under the loading overlay and cross-fades in the result, so the frame is never empty.
- Rotating encouragement messages during the wait.
- Reassuring error copy clarifying that the cropped photo is kept as a fallback.

Team generation is unaffected (`TeamImageGenerator` does not use AI generation).

## Notes
- Biggest *latency* win (warm comfyICU worker to remove the cold start) is a backend/provider config change and is intentionally out of scope here; this PR focuses on perceived performance + expectations.

## Test plan
- [ ] Onboarding: upload a photo, crop, Generate — confirm staged status, timer, progress bar, tips, and cross-fade to result.
- [ ] Edit flow (`CitizenMetadataModal`): regenerate a profile picture and confirm the same UX appears.
- [ ] Trigger a failure (e.g. bad input) and confirm the reassuring fallback message and that the cropped photo is retained.
- [ ] Confirm no regression for the "Continue while generating in background" path and the team image flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only UX and polling tweaks on the existing image-gen hook; no auth, payment, or API contract changes.
> 
> **Overview**
> Improves **perceived** wait during citizen AI portrait generation (onboarding and edit flows that share `ImageGenerator`) without changing the generation API itself.
> 
> **`useImageGenerator`** now exposes a **`phase`** (`uploading` → `queued` → `generating` → `finishing` → `done` / `error`) derived from upload and comfy.icu job status, polls every **3s** (was 5s) with more attempts to keep the same ~7.5 min cap, and guards internal React state after unmount so background generation can still call the parent **`setImage`**.
> 
> **`CitizenImageGenerator`** uses that phase for staged labels, an elapsed timer, an eased progress bar, rotating tips, and “usually 30–60 seconds” copy; the loading overlay shows a dimmed preview of the user’s photo and the result **fade-in**s; errors add copy that the **cropped photo is kept** as a fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4885706aecda879de34e6481f77bb3300f4cc700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->