### PR TITLE
Confetti welcome on citizen mint + reliable dashboard landing

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -999,11 +999,28 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
     router.push('/dashboard')
   }, [router])
 
+  // Memoize the welcome image object URL so the overlay doesn't allocate a new
+  // one on every render, and revoke it when the source changes / on unmount.
+  const welcomeImageFile = citizenImage || inputImage
+  const welcomeImageUrl = useMemo(
+    () => (welcomeImageFile ? URL.createObjectURL(welcomeImageFile) : null),
+    [welcomeImageFile]
+  )
+  useEffect(() => {
+    return () => {
+      if (welcomeImageUrl) URL.revokeObjectURL(welcomeImageUrl)
+    }
+  }, [welcomeImageUrl])
+
+  const welcomeButtonRef = useRef<HTMLButtonElement>(null)
+
   // ===== Effect Group: Post-Mint Celebration =====
   // Auto-advance to the dashboard a few seconds after the welcome screen so the
-  // user lands there even if they don't click the button.
+  // user lands there even if they don't click the button. Move keyboard focus to
+  // the primary action so keyboard users can proceed without extra tabbing.
   useEffect(() => {
     if (!mintComplete) return
+    welcomeButtonRef.current?.focus()
     const timer = setTimeout(goToDashboard, 6000)
     return () => clearTimeout(timer)
   }, [mintComplete, goToDashboard])
@@ -1321,11 +1338,16 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       {/* Post-mint celebration / welcome screen */}
       {mintComplete && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/80 backdrop-blur-md px-4 animate-fadeIn">
-          <div className="relative w-full max-w-md rounded-3xl border border-white/10 bg-gradient-to-b from-slate-800/80 to-slate-900/95 p-8 text-center shadow-2xl">
-            {(citizenImage || inputImage) && (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="citizen-welcome-heading"
+            className="relative w-full max-w-md rounded-3xl border border-white/10 bg-gradient-to-b from-slate-800/80 to-slate-900/95 p-8 text-center shadow-2xl"
+          >
+            {welcomeImageUrl && (
               <div className="mx-auto mb-6 h-28 w-28 overflow-hidden rounded-2xl border border-white/15 shadow-lg">
                 <Image
-                  src={URL.createObjectURL(citizenImage || inputImage)}
+                  src={welcomeImageUrl}
                   alt={citizenData.name || 'Your citizen'}
                   width={112}
                   height={112}
@@ -1337,7 +1359,10 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
             <p className="text-xs uppercase tracking-[0.2em] text-amber-300/80 mb-2">
               Welcome to MoonDAO
             </p>
-            <h2 className="font-GoodTimes text-2xl sm:text-3xl text-white mb-3">
+            <h2
+              id="citizen-welcome-heading"
+              className="font-GoodTimes text-2xl sm:text-3xl text-white mb-3"
+            >
               You&apos;re a Citizen!
             </h2>
             <p className="text-slate-300 text-sm leading-relaxed mb-7">
@@ -1346,6 +1371,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
               everything you can do next.
             </p>
             <button
+              ref={welcomeButtonRef}
               onClick={goToDashboard}
               className="w-full py-3 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white flex items-center justify-center gap-2"
             >

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -228,7 +228,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
   const LAYER_ZERO_TRANSFER_COST = useMemo(() => BigInt('3000000000000000'), [])
   const isCrossChain = useMemo(
     () => selectedChainSlug !== defaultChainSlug,
-    [selectedChainSlug, defaultChainSlug]
+    [selectedChainSlug, defaultChainSlug],
   )
 
   // ===== Internal Helper Functions =====
@@ -243,7 +243,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       }
       return totalCost
     },
-    [LAYER_ZERO_TRANSFER_COST]
+    [LAYER_ZERO_TRANSFER_COST],
   )
 
   const serializeCacheData = useCallback(async () => {
@@ -268,7 +268,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       }
       return false
     },
-    []
+    [],
   )
 
   const executeFreeMint = useCallback(
@@ -291,7 +291,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       }
       return await res.json()
     },
-    [address, citizenData.name, citizenData.formResponseId]
+    [address, citizenData.name, citizenData.formResponseId],
   )
 
   const executeCrossChainMint = useCallback(
@@ -330,7 +330,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       })
       const message = await waitForMessageReceived(
         isTestnet ? 19999 : 1,
-        originReceipt.transactionHash
+        originReceipt.transactionHash,
       )
       return await waitForReceipt({
         client: client,
@@ -348,7 +348,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       LAYER_ZERO_TRANSFER_COST,
       isTestnet,
       destinationChain,
-    ]
+    ],
   )
 
   const executeDirectMint = useCallback(
@@ -380,7 +380,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         account,
       })
     },
-    [account, citizenContract, address, citizenData.name, citizenData.formResponseId]
+    [account, citizenContract, address, citizenData.name, citizenData.formResponseId],
   )
 
   const handlePostMint = useCallback(
@@ -433,7 +433,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       // Fire-and-forget side effects — don't block the celebration on them.
       sendDiscordMessage(
         'networkNotifications',
-        `## [**${citizenName}**](${DEPLOYED_ORIGIN}/citizen/${citizenPrettyLink}?_timestamp=123456789) has just become a <@&${DISCORD_CITIZEN_ROLE_ID}> of the Space Acceleration Network!`
+        `## [**${citizenName}**](${DEPLOYED_ORIGIN}/citizen/${citizenPrettyLink}?_timestamp=123456789) has just become a <@&${DISCORD_CITIZEN_ROLE_ID}> of the Space Acceleration Network!`,
       ).catch((err) => console.error('Failed to send Discord message:', err))
 
       // Clear the onboarding form cache (the citizen cache was just seeded).
@@ -447,7 +447,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       address,
       clearCache,
       seedCitizen,
-    ]
+    ],
   )
 
   // ===== Event Handlers & Callbacks =====
@@ -458,7 +458,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       const baseCost = BigInt(ethers.utils.parseEther(formattedCost).toString())
       return calculateTotalCost(baseCost, estimatedGas, gasPriceToUse, isCrossChain)
     },
-    [estimatedGas, effectiveGasPrice, calculateTotalCost, isCrossChain]
+    [estimatedGas, effectiveGasPrice, calculateTotalCost, isCrossChain],
   )
 
   // Gas Estimation Handler
@@ -619,12 +619,12 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       const citizenImageRestored = restoreImageFromCache(
         formData.citizenImage,
         setCitizenImage,
-        'citizen image'
+        'citizen image',
       )
       const inputImageRestored = restoreImageFromCache(
         formData.inputImage,
         setInputImage,
-        'input image'
+        'input image',
       )
 
       imagesRestoredRef.current = citizenImageRestored || inputImageRestored
@@ -639,7 +639,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         }
       }
     },
-    [setSelectedChain, setAgreedToCondition, restoreImageFromCache, estimateMintGas]
+    [setSelectedChain, setAgreedToCondition, restoreImageFromCache, estimateMintGas],
   )
 
   // ===== Side Effects =====
@@ -814,13 +814,13 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         console.error('Typeform submission error:', error)
         toast.error(
           error?.message || 'Failed to process your profile. Please try again or contact support.',
-          { duration: 8000 }
+          { duration: 8000 },
         )
       } finally {
         setIsSubmittingTypeform(false)
       }
     },
-    [subscribeToNetworkSignup]
+    [subscribeToNetworkSignup],
   )
 
   // ===== Effect Group: Gas Estimation =====
@@ -927,13 +927,13 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
             citizenImage: hasSerializedCitizenImage
               ? existingFormData.citizenImage
               : citizenImageRef.current
-              ? 'PENDING_SERIALIZATION'
-              : null,
+                ? 'PENDING_SERIALIZATION'
+                : null,
             inputImage: hasSerializedInputImage
               ? existingFormData.inputImage
               : inputImageRef.current
-              ? 'PENDING_SERIALIZATION'
-              : null,
+                ? 'PENDING_SERIALIZATION'
+                : null,
             agreedToCondition: agreedToConditionRef.current,
             selectedChainSlug: selectedChainSlugRef.current,
           },
@@ -953,7 +953,12 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
 
   // Cache form state continuously (removed onrampModalOpen guard for more aggressive caching)
   useEffect(() => {
-    if (stage >= 0 && address && (citizenData.name || citizenImage || inputImage)) {
+    if (
+      stage >= 0 &&
+      address &&
+      (citizenData.name || citizenImage || inputImage) &&
+      !mintComplete
+    ) {
       const performCache = async () => {
         const cacheData = await serializeCacheData()
         setCache(cacheData, stage)
@@ -970,6 +975,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
     inputImage,
     agreedToCondition,
     selectedChainSlug,
+    mintComplete,
   ])
 
   // Listen for Typeform submit via postMessage (raw iframe approach)
@@ -1169,8 +1175,8 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
                           citizenImage
                             ? URL.createObjectURL(citizenImage)
                             : inputImage
-                            ? URL.createObjectURL(inputImage)
-                            : '/assets/MoonDAO-Loading-Animation.svg'
+                              ? URL.createObjectURL(inputImage)
+                              : '/assets/MoonDAO-Loading-Animation.svg'
                         }
                         alt="citizen-image"
                         fill
@@ -1241,8 +1247,8 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
                       isLoadingMint
                         ? 'Creating Citizen...'
                         : isLoadingGasEstimate
-                        ? 'Estimating Gas...'
-                        : 'Become a Citizen'
+                          ? 'Estimating Gas...'
+                          : 'Become a Citizen'
                     }
                     className="w-full py-3 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-base disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
                     isDisabled={!agreedToCondition || isLoadingMint || isLoadingGasEstimate}

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -2,6 +2,7 @@ import { XMarkIcon } from '@heroicons/react/24/outline'
 import { Options } from '@layerzerolabs/lz-v2-utilities'
 import { waitForMessageReceived } from '@layerzerolabs/scan-client'
 import { getAccessToken } from '@privy-io/react-auth'
+import confetti from 'canvas-confetti'
 import {
   CITIZEN_ADDRESSES,
   CITIZEN_CROSS_CHAIN_MINT_ADDRESSES,
@@ -27,6 +28,7 @@ import {
 import { useActiveAccount } from 'thirdweb/react'
 import useWindowSize from '../../lib/team/use-window-size'
 import { useOnrampAutoTransaction } from '@/lib/coinbase/useOnrampAutoTransaction'
+import CitizenContext from '@/lib/citizen/citizen-context'
 import { useOnrampInitialStage } from '@/lib/coinbase/useOnrampInitialStage'
 import useOnrampJWT from '@/lib/coinbase/useOnrampJWT'
 import useSubscribe from '@/lib/convert-kit/useSubscribe'
@@ -87,11 +89,30 @@ import { TermsCheckbox } from './TermsCheckbox'
  * 8. Side Effects (grouped by purpose)
  * 9. JSX Render
  */
+
+// Celebratory confetti burst for the citizen welcome screen (space palette).
+function fireCelebrationConfetti() {
+  if (typeof window === 'undefined') return
+  const colors = ['#ffffff', '#FFD700', '#00FFFF', '#ff69b4', '#8A2BE2']
+  const fire = (originY: number, particleCount: number, spread: number) =>
+    confetti({
+      particleCount,
+      spread,
+      origin: { y: originY },
+      shapes: ['circle', 'star'],
+      colors,
+    })
+  fire(0.6, 160, 100)
+  setTimeout(() => fire(0.7, 120, 120), 250)
+  setTimeout(() => fire(0.5, 100, 90), 550)
+}
+
 export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
   // ===== Context & Constants =====
   const router = useRouter()
   const { setSelectedChain } = useContext(ChainContextV5)
   const { selectedWallet, setSelectedWallet } = useContext(PrivyWalletContext)
+  const { seedCitizen } = useContext(CitizenContext)
 
   const defaultChainSlug = getChainSlug(DEFAULT_CHAIN_V5)
   const selectedChainSlug = getChainSlug(selectedChain)
@@ -156,6 +177,8 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
 
   // ===== State: Loading State =====
   const [isLoadingMint, setIsLoadingMint] = useState<boolean>(false)
+  // Celebration shown after a successful mint, before landing on the dashboard.
+  const [mintComplete, setMintComplete] = useState<boolean>(false)
   const [isImageGenerating, setIsImageGenerating] = useState(false)
   const [isLoadingGasEstimate, setIsLoadingGasEstimate] = useState(false)
   const [isSubmittingTypeform, setIsSubmittingTypeform] = useState(false)
@@ -398,20 +421,23 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         console.error('Error recording referral:', error)
       }
 
-      // Send Discord notification and cleanup
-      setTimeout(async () => {
-        await sendDiscordMessage(
-          'networkNotifications',
-          `## [**${citizenName}**](${DEPLOYED_ORIGIN}/citizen/${citizenPrettyLink}?_timestamp=123456789) has just become a <@&${DISCORD_CITIZEN_ROLE_ID}> of the Space Acceleration Network!`
-        )
+      // Seed the citizen into context/cache so the app recognizes them right
+      // away. Without this, Tableland indexing lag can land a brand-new citizen
+      // on the marketing homepage instead of their dashboard.
+      seedCitizen(citizenNFT)
 
-        const cacheKey = `moondao_citizen_${address?.toLowerCase()}_${DEFAULT_CHAIN_V5.id}`
-        if (typeof window !== 'undefined') {
-          localStorage.removeItem(cacheKey)
-        }
-        clearCache()
-        router.push('/')
-      }, 10000)
+      // Celebrate: show the welcome screen and fire confetti.
+      setMintComplete(true)
+      fireCelebrationConfetti()
+
+      // Fire-and-forget side effects — don't block the celebration on them.
+      sendDiscordMessage(
+        'networkNotifications',
+        `## [**${citizenName}**](${DEPLOYED_ORIGIN}/citizen/${citizenPrettyLink}?_timestamp=123456789) has just become a <@&${DISCORD_CITIZEN_ROLE_ID}> of the Space Acceleration Network!`
+      ).catch((err) => console.error('Failed to send Discord message:', err))
+
+      // Clear the onboarding form cache (the citizen cache was just seeded).
+      clearCache()
     },
     [
       tagToNetworkSignup,
@@ -420,7 +446,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
       citizenContract,
       address,
       clearCache,
-      router,
+      seedCitizen,
     ]
   )
 
@@ -961,6 +987,21 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
     return () => window.removeEventListener('message', handler)
   }, [stage, submitTypeform])
 
+  // Navigate to the citizen dashboard (context is already seeded, so it renders
+  // immediately instead of bouncing to the marketing homepage).
+  const goToDashboard = useCallback(() => {
+    router.push('/dashboard')
+  }, [router])
+
+  // ===== Effect Group: Post-Mint Celebration =====
+  // Auto-advance to the dashboard a few seconds after the welcome screen so the
+  // user lands there even if they don't click the button.
+  useEffect(() => {
+    if (!mintComplete) return
+    const timer = setTimeout(goToDashboard, 6000)
+    return () => clearTimeout(timer)
+  }, [mintComplete, goToDashboard])
+
   // ===== Effect Group: Data Fetching =====
   useEffect(() => {
     if (!address) return
@@ -1269,6 +1310,52 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
             setCache(cacheData, currentStage)
           }}
         />
+      )}
+
+      {/* Post-mint celebration / welcome screen */}
+      {mintComplete && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/80 backdrop-blur-md px-4 animate-fadeIn">
+          <div className="relative w-full max-w-md rounded-3xl border border-white/10 bg-gradient-to-b from-slate-800/80 to-slate-900/95 p-8 text-center shadow-2xl">
+            {(citizenImage || inputImage) && (
+              <div className="mx-auto mb-6 h-28 w-28 overflow-hidden rounded-2xl border border-white/15 shadow-lg">
+                <Image
+                  src={URL.createObjectURL(citizenImage || inputImage)}
+                  alt={citizenData.name || 'Your citizen'}
+                  width={112}
+                  height={112}
+                  className="h-full w-full object-cover"
+                  unoptimized
+                />
+              </div>
+            )}
+            <p className="text-xs uppercase tracking-[0.2em] text-amber-300/80 mb-2">
+              Welcome to MoonDAO
+            </p>
+            <h2 className="font-GoodTimes text-2xl sm:text-3xl text-white mb-3">
+              You&apos;re a Citizen!
+            </h2>
+            <p className="text-slate-300 text-sm leading-relaxed mb-7">
+              {citizenData.name ? `Welcome aboard, ${citizenData.name}. ` : 'Welcome aboard. '}
+              You&apos;re now part of the Space Acceleration Network. Your dashboard is ready with
+              everything you can do next.
+            </p>
+            <button
+              onClick={goToDashboard}
+              className="w-full py-3 gradient-2 hover:scale-[1.02] active:scale-[0.98] transition-all duration-200 rounded-2xl font-semibold text-white flex items-center justify-center gap-2"
+            >
+              Enter your Dashboard
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M9 5l7 7-7 7"
+                />
+              </svg>
+            </button>
+            <p className="mt-3 text-xs text-slate-500">Taking you there automatically…</p>
+          </div>
+        </div>
       )}
     </Container>
   )

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -421,10 +421,37 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
         console.error('Error recording referral:', error)
       }
 
+      // Normalize the thirdweb NFT to match the Tableland format before seeding
+      const normalizedCitizen = {
+        id: typeof citizenNFT.id === 'bigint' ? Number(citizenNFT.id) : citizenNFT.id,
+        metadata: {
+          id: typeof citizenNFT.id === 'bigint' ? Number(citizenNFT.id) : citizenNFT.id,
+          uri: citizenNFT.tokenURI || '',
+          name: citizenNFT.metadata?.name || '',
+          description: citizenNFT.metadata?.description || '',
+          image: citizenNFT.metadata?.image || '',
+          animation_url: '',
+          external_url: '',
+          attributes: [
+            { trait_type: 'location', value: JSON.stringify(citizenData.location || '') },
+            { trait_type: 'website', value: citizenData.website || '' },
+            { trait_type: 'discord', value: citizenData.discord || '' },
+            { trait_type: 'twitter', value: citizenData.twitter || '' },
+            { trait_type: 'instagram', value: '' },
+            { trait_type: 'linkedin', value: '' },
+            { trait_type: 'view', value: citizenData.view || '' },
+            { trait_type: 'formId', value: citizenData.formResponseId || '' },
+          ],
+        },
+        owner: citizenNFT.owner || address || '',
+        tokenURI: citizenNFT.tokenURI || '',
+        type: 'ERC721',
+      }
+
       // Seed the citizen into context/cache so the app recognizes them right
       // away. Without this, Tableland indexing lag can land a brand-new citizen
       // on the marketing homepage instead of their dashboard.
-      seedCitizen(citizenNFT)
+      seedCitizen(normalizedCitizen)
 
       // Celebrate: show the welcome screen and fire confetti.
       setMintComplete(true)
@@ -1004,7 +1031,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier }: any) {
   const welcomeImageFile = citizenImage || inputImage
   const welcomeImageUrl = useMemo(
     () => (welcomeImageFile ? URL.createObjectURL(welcomeImageFile) : null),
-    [welcomeImageFile]
+    [welcomeImageFile],
   )
   useEffect(() => {
     return () => {

--- a/ui/lib/citizen/CitizenProvider.tsx
+++ b/ui/lib/citizen/CitizenProvider.tsx
@@ -352,6 +352,14 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
       setCitizen(undefined)
       setIsLoading(false)
       hasLoadedNonDefaultCache.current = false
+      // Drop any optimistic seed so re-authenticating doesn't resurrect the
+      // just-minted state (or keep Tableland polling alive via refreshInterval).
+      optimisticUntilRef.current = 0
+      setOptimisticActive(false)
+      if (optimisticTimerRef.current) {
+        clearTimeout(optimisticTimerRef.current)
+        optimisticTimerRef.current = null
+      }
     }
   }, [authenticated, mock])
 

--- a/ui/lib/citizen/CitizenProvider.tsx
+++ b/ui/lib/citizen/CitizenProvider.tsx
@@ -1,6 +1,6 @@
 import { usePrivy } from '@privy-io/react-auth'
 import { CITIZEN_TABLE_NAMES, DEFAULT_CHAIN_V5 } from 'const/config'
-import { useEffect, useState, useRef } from 'react'
+import { useCallback, useEffect, useState, useRef } from 'react'
 import { useActiveAccount } from 'thirdweb/react'
 import { useTablelandQuery } from '../swr/useTablelandQuery'
 import { citizenRowToNFT } from '../tableland/convertRow'
@@ -10,6 +10,10 @@ import CitizenContext from './citizen-context'
 // Cache configuration
 const CACHE_PREFIX = 'moondao_citizen_'
 const CACHE_EXPIRY_MS = 5 * 60 * 1000 // 5 minutes
+// How long to trust an optimistically-seeded citizen (just minted) before
+// deferring to Tableland again. Indexing usually catches up within seconds.
+const OPTIMISTIC_WINDOW_MS = 2 * 60 * 1000 // 2 minutes
+const OPTIMISTIC_POLL_MS = 5000
 
 interface CachedCitizenData {
   data: any
@@ -173,6 +177,10 @@ export const clearAllCitizenCache = () => {
 export default function CitizenProvider({ selectedChain, children, mock = false }: any) {
   const [citizen, setCitizen] = useState<any>()
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  // While true, a freshly-minted citizen is being trusted optimistically and we
+  // poll Tableland until the real record shows up (see OPTIMISTIC_WINDOW_MS).
+  const [optimisticActive, setOptimisticActive] = useState(false)
+  const optimisticUntilRef = useRef(0)
   const account = useActiveAccount()
   const { authenticated, user } = usePrivy()
   const hasLoadedNonDefaultCache = useRef(false)
@@ -185,6 +193,8 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
   // Reset cache loading flag when address or chain changes
   useEffect(() => {
     hasLoadedNonDefaultCache.current = false
+    optimisticUntilRef.current = 0
+    setOptimisticActive(false)
   }, [address, chainId])
 
   // Load cached data immediately when address/chain are available
@@ -222,9 +232,32 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
       ? null
       : `SELECT * FROM ${CITIZEN_TABLE_NAMES[chainSlug]} WHERE owner = '${address?.toLowerCase()}'`
 
-  const { data: citizenData, isLoading: isLoadingQuery } = useTablelandQuery(statement, {
-    revalidateOnFocus: false,
-  })
+  const { data: citizenData, isLoading: isLoadingQuery, mutate } = useTablelandQuery(
+    statement,
+    {
+      revalidateOnFocus: false,
+      // Poll while we're optimistically trusting a just-minted citizen so the
+      // real Tableland row replaces the seed as soon as it's indexed.
+      refreshInterval: optimisticActive ? OPTIMISTIC_POLL_MS : 0,
+    }
+  )
+
+  // Optimistically mark the wallet as a citizen right after minting. Updates
+  // state + cache immediately and kicks off a refetch; the empty-result branch
+  // below won't clobber this until OPTIMISTIC_WINDOW_MS elapses.
+  const seedCitizen = useCallback(
+    (nft: any) => {
+      if (!nft) return
+      optimisticUntilRef.current = Date.now() + OPTIMISTIC_WINDOW_MS
+      setOptimisticActive(true)
+      setCitizen(nft)
+      if (address) {
+        setCachedCitizen(address, DEFAULT_CHAIN_V5.id, nft)
+      }
+      mutate()
+    },
+    [address, mutate]
+  )
 
   // Update citizen state when data changes
   useEffect(() => {
@@ -259,6 +292,15 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
     setIsLoading(false)
 
     if (!citizenData || citizenData.length === 0) {
+      // A freshly-minted citizen may not be indexed by Tableland yet — keep the
+      // optimistic seed (and keep polling) until the window elapses.
+      if (optimisticActive) {
+        if (Date.now() < optimisticUntilRef.current) {
+          return
+        }
+        setOptimisticActive(false)
+        optimisticUntilRef.current = 0
+      }
       setCitizen(undefined)
       setCachedCitizen(address || '', chainId, undefined)
       return
@@ -267,6 +309,10 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
     const nft = citizenRowToNFT(citizenData?.[0])
     setCitizen(nft)
     setCachedCitizen(address || '', chainId, nft)
+    if (optimisticActive) {
+      setOptimisticActive(false)
+      optimisticUntilRef.current = 0
+    }
   }, [
     citizenData,
     isLoadingQuery,
@@ -277,6 +323,7 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
     chainSlug,
     mock,
     isDefaultChain,
+    optimisticActive,
   ])
 
   useEffect(() => {
@@ -290,7 +337,7 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
   }, [authenticated, mock])
 
   return (
-    <CitizenContext.Provider value={{ citizen, setCitizen, isLoading }}>
+    <CitizenContext.Provider value={{ citizen, setCitizen, seedCitizen, isLoading }}>
       {children}
     </CitizenContext.Provider>
   )

--- a/ui/lib/citizen/CitizenProvider.tsx
+++ b/ui/lib/citizen/CitizenProvider.tsx
@@ -181,6 +181,7 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
   // poll Tableland until the real record shows up (see OPTIMISTIC_WINDOW_MS).
   const [optimisticActive, setOptimisticActive] = useState(false)
   const optimisticUntilRef = useRef(0)
+  const optimisticTimerRef = useRef<NodeJS.Timeout | null>(null)
   const account = useActiveAccount()
   const { authenticated, user } = usePrivy()
   const hasLoadedNonDefaultCache = useRef(false)
@@ -195,6 +196,10 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
     hasLoadedNonDefaultCache.current = false
     optimisticUntilRef.current = 0
     setOptimisticActive(false)
+    if (optimisticTimerRef.current) {
+      clearTimeout(optimisticTimerRef.current)
+      optimisticTimerRef.current = null
+    }
   }, [address, chainId])
 
   // Load cached data immediately when address/chain are available
@@ -232,15 +237,16 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
       ? null
       : `SELECT * FROM ${CITIZEN_TABLE_NAMES[chainSlug]} WHERE owner = '${address?.toLowerCase()}'`
 
-  const { data: citizenData, isLoading: isLoadingQuery, mutate } = useTablelandQuery(
-    statement,
-    {
-      revalidateOnFocus: false,
-      // Poll while we're optimistically trusting a just-minted citizen so the
-      // real Tableland row replaces the seed as soon as it's indexed.
-      refreshInterval: optimisticActive ? OPTIMISTIC_POLL_MS : 0,
-    }
-  )
+  const {
+    data: citizenData,
+    isLoading: isLoadingQuery,
+    mutate,
+  } = useTablelandQuery(statement, {
+    revalidateOnFocus: false,
+    // Poll while we're optimistically trusting a just-minted citizen so the
+    // real Tableland row replaces the seed as soon as it's indexed.
+    refreshInterval: optimisticActive ? OPTIMISTIC_POLL_MS : 0,
+  })
 
   // Optimistically mark the wallet as a citizen right after minting. Updates
   // state + cache immediately and kicks off a refetch; the empty-result branch
@@ -255,8 +261,17 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
         setCachedCitizen(address, DEFAULT_CHAIN_V5.id, nft)
       }
       mutate()
+      // Set up a timer to expire the optimistic window, independently of effect re-runs
+      if (optimisticTimerRef.current) {
+        clearTimeout(optimisticTimerRef.current)
+      }
+      optimisticTimerRef.current = setTimeout(() => {
+        setOptimisticActive(false)
+        optimisticUntilRef.current = 0
+        optimisticTimerRef.current = null
+      }, OPTIMISTIC_WINDOW_MS)
     },
-    [address, mutate]
+    [address, mutate],
   )
 
   // Update citizen state when data changes
@@ -312,6 +327,10 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
     if (optimisticActive) {
       setOptimisticActive(false)
       optimisticUntilRef.current = 0
+      if (optimisticTimerRef.current) {
+        clearTimeout(optimisticTimerRef.current)
+        optimisticTimerRef.current = null
+      }
     }
   }, [
     citizenData,
@@ -335,6 +354,15 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
       hasLoadedNonDefaultCache.current = false
     }
   }, [authenticated, mock])
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (optimisticTimerRef.current) {
+        clearTimeout(optimisticTimerRef.current)
+      }
+    }
+  }, [])
 
   return (
     <CitizenContext.Provider value={{ citizen, setCitizen, seedCitizen, isLoading }}>

--- a/ui/lib/citizen/citizen-context.tsx
+++ b/ui/lib/citizen/citizen-context.tsx
@@ -3,10 +3,15 @@ import { createContext } from 'react'
 const CitizenContext = createContext<{
   citizen: any
   setCitizen: (citizen: any) => void
+  // Optimistically mark the connected wallet as a citizen (e.g. right after a
+  // successful mint) so the app routes to the dashboard immediately instead of
+  // waiting on Tableland indexing. The real record replaces it once indexed.
+  seedCitizen: (citizen: any) => void
   isLoading: boolean
 }>({
   citizen: undefined,
   setCitizen: (citizen: any) => {},
+  seedCitizen: (citizen: any) => {},
   isLoading: false,
 })
 


### PR DESCRIPTION
## Summary

After a user becomes a Citizen, celebrate it and make sure they actually land on their **dashboard** (with all the new actions) instead of the plain marketing homepage.

- **Confetti + welcome screen**: On a successful mint, a full-screen welcome overlay appears with a confetti burst (reusing the already-installed `canvas-confetti`), the new citizen's photo/name, an **Enter your Dashboard** button, and an automatic redirect to `/dashboard` after a few seconds.
- **Reliable dashboard landing**: Previously `handlePostMint` wiped the citizen cache and pushed to `/`; with Tableland indexing lag the homepage's "am I a citizen?" check could come back empty and the brand-new citizen would see the marketing page. Now we:
  - **Seed** the minted citizen into `CitizenContext` + the local cache via a new `seedCitizen(nft)` so the app recognizes them immediately.
  - Add an **optimistic window** in `CitizenProvider` that keeps the seeded citizen and polls Tableland until the real row is indexed, then swaps it in. This prevents an empty Tableland result from clobbering the just-minted citizen.
  - Redirect straight to `/dashboard` instead of `/`.

## Why
Root cause of "new citizen lands on homepage" was a combination of: cache deletion without re-seeding, Tableland indexing lag, and redirecting to `/` (whose citizen→dashboard redirect depends on that same lagging detection). This addresses all three.

## Files
- `ui/lib/citizen/citizen-context.tsx` — add `seedCitizen` to the context type.
- `ui/lib/citizen/CitizenProvider.tsx` — implement `seedCitizen`, optimistic-window guard, and Tableland polling.
- `ui/components/onboarding/CreateCitizen.tsx` — confetti + welcome overlay, seed on mint, redirect to `/dashboard`.

## Test plan
- [ ] Mint a citizen (direct, cross-chain, and free-mint paths) → confetti + welcome screen appears.
- [ ] Clicking **Enter your Dashboard** and the auto-redirect both land on `/dashboard` showing the citizen actions (no flash of the marketing homepage).
- [ ] Simulate Tableland lag (empty result right after mint) → user stays recognized as a citizen; once indexed, the real record replaces the seed.
- [ ] Existing citizen / non-citizen detection still works on normal page loads (cache + 5-min expiry unaffected).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes citizen detection and post-mint routing; incorrect optimistic handling could briefly mis-identify users or show stale seeded NFT data until Tableland catches up.
> 
> **Overview**
> Successful citizen mints now show a **confetti welcome overlay** (via `canvas-confetti`) with photo/name, an **Enter your Dashboard** CTA, and a **6s auto-redirect** to `/dashboard` instead of the old delayed push to `/`.
> 
> **Post-mint handling** no longer deletes citizen cache and waits on Discord before navigation. It **normalizes** the minted NFT to Tableland-shaped data, calls new **`seedCitizen`** on `CitizenContext`, clears only the onboarding form cache, and sends Discord **fire-and-forget**. Form caching is skipped while `mintComplete` is true.
> 
> **`CitizenProvider`** adds **`seedCitizen`**: immediate state + localStorage on the default chain, a **2-minute optimistic window** so empty Tableland results don’t clear the user, and **5s polling** until the indexed row replaces the seed. Optimistic state resets on address/chain change and logout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b07ba8628e79aa37f05ce361aa81e28803985f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->