### PR TITLE
One-time magic-link invites for sponsored citizen mints

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -278,7 +278,7 @@ function restoreWizardStageFromSession(): number {
   return 1
 }
 
-export default function CreateCitizen({ selectedChain, setSelectedTier, freeMintProp }: any) {
+export default function CreateCitizen({ selectedChain, setSelectedTier, freeMintProp, inviteToken }: any) {
   // ===== Context & Constants =====
   const router = useRouter()
   const { setSelectedChain } = useContext(ChainContextV5)
@@ -665,15 +665,22 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
 
   const executeFreeMint = useCallback(
     async (imageIpfsHash: string) => {
+      // Invite-sponsored mints must prove the signed-in Privy user owns this
+      // wallet, so the one-time token can only be redeemed by its recipient.
+      const accessToken = inviteToken ? await getAccessToken() : null
       const res = await fetch(`/api/mission/freeMint`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
         body: JSON.stringify({
           address: address,
           name: citizenData.name,
           image: `ipfs://${imageIpfsHash}`,
           privacy: 'public',
           formId: citizenData.formResponseId,
+          ...(inviteToken ? { inviteToken, accessToken } : {}),
         }),
       })
       if (!res.ok) {
@@ -683,7 +690,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
       }
       return await res.json()
     },
-    [address, citizenData.name, citizenData.formResponseId],
+    [address, citizenData.name, citizenData.formResponseId, inviteToken],
   )
 
   const executeCrossChainMint = useCallback(
@@ -1948,7 +1955,12 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
     if (!address) return
 
     const getTotalPaid = async () => {
-      const res = await fetch(`/api/mission/freeMint?address=${address}`, {
+      // A magic-link invite token makes this wallet eligible for a sponsored
+      // mint even without a contribution history or on-chain allowlist entry.
+      const query = inviteToken
+        ? `address=${address}&invite=${encodeURIComponent(inviteToken)}`
+        : `address=${address}`
+      const res = await fetch(`/api/mission/freeMint?${query}`, {
         method: 'GET',
       })
       if (!res.ok) {
@@ -1962,7 +1974,7 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
       }
     }
     getTotalPaid()
-  }, [address])
+  }, [address, inviteToken])
 
   // ===== JSX Render =====
   return (

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -1957,19 +1957,26 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
     const getTotalPaid = async () => {
       // A magic-link invite token makes this wallet eligible for a sponsored
       // mint even without a contribution history or on-chain allowlist entry.
-      const query = inviteToken
-        ? `address=${address}&invite=${encodeURIComponent(inviteToken)}`
-        : `address=${address}`
-      const res = await fetch(`/api/mission/freeMint?${query}`, {
+      // Send the invite token via header instead of query string to prevent
+      // leakage via browser history, analytics, and Referer headers.
+      const headers: Record<string, string> = {}
+      if (inviteToken) {
+        headers['x-invite-token'] = inviteToken
+      }
+      const res = await fetch(`/api/mission/freeMint?address=${address}`, {
         method: 'GET',
+        headers,
       })
       if (!res.ok) {
         const errorText = await res.text() // Or response.json()
         console.error(errorText)
+        setFreeMint(false)
       } else {
         const { data } = await res.json()
         if (data.eligible) {
           setFreeMint(true)
+        } else {
+          setFreeMint(false)
         }
       }
     }

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -278,7 +278,12 @@ function restoreWizardStageFromSession(): number {
   return 1
 }
 
-export default function CreateCitizen({ selectedChain, setSelectedTier, freeMintProp, inviteToken }: any) {
+export default function CreateCitizen({
+  selectedChain,
+  setSelectedTier,
+  freeMintProp,
+  inviteToken,
+}: any) {
   // ===== Context & Constants =====
   const router = useRouter()
   const { setSelectedChain } = useContext(ChainContextV5)
@@ -1182,11 +1187,17 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
         'citizen image',
       )
       // If citizenImage was restored and differs from croppedInputImage, it's an AI portrait
-      if (citizenImageRestored && formData.citizenImage && isSerializedFile(formData.citizenImage)) {
+      if (
+        citizenImageRestored &&
+        formData.citizenImage &&
+        isSerializedFile(formData.citizenImage)
+      ) {
         // Compare serialized data to determine if it's an AI portrait
-        if (!formData.croppedInputImage || 
-            !isSerializedFile(formData.croppedInputImage) ||
-            formData.citizenImage.dataURL !== formData.croppedInputImage.dataURL) {
+        if (
+          !formData.croppedInputImage ||
+          !isSerializedFile(formData.croppedInputImage) ||
+          formData.citizenImage.dataURL !== formData.croppedInputImage.dataURL
+        ) {
           markAiPortraitReady()
         }
       }
@@ -1977,13 +1988,23 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
       if (!res.ok) {
         const errorText = await res.text() // Or response.json()
         console.error(errorText)
-        setFreeMint(false)
+        // Don't clear freeMint if we have an invite token — transient GET
+        // failures shouldn't block the sponsored flow. The token is validated
+        // again at mint time (POST).
+        if (!inviteToken) {
+          setFreeMint(false)
+        }
       } else {
         const { data } = await res.json()
         if (data.eligible) {
           setFreeMint(true)
         } else {
-          setFreeMint(false)
+          // Don't clear freeMint if we have an invite token — the server's
+          // eligibility check can return false due to Redis errors even when
+          // the token is valid. It will be re-validated at mint time (POST).
+          if (!inviteToken) {
+            setFreeMint(false)
+          }
         }
       }
     }

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -383,10 +383,17 @@ export default function CreateCitizen({ selectedChain, setSelectedTier, freeMint
     startTransition(() => setStage(restoredStage))
   }, [isClientHydrated, restoredStage])
 
+  // Sync freeMint state when freeMintProp or inviteToken becomes available
+  useEffect(() => {
+    if (freeMintProp || inviteToken) {
+      setFreeMint(true)
+    }
+  }, [freeMintProp, inviteToken])
+
   // ===== State: Onramp State =====
   const [onrampModalOpen, setOnrampModalOpen] = useState(false)
   const [requiredEthAmount, setRequiredEthAmount] = useState(0)
-  const [freeMint, setFreeMint] = useState(freeMintProp || false)
+  const [freeMint, setFreeMint] = useState(false)
 
   // ===== State: Gas Estimation =====
   const [estimatedGas, setEstimatedGas] = useState<bigint>(BigInt(0))

--- a/ui/lib/citizen/inviteTokens.ts
+++ b/ui/lib/citizen/inviteTokens.ts
@@ -1,0 +1,156 @@
+import { randomBytes } from 'crypto'
+import { Redis } from '@upstash/redis'
+
+/**
+ * One-time "magic link" invite tokens for sponsored citizen mints.
+ *
+ * A token grants a single free (relayer-sponsored) citizen mint to whichever
+ * wallet redeems it. Tokens live in Upstash Redis (the same store used for the
+ * Typeform answer cache and rate limiting) so redemption can be enforced
+ * exactly once across serverless invocations.
+ *
+ * Security model:
+ *  - Tokens are high-entropy random strings (unguessable).
+ *  - `peekInvite` is a read-only check used for UI eligibility; it never
+ *    consumes the token.
+ *  - `consumeInvite` performs an atomic GETDEL so two concurrent requests can
+ *    never both redeem the same token. Redemption is also bound to the
+ *    redeeming wallet address, which the caller must verify belongs to the
+ *    authenticated Privy user before calling.
+ *  - If Redis is not configured, invites are treated as disabled (peek →
+ *    null, consume → false) so the feature fails closed.
+ */
+
+const TOKEN_PREFIX = 'citizen:invite:'
+const REDEEMED_PREFIX = 'citizen:invite:redeemed:'
+const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60 // 30 days
+const REDEEMED_AUDIT_TTL_SECONDS = 90 * 24 * 60 * 60 // keep an audit trail 90 days
+
+export type CitizenInvite = {
+  /** ms epoch the invite was created. */
+  createdAt: number
+  /** Optional human label, e.g. "ETHDenver booth" or a recipient name. */
+  label?: string
+  /** Optional creator note (who minted the link). */
+  createdBy?: string
+}
+
+export type RedeemedInvite = CitizenInvite & {
+  redeemedBy: string
+  redeemedAt: number
+}
+
+let redis: Redis | null = null
+
+function getRedis(): Redis | null {
+  if (redis) return redis
+  const url = process.env.UPSTASH_REDIS_URL
+  const token = process.env.UPSTASH_REDIS_TOKEN
+  if (!url || !token) return null
+  redis = new Redis({ url, token })
+  return redis
+}
+
+function tokenKey(token: string): string {
+  return `${TOKEN_PREFIX}${token}`
+}
+
+function redeemedKey(token: string): string {
+  return `${REDEEMED_PREFIX}${token}`
+}
+
+/** Generate an unguessable invite token (URL-safe base64, ~256 bits). */
+export function generateInviteToken(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+/**
+ * Create a new invite token in Redis. Returns the created record, or null when
+ * Redis is unavailable. `ttlSeconds` controls how long the link stays valid.
+ */
+export async function createInvite(
+  token: string,
+  meta: CitizenInvite,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS
+): Promise<CitizenInvite | null> {
+  const client = getRedis()
+  if (!client || !token) return null
+  await client.set(tokenKey(token), meta, { ex: ttlSeconds })
+  return meta
+}
+
+/**
+ * Read an invite without consuming it (used for UI eligibility checks).
+ * Returns the invite record if the token exists and is unredeemed, else null.
+ */
+export async function peekInvite(token: string): Promise<CitizenInvite | null> {
+  const client = getRedis()
+  if (!client || !token) return null
+  try {
+    const invite = await client.get<CitizenInvite>(tokenKey(token))
+    return invite ?? null
+  } catch (err) {
+    console.warn('[citizen-invite] peek failed:', err)
+    return null
+  }
+}
+
+/**
+ * Atomically redeem an invite for `address`. Uses GETDEL so the token can only
+ * be consumed once even under concurrent requests. Returns true if this call
+ * won the redemption, false if the token was missing/expired/already used.
+ *
+ * The caller MUST have already verified that `address` belongs to the
+ * authenticated Privy user before calling this.
+ */
+export async function consumeInvite(
+  token: string,
+  address: string
+): Promise<boolean> {
+  const client = getRedis()
+  if (!client || !token || !address) return false
+  let invite: CitizenInvite | null = null
+  try {
+    // GETDEL is atomic: the first caller gets the value, everyone else gets null.
+    invite = await client.getdel<CitizenInvite>(tokenKey(token))
+  } catch (err) {
+    console.error('[citizen-invite] consume failed:', err)
+    return false
+  }
+  if (!invite) return false
+
+  // Best-effort audit record of who redeemed the link (does not gate success).
+  try {
+    const redeemed: RedeemedInvite = {
+      ...invite,
+      redeemedBy: address,
+      redeemedAt: Date.now(),
+    }
+    await client.set(redeemedKey(token), redeemed, {
+      ex: REDEEMED_AUDIT_TTL_SECONDS,
+    })
+  } catch (err) {
+    console.warn('[citizen-invite] failed to write redeemed audit record:', err)
+  }
+  return true
+}
+
+/**
+ * Restore a previously consumed invite. Best-effort compensation used when a
+ * mint fails after the token was consumed, so a valid recipient isn't left
+ * with a burned link.
+ */
+export async function restoreInvite(
+  token: string,
+  meta: CitizenInvite,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS
+): Promise<void> {
+  const client = getRedis()
+  if (!client || !token) return
+  try {
+    await client.set(tokenKey(token), meta, { ex: ttlSeconds })
+    await client.del(redeemedKey(token))
+  } catch (err) {
+    console.warn('[citizen-invite] failed to restore invite after error:', err)
+  }
+}

--- a/ui/lib/privy/index.ts
+++ b/ui/lib/privy/index.ts
@@ -6,9 +6,7 @@ export interface PrivyUserData {
   userData: any
 }
 
-export async function getPrivyUserData(
-  accessToken: string
-): Promise<PrivyUserData | null> {
+export async function getPrivyUserData(accessToken: string): Promise<PrivyUserData | null> {
   try {
     // Verify Privy auth and get user data
     const verifiedClaims = await verifyPrivyAuth(accessToken)
@@ -23,18 +21,15 @@ export async function getPrivyUserData(
     const timeout = setTimeout(() => controller.abort(), 8000)
     let userResponse: Response
     try {
-      userResponse = await fetch(
-        `https://auth.privy.io/api/v1/users/${verifiedClaims.userId}`,
-        {
-          headers: {
-            Authorization: `Basic ${Buffer.from(
-              `${process.env.NEXT_PUBLIC_PRIVY_APP_ID}:${process.env.PRIVY_APP_SECRET}`
-            ).toString('base64')}`,
-            'privy-app-id': process.env.NEXT_PUBLIC_PRIVY_APP_ID as string,
-          },
-          signal: controller.signal,
-        }
-      )
+      userResponse = await fetch(`https://auth.privy.io/api/v1/users/${verifiedClaims.userId}`, {
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${process.env.NEXT_PUBLIC_PRIVY_APP_ID}:${process.env.PRIVY_APP_SECRET}`,
+          ).toString('base64')}`,
+          'privy-app-id': process.env.NEXT_PUBLIC_PRIVY_APP_ID as string,
+        },
+        signal: controller.signal,
+      })
     } finally {
       clearTimeout(timeout)
     }
@@ -73,7 +68,7 @@ export async function getPrivyUserData(
 
 export async function addressBelongsToPrivyUser(
   accessToken: string,
-  address: string
+  address: string,
 ): Promise<boolean> {
   const privyUserData = await getPrivyUserData(accessToken)
   if (!privyUserData) {
@@ -82,5 +77,7 @@ export async function addressBelongsToPrivyUser(
   if (privyUserData.walletAddresses.length === 0) {
     return false
   }
-  return privyUserData.walletAddresses.includes(address)
+  return privyUserData.walletAddresses
+    .map((addr) => addr.toLowerCase())
+    .includes(address.toLowerCase())
 }

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -57,6 +57,12 @@ function App({ Component, pageProps: { session, ...pageProps } }: any) {
             appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID as string}
             config={{
               loginMethods: ['wallet', 'sms', 'google', 'twitter', 'discord', 'github'],
+              // Auto-provision an embedded wallet for users who sign up without
+              // one (e.g. via SMS/social on a magic-link invite) so they have an
+              // address to receive their sponsored citizen mint.
+              embeddedWallets: {
+                createOnLogin: 'users-without-wallets',
+              },
               appearance: {
                 theme: '#252c4d',
                 showWalletLoginFirst: false,

--- a/ui/pages/admin/citizen-invites.tsx
+++ b/ui/pages/admin/citizen-invites.tsx
@@ -1,0 +1,249 @@
+import { usePrivy } from '@privy-io/react-auth'
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import { useIsExecutive } from '@/lib/operator/useIsExecutive'
+import { useChainDefault } from '@/lib/thirdweb/hooks/useChainDefault'
+import Container from '../../components/layout/Container'
+import ContentLayout from '../../components/layout/ContentLayout'
+import WebsiteHead from '../../components/layout/Head'
+import { NoticeFooter } from '../../components/layout/NoticeFooter'
+
+type GeneratedLink = { token: string; url: string }
+type Status = 'idle' | 'generating' | 'success' | 'error'
+
+export default function CitizenInvitesAdmin() {
+  useChainDefault()
+  const { authenticated, login } = usePrivy()
+  const { isExecutive, status: authStatus } = useIsExecutive()
+
+  const [count, setCount] = useState(1)
+  const [label, setLabel] = useState('')
+  const [ttlDays, setTtlDays] = useState(30)
+  const [status, setStatus] = useState<Status>('idle')
+  const [links, setLinks] = useState<GeneratedLink[]>([])
+
+  const isGenerating = status === 'generating'
+
+  const copy = async (text: string, what: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success(`Copied ${what}.`, { style: toastStyle })
+    } catch {
+      toast.error('Could not copy to clipboard.', { style: toastStyle })
+    }
+  }
+
+  const generate = async () => {
+    setStatus('generating')
+    setLinks([])
+    try {
+      const res = await fetch('/api/operator/create-citizen-invite', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          count,
+          ttlDays,
+          label: label.trim() || undefined,
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok) {
+        throw new Error(json?.error || `Request failed (${res.status})`)
+      }
+      setLinks(json.links || [])
+      setStatus('success')
+      toast.success(`Created ${json.links?.length || 0} invite link(s).`, {
+        style: toastStyle,
+      })
+    } catch (err: any) {
+      console.error('Generate citizen invites failed:', err)
+      setStatus('error')
+      toast.error(err?.message || 'Failed to generate links.', {
+        style: toastStyle,
+      })
+    }
+  }
+
+  const renderBody = () => {
+    // Not signed in yet.
+    if (!authenticated) {
+      return (
+        <div className="bg-black/20 rounded-xl p-6 border border-white/10 text-center">
+          <p className="text-gray-300 mb-4">
+            Sign in with an operator wallet (e.g. ryand2d.eth or pmoncada.eth)
+            to generate citizen invite links.
+          </p>
+          <button
+            type="button"
+            onClick={() => login()}
+            className="px-6 py-3 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-medium rounded-lg transition"
+          >
+            Sign In
+          </button>
+        </div>
+      )
+    }
+
+    // Signed in, but still confirming operator status.
+    if (authStatus === 'loading' || authStatus === 'idle') {
+      return (
+        <div className="bg-black/20 rounded-xl p-6 border border-white/10 text-center text-gray-300">
+          Checking operator access…
+        </div>
+      )
+    }
+
+    // Signed in but not an allow-listed operator.
+    if (!isExecutive) {
+      return (
+        <div className="bg-black/20 rounded-xl p-6 border border-rose-400/30 text-center">
+          <p className="text-rose-300">
+            This wallet isn&apos;t an authorized operator. Ask an admin to add
+            your address to the operator allowlist.
+          </p>
+        </div>
+      )
+    }
+
+    // Authorized: show the generator.
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="bg-black/20 rounded-xl p-6 border border-white/10 flex flex-col gap-4">
+          <p className="text-gray-300 text-sm">
+            Each link lets one person sign up and mint a free 1-year citizenship,
+            fully sponsored. A link can be redeemed exactly once.
+          </p>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <label className="flex flex-col gap-1">
+              <span className="text-xs uppercase tracking-wider text-gray-400">
+                How many links
+              </span>
+              <input
+                type="number"
+                min={1}
+                max={50}
+                value={count}
+                onChange={(e) =>
+                  setCount(Math.max(1, Math.min(50, Number(e.target.value) || 1)))
+                }
+                className="bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-400/40"
+                disabled={isGenerating}
+              />
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-xs uppercase tracking-wider text-gray-400">
+                Valid for (days)
+              </span>
+              <input
+                type="number"
+                min={1}
+                max={365}
+                value={ttlDays}
+                onChange={(e) =>
+                  setTtlDays(
+                    Math.max(1, Math.min(365, Number(e.target.value) || 30))
+                  )
+                }
+                className="bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-400/40"
+                disabled={isGenerating}
+              />
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-xs uppercase tracking-wider text-gray-400">
+                Label (optional)
+              </span>
+              <input
+                type="text"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="e.g. ETHDenver booth"
+                className="bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-white placeholder:text-gray-600 focus:outline-none focus:border-blue-400/40"
+                disabled={isGenerating}
+              />
+            </label>
+          </div>
+
+          <button
+            type="button"
+            onClick={generate}
+            disabled={isGenerating}
+            className="self-start px-6 py-3 rounded-lg bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white font-RobotoMono shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isGenerating ? 'Generating…' : 'Generate Links'}
+          </button>
+        </div>
+
+        {links.length > 0 && (
+          <div className="bg-black/20 rounded-xl p-6 border border-green-400/30 flex flex-col gap-3">
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <h3 className="text-green-300 font-GoodTimes text-sm">
+                {links.length} link{links.length > 1 ? 's' : ''} created
+              </h3>
+              <button
+                type="button"
+                onClick={() =>
+                  copy(links.map((l) => l.url).join('\n'), 'all links')
+                }
+                className="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/20 text-white text-xs"
+              >
+                Copy all
+              </button>
+            </div>
+            <ul className="flex flex-col gap-2">
+              {links.map((l) => (
+                <li
+                  key={l.token}
+                  className="flex items-center gap-2 bg-black/40 border border-white/10 rounded-lg px-3 py-2"
+                >
+                  <span className="text-gray-200 text-xs break-all flex-1 font-mono">
+                    {l.url}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => copy(l.url, 'link')}
+                    className="shrink-0 px-3 py-1.5 rounded-lg bg-blue-500/80 hover:bg-blue-500 text-white text-xs"
+                  >
+                    Copy
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <p className="text-[11px] text-gray-500">
+              Share each link with one person. Once redeemed, a link can&apos;t be
+              used again.
+            </p>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <WebsiteHead
+        title="Citizen Invite Links"
+        description="Generate one-time sponsored citizenship invite links."
+      />
+      <section className="flex flex-col justify-start px-5 mt-5 items-start animate-fadeIn w-[90vw] md:w-full">
+        <Container>
+          <ContentLayout
+            header="Citizen Invite Links"
+            headerSize="40px"
+            description="Generate one-time links that let someone sign up and mint a free, fully sponsored 1-year citizenship."
+            mainPadding
+            mode="compact"
+            isProfile={true}
+          >
+            <div className="max-w-[900px] w-full">{renderBody()}</div>
+          </ContentLayout>
+          <NoticeFooter />
+        </Container>
+      </section>
+    </>
+  )
+}

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -208,45 +208,62 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       return res.status(400).json({ error: 'You are already a citizen!' })
     }
 
-    // Magic-link path: a one-time invite token sponsors the mint. We require
-    // the caller to prove (via Privy auth) that they own `address`, then
-    // atomically consume the token so it can never be reused. `consumedInvite`
-    // is kept so we can restore the token if the mint later fails.
+    // Check existing eligibility first (allowlist or contribution threshold)
+    // before consuming any invite token. This prevents burning a one-time invite
+    // when the user is already eligible through other means.
+    const listed = await isCitizenFreeMintListed(address)
+    const alreadyEligible = listed === true
+    let totalPaid = BigInt(0)
+    if (!alreadyEligible && listed !== null) {
+      totalPaid = await getTotalPaid(address)
+      if (totalPaid >= BigInt(FREE_MINT_THRESHOLD)) {
+        // User meets contribution threshold; no invite needed.
+        // (Don't set alreadyEligible in the `listed === null` branch since
+        // that signals an RPC error, and we should still accept a valid invite.)
+      }
+    }
+
+    // Magic-link path: a one-time invite token sponsors the mint, but only
+    // consume it if the user is NOT already eligible. We require the caller to
+    // prove (via Privy auth) that they own `address`, then atomically consume
+    // the token so it can never be reused. `consumedInvite` is kept so we can
+    // restore the token if the mint later fails.
     let consumedInvite: CitizenInvite | null = null
     if (inviteToken) {
-      const accessToken = getAccessTokenFromReq(req)
-      if (
-        !accessToken ||
-        !(await addressBelongsToPrivyUser(accessToken, address))
-      ) {
-        return res
-          .status(401)
-          .json({ error: 'You must be signed in with this wallet to redeem an invite.' })
-      }
-      // Peek to get invite metadata for potential restore, but always attempt
-      // consume even if peek fails (peek failures might be transient Redis
-      // errors while the key still exists). consumeInvite is atomic and will
-      // return false if the invite doesn't exist, is expired, or was already used.
-      const invite = await peekInvite(inviteToken)
-      const consumed = await consumeInvite(inviteToken, address)
-      if (!consumed) {
-        return res
-          .status(400)
-          .json({ error: 'This invite link is invalid or has already been used.' })
-      }
-      // Use peeked metadata if available; fall back to minimal record if peek
-      // failed but consume succeeded (transient Redis error during peek).
-      consumedInvite = invite || { createdAt: Date.now() }
-    } else {
-      // Existing eligibility: on-chain allowlist or contribution threshold.
-      const listed = await isCitizenFreeMintListed(address)
-      if (listed !== true) {
-        const totalPaid = await getTotalPaid(address)
-        if (totalPaid < BigInt(FREE_MINT_THRESHOLD)) {
-          return res.status(400).json({
-            error: 'You have not contributed enough to earn a free citizen NFT!',
-          })
+      if (alreadyEligible || totalPaid >= BigInt(FREE_MINT_THRESHOLD)) {
+        // User is already eligible; ignore the invite token (don't consume it)
+        // so they can share it with someone who needs it.
+      } else {
+        const accessToken = getAccessTokenFromReq(req)
+        if (
+          !accessToken ||
+          !(await addressBelongsToPrivyUser(accessToken, address))
+        ) {
+          return res
+            .status(401)
+            .json({ error: 'You must be signed in with this wallet to redeem an invite.' })
         }
+        // Peek to get invite metadata for potential restore, but always attempt
+        // consume even if peek fails (peek failures might be transient Redis
+        // errors while the key still exists). consumeInvite is atomic and will
+        // return false if the invite doesn't exist, is expired, or was already used.
+        const invite = await peekInvite(inviteToken)
+        const consumed = await consumeInvite(inviteToken, address)
+        if (!consumed) {
+          return res
+            .status(400)
+            .json({ error: 'This invite link is invalid or has already been used.' })
+        }
+        // Use peeked metadata if available; fall back to minimal record if peek
+        // failed but consume succeeded (transient Redis error during peek).
+        consumedInvite = invite || { createdAt: Date.now() }
+      }
+    } else {
+      // No invite token: user must be eligible via allowlist or contribution.
+      if (!alreadyEligible && totalPaid < BigInt(FREE_MINT_THRESHOLD)) {
+        return res.status(400).json({
+          error: 'You have not contributed enough to earn a free citizen NFT!',
+        })
       }
     }
 

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -15,7 +15,14 @@ import withMiddleware from 'middleware/withMiddleware'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { readContract, prepareContractCall, sendAndConfirmTransaction, getContract } from 'thirdweb'
 import { cacheExchange, createClient, fetchExchange } from 'urql'
+import {
+  CitizenInvite,
+  consumeInvite,
+  peekInvite,
+  restoreInvite,
+} from '@/lib/citizen/inviteTokens'
 import { createHSMWallet } from '@/lib/google/hsm-signer'
+import { addressBelongsToPrivyUser } from '@/lib/privy'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import { serverClient } from '@/lib/thirdweb/client'
@@ -37,6 +44,16 @@ const subgraphClient = createClient({
 
 function isValidEvmAddress(addr: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(addr)
+}
+
+// Pull the Privy access token from the Authorization header or request body.
+function getAccessTokenFromReq(req: NextApiRequest): string | null {
+  const authHeader = req.headers.authorization
+  if (authHeader?.startsWith('Bearer ')) {
+    return authHeader.slice('Bearer '.length).trim()
+  }
+  const bodyToken = req.body?.accessToken
+  return typeof bodyToken === 'string' && bodyToken.length > 0 ? bodyToken : null
 }
 
 // Cache MoonDAO mission projectIds (refreshes every 5 minutes)
@@ -170,7 +187,7 @@ async function isCitizenFreeMintListed(
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   setCDNCacheHeaders(res, 60, 60, 'Accept-Encoding, address')
   if (req.method === 'POST') {
-    const { address, name, image, privacy, formId } = req.body
+    const { address, name, image, privacy, formId, inviteToken } = req.body
     if (!address || !name || !image || !privacy || !formId) {
       return res.status(400).json({ error: 'Mint params not found!' })
     }
@@ -191,47 +208,97 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (balance !== BigInt(0)) {
       return res.status(400).json({ error: 'You are already a citizen!' })
     }
-    const listed = await isCitizenFreeMintListed(address)
-    if (listed !== true) {
-      const totalPaid = await getTotalPaid(address)
-      if (totalPaid < BigInt(FREE_MINT_THRESHOLD)) {
-        return res.status(400).json({
-          error: 'You have not contributed enough to earn a free citizen NFT!',
-        })
+
+    // Magic-link path: a one-time invite token sponsors the mint. We require
+    // the caller to prove (via Privy auth) that they own `address`, then
+    // atomically consume the token so it can never be reused. `consumedInvite`
+    // is kept so we can restore the token if the mint later fails.
+    let consumedInvite: CitizenInvite | null = null
+    if (inviteToken) {
+      const accessToken = getAccessTokenFromReq(req)
+      if (
+        !accessToken ||
+        !(await addressBelongsToPrivyUser(accessToken, address))
+      ) {
+        return res
+          .status(401)
+          .json({ error: 'You must be signed in with this wallet to redeem an invite.' })
+      }
+      const invite = await peekInvite(inviteToken)
+      const consumed = invite ? await consumeInvite(inviteToken, address) : false
+      if (!consumed) {
+        return res
+          .status(400)
+          .json({ error: 'This invite link is invalid or has already been used.' })
+      }
+      consumedInvite = invite
+    } else {
+      // Existing eligibility: on-chain allowlist or contribution threshold.
+      const listed = await isCitizenFreeMintListed(address)
+      if (listed !== true) {
+        const totalPaid = await getTotalPaid(address)
+        if (totalPaid < BigInt(FREE_MINT_THRESHOLD)) {
+          return res.status(400).json({
+            error: 'You have not contributed enough to earn a free citizen NFT!',
+          })
+        }
       }
     }
-    const cost: any = await readContract({
-      contract: citizenContract,
-      method: 'getRenewalPrice' as string,
-      params: [address, 365 * 24 * 60 * 60],
-    })
-    const account = await createHSMWallet()
-    const transaction = prepareContractCall({
-      contract: citizenContract,
-      method: 'mintTo' as string,
-      params: [address, name, '', image, '', '', '', '', privacy, formId],
-      value: cost,
-    })
-    const receipt = await sendAndConfirmTransaction({
-      transaction,
-      account,
-    })
-    const jsonReceipt = JSON.stringify(receipt, (key, value) => {
-      if (typeof value === 'bigint') {
-        return value.toString()
+
+    try {
+      const cost: any = await readContract({
+        contract: citizenContract,
+        method: 'getRenewalPrice' as string,
+        params: [address, 365 * 24 * 60 * 60],
+      })
+      const account = await createHSMWallet()
+      const transaction = prepareContractCall({
+        contract: citizenContract,
+        method: 'mintTo' as string,
+        params: [address, name, '', image, '', '', '', '', privacy, formId],
+        value: cost,
+      })
+      const receipt = await sendAndConfirmTransaction({
+        transaction,
+        account,
+      })
+      const jsonReceipt = JSON.stringify(receipt, (key, value) => {
+        if (typeof value === 'bigint') {
+          return value.toString()
+        }
+        return value
+      })
+      res.status(200).json(JSON.parse(jsonReceipt))
+    } catch (err) {
+      // The mint failed after the invite was consumed — restore the token so a
+      // legitimate recipient isn't left with a burned link.
+      if (inviteToken && consumedInvite) {
+        await restoreInvite(inviteToken, consumedInvite)
       }
-      return value
-    })
-    res.status(200).json(JSON.parse(jsonReceipt))
+      console.error('Free mint failed:', err)
+      return res.status(500).json({ error: 'Mint failed. Please try again.' })
+    }
   }
   if (req.method === 'GET') {
     const address = req.query.address
+    const inviteToken =
+      typeof req.query.invite === 'string' ? req.query.invite : undefined
 
     if (!address || typeof address !== 'string') {
       return res.status(400).json({ error: 'Address is required.' })
     }
     if (!isValidEvmAddress(address)) {
       return res.status(400).json({ error: 'Invalid wallet address format.' })
+    }
+
+    // A valid (unconsumed) invite token makes the user eligible for a sponsored
+    // mint. We only peek here — the token is consumed at mint time (POST).
+    if (inviteToken && (await peekInvite(inviteToken))) {
+      return res.status(200).json({
+        success: true,
+        message: 'Invite is valid.',
+        data: { totalPaid: '0', whitelisted: false, invited: true, eligible: true },
+      })
     }
 
     const listed = await isCitizenFreeMintListed(address as string)
@@ -261,6 +328,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       data: {
         totalPaid: totalPaid.toString(),
         whitelisted: listed === true,
+        invited: false,
         eligible: listed === true || totalPaid >= BigInt(FREE_MINT_THRESHOLD),
       },
     })

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -15,12 +15,7 @@ import withMiddleware from 'middleware/withMiddleware'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { readContract, prepareContractCall, sendAndConfirmTransaction, getContract } from 'thirdweb'
 import { cacheExchange, createClient, fetchExchange } from 'urql'
-import {
-  CitizenInvite,
-  consumeInvite,
-  peekInvite,
-  restoreInvite,
-} from '@/lib/citizen/inviteTokens'
+import { CitizenInvite, consumeInvite, peekInvite, restoreInvite } from '@/lib/citizen/inviteTokens'
 import { createHSMWallet } from '@/lib/google/hsm-signer'
 import { addressBelongsToPrivyUser } from '@/lib/privy'
 import queryTable from '@/lib/tableland/queryTable'
@@ -145,7 +140,7 @@ async function getTotalPaid(address: string) {
 // Returns true if listed, false if confirmed not listed, null if the RPC failed.
 async function isOnCitizenList(
   address: string,
-  listAddress: string | undefined
+  listAddress: string | undefined,
 ): Promise<boolean | null> {
   if (!listAddress) return false
   try {
@@ -171,9 +166,7 @@ async function isOnCitizenList(
 // discount list. Returns null only when a list check failed and the address was
 // not confirmed on the other list, so callers can fall back to the contribution
 // check rather than wrongly rejecting an eligible user.
-async function isCitizenFreeMintListed(
-  address: string
-): Promise<boolean | null> {
+async function isCitizenFreeMintListed(address: string): Promise<boolean | null> {
   if (!isValidEvmAddress(address)) return false
   const [whitelisted, discounted] = await Promise.all([
     isOnCitizenList(address, CITIZEN_WHITELIST_ADDRESSES[chainSlug]),
@@ -214,7 +207,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const listed = await isCitizenFreeMintListed(address)
     const alreadyEligible = listed === true
     let totalPaid = BigInt(0)
-    if (!alreadyEligible && listed !== null) {
+    if (!alreadyEligible) {
       totalPaid = await getTotalPaid(address)
       if (totalPaid >= BigInt(FREE_MINT_THRESHOLD)) {
         // User meets contribution threshold; no invite needed.
@@ -235,10 +228,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         // so they can share it with someone who needs it.
       } else {
         const accessToken = getAccessTokenFromReq(req)
-        if (
-          !accessToken ||
-          !(await addressBelongsToPrivyUser(accessToken, address))
-        ) {
+        if (!accessToken || !(await addressBelongsToPrivyUser(accessToken, address))) {
           return res
             .status(401)
             .json({ error: 'You must be signed in with this wallet to redeem an invite.' })
@@ -313,7 +303,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     let inviteToken =
       req.headers['x-invite-token'] ||
       (typeof req.query.invite === 'string' ? req.query.invite : undefined)
-    
+
     // Normalize header to string (Next.js can provide string | string[])
     if (Array.isArray(inviteToken)) {
       inviteToken = inviteToken[0]

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -295,9 +295,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     // Accept invite token from header instead of query string to prevent leakage
     // via browser history, analytics, proxies, and Referer headers.
     const inviteToken =
-      req.headers['x-invite-token'] || typeof req.query.invite === 'string'
-        ? req.query.invite
-        : undefined
+      req.headers['x-invite-token'] ||
+      (typeof req.query.invite === 'string' ? req.query.invite : undefined)
 
     if (!address || typeof address !== 'string') {
       return res.status(400).json({ error: 'Address is required.' })

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -224,14 +224,20 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           .status(401)
           .json({ error: 'You must be signed in with this wallet to redeem an invite.' })
       }
+      // Peek to get invite metadata for potential restore, but always attempt
+      // consume even if peek fails (peek failures might be transient Redis
+      // errors while the key still exists). consumeInvite is atomic and will
+      // return false if the invite doesn't exist, is expired, or was already used.
       const invite = await peekInvite(inviteToken)
-      const consumed = invite ? await consumeInvite(inviteToken, address) : false
+      const consumed = await consumeInvite(inviteToken, address)
       if (!consumed) {
         return res
           .status(400)
           .json({ error: 'This invite link is invalid or has already been used.' })
       }
-      consumedInvite = invite
+      // Use peeked metadata if available; fall back to minimal record if peek
+      // failed but consume succeeded (transient Redis error during peek).
+      consumedInvite = invite || { createdAt: Date.now() }
     } else {
       // Existing eligibility: on-chain allowlist or contribution threshold.
       const listed = await isCitizenFreeMintListed(address)
@@ -245,6 +251,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       }
     }
 
+    // Track whether the mint transaction succeeded so we only restore the invite
+    // on actual mint failures, not on subsequent response serialization errors.
+    let mintSucceeded = false
     try {
       const cost: any = await readContract({
         contract: citizenContract,
@@ -262,6 +271,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         transaction,
         account,
       })
+      mintSucceeded = true
       const jsonReceipt = JSON.stringify(receipt, (key, value) => {
         if (typeof value === 'bigint') {
           return value.toString()
@@ -270,9 +280,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
       res.status(200).json(JSON.parse(jsonReceipt))
     } catch (err) {
-      // The mint failed after the invite was consumed — restore the token so a
-      // legitimate recipient isn't left with a burned link.
-      if (inviteToken && consumedInvite) {
+      // Only restore the invite if the mint transaction itself failed. If the
+      // transaction succeeded but response serialization/sending failed, the
+      // citizen already exists and we must not restore the one-time token.
+      if (!mintSucceeded && inviteToken && consumedInvite) {
         await restoreInvite(inviteToken, consumedInvite)
       }
       console.error('Free mint failed:', err)
@@ -281,8 +292,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
   if (req.method === 'GET') {
     const address = req.query.address
+    // Accept invite token from header instead of query string to prevent leakage
+    // via browser history, analytics, proxies, and Referer headers.
     const inviteToken =
-      typeof req.query.invite === 'string' ? req.query.invite : undefined
+      req.headers['x-invite-token'] || typeof req.query.invite === 'string'
+        ? req.query.invite
+        : undefined
 
     if (!address || typeof address !== 'string') {
       return res.status(400).json({ error: 'Address is required.' })
@@ -292,8 +307,23 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     // A valid (unconsumed) invite token makes the user eligible for a sponsored
-    // mint. We only peek here — the token is consumed at mint time (POST).
+    // mint, but only if they don't already hold a citizen NFT. We only peek
+    // here — the token is consumed at mint time (POST).
     if (inviteToken && (await peekInvite(inviteToken))) {
+      const citizenContract = getContract({
+        client: serverClient,
+        address: CITIZEN_ADDRESSES[chainSlug],
+        abi: CitizenABI as any,
+        chain: chain,
+      })
+      const balance: any = await readContract({
+        contract: citizenContract,
+        method: 'balanceOf' as string,
+        params: [address as string],
+      })
+      if (balance !== BigInt(0)) {
+        return res.status(400).json({ error: 'You are already a citizen!' })
+      }
       return res.status(200).json({
         success: true,
         message: 'Invite is valid.',

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -185,7 +185,6 @@ async function isCitizenFreeMintListed(
 }
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  setCDNCacheHeaders(res, 60, 60, 'Accept-Encoding, address')
   if (req.method === 'POST') {
     const { address, name, image, privacy, formId, inviteToken } = req.body
     if (!address || !name || !image || !privacy || !formId) {
@@ -294,9 +293,14 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const address = req.query.address
     // Accept invite token from header instead of query string to prevent leakage
     // via browser history, analytics, proxies, and Referer headers.
-    const inviteToken =
+    let inviteToken =
       req.headers['x-invite-token'] ||
       (typeof req.query.invite === 'string' ? req.query.invite : undefined)
+    
+    // Normalize header to string (Next.js can provide string | string[])
+    if (Array.isArray(inviteToken)) {
+      inviteToken = inviteToken[0]
+    }
 
     if (!address || typeof address !== 'string') {
       return res.status(400).json({ error: 'Address is required.' })
@@ -309,6 +313,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     // mint, but only if they don't already hold a citizen NFT. We only peek
     // here — the token is consumed at mint time (POST).
     if (inviteToken && (await peekInvite(inviteToken))) {
+      // Invite-based eligibility responses should not be cached since they
+      // depend on the one-time token header, not just the address.
+      res.setHeader('Cache-Control', 'private, no-cache, no-store, must-revalidate')
       const citizenContract = getContract({
         client: serverClient,
         address: CITIZEN_ADDRESSES[chainSlug],
@@ -330,6 +337,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
     }
 
+    // Standard eligibility check (allowlist or contribution threshold) can be cached
+    setCDNCacheHeaders(res, 60, 60, 'Accept-Encoding')
     const listed = await isCitizenFreeMintListed(address as string)
     let totalPaid = BigInt(0)
     if (listed === true) {

--- a/ui/pages/api/operator/create-citizen-invite.ts
+++ b/ui/pages/api/operator/create-citizen-invite.ts
@@ -1,0 +1,93 @@
+import { isOperator } from 'middleware/isOperator'
+import withMiddleware from 'middleware/withMiddleware'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  createInvite,
+  generateInviteToken,
+} from '@/lib/citizen/inviteTokens'
+
+type Body = {
+  count?: number | string
+  label?: string
+  ttlDays?: number | string
+}
+
+const MAX_COUNT = 50
+const MAX_TTL_DAYS = 365
+const DEFAULT_TTL_DAYS = 30
+
+// Build the public origin for the invite links from the incoming request, so
+// the generated links automatically point at whatever host the operator is on
+// (production, a preview deployment, or localhost) without any config.
+function getOrigin(req: NextApiRequest): string {
+  const envBase = process.env.NEXT_PUBLIC_BASE_URL
+  if (envBase) return envBase.replace(/\/$/, '')
+  const forwardedProto = req.headers['x-forwarded-proto']
+  const proto =
+    (Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto) ||
+    'https'
+  const host = req.headers.host
+  return `${proto}://${host}`
+}
+
+// Operator-only endpoint to mint one-time citizen invite links. Gated by the
+// `isOperator` allowlist (see OPERATORS in const/config.ts), so a non-technical
+// admin can generate links from the website without any local environment.
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const body = (req.body ?? {}) as Body
+
+  let count = Number(body.count ?? 1)
+  if (!Number.isInteger(count) || count < 1) count = 1
+  if (count > MAX_COUNT) count = MAX_COUNT
+
+  let ttlDays = Number(body.ttlDays ?? DEFAULT_TTL_DAYS)
+  if (!Number.isFinite(ttlDays) || ttlDays < 1) ttlDays = DEFAULT_TTL_DAYS
+  if (ttlDays > MAX_TTL_DAYS) ttlDays = MAX_TTL_DAYS
+
+  const label =
+    typeof body.label === 'string' && body.label.trim()
+      ? body.label.trim().slice(0, 120)
+      : undefined
+
+  const origin = getOrigin(req)
+  const ttlSeconds = ttlDays * 24 * 60 * 60
+
+  const links: Array<{ token: string; url: string }> = []
+  try {
+    for (let i = 0; i < count; i++) {
+      const token = generateInviteToken()
+      const created = await createInvite(
+        token,
+        { createdAt: Date.now(), label, createdBy: 'operator-panel' },
+        ttlSeconds
+      )
+      if (!created) {
+        // createInvite returns null only when Redis is unconfigured.
+        return res.status(500).json({
+          error:
+            'Invite storage is not configured (UPSTASH_REDIS_URL / UPSTASH_REDIS_TOKEN).',
+        })
+      }
+      links.push({ token, url: `${origin}/citizen?invite=${token}` })
+    }
+  } catch (err: any) {
+    console.error('create-citizen-invite failed:', err)
+    return res
+      .status(500)
+      .json({ error: err?.message || 'Failed to create invite links.' })
+  }
+
+  return res.status(200).json({
+    success: true,
+    count: links.length,
+    ttlDays,
+    label: label ?? null,
+    links,
+  })
+}
+
+export default withMiddleware(handler, isOperator)

--- a/ui/pages/citizen/index.tsx
+++ b/ui/pages/citizen/index.tsx
@@ -24,7 +24,11 @@ export default function Join() {
     [router],
   )
 
-  const freeMint = router.query.freeMint === 'true'
+  // A one-time magic-link invite (`?invite=<token>`) sponsors a free mint for
+  // whoever redeems it; eligibility is verified server-side against the token.
+  const inviteToken =
+    typeof router.query.invite === 'string' ? router.query.invite : undefined
+  const freeMint = router.query.freeMint === 'true' || Boolean(inviteToken)
 
   return (
     <>
@@ -39,6 +43,7 @@ export default function Join() {
         selectedChain={selectedChain}
         setSelectedTier={handleExitFlow}
         freeMintProp={freeMint}
+        inviteToken={inviteToken}
       />
     </>
   )

--- a/ui/scripts/create-citizen-invite.mjs
+++ b/ui/scripts/create-citizen-invite.mjs
@@ -1,0 +1,106 @@
+// Generates one-time "magic link" invite tokens for sponsored citizen mints.
+//
+// Each token grants a single free (relayer-sponsored) citizen mint to whoever
+// redeems it. Tokens are stored in Upstash Redis (key `citizen:invite:<token>`)
+// and consumed atomically at mint time by /api/mission/freeMint.
+//
+// Usage (from repo root or ui/):
+//   node ui/scripts/create-citizen-invite.mjs [--count 5] [--label "ETHDenver"] \
+//       [--ttl-days 30] [--base-url https://moondao.com]
+//
+// Reads UPSTASH_REDIS_URL and UPSTASH_REDIS_TOKEN from ui/.env.local (or env).
+
+import { randomBytes } from 'crypto'
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+function loadEnvLocal() {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const envPath = join(here, '..', '.env.local')
+  const env = {}
+  try {
+    const raw = readFileSync(envPath, 'utf8')
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq === -1) continue
+      const key = trimmed.slice(0, eq).trim()
+      let value = trimmed.slice(eq + 1).trim()
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      env[key] = value
+    }
+  } catch (err) {
+    console.warn(`Could not read ${envPath}: ${err.message}`)
+  }
+  return env
+}
+
+function parseArgs(argv) {
+  const args = { count: 1, label: undefined, ttlDays: 30, baseUrl: undefined }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--count') args.count = parseInt(argv[++i], 10)
+    else if (a === '--label') args.label = argv[++i]
+    else if (a === '--ttl-days') args.ttlDays = parseInt(argv[++i], 10)
+    else if (a === '--base-url') args.baseUrl = argv[++i]
+  }
+  if (!Number.isFinite(args.count) || args.count < 1) args.count = 1
+  if (!Number.isFinite(args.ttlDays) || args.ttlDays < 1) args.ttlDays = 30
+  return args
+}
+
+async function main() {
+  const env = loadEnvLocal()
+  const url = process.env.UPSTASH_REDIS_URL || env.UPSTASH_REDIS_URL
+  const token = process.env.UPSTASH_REDIS_TOKEN || env.UPSTASH_REDIS_TOKEN
+  if (!url || !token) {
+    console.error(
+      'Missing UPSTASH_REDIS_URL or UPSTASH_REDIS_TOKEN (checked env and ui/.env.local).'
+    )
+    process.exit(1)
+  }
+
+  const { count, label, ttlDays, baseUrl } = parseArgs(process.argv.slice(2))
+  const linkBase =
+    baseUrl ||
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    env.NEXT_PUBLIC_BASE_URL ||
+    'https://moondao.com'
+  const ttlSeconds = ttlDays * 24 * 60 * 60
+
+  const { Redis } = await import('@upstash/redis')
+  const redis = new Redis({ url, token })
+
+  const links = []
+  for (let i = 0; i < count; i++) {
+    const inviteToken = randomBytes(32).toString('base64url')
+    const meta = {
+      createdAt: Date.now(),
+      ...(label ? { label } : {}),
+      createdBy: 'create-citizen-invite-script',
+    }
+    await redis.set(`citizen:invite:${inviteToken}`, meta, { ex: ttlSeconds })
+    links.push(`${linkBase.replace(/\/$/, '')}/citizen?invite=${inviteToken}`)
+  }
+
+  console.log(
+    `\nCreated ${count} citizen invite link${count > 1 ? 's' : ''}` +
+      `${label ? ` (label: ${label})` : ''}, valid for ${ttlDays} day${
+        ttlDays > 1 ? 's' : ''
+      }:\n`
+  )
+  for (const link of links) console.log(link)
+  console.log('\nEach link can be redeemed exactly once.\n')
+}
+
+main().catch((err) => {
+  console.error('Failed to create invite(s):', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Stacked on top of #1354. Adds a **one-time "magic link" invite** so a person can open a link, sign up with Privy (auto-creating an embedded wallet), and mint a **free 1-year Citizen** sponsored end-to-end by the HSM relayer — with **no contribution history or on-chain allowlist entry required**.

This is the "Option A" (off-chain eligibility) design: the invite token grants eligibility in our own `freeMint` relayer; the renewal fee is paid by the relayer to `moonDAOTreasury`, so there are no contract or list-ownership changes.

## How it works

1. An executive generates links from the website at `/admin/citizen-invites` (or via `scripts/create-citizen-invite.mjs`) → tokens stored in Upstash Redis (`citizen:invite:<token>`), each valid once.
2. Recipient opens `/citizen?invite=<token>` → lands in the existing citizen wizard, signs in with Privy (embedded wallet auto-created for SMS/social signups).
3. `GET /api/mission/freeMint?address=&invite=` **peeks** the token (no consume) and reports `eligible: true`, so the UI shows the sponsored/free checkout.
4. `POST /api/mission/freeMint` with the token: requires **Privy auth proving the caller owns `address`**, **atomically consumes** the token (Redis `GETDEL`), then the HSM mints. If the mint throws, the token is **restored** so a legitimate recipient isn't left with a burned link.

## Generating links (for executives)

No local setup or environment variables needed — links are generated from the live site (or any deploy preview). Access is restricted to wallets on the operator allowlist (`OPERATORS` in `const/config.ts`, e.g. ryand2d.eth, pmoncada.eth).

1. Go to **`/admin/citizen-invites`** (e.g. `https://moondao.com/admin/citizen-invites`, or the same path on a Vercel preview link).
2. **Sign in** with your operator wallet using the normal site login.
3. Set **how many links** (1–50), **valid for (days)** (default 30), and an optional **label** (e.g. "ETHDenver booth") to help you remember what a batch was for.
4. Click **Generate Links**.
5. **Copy** each link individually, or **Copy all**, and share them. Each link can be redeemed exactly once; once used it stops working.

> If you see "not an authorized operator," your wallet needs to be added to the `OPERATORS` allowlist.

## Changes

- `lib/citizen/inviteTokens.ts` — Redis-backed one-time token store: `peekInvite` (read-only eligibility), `consumeInvite` (atomic GETDEL, bound to the redeeming address, with an audit record), `restoreInvite`, `generateInviteToken`. Fails closed when Redis is unconfigured.
- `pages/api/mission/freeMint.ts` — invite eligibility path on GET; auth + atomic consume + restore-on-failure on POST. Existing whitelist/discount-list and contribution-threshold paths are unchanged.
- `components/onboarding/CreateCitizen.tsx` + `pages/citizen/index.tsx` — thread `?invite=<token>` through the eligibility check and the mint call (Bearer + body access token).
- `pages/_app.tsx` — `embeddedWallets.createOnLogin: 'users-without-wallets'` so new signups get an address.
- `pages/api/operator/create-citizen-invite.ts` — `isOperator`-gated POST that mints N one-time tokens and returns full links; link origin derived from the request so prod/preview/localhost all work with no config.
- `pages/admin/citizen-invites.tsx` — executive-facing page (count / TTL / label form, copy + copy-all), gated client-side by `useIsExecutive`.
- `scripts/create-citizen-invite.mjs` — CLI link generator for technical admins (`--count`, `--label`, `--ttl-days`, `--base-url`).

## Security notes

- Tokens are 256-bit random, single-use (atomic GETDEL prevents double-redeem under concurrency).
- Invite mints are authenticated: the redeemer must be the signed-in Privy user who owns the wallet.
- Contract already enforces one citizen per wallet (`balanceOf` check) and the relayer's `mintTo` permission is unchanged.
- Abuse controls to consider before scaling: cap total live invites, monitor the HSM balance, and the existing `rateLimit` middleware applies.

## Requires
- `UPSTASH_REDIS_URL` / `UPSTASH_REDIS_TOKEN` (already used for Typeform cache + rate limiting).
- Privy dashboard embedded-wallet creation enabled (paired with the provider config here).

## Test plan
- [ ] Generate a link with the script; open `/citizen?invite=<token>` as a brand-new user (SMS/social) → embedded wallet created, checkout shows Sponsored/Free, mint succeeds, user pays nothing.
- [ ] Re-open the same link after redemption → rejected as already used.
- [ ] Tamper with / fake a token → rejected as invalid.
- [ ] Call `POST /freeMint` with a token but a wallet the Privy user doesn't own → 401.
- [ ] Concurrent redemptions of one token → only one mint succeeds.
- [ ] Redis unconfigured → invites simply disabled (no crash); existing whitelist/threshold free mints still work.
- [ ] Already-a-citizen address with a valid token → rejected ("already a citizen").

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Sponsored on-chain mints via the HSM relayer and new auth-bound one-time tokens; misconfiguration or abuse could drain relayer funds or wrongly redeem invites.
> 
> **Overview**
> Adds **one-time magic-link invites** so recipients can mint a **fully sponsored** 1-year Citizen via the existing relayer, without on-chain allowlist or contribution history.
> 
> **Backend:** New `inviteTokens` module (Upstash Redis) with `peekInvite` (UI eligibility), atomic `consumeInvite` (GETDEL), and `restoreInvite` on failed mints. `GET/POST /api/mission/freeMint` accepts invites via `x-invite-token` / body; POST requires Privy proof that the mint wallet belongs to the signed-in user. Operators get `POST /api/operator/create-citizen-invite` plus an admin UI at `pages/admin/citizen-invites.tsx` and a CLI script.
> 
> **Frontend:** `/citizen?invite=…` threads the token through `CreateCitizen` (sponsored checkout, resilient eligibility when GET flakes). Privy auto-creates embedded wallets for social/SMS signups. Wallet ownership checks are now case-insensitive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4855d9ced8ecbdf4036e9c6d17ef2b523272010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
