### PR TITLE
Streamline citizen image flow to default to AI generation

### DIFF
--- a/ui/components/onboarding/CitizenImageGenerator.tsx
+++ b/ui/components/onboarding/CitizenImageGenerator.tsx
@@ -1,8 +1,6 @@
 import Image from 'next/image'
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import useImageGenerator, {
-  GenerationPhase,
-} from '@/lib/image-generator/useImageGenerator'
+import useImageGenerator, { GenerationPhase } from '@/lib/image-generator/useImageGenerator'
 import { cropImageWithCoordinates } from '@/lib/utils/images'
 import FileInput from '../layout/FileInput'
 import IPFSRenderer from '../layout/IPFSRenderer'
@@ -78,10 +76,7 @@ export function ImageGenerator({
     }
     const start = Date.now()
     const elapsedTimer = setInterval(() => setElapsedMs(Date.now() - start), 250)
-    const tipTimer = setInterval(
-      () => setTipIndex((i) => (i + 1) % GENERATION_TIPS.length),
-      4000
-    )
+    const tipTimer = setInterval(() => setTipIndex((i) => (i + 1) % GENERATION_TIPS.length), 4000)
     return () => {
       clearInterval(elapsedTimer)
       clearInterval(tipTimer)
@@ -127,7 +122,7 @@ export function ImageGenerator({
         inputImage,
         cropArea.x,
         cropArea.y,
-        cropArea.size
+        cropArea.size,
       )
 
       // Store the cropped image for fallback / "Use my photo" and lift to parent
@@ -169,34 +164,46 @@ export function ImageGenerator({
   // Regenerate using the existing crop (no re-upload / re-crop needed).
   const handleRegenerate = useCallback(async () => {
     setIsGenerating(true)
+    if (onGenerationStateChange) {
+      onGenerationStateChange(true)
+    }
     setImage(null)
     setHasGeneratedImage(false)
     setShowError(false)
-    let cropped = croppedImage
-    if (!cropped && inputImage) {
-      cropped = await cropImageWithCoordinates(
-        inputImage,
-        cropArea.x,
-        cropArea.y,
-        cropArea.size
-      )
-      setCroppedImage(cropped)
-      onCrop?.(cropped)
+
+    try {
+      let cropped = croppedImage
+      if (!cropped && inputImage) {
+        cropped = await cropImageWithCoordinates(inputImage, cropArea.x, cropArea.y, cropArea.size)
+        setCroppedImage(cropped)
+        onCrop?.(cropped)
+      }
+      await generateImage(cropped || undefined)
+    } catch (error) {
+      console.error('Error cropping or generating image:', error)
+      setIsGenerating(false)
+      if (onGenerationStateChange) {
+        onGenerationStateChange(false)
+      }
     }
-    await generateImage(cropped || undefined)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [croppedImage, inputImage, cropArea.x, cropArea.y, cropArea.size, generateImage, onCrop, setImage])
+  }, [
+    croppedImage,
+    inputImage,
+    cropArea.x,
+    cropArea.y,
+    cropArea.size,
+    generateImage,
+    onCrop,
+    onGenerationStateChange,
+    setImage,
+  ])
 
   // Use the user's own (cropped) photo instead of the AI version.
   const handleUseMyPhoto = useCallback(async () => {
     let cropped = croppedImage
     if (!cropped && inputImage) {
-      cropped = await cropImageWithCoordinates(
-        inputImage,
-        cropArea.x,
-        cropArea.y,
-        cropArea.size
-      )
+      cropped = await cropImageWithCoordinates(inputImage, cropArea.x, cropArea.y, cropArea.size)
     }
     if (cropped) {
       setCroppedImage(cropped)
@@ -371,7 +378,7 @@ export function ImageGenerator({
           case 'nw':
             newSize = Math.max(
               50,
-              Math.min(prev.x + prev.size - imageX, prev.y + prev.size - imageY)
+              Math.min(prev.x + prev.size - imageX, prev.y + prev.size - imageY),
             )
             newX = prev.x + prev.size - newSize
             newY = prev.y + prev.size - newSize
@@ -419,7 +426,7 @@ export function ImageGenerator({
       displayedImageSize.height,
       displayedImageSize.offsetX,
       displayedImageSize.offsetY,
-    ]
+    ],
   )
 
   const handleMouseMove = useCallback(
@@ -464,7 +471,7 @@ export function ImageGenerator({
       resizeHandle,
       isDragging,
       handleResize,
-    ]
+    ],
   )
 
   const handleMouseUp = useCallback(() => {
@@ -497,7 +504,7 @@ export function ImageGenerator({
           inputImage,
           cropArea.x,
           cropArea.y,
-          cropArea.size
+          cropArea.size,
         )
         setImage(croppedFile)
       } catch (error) {
@@ -516,19 +523,20 @@ export function ImageGenerator({
         inputImage,
         cropArea.x,
         cropArea.y,
-        cropArea.size
+        cropArea.size,
       )
 
       // Set the cropped image as the final image
       setImage(croppedFile)
       setCroppedImage(croppedFile)
+      onCrop?.(croppedFile)
       setIsReCropping(false)
 
       nextStage?.()
     } catch (error) {
       console.error('Error cropping image:', error)
     }
-  }, [inputImage, cropArea.x, cropArea.y, cropArea.size, setImage, nextStage])
+  }, [inputImage, cropArea.x, cropArea.y, cropArea.size, setImage, onCrop, nextStage])
 
   // Calculate the scale and position for the crop overlay
   const cropScale = displayedImageSize.width / imageSize.width
@@ -557,10 +565,10 @@ export function ImageGenerator({
               {generating
                 ? 'Generating your AI photo…'
                 : inputImage && !image
-                ? 'Drag to reposition crop · Handles to resize'
-                : image
-                ? 'Your photo'
-                : 'Current image'}
+                  ? 'Drag to reposition crop · Handles to resize'
+                  : image
+                    ? 'Your photo'
+                    : 'Current image'}
             </p>
             {inputImage && (
               <button
@@ -575,7 +583,12 @@ export function ImageGenerator({
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-white/10 hover:bg-white/20 border border-white/10 rounded-lg transition-all duration-200"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
                 </svg>
                 Change Photo
               </button>
@@ -641,9 +654,7 @@ export function ImageGenerator({
                               style={{ width: `${progressPct}%` }}
                             />
                           </div>
-                          <p className="text-xs text-slate-500">
-                            Usually takes 30–60 seconds
-                          </p>
+                          <p className="text-xs text-slate-500">Usually takes 30–60 seconds</p>
                         </div>
                         <p className="min-h-[1rem] text-xs text-slate-400 transition-opacity duration-300">
                           {GENERATION_TIPS[tipIndex]}
@@ -696,19 +707,9 @@ export function ImageGenerator({
                                 className="resize-handle absolute w-3 h-3 bg-indigo-400 border-2 border-white rounded-full shadow-lg"
                                 data-handle={handle}
                                 style={{
-                                  top:
-                                    handle === 'n'
-                                      ? -6
-                                      : handle === 's'
-                                      ? undefined
-                                      : '50%',
+                                  top: handle === 'n' ? -6 : handle === 's' ? undefined : '50%',
                                   bottom: handle === 's' ? -6 : undefined,
-                                  left:
-                                    handle === 'w'
-                                      ? -6
-                                      : handle === 'e'
-                                      ? undefined
-                                      : '50%',
+                                  left: handle === 'w' ? -6 : handle === 'e' ? undefined : '50%',
                                   right: handle === 'e' ? -6 : undefined,
                                   transform:
                                     handle === 'n' || handle === 's'
@@ -735,8 +736,7 @@ export function ImageGenerator({
                             <div
                               className="absolute bg-black/60"
                               style={{
-                                left:
-                                  (cropArea.x + cropArea.size) * cropScale + cropOffsetX,
+                                left: (cropArea.x + cropArea.size) * cropScale + cropOffsetX,
                                 top: 0,
                                 width:
                                   displayedImageSize.width -
@@ -757,8 +757,7 @@ export function ImageGenerator({
                               className="absolute bg-black/60"
                               style={{
                                 left: cropArea.x * cropScale + cropOffsetX,
-                                top:
-                                  (cropArea.y + cropArea.size) * cropScale + cropOffsetY,
+                                top: (cropArea.y + cropArea.size) * cropScale + cropOffsetY,
                                 width: cropArea.size * cropScale,
                                 height:
                                   displayedImageSize.height -
@@ -780,8 +779,7 @@ export function ImageGenerator({
             <div className="px-1">
               <p className="text-sm text-red-400/80">{generateError}</p>
               <p className="text-xs text-slate-500 mt-1">
-                We&apos;ve kept your cropped photo so you can continue, or try
-                generating again.
+                We&apos;ve kept your cropped photo so you can continue, or try generating again.
               </p>
             </div>
           )}
@@ -839,12 +837,7 @@ export function ImageGenerator({
                   className="flex-1 py-3 px-6 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2"
                   onClick={handleRegenerate}
                 >
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"

--- a/ui/components/onboarding/CitizenImageGenerator.tsx
+++ b/ui/components/onboarding/CitizenImageGenerator.tsx
@@ -817,10 +817,10 @@ export function ImageGenerator({
             Generate AI Photo
           </button>
           <p className="text-xs text-slate-500 px-1 text-center">
-            Position the crop on the face, then generate.{' '}
+            Crop to just your head and shoulders, keeping your whole face inside the box.{' '}
             {isBackgroundFlow
-              ? 'Takes ~30–60s — you can keep going while it renders.'
-              : 'Usually takes 30–60 seconds.'}
+              ? 'Generation takes ~30–60s — you can keep going while it renders.'
+              : 'Generation usually takes 30–60 seconds.'}
           </p>
           <button
             className="text-xs text-slate-500 hover:text-slate-300 transition-colors underline underline-offset-2 mx-auto"

--- a/ui/components/onboarding/CitizenImageGenerator.tsx
+++ b/ui/components/onboarding/CitizenImageGenerator.tsx
@@ -43,7 +43,12 @@ export function ImageGenerator({
   nextStage,
   generateInBG,
   onGenerationStateChange, // Add this prop
+  onCrop, // Lifts the cropped upload to the parent (used for "Use my photo")
 }: any) {
+  // In the onboarding flow we generate in the background and advance to the next
+  // step immediately; the AI image (and Regenerate / Use-my-photo choices) then
+  // live on the Review step. Standalone usages (e.g. the edit modal) stay put.
+  const isBackgroundFlow = !!(generateInBG && nextStage)
   const [originalInputImage, setOriginalInputImage] = useState<File | null>(null)
   const [isGenerating, setIsGenerating] = useState(false)
   const [croppedImage, setCroppedImage] = useState<File | null>(null)
@@ -125,14 +130,21 @@ export function ImageGenerator({
         cropArea.size
       )
 
-      // Store the cropped image for fallback
+      // Store the cropped image for fallback / "Use my photo" and lift to parent
       setCroppedImage(croppedFile)
+      onCrop?.(croppedFile)
 
       setImage(null) // Clear any existing generated image
       setShowError(false)
 
-      // Generate the AI image using the cropped version (pass directly to avoid mutating inputImage)
-      await generateImage(croppedFile)
+      // Kick off generation. In the background flow we don't await it — we
+      // advance to the next step and let it finish off-screen.
+      const generationPromise = generateImage(croppedFile)
+      if (isBackgroundFlow) {
+        nextStage?.()
+      } else {
+        await generationPromise
+      }
     } catch (error) {
       console.error('Error cropping or generating image:', error)
       setIsGenerating(false)
@@ -149,6 +161,58 @@ export function ImageGenerator({
     setImage,
     generateImage,
     onGenerationStateChange,
+    onCrop,
+    isBackgroundFlow,
+    nextStage,
+  ])
+
+  // Regenerate using the existing crop (no re-upload / re-crop needed).
+  const handleRegenerate = useCallback(async () => {
+    setIsGenerating(true)
+    setImage(null)
+    setHasGeneratedImage(false)
+    setShowError(false)
+    let cropped = croppedImage
+    if (!cropped && inputImage) {
+      cropped = await cropImageWithCoordinates(
+        inputImage,
+        cropArea.x,
+        cropArea.y,
+        cropArea.size
+      )
+      setCroppedImage(cropped)
+      onCrop?.(cropped)
+    }
+    await generateImage(cropped || undefined)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [croppedImage, inputImage, cropArea.x, cropArea.y, cropArea.size, generateImage, onCrop, setImage])
+
+  // Use the user's own (cropped) photo instead of the AI version.
+  const handleUseMyPhoto = useCallback(async () => {
+    let cropped = croppedImage
+    if (!cropped && inputImage) {
+      cropped = await cropImageWithCoordinates(
+        inputImage,
+        cropArea.x,
+        cropArea.y,
+        cropArea.size
+      )
+    }
+    if (cropped) {
+      setCroppedImage(cropped)
+      setImage(cropped)
+      setHasGeneratedImage(false)
+      if (isBackgroundFlow) nextStage?.()
+    }
+  }, [
+    croppedImage,
+    inputImage,
+    cropArea.x,
+    cropArea.y,
+    cropArea.size,
+    setImage,
+    isBackgroundFlow,
+    nextStage,
   ])
 
   // When generation completes (success or failure), update image and reset local generating
@@ -724,88 +788,86 @@ export function ImageGenerator({
         </div>
       )}
 
-      {/* Action buttons */}
+      {/* Primary action: position the crop, then generate (defaults to AI) */}
       {inputImage && !image && !generating && (
         <div className="flex flex-col gap-2">
-          <div className="flex flex-col sm:flex-row gap-3">
-            <button
-              className="flex-1 py-3 px-6 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2"
-              onClick={handleGenerateImage}
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-                />
-              </svg>
-              Generate AI Photo
-            </button>
-            <button
-              className="flex-1 py-3 px-6 bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.1] hover:border-white/[0.2] transition-all duration-200 rounded-2xl font-semibold text-white text-sm"
-              onClick={handleUseCroppedImage}
-            >
-              Use Cropped Image
-            </button>
-          </div>
-          <p className="text-xs text-slate-500 px-1 text-center sm:text-left">
-            AI generation usually takes 30–60 seconds.
-          </p>
-        </div>
-      )}
-
-      {inputImage && (image || generating) && (
-        <div className="flex flex-col sm:flex-row gap-3">
-          {!generating && (
-            <button
-              className="py-3 px-6 bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.1] hover:border-white/[0.2] transition-all duration-200 rounded-2xl font-medium text-white text-sm"
-              onClick={() => {
-                if (originalInputImage) {
-                  setIsReCropping(true)
-                  setInputImage(originalInputImage)
-                  setCroppedImage(null)
-                  setImage(null)
-                  setHasGeneratedImage(false)
-                  setShowError(false)
-                  const minDimension = Math.min(imageSize.width, imageSize.height)
-                  setCropArea({
-                    x: (imageSize.width - minDimension) / 2,
-                    y: (imageSize.height - minDimension) / 2,
-                    size: minDimension,
-                  })
-                }
-              }}
-            >
-              Re-crop
-            </button>
-          )}
           <button
-            className="flex-1 py-3 px-6 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2"
-            onClick={() => {
-              setIsGenerating(true)
-              setImage(null)
-              setHasGeneratedImage(false)
-              setShowError(false)
-              generateImage(croppedImage || undefined)
-            }}
+            className="w-full py-3 px-6 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2"
+            onClick={handleGenerateImage}
           >
-            {generating ? (
-              <>
-                <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                Generating…
-              </>
-            ) : hasGeneratedImage ? (
-              'Regenerate'
-            ) : (
-              'Generate AI Photo'
-            )}
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+              />
+            </svg>
+            Generate AI Photo
+          </button>
+          <p className="text-xs text-slate-500 px-1 text-center">
+            Position the crop on the face, then generate.{' '}
+            {isBackgroundFlow
+              ? 'Takes ~30–60s — you can keep going while it renders.'
+              : 'Usually takes 30–60 seconds.'}
+          </p>
+          <button
+            className="text-xs text-slate-500 hover:text-slate-300 transition-colors underline underline-offset-2 mx-auto"
+            onClick={handleUseCroppedImage}
+          >
+            Skip AI and use my photo
           </button>
         </div>
       )}
 
-      {/* Next / Continue — hidden when nextStage is not provided */}
-      {nextStage && ((currImage && !inputImage) || image || (generateInBG && inputImage)) && (
+      {/* Post-generation choices (in-component for standalone / edit usage; the
+          onboarding flow surfaces the same choices on the Review step). */}
+      {inputImage && (image || generating) && (
+        <div className="flex flex-col gap-3">
+          {generating ? (
+            <button
+              disabled
+              className="w-full py-3 px-6 gradient-2 opacity-70 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2 cursor-not-allowed"
+            >
+              <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              Generating…
+            </button>
+          ) : (
+            <>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <button
+                  className="flex-1 py-3 px-6 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2"
+                  onClick={handleRegenerate}
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                    />
+                  </svg>
+                  Regenerate
+                </button>
+                <button
+                  className="flex-1 py-3 px-6 bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.1] hover:border-white/[0.2] transition-all duration-200 rounded-2xl font-semibold text-white text-sm"
+                  onClick={handleUseMyPhoto}
+                >
+                  Use my photo instead
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Next / Continue — only once an image exists (generation auto-advances) */}
+      {nextStage && !generating && ((currImage && !inputImage) || image) && (
         <button
           className="w-full py-3 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white flex items-center justify-center gap-2"
           onClick={submitImage}

--- a/ui/components/onboarding/CitizenImageGenerator.tsx
+++ b/ui/components/onboarding/CitizenImageGenerator.tsx
@@ -168,7 +168,6 @@ export function ImageGenerator({
       onGenerationStateChange(true)
     }
     setImage(null)
-    setHasGeneratedImage(false)
     setShowError(false)
 
     try {
@@ -208,7 +207,7 @@ export function ImageGenerator({
     if (cropped) {
       setCroppedImage(cropped)
       setImage(cropped)
-      setHasGeneratedImage(false)
+      onCrop?.(cropped)
       if (isBackgroundFlow) nextStage?.()
     }
   }, [
@@ -218,6 +217,7 @@ export function ImageGenerator({
     cropArea.y,
     cropArea.size,
     setImage,
+    onCrop,
     isBackgroundFlow,
     nextStage,
   ])
@@ -227,15 +227,10 @@ export function ImageGenerator({
     if (!generating) {
       if (generateError && croppedImage) {
         setImage(croppedImage)
-      } else if (!generateError && image) {
-        // AI generation succeeded — mark it
-        setHasGeneratedImage(true)
       }
       setIsGenerating(false)
     }
   }, [generating, generateError, croppedImage, setImage, image])
-
-  const [hasGeneratedImage, setHasGeneratedImage] = useState(false)
   const [showError, setShowError] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
   const [isResizing, setIsResizing] = useState(false)
@@ -589,7 +584,6 @@ export function ImageGenerator({
                   setInputImage(undefined)
                   setImage(null)
                   setCroppedImage(null)
-                  setHasGeneratedImage(false)
                   setIsReCropping(false)
                   setShowError(false)
                 }}

--- a/ui/components/onboarding/CitizenImageGenerator.tsx
+++ b/ui/components/onboarding/CitizenImageGenerator.tsx
@@ -96,6 +96,10 @@ export function ImageGenerator({
 
   const phaseLabel = PHASE_LABELS[phase] ?? 'Creating your AI image…'
 
+  // The working image is an AI result only when it differs from the user's own
+  // cropped upload (which is what "Use my photo" / the error fallback set).
+  const hasGeneratedImage = !!image && image !== croppedImage
+
   // Store original image when first uploaded
   useEffect(() => {
     if (inputImage) {
@@ -202,15 +206,19 @@ export function ImageGenerator({
 
   // Use the user's own (cropped) photo instead of the AI version.
   const handleUseMyPhoto = useCallback(async () => {
-    let cropped = croppedImage
-    if (!cropped && inputImage) {
-      cropped = await cropImageWithCoordinates(inputImage, cropArea.x, cropArea.y, cropArea.size)
-    }
-    if (cropped) {
-      setCroppedImage(cropped)
-      setImage(cropped)
-      onCrop?.(cropped)
-      if (isBackgroundFlow) nextStage?.()
+    try {
+      let cropped = croppedImage
+      if (!cropped && inputImage) {
+        cropped = await cropImageWithCoordinates(inputImage, cropArea.x, cropArea.y, cropArea.size)
+      }
+      if (cropped) {
+        setCroppedImage(cropped)
+        setImage(cropped)
+        onCrop?.(cropped)
+        if (isBackgroundFlow) nextStage?.()
+      }
+    } catch (error) {
+      console.error('Error cropping image:', error)
     }
   }, [
     croppedImage,
@@ -799,8 +807,9 @@ export function ImageGenerator({
       {inputImage && !image && !generating && (
         <div className="flex flex-col gap-2">
           <button
-            className="w-full py-3 px-6 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2"
+            className="w-full py-3 px-6 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed disabled:hover:scale-100"
             onClick={handleGenerateImage}
+            disabled={isGenerating || generating}
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
@@ -819,8 +828,9 @@ export function ImageGenerator({
               : 'Generation usually takes 30–60 seconds.'}
           </p>
           <button
-            className="text-xs text-slate-500 hover:text-slate-300 transition-colors underline underline-offset-2 mx-auto"
+            className="text-xs text-slate-500 hover:text-slate-300 transition-colors underline underline-offset-2 mx-auto disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={handleUseCroppedImage}
+            disabled={isGenerating || generating}
           >
             Skip AI and use my photo
           </button>
@@ -854,7 +864,7 @@ export function ImageGenerator({
                       d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
                     />
                   </svg>
-                  Regenerate
+                  {hasGeneratedImage ? 'Regenerate' : 'Generate AI Photo'}
                 </button>
                 <button
                   className="flex-1 py-3 px-6 bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.1] hover:border-white/[0.2] transition-all duration-200 rounded-2xl font-semibold text-white text-sm"

--- a/ui/components/onboarding/CitizenImageGenerator.tsx
+++ b/ui/components/onboarding/CitizenImageGenerator.tsx
@@ -547,13 +547,26 @@ export function ImageGenerator({
     <div className="animate-fadeIn flex flex-col gap-6" key={forceRerender}>
       {/* Upload zone — only show when no image yet, or allow re-upload */}
       {!inputImage && (
-        <FileInput
-          file={inputImage}
-          setFile={setInputImage}
-          noBlankImages
-          accept="image/png, image/jpeg, image/webp, image/gif, image/svg"
-          acceptText="PNG, JPEG, WEBP, GIF, SVG — must contain a face"
-        />
+        <>
+          <FileInput
+            file={inputImage}
+            setFile={setInputImage}
+            noBlankImages
+            accept="image/png, image/jpeg, image/webp, image/gif, image/svg"
+            acceptText="PNG, JPEG, WEBP, GIF, SVG — must contain a face"
+          />
+          <div className="rounded-xl border border-white/[0.06] bg-white/[0.03] px-4 py-3">
+            <p className="text-xs font-semibold text-slate-300 mb-1.5">
+              For the best result:
+            </p>
+            <ul className="text-xs text-slate-400 space-y-1 list-disc list-inside">
+              <li>Use a photo cropped to just your head and shoulders.</li>
+              <li>Make sure your face is fully visible.</li>
+              <li>Pick a clear, well-lit, front-facing photo.</li>
+              <li>Avoid hats, sunglasses, or anything covering your face.</li>
+            </ul>
+          </div>
+        </>
       )}
 
       {/* Image preview / crop area */}

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -109,6 +109,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
     citizenData: CitizenData
     citizenImage: SerializedFile | null
     inputImage: SerializedFile | null
+    croppedInputImage: SerializedFile | null
     agreedToCondition: boolean
     selectedChainSlug: string
   }>('CreateCitizenCacheV1', address)
@@ -229,15 +230,27 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
   const serializeCacheData = useCallback(async () => {
     const serializedCitizenImage = citizenImage ? await fileToBase64(citizenImage) : null
     const serializedInputImage = inputImage ? await fileToBase64(inputImage) : null
+    const serializedCroppedInputImage = croppedInputImage
+      ? await fileToBase64(croppedInputImage)
+      : null
     return {
       stage,
       citizenData,
       citizenImage: serializedCitizenImage,
       inputImage: serializedInputImage,
+      croppedInputImage: serializedCroppedInputImage,
       agreedToCondition,
       selectedChainSlug,
     }
-  }, [stage, citizenData, citizenImage, inputImage, agreedToCondition, selectedChainSlug])
+  }, [
+    stage,
+    citizenData,
+    citizenImage,
+    inputImage,
+    croppedInputImage,
+    agreedToCondition,
+    selectedChainSlug,
+  ])
 
   const restoreImageFromCache = useCallback(
     (imageData: SerializedFile | string | null, setImage: Function, imageName: string) => {
@@ -603,6 +616,11 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         setInputImage,
         'input image',
       )
+      const croppedInputImageRestored = restoreImageFromCache(
+        formData.croppedInputImage,
+        setCroppedInputImage,
+        'cropped input image',
+      )
 
       imagesRestoredRef.current = citizenImageRestored || inputImageRestored
 
@@ -843,7 +861,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
     if (isImageGenerating && citizenImage) {
       setIsImageGenerating(false)
     }
-  }, [citizenImage, inputImage, isImageGenerating])
+  }, [citizenImage, isImageGenerating])
 
   useEffect(() => {
     if (stage > lastStage) {

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -137,6 +137,9 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
   const [lastStage, setLastStage] = useState<number>(0)
   const [inputImage, setInputImage] = useState<File>()
   const [citizenImage, setCitizenImage] = useState<any>()
+  // The user's own cropped upload, kept so they can fall back to it on the
+  // Review step ("Use my photo instead") without re-cropping.
+  const [croppedInputImage, setCroppedInputImage] = useState<File>()
   const [citizenData, setCitizenData] = useState<CitizenData>({
     name: '',
     email: '',
@@ -1039,9 +1042,10 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
                   <div className="mb-6">
                     <h2 className="text-2xl font-GoodTimes text-white mb-2">Design</h2>
                     <p className="text-slate-400 text-sm leading-relaxed">
-                      Create your unique AI passport photo. Upload a photo with a clear face —
-                      yourself or an avatar. Generation may take up to a minute, so feel free to
-                      continue to the next step.
+                      Upload a photo with a clear face — yourself or an avatar — position the crop,
+                      and we&apos;ll generate your AI passport photo. It renders in the background
+                      (~30–60s) while you keep going; you can regenerate or switch back to your own
+                      photo on the review step.
                     </p>
                   </div>
                   <ImageGenerator
@@ -1053,6 +1057,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
                     stage={stage}
                     generateInBG
                     onGenerationStateChange={setIsImageGenerating}
+                    onCrop={setCroppedInputImage}
                   />
                   {process.env.NEXT_PUBLIC_ENV === 'dev' && (
                     <button
@@ -1155,16 +1160,54 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
                         </div>
                       )}
                     </div>
-                    {(citizenImage || inputImage) && (
-                      <button
-                        onClick={() => {
-                          setCitizenImage(undefined)
-                          setStage(0)
-                        }}
-                        className="text-sky-400 hover:text-sky-300 text-sm transition-colors"
-                      >
-                        ← Edit Image
-                      </button>
+                    {(citizenImage || inputImage) && !isImageGenerating && (
+                      <div className="flex flex-col items-center gap-3 w-full max-w-[400px]">
+                        <div className="flex flex-col sm:flex-row gap-3 w-full">
+                          <button
+                            onClick={() => {
+                              setCitizenImage(undefined)
+                              setStage(0)
+                            }}
+                            className="flex-1 py-2.5 px-5 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white text-sm flex items-center justify-center gap-2"
+                          >
+                            <svg
+                              className="w-4 h-4"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth="2"
+                                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                              />
+                            </svg>
+                            Regenerate
+                          </button>
+                          {(croppedInputImage || inputImage) && (
+                            <button
+                              onClick={() => {
+                                setCitizenImage(croppedInputImage || inputImage)
+                              }}
+                              className="flex-1 py-2.5 px-5 bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.1] hover:border-white/[0.2] transition-all duration-200 rounded-2xl font-semibold text-white text-sm"
+                            >
+                              Use my photo instead
+                            </button>
+                          )}
+                        </div>
+                        <button
+                          onClick={() => {
+                            setCitizenImage(undefined)
+                            setInputImage(undefined)
+                            setCroppedInputImage(undefined)
+                            setStage(0)
+                          }}
+                          className="text-xs text-slate-500 hover:text-slate-300 transition-colors underline underline-offset-2"
+                        >
+                          Change photo
+                        </button>
+                      </div>
                     )}
                   </div>
 

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -840,7 +840,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
 
   // ===== Effect Group: UI State Sync =====
   useEffect(() => {
-    if (isImageGenerating && (citizenImage || inputImage)) {
+    if (isImageGenerating && citizenImage) {
       setIsImageGenerating(false)
     }
   }, [citizenImage, inputImage, isImageGenerating])

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -208,7 +208,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
   const LAYER_ZERO_TRANSFER_COST = useMemo(() => BigInt('3000000000000000'), [])
   const isCrossChain = useMemo(
     () => selectedChainSlug !== defaultChainSlug,
-    [selectedChainSlug, defaultChainSlug]
+    [selectedChainSlug, defaultChainSlug],
   )
 
   // ===== Internal Helper Functions =====
@@ -223,7 +223,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       }
       return totalCost
     },
-    [LAYER_ZERO_TRANSFER_COST]
+    [LAYER_ZERO_TRANSFER_COST],
   )
 
   const serializeCacheData = useCallback(async () => {
@@ -248,7 +248,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       }
       return false
     },
-    []
+    [],
   )
 
   const executeFreeMint = useCallback(
@@ -271,7 +271,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       }
       return await res.json()
     },
-    [address, citizenData.name, citizenData.formResponseId]
+    [address, citizenData.name, citizenData.formResponseId],
   )
 
   const executeCrossChainMint = useCallback(
@@ -310,7 +310,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       })
       const message = await waitForMessageReceived(
         isTestnet ? 19999 : 1,
-        originReceipt.transactionHash
+        originReceipt.transactionHash,
       )
       return await waitForReceipt({
         client: client,
@@ -328,7 +328,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       LAYER_ZERO_TRANSFER_COST,
       isTestnet,
       destinationChain,
-    ]
+    ],
   )
 
   const executeDirectMint = useCallback(
@@ -360,7 +360,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         account,
       })
     },
-    [account, citizenContract, address, citizenData.name, citizenData.formResponseId]
+    [account, citizenContract, address, citizenData.name, citizenData.formResponseId],
   )
 
   const handlePostMint = useCallback(
@@ -405,7 +405,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       setTimeout(async () => {
         await sendDiscordMessage(
           'networkNotifications',
-          `## [**${citizenName}**](${DEPLOYED_ORIGIN}/citizen/${citizenPrettyLink}?_timestamp=123456789) has just become a <@&${DISCORD_CITIZEN_ROLE_ID}> of the Space Acceleration Network!`
+          `## [**${citizenName}**](${DEPLOYED_ORIGIN}/citizen/${citizenPrettyLink}?_timestamp=123456789) has just become a <@&${DISCORD_CITIZEN_ROLE_ID}> of the Space Acceleration Network!`,
         )
 
         const cacheKey = `moondao_citizen_${address?.toLowerCase()}_${DEFAULT_CHAIN_V5.id}`
@@ -424,7 +424,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       address,
       clearCache,
       router,
-    ]
+    ],
   )
 
   // ===== Event Handlers & Callbacks =====
@@ -435,7 +435,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       const baseCost = BigInt(ethers.utils.parseEther(formattedCost).toString())
       return calculateTotalCost(baseCost, estimatedGas, gasPriceToUse, isCrossChain)
     },
-    [estimatedGas, effectiveGasPrice, calculateTotalCost, isCrossChain]
+    [estimatedGas, effectiveGasPrice, calculateTotalCost, isCrossChain],
   )
 
   // Gas Estimation Handler
@@ -596,12 +596,12 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       const citizenImageRestored = restoreImageFromCache(
         formData.citizenImage,
         setCitizenImage,
-        'citizen image'
+        'citizen image',
       )
       const inputImageRestored = restoreImageFromCache(
         formData.inputImage,
         setInputImage,
-        'input image'
+        'input image',
       )
 
       imagesRestoredRef.current = citizenImageRestored || inputImageRestored
@@ -616,7 +616,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         }
       }
     },
-    [setSelectedChain, setAgreedToCondition, restoreImageFromCache, estimateMintGas]
+    [setSelectedChain, setAgreedToCondition, restoreImageFromCache, estimateMintGas],
   )
 
   // ===== Side Effects =====
@@ -791,13 +791,13 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         console.error('Typeform submission error:', error)
         toast.error(
           error?.message || 'Failed to process your profile. Please try again or contact support.',
-          { duration: 8000 }
+          { duration: 8000 },
         )
       } finally {
         setIsSubmittingTypeform(false)
       }
     },
-    [subscribeToNetworkSignup]
+    [subscribeToNetworkSignup],
   )
 
   // ===== Effect Group: Gas Estimation =====
@@ -840,10 +840,10 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
 
   // ===== Effect Group: UI State Sync =====
   useEffect(() => {
-    if (isImageGenerating && citizenImage) {
+    if (isImageGenerating && (citizenImage || inputImage)) {
       setIsImageGenerating(false)
     }
-  }, [citizenImage, isImageGenerating])
+  }, [citizenImage, inputImage, isImageGenerating])
 
   useEffect(() => {
     if (stage > lastStage) {
@@ -904,13 +904,13 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
             citizenImage: hasSerializedCitizenImage
               ? existingFormData.citizenImage
               : citizenImageRef.current
-              ? 'PENDING_SERIALIZATION'
-              : null,
+                ? 'PENDING_SERIALIZATION'
+                : null,
             inputImage: hasSerializedInputImage
               ? existingFormData.inputImage
               : inputImageRef.current
-              ? 'PENDING_SERIALIZATION'
-              : null,
+                ? 'PENDING_SERIALIZATION'
+                : null,
             agreedToCondition: agreedToConditionRef.current,
             selectedChainSlug: selectedChainSlugRef.current,
           },
@@ -1133,8 +1133,8 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
                           citizenImage
                             ? URL.createObjectURL(citizenImage)
                             : inputImage
-                            ? URL.createObjectURL(inputImage)
-                            : '/assets/MoonDAO-Loading-Animation.svg'
+                              ? URL.createObjectURL(inputImage)
+                              : '/assets/MoonDAO-Loading-Animation.svg'
                         }
                         alt="citizen-image"
                         fill
@@ -1243,8 +1243,8 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
                       isLoadingMint
                         ? 'Creating Citizen...'
                         : isLoadingGasEstimate
-                        ? 'Estimating Gas...'
-                        : 'Become a Citizen'
+                          ? 'Estimating Gas...'
+                          : 'Become a Citizen'
                     }
                     className="w-full py-3 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-base disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
                     isDisabled={!agreedToCondition || isLoadingMint || isLoadingGasEstimate}


### PR DESCRIPTION
## Summary

Reworks the citizen image step so **AI generation is the default path** instead of a co-equal choice with the uploaded photo, reducing clicks and guesswork.

New flow:
1. Upload image
2. Position the crop
3. A single **Generate AI Photo** button confirms the crop and starts generation
4. After generation, the user can **Regenerate** or **Use my photo instead** (their cropped upload)

### Onboarding (`CreateCitizen`)
- Clicking **Generate AI Photo** kicks off generation in the **background** and advances to the Profile step immediately (no on-screen wait).
- The AI image is shown by default on the **Review** step, where the user can **Regenerate**, **Use my photo instead** (the cropped upload), or **Change photo**.
- The cropped upload is lifted to the parent so "Use my photo" needs no re-crop.

### Edit modal (`CitizenMetadataModal`)
- Has no next step, so it keeps a **stay-and-wait** flow: generate in place, then the same post-generation **Regenerate / Use my photo** choices appear inline.

### Other
- Removes the old dual "Generate AI Photo" / "Use Cropped Image" pre-generation buttons and the separate Re-crop button.
- Keeps a subtle "Skip AI and use my photo" link for users who do not want to wait on a generation.

> Note: stacked on `feature/citizen-image-gen-ux` (#1340), which adds the wait/progress UX this flow relies on. Re-target to `main` once that merges.

## Test plan
- [ ] Onboarding: upload → crop → Generate → advances to Profile; AI image appears on Review.
- [ ] Review: Regenerate returns to design step; Use my photo swaps to the cropped upload; Change photo resets.
- [ ] Edit modal: upload → crop → Generate stays in place, then Regenerate / Use my photo work.
- [ ] "Skip AI and use my photo" sets the cropped photo without generating.
- [ ] Generation failure falls back to the cropped/fitted photo.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only onboarding and image-picker flow changes; no auth, mint, or API contract changes beyond existing image-gen usage.
> 
> **Overview**
> **AI generation is now the default** after upload and crop: one primary **Generate AI Photo** action replaces the old side-by-side “Generate AI” / “Use cropped image” buttons, with a low-friction **Skip AI and use my photo** link.
> 
> In **`ImageGenerator`**, onboarding (`generateInBG` + `nextStage`) **starts generation without awaiting** and advances immediately; **`onCrop`** lifts the cropped file to the parent. Standalone flows (e.g. edit modal) still wait in place and show inline **Regenerate** / **Use my photo instead**. Upload tips and clearer copy were added; **Re-crop** and duplicate pre-gen paths were removed.
> 
> **`CreateCitizen`** stores **`croppedInputImage`** in form cache and on the **Review** step adds **Regenerate**, **Use my photo instead**, and **Change photo** so users can finish the profile while AI renders in the background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429f9e08a4f084b8e5b9eeffb7efa1f0274cccba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->