### PR TITLE
feat(citizen): sponsor mints for on-chain whitelisted wallets

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -533,7 +533,8 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
         : 0
     const bridgeEth = isCrossChain ? Number(LAYER_ZERO_TRANSFER_COST) / 1e18 : 0
     if (freeMint) {
-      // Citizenship fee is waived; network gas is still paid by the user.
+      // Sponsored mint: the server relayer signs and submits the mint, so the
+      // user pays neither the citizenship fee nor network gas.
       return { renewalEth: 0, gasEth, bridgeEth, totalEth: gasEth + bridgeEth }
     }
     const renewalEth = renewalPriceWei ? Number(ethers.utils.formatEther(renewalPriceWei)) : 0
@@ -2315,11 +2316,17 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
                       </div>
                       <div className="flex justify-between gap-4">
                         <dt className="text-slate-400">Network fee (est.)</dt>
-                        <dd className="text-white text-right tabular-nums">
-                          {formatEthAmount(mintCostBreakdown.gasEth)} {nativeSymbol}
+                        <dd className="text-right tabular-nums">
+                          {freeMint ? (
+                            <span className="text-emerald-400 font-medium">Sponsored</span>
+                          ) : (
+                            <span className="text-white">
+                              {formatEthAmount(mintCostBreakdown.gasEth)} {nativeSymbol}
+                            </span>
+                          )}
                         </dd>
                       </div>
-                      {isCrossChain && mintCostBreakdown.bridgeEth > 0 && (
+                      {!freeMint && isCrossChain && mintCostBreakdown.bridgeEth > 0 && (
                         <div className="flex justify-between gap-4">
                           <dt className="text-slate-400">Cross-chain bridge (est.)</dt>
                           <dd className="text-white text-right tabular-nums">
@@ -2330,11 +2337,17 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
                       <div className="flex justify-between gap-4 pt-3 border-t border-white/[0.08]">
                         <dt className="text-slate-300 font-medium">Total due at mint</dt>
                         <dd className="text-white font-medium text-right tabular-nums">
-                          {formatEthAmount(mintCostBreakdown.totalEth)} {nativeSymbol}
-                          {totalMintUsd > 0 && (
-                            <span className="block text-slate-400 text-xs font-normal mt-0.5">
-                              ~${Math.round(totalMintUsd)} today
-                            </span>
+                          {freeMint ? (
+                            <span className="text-emerald-400">Free</span>
+                          ) : (
+                            <>
+                              {formatEthAmount(mintCostBreakdown.totalEth)} {nativeSymbol}
+                              {totalMintUsd > 0 && (
+                                <span className="block text-slate-400 text-xs font-normal mt-0.5">
+                                  ~${Math.round(totalMintUsd)} today
+                                </span>
+                              )}
+                            </>
                           )}
                         </dd>
                       </div>
@@ -2342,9 +2355,8 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
                   )}
                   <p className="mt-4 text-slate-500 text-xs leading-relaxed">
                     {freeMint
-                      ? `Your citizenship fee is sponsored. You only pay the network gas fee in ${nativeSymbol} on ${selectedChain?.name ?? 'your network'}.`
-                      : `Citizenship is paid in ${nativeSymbol} on ${selectedChain?.name ?? 'your network'}.`}{' '}
-                    Gas varies with network conditions. Renewal is ~1 year from mint.
+                      ? `Your citizenship and network fees are fully sponsored — you pay nothing to mint. Renewal is ~1 year from mint.`
+                      : `Citizenship is paid in ${nativeSymbol} on ${selectedChain?.name ?? 'your network'}. Gas varies with network conditions. Renewal is ~1 year from mint.`}
                   </p>
                 </div>
 

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -535,7 +535,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
     if (freeMint) {
       // Sponsored mint: the server relayer signs and submits the mint, so the
       // user pays neither the citizenship fee nor network gas.
-      return { renewalEth: 0, gasEth, bridgeEth, totalEth: gasEth + bridgeEth }
+      return { renewalEth: 0, gasEth: 0, bridgeEth: 0, totalEth: 0 }
     }
     const renewalEth = renewalPriceWei ? Number(ethers.utils.formatEther(renewalPriceWei)) : 0
     return {
@@ -563,7 +563,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
   )
 
   const isLoadingMintCosts = freeMint
-    ? isLoadingGasEstimate || isLoadingTotalMintUsd
+    ? false
     : isLoadingRenewalPrice ||
       isLoadingGasEstimate ||
       isLoadingRenewalUsd ||

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -527,16 +527,16 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
   const nativeSymbol = selectedChain?.nativeCurrency?.symbol ?? 'ETH'
 
   const mintCostBreakdown = useMemo(() => {
+    if (freeMint) {
+      // Sponsored mint: the server relayer signs and submits the mint, so the
+      // user pays nothing (no citizenship fee, no network gas, no bridge fee).
+      return { renewalEth: 0, gasEth: 0, bridgeEth: 0, totalEth: 0 }
+    }
     const gasEth =
       estimatedGas > BigInt(0) && effectiveGasPrice && effectiveGasPrice > BigInt(0)
         ? Number(estimatedGas * effectiveGasPrice) / 1e18
         : 0
     const bridgeEth = isCrossChain ? Number(LAYER_ZERO_TRANSFER_COST) / 1e18 : 0
-    if (freeMint) {
-      // Sponsored mint: the server relayer signs and submits the mint, so the
-      // user pays neither the citizenship fee nor network gas.
-      return { renewalEth: 0, gasEth: 0, bridgeEth: 0, totalEth: 0 }
-    }
     const renewalEth = renewalPriceWei ? Number(ethers.utils.formatEther(renewalPriceWei)) : 0
     return {
       renewalEth,

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -122,23 +122,18 @@ async function isCitizenWhitelisted(address: string): Promise<boolean> {
   if (!isValidEvmAddress(address)) return false
   const whitelistAddress = CITIZEN_WHITELIST_ADDRESSES[chainSlug]
   if (!whitelistAddress) return false
-  try {
-    const whitelistContract = getContract({
-      client: serverClient,
-      address: whitelistAddress,
-      abi: WhitelistABI as any,
-      chain,
-    })
-    const whitelisted = await readContract({
-      contract: whitelistContract,
-      method: 'isWhitelisted' as string,
-      params: [address],
-    })
-    return Boolean(whitelisted)
-  } catch (err) {
-    console.error('Error checking citizen whitelist:', err)
-    return false
-  }
+  const whitelistContract = getContract({
+    client: serverClient,
+    address: whitelistAddress,
+    abi: WhitelistABI as any,
+    chain,
+  })
+  const whitelisted = await readContract({
+    contract: whitelistContract,
+    method: 'isWhitelisted' as string,
+    params: [address],
+  })
+  return Boolean(whitelisted)
 }
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -165,14 +165,14 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (balance !== BigInt(0)) {
       return res.status(400).json({ error: 'You are already a citizen!' })
     }
-    const [totalPaid, whitelisted] = await Promise.all([
-      getTotalPaid(address),
-      isCitizenWhitelisted(address),
-    ])
-    if (!whitelisted && totalPaid < BigInt(FREE_MINT_THRESHOLD)) {
-      return res.status(400).json({
-        error: 'You have not contributed enough to earn a free citizen NFT!',
-      })
+    const whitelisted = await isCitizenWhitelisted(address)
+    if (!whitelisted) {
+      const totalPaid = await getTotalPaid(address)
+      if (totalPaid < BigInt(FREE_MINT_THRESHOLD)) {
+        return res.status(400).json({
+          error: 'You have not contributed enough to earn a free citizen NFT!',
+        })
+      }
     }
     const cost: any = await readContract({
       contract: citizenContract,
@@ -208,10 +208,19 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       return res.status(400).json({ error: 'Invalid wallet address format.' })
     }
 
-    const [totalPaid, whitelisted] = await Promise.all([
-      getTotalPaid(address as string),
-      isCitizenWhitelisted(address as string),
-    ])
+    const whitelisted = await isCitizenWhitelisted(address as string)
+    let totalPaid = BigInt(0)
+    if (!whitelisted) {
+      totalPaid = await getTotalPaid(address as string)
+    } else {
+      // For whitelisted users, try to get totalPaid but don't fail if subgraph is down
+      try {
+        totalPaid = await getTotalPaid(address as string)
+      } catch (err) {
+        console.error('Could not fetch totalPaid for whitelisted user:', err)
+        // totalPaid stays 0, but user is still eligible due to whitelist
+      }
+    }
     res.status(200).json({
       success: true,
       message: 'Fetched total paid.',

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -118,22 +118,28 @@ async function getTotalPaid(address: string) {
 // Addresses on the Citizen whitelist contract get a free (fully sponsored)
 // mint regardless of how much they've contributed. The whitelist also makes
 // getRenewalPrice() return 0, so the relayer only pays gas for these mints.
-async function isCitizenWhitelisted(address: string): Promise<boolean> {
+// Returns true if whitelisted, false if not, null if RPC check failed.
+async function isCitizenWhitelisted(address: string): Promise<boolean | null> {
   if (!isValidEvmAddress(address)) return false
   const whitelistAddress = CITIZEN_WHITELIST_ADDRESSES[chainSlug]
   if (!whitelistAddress) return false
-  const whitelistContract = getContract({
-    client: serverClient,
-    address: whitelistAddress,
-    abi: WhitelistABI as any,
-    chain,
-  })
-  const whitelisted = await readContract({
-    contract: whitelistContract,
-    method: 'isWhitelisted' as string,
-    params: [address],
-  })
-  return Boolean(whitelisted)
+  try {
+    const whitelistContract = getContract({
+      client: serverClient,
+      address: whitelistAddress,
+      abi: WhitelistABI as any,
+      chain,
+    })
+    const whitelisted = await readContract({
+      contract: whitelistContract,
+      method: 'isWhitelisted' as string,
+      params: [address],
+    })
+    return Boolean(whitelisted)
+  } catch (err) {
+    console.error('Error checking citizen whitelist:', err)
+    return null
+  }
 }
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -161,6 +167,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       return res.status(400).json({ error: 'You are already a citizen!' })
     }
     const whitelisted = await isCitizenWhitelisted(address)
+    if (whitelisted === null) {
+      return res.status(503).json({ error: 'Unable to verify whitelist status. Please try again.' })
+    }
     if (!whitelisted) {
       const totalPaid = await getTotalPaid(address)
       if (totalPaid < BigInt(FREE_MINT_THRESHOLD)) {
@@ -205,9 +214,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
     const whitelisted = await isCitizenWhitelisted(address as string)
     let totalPaid = BigInt(0)
-    if (!whitelisted) {
-      totalPaid = await getTotalPaid(address as string)
-    } else {
+    if (whitelisted === true) {
       // For whitelisted users, try to get totalPaid but don't fail if subgraph is down
       try {
         totalPaid = await getTotalPaid(address as string)
@@ -215,14 +222,24 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         console.error('Could not fetch totalPaid for whitelisted user:', err)
         // totalPaid stays 0, but user is still eligible due to whitelist
       }
+    } else if (whitelisted === false) {
+      totalPaid = await getTotalPaid(address as string)
+    } else {
+      // whitelisted === null (RPC error): fall back to contribution check only
+      try {
+        totalPaid = await getTotalPaid(address as string)
+      } catch (err) {
+        console.error('Both whitelist and subgraph checks failed:', err)
+        return res.status(503).json({ error: 'Unable to verify eligibility. Please try again.' })
+      }
     }
     res.status(200).json({
       success: true,
       message: 'Fetched total paid.',
       data: {
         totalPaid: totalPaid.toString(),
-        whitelisted,
-        eligible: whitelisted || totalPaid >= BigInt(FREE_MINT_THRESHOLD),
+        whitelisted: whitelisted === true,
+        eligible: whitelisted === true || totalPaid >= BigInt(FREE_MINT_THRESHOLD),
       },
     })
   }

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -1,8 +1,10 @@
 import CitizenABI from 'const/abis/Citizen.json'
+import WhitelistABI from 'const/abis/Whitelist.json'
 import {
   BENDYSTRAW_JB_VERSION,
   DEFAULT_CHAIN_V5,
   CITIZEN_ADDRESSES,
+  CITIZEN_WHITELIST_ADDRESSES,
   FREE_MINT_THRESHOLD,
   MISSION_TABLE_NAMES,
 } from 'const/config'
@@ -113,6 +115,32 @@ async function getTotalPaid(address: string) {
   return totalPaid
 }
 
+// Addresses on the Citizen whitelist contract get a free (fully sponsored)
+// mint regardless of how much they've contributed. The whitelist also makes
+// getRenewalPrice() return 0, so the relayer only pays gas for these mints.
+async function isCitizenWhitelisted(address: string): Promise<boolean> {
+  if (!isValidEvmAddress(address)) return false
+  const whitelistAddress = CITIZEN_WHITELIST_ADDRESSES[chainSlug]
+  if (!whitelistAddress) return false
+  try {
+    const whitelistContract = getContract({
+      client: serverClient,
+      address: whitelistAddress,
+      abi: WhitelistABI as any,
+      chain,
+    })
+    const whitelisted = await readContract({
+      contract: whitelistContract,
+      method: 'isWhitelisted' as string,
+      params: [address],
+    })
+    return Boolean(whitelisted)
+  } catch (err) {
+    console.error('Error checking citizen whitelist:', err)
+    return false
+  }
+}
+
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   setCDNCacheHeaders(res, 60, 60, 'Accept-Encoding, address')
   if (req.method === 'POST') {
@@ -137,8 +165,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (balance !== BigInt(0)) {
       return res.status(400).json({ error: 'You are already a citizen!' })
     }
-    const totalPaid = await getTotalPaid(address)
-    if (totalPaid < BigInt(FREE_MINT_THRESHOLD)) {
+    const [totalPaid, whitelisted] = await Promise.all([
+      getTotalPaid(address),
+      isCitizenWhitelisted(address),
+    ])
+    if (!whitelisted && totalPaid < BigInt(FREE_MINT_THRESHOLD)) {
       return res.status(400).json({
         error: 'You have not contributed enough to earn a free citizen NFT!',
       })
@@ -177,13 +208,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       return res.status(400).json({ error: 'Invalid wallet address format.' })
     }
 
-    const totalPaid = await getTotalPaid(address as string)
+    const [totalPaid, whitelisted] = await Promise.all([
+      getTotalPaid(address as string),
+      isCitizenWhitelisted(address as string),
+    ])
     res.status(200).json({
       success: true,
       message: 'Fetched total paid.',
       data: {
         totalPaid: totalPaid.toString(),
-        eligible: totalPaid >= BigInt(FREE_MINT_THRESHOLD),
+        whitelisted,
+        eligible: whitelisted || totalPaid >= BigInt(FREE_MINT_THRESHOLD),
       },
     })
   }


### PR DESCRIPTION
Make being on the Citizen whitelist contract a path to a free (fully sponsored) mint, in addition to the existing contribution threshold. The /api/mission/freeMint route now reads isWhitelisted from CITIZEN_WHITELIST_ADDRESSES for both eligibility (GET) and the mint gate (POST).

Since the relayer signs and submits the mint server-side, sponsored users pay neither the citizenship fee nor network gas. Update the checkout copy to reflect this (Network fee + Total due show as Sponsored/Free) instead of showing a gas charge the user never pays.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mint eligibility and relayer-gated POST behavior on a security-sensitive API; misconfiguration or RPC failures could block or incorrectly allow sponsored mints.
> 
> **Overview**
> Adds **on-chain Citizen whitelist** as a second path to a **fully sponsored** free mint (alongside the existing contribution threshold).
> 
> **API (`/api/mission/freeMint`):** Reads `isWhitelisted` from `CITIZEN_WHITELIST_ADDRESSES` on GET and POST. Whitelisted users skip the contribution check; POST returns **503** if the whitelist RPC check fails. GET returns `whitelisted` and sets `eligible` when whitelisted **or** over threshold, with subgraph fallbacks when RPC or indexing is flaky.
> 
> **Checkout UI:** Treats sponsored mints as **$0** (no citizenship fee, gas, or bridge in the breakdown), shows **Sponsored/Free** for network and total, hides bridge line when sponsored, and updates copy so users are not told they still pay gas when the relayer submits the mint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3eec450936fab74f3455ffa1b854d7a87bdef5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->