### PR TITLE
fix: cleaner buy, bridge, and lock page UX

### DIFF
--- a/ui/components/bridge/ArbitrumBridge.tsx
+++ b/ui/components/bridge/ArbitrumBridge.tsx
@@ -264,6 +264,11 @@ export default function ArbitrumBridge() {
     setSelectedChain(ethereum)
   }, [setSelectedChain])
 
+  const numAmount = parseFloat(String(amount)) || 0
+  const isOverBalance =
+    balance !== undefined && numAmount > 0 && numAmount > Number(balance)
+  const tokenLabel = inputToken === 'eth' ? 'ETH' : 'MOONEY'
+
   return (
     <div className="w-full mt-3 sm:mt-4">
       <div className="text-sm font-RobotoMono rounded-xl sm:rounded-2xl animate-fadeIn p-3 sm:p-4 flex flex-col bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 shadow-2xl text-white">
@@ -305,7 +310,6 @@ export default function ArbitrumBridge() {
                     className="text-white bg-transparent text-xl sm:text-2xl font-RobotoMono placeholder-gray-500 focus:outline-none w-full min-w-0 border-0 !p-0 min-h-[28px] tabular-nums"
                     bare
                     value={amount}
-                    max={balance ? Number(balance) : undefined}
                     onChange={(e) => {
                       let value = e.target.value
                       value = value.replace(/[^0-9.]/g, '')
@@ -314,9 +318,6 @@ export default function ArbitrumBridge() {
                         value = parts[0] + '.' + parts.slice(1).join('')
                       }
                       if (parseFloat(value) < 0) value = '0'
-                      if (balance && parseFloat(value) > balance) {
-                        value = String(balance)
-                      }
                       if (value.startsWith('0') && value.length > 1 && value[1] !== '.') {
                         value = value.substring(1)
                       }
@@ -399,8 +400,14 @@ export default function ArbitrumBridge() {
               skipNetworkCheck={skipNetworkCheck}
               requiredChain={ethereum}
               className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white py-3 sm:py-4 px-4 rounded-xl text-base sm:text-lg font-semibold transition-all duration-200 transform hover:scale-[1.02] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:from-gray-500 disabled:to-gray-600"
-              label="Bridge to Arbitrum"
-              isDisabled={!isEOA}
+              label={
+                numAmount === 0
+                  ? 'Enter Amount'
+                  : isOverBalance
+                  ? `Not Enough ${tokenLabel}`
+                  : 'Bridge to Arbitrum'
+              }
+              isDisabled={!isEOA || numAmount === 0 || isOverBalance}
               action={async () => {
                 try {
                   if (inputToken === 'eth') {

--- a/ui/components/bridge/ArbitrumBridge.tsx
+++ b/ui/components/bridge/ArbitrumBridge.tsx
@@ -394,9 +394,10 @@ export default function ArbitrumBridge() {
 
         {/* Action Button */}
         <div className="w-full">
-          {isEOA ? (
+          {!address || isEOA ? (
             <PrivyWeb3Button
               v5
+              signInLabel="Sign In to Bridge to Arbitrum"
               skipNetworkCheck={skipNetworkCheck}
               requiredChain={ethereum}
               className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white py-3 sm:py-4 px-4 rounded-xl text-base sm:text-lg font-semibold transition-all duration-200 transform hover:scale-[1.02] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:from-gray-500 disabled:to-gray-600"

--- a/ui/components/privy/PrivyWeb3Button.tsx
+++ b/ui/components/privy/PrivyWeb3Button.tsx
@@ -40,6 +40,9 @@ type PrivyWeb3BtnProps = {
   noPadding?: boolean
   noGradient?: boolean
   showSignInLabel?: boolean
+  /** Custom label shown when the user is signed out (state 0). Takes
+   *  precedence over `showSignInLabel`. e.g. "Sign In to Buy MOONEY". */
+  signInLabel?: string
   /** When set, shown next to the spinner while the action is running (e.g. transaction steps). */
   loadingLabel?: string
 }
@@ -88,6 +91,7 @@ export function PrivyWeb3Button({
   noPadding = false,
   noGradient = false,
   showSignInLabel = false,
+  signInLabel,
   loadingLabel,
 }: PrivyWeb3BtnProps) {
   const router = useRouter()
@@ -183,7 +187,7 @@ export function PrivyWeb3Button({
           noPadding={noPadding}
           noGradient={noGradient}
         >
-          {showSignInLabel ? 'Sign In' : label}
+          {signInLabel ? signInLabel : showSignInLabel ? 'Sign In' : label}
         </Button>
       )}
       {btnState === 1 && (

--- a/ui/components/uniswap/NativeToMooney.tsx
+++ b/ui/components/uniswap/NativeToMooney.tsx
@@ -38,9 +38,13 @@ export default function NativeToMooney({ selectedChain }: any) {
   const { effectiveGasPrice } = useGasPrice(selectedChain)
   const { ethPrice } = useETHPrice(1, 'ETH_TO_USD')
 
+  const isOverBalance =
+    nativeBalance !== undefined && !!amount && parseFloat(amount) > nativeBalance
+
   useEffect(() => {
     const numAmount = parseFloat(amount) || 0
-    if (numAmount > 0 && mooneyAddress) {
+    const overBalance = nativeBalance !== undefined && numAmount > nativeBalance
+    if (numAmount > 0 && mooneyAddress && !overBalance) {
       setIsGeneratingRoute(true)
       quote(amount)
         .then(async (quotedAmount) => {
@@ -114,7 +118,7 @@ export default function NativeToMooney({ selectedChain }: any) {
       setEstimatedGasUsedUSD('0.00')
       setPriceImpact(null)
     }
-  }, [amount, mooneyAddress, quote, estimateGas, effectiveGasPrice, ethPrice])
+  }, [amount, nativeBalance, mooneyAddress, quote, estimateGas, effectiveGasPrice, ethPrice])
 
   return (
     <div className="w-full mt-3 sm:mt-4">
@@ -170,7 +174,6 @@ export default function NativeToMooney({ selectedChain }: any) {
                     className="text-white bg-transparent text-xl sm:text-2xl font-RobotoMono placeholder-gray-500 focus:outline-none w-full min-w-0 border-0 !p-0 min-h-[28px] tabular-nums"
                     bare
                     value={amount}
-                    max={nativeBalance ? parseFloat(nativeBalance) : undefined}
                     onChange={(e) => {
                       let value = e.target.value
                       value = value.replace(/[^0-9.]/g, '')
@@ -179,9 +182,6 @@ export default function NativeToMooney({ selectedChain }: any) {
                         value = parts[0] + '.' + parts.slice(1).join('')
                       }
                       if (parseFloat(value) < 0) value = '0'
-                      if (nativeBalance && parseFloat(value) > parseFloat(nativeBalance)) {
-                        value = nativeBalance
-                      }
                       setAmount(value)
                     }}
                     formatNumbers={true}
@@ -196,8 +196,16 @@ export default function NativeToMooney({ selectedChain }: any) {
                       </p>
                       <button
                         className="text-xs text-blue-400 hover:text-blue-300 font-medium transition-colors px-3 py-1.5 bg-blue-400/10 hover:bg-blue-400/20 rounded-lg border border-blue-400/20 flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-blue-400/10"
-                        onClick={() => setAmount(nativeBalance ?? '0')}
-                        disabled={!nativeBalance || parseFloat(nativeBalance) === 0}
+                        onClick={() => {
+                          // Reserve gas so the swap doesn't fail due to no ETH left for fees
+                          const gasReserveEth =
+                            effectiveGasPrice > BigInt(0)
+                              ? Number(effectiveGasPrice * BigInt(350000)) / 1e18
+                              : 0.002
+                          const maxAmount = Math.max(0, (nativeBalance || 0) - gasReserveEth)
+                          setAmount(maxAmount > 0 ? String(parseFloat(maxAmount.toFixed(7))) : '0')
+                        }}
+                        disabled={!nativeBalance || nativeBalance === 0}
                       >
                         MAX
                       </button>
@@ -307,6 +315,8 @@ export default function NativeToMooney({ selectedChain }: any) {
                   ? 'Finding Route...'
                   : !amount || parseFloat(amount) === 0
                   ? 'Enter Amount'
+                  : isOverBalance
+                  ? 'Not Enough ETH'
                   : !hasValidRoute
                   ? 'No Route Available'
                   : 'Swap'
@@ -331,7 +341,11 @@ export default function NativeToMooney({ selectedChain }: any) {
                 }
               }}
               isDisabled={
-                isGeneratingRoute || !amount || parseFloat(amount) === 0 || !hasValidRoute
+                isGeneratingRoute ||
+                !amount ||
+                parseFloat(amount) === 0 ||
+                isOverBalance ||
+                !hasValidRoute
               }
             />
           </div>

--- a/ui/components/uniswap/NativeToMooney.tsx
+++ b/ui/components/uniswap/NativeToMooney.tsx
@@ -1,4 +1,5 @@
 import { CHAIN_TOKEN_NAMES, MOONEY_ADDRESSES, FEE_HOOK_ADDRESSES, TICK_SPACING } from 'const/config'
+import confetti from 'canvas-confetti'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
@@ -12,6 +13,23 @@ import GasIcon from '../assets/GasIcon'
 import Input from '../layout/Input'
 import { PrivyWeb3Button } from '../privy/PrivyWeb3Button'
 import NetworkSelector from '@/components/thirdweb/NetworkSelector'
+
+function fireMooneyConfetti() {
+  if (typeof window === 'undefined') return
+  const colors = ['#ffffff', '#FFD700', '#7B61FF', '#00CFFF', '#FF69B4']
+  const fire = (originX: number, originY: number, angle: number) =>
+    confetti({
+      particleCount: 80,
+      angle,
+      spread: 55,
+      origin: { x: originX, y: originY },
+      shapes: ['circle', 'star'],
+      colors,
+    })
+  fire(0.2, 0.8, 60)
+  setTimeout(() => fire(0.8, 0.8, 120), 150)
+  setTimeout(() => fire(0.5, 0.6, 90), 300)
+}
 
 export default function NativeToMooney({ selectedChain }: any) {
   const chainSlug = getChainSlug(selectedChain)
@@ -335,6 +353,7 @@ export default function NativeToMooney({ selectedChain }: any) {
                   const minOut = (parseFloat(output) * 0.95).toString() // 5% slippage
                   await swap(amount, minOut)
                   toast.success('Swap completed! MOONEY incoming.')
+                  fireMooneyConfetti()
                 } catch (error) {
                   console.error('Swap error:', error)
                   toast.error('Swap failed — transaction rejected or price slipped.')

--- a/ui/components/uniswap/NativeToMooney.tsx
+++ b/ui/components/uniswap/NativeToMooney.tsx
@@ -327,6 +327,7 @@ export default function NativeToMooney({ selectedChain }: any) {
           <div className="w-full">
             <PrivyWeb3Button
               v5
+              signInLabel="Sign In to Buy MOONEY"
               className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white py-3 sm:py-4 px-4 rounded-xl text-base sm:text-lg font-semibold transition-all duration-200 transform hover:scale-[1.02] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:from-gray-500 disabled:to-gray-600"
               label={
                 isGeneratingRoute

--- a/ui/components/uniswap/NativeToMooney.tsx
+++ b/ui/components/uniswap/NativeToMooney.tsx
@@ -335,7 +335,7 @@ export default function NativeToMooney({ selectedChain }: any) {
                   : !amount || parseFloat(amount) === 0
                   ? 'Enter Amount'
                   : isOverBalance
-                  ? 'Not Enough ETH'
+                  ? `Not Enough ${CHAIN_TOKEN_NAMES[chainSlug] ?? 'ETH'}`
                   : !hasValidRoute
                   ? 'No Route Available'
                   : 'Swap'

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -682,6 +682,7 @@ export default function Lock() {
                         <div className="p-5 border-t border-white/10 bg-black/10">
                           <PrivyWeb3Button
                             v5
+                            signInLabel="Sign In to Lock MOONEY"
                             className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white py-3 px-6 rounded-xl text-base font-semibold transition-all duration-200 transform hover:scale-[1.01] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:from-gray-500 disabled:to-gray-600"
                             label={
                               !hasLock

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -31,6 +31,19 @@ import ERC20ABI from '../const/abis/ERC20.json'
 import VotingEscrowABI from '../const/abis/VotingEscrow.json'
 import { MOONEY_ADDRESSES, VMOONEY_ADDRESSES } from '../const/config'
 
+// Safely parse a user-typed amount to wei. Returns null for intermediate
+// states like '', '.' or '1.' so callers don't crash on parseEther.
+function safeParseEther(value?: string) {
+  if (!value) return null
+  const normalized = value.endsWith('.') ? value.slice(0, -1) : value
+  if (normalized === '' || isNaN(parseFloat(normalized))) return null
+  try {
+    return ethers.utils.parseEther(normalized)
+  } catch {
+    return null
+  }
+}
+
 export default function Lock() {
   const router = useRouter()
   const { selectedChain }: any = useContext(ChainContextV5)
@@ -184,12 +197,12 @@ export default function Lock() {
       })
 
       setCanIncrease({
-        amount:
+        amount: !!(
           lockAmount &&
-          lockAmount !== '' &&
           lockAmount !== '0' &&
           VMOONEYLock &&
-          ethers.utils.parseEther(lockAmount).gt(VMOONEYLock[0]),
+          safeParseEther(lockAmount)?.gt(VMOONEYLock[0])
+        ),
         time:
           lockTime?.value &&
           lockTime.value.gt(BigNumber.from(VMOONEYLock[1]).mul(1000)) && // New time must be greater than current lock end
@@ -229,6 +242,11 @@ export default function Lock() {
         )
       : parseFloat(ethers.utils.formatEther(MOONEYBalance.toString()))
     : undefined
+
+  const isOverBalance =
+    maxAmountValue !== undefined &&
+    !!lockAmount &&
+    (parseFloat(lockAmount) || 0) > maxAmountValue
 
   function selectAddMode() {
     if (lockMode === 'add') return
@@ -382,7 +400,6 @@ export default function Lock() {
                                   disabled={
                                     (!MOONEYBalance || +MOONEYBalance.toString() === 0) && !hasLock
                                   }
-                                  max={maxAmountValue}
                                   onFocus={() => {
                                     setIsAmountInputFocused(true)
                                     // Remove formatting when focusing for easier editing
@@ -412,13 +429,6 @@ export default function Lock() {
                                     // Prevent negative values
                                     if (parseFloat(value) < 0) {
                                       value = '0'
-                                    }
-
-                                    // Enforce max value (already-locked + wallet balance)
-                                    if (maxAmountValue !== undefined) {
-                                      if (parseFloat(value) > maxAmountValue) {
-                                        value = maxAmountValue.toString()
-                                      }
                                     }
 
                                     // Remove leading zero if user types a number after it
@@ -685,7 +695,9 @@ export default function Lock() {
                             signInLabel="Sign In to Lock MOONEY"
                             className="w-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white py-3 px-6 rounded-xl text-base font-semibold transition-all duration-200 transform hover:scale-[1.01] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:from-gray-500 disabled:to-gray-600"
                             label={
-                              !hasLock
+                              isOverBalance && (!hasLock || lockMode === 'add')
+                                ? 'Not Enough MOONEY'
+                                : !hasLock
                                 ? 'Lock MOONEY'
                                 : lockMode === 'add'
                                 ? 'Add MOONEY'
@@ -709,7 +721,10 @@ export default function Lock() {
                                 }
 
                                 const lockedMooney = VMOONEYLock?.[0]
-                                const lockAmountBigNum = ethers.utils.parseEther(lockAmount)
+                                const lockAmountBigNum = safeParseEther(lockAmount)
+                                if (!lockAmountBigNum) {
+                                  throw new Error('Please enter a valid amount.')
+                                }
 
                                 const increaseAmount = lockedMooney
                                   ? lockAmountBigNum.sub(lockedMooney)
@@ -738,7 +753,7 @@ export default function Lock() {
                                   : await createLock({
                                       account,
                                       votingEscrowContract: vMooneyContract,
-                                      amount: lockAmount && ethers.utils.parseEther(lockAmount),
+                                      amount: lockAmountBigNum,
                                       time: lockTime?.value.div(1000),
                                     })
 
@@ -766,8 +781,10 @@ export default function Lock() {
                               }
                             }}
                             isDisabled={
+                              // Never let the user submit more than they hold
+                              (isOverBalance && (!hasLock || lockMode === 'add')) ||
                               // For new locks, require both amount and time
-                              !hasLock
+                              (!hasLock
                                 ? !lockAmount ||
                                   lockAmount === '' ||
                                   lockAmount === '0' ||
@@ -775,7 +792,7 @@ export default function Lock() {
                                 : // For existing locks, only the active mode's change is required
                                 lockMode === 'add'
                                 ? !canIncrease.amount
-                                : !canIncrease.time
+                                : !canIncrease.time)
                             }
                           />
 

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -89,6 +89,8 @@ export default function Lock() {
   //reset lock amount on chain switch
   useEffect(() => {
     setLockAmount('')
+    setLockMode('add')
+    setWantsToIncrease(false)
     setLockTime({
       value: ethers.BigNumber.from(+oneWeekOut),
       formatted: dateToReadable(oneWeekOut),
@@ -106,6 +108,9 @@ export default function Lock() {
 
   const [canIncrease, setCanIncrease] = useState({ amount: true, time: true })
   const [wantsToIncrease, setWantsToIncrease] = useState(false)
+  // For an existing lock the contract can only do one thing per tx (add amount OR
+  // extend time), so we make the user pick one explicitly instead of showing both.
+  const [lockMode, setLockMode] = useState<'add' | 'extend'>('add')
 
   const { data: tokenAllowance } = useRead({
     contract: mooneyContract,
@@ -149,9 +154,10 @@ export default function Lock() {
     }
   }, [hasLock, VMOONEYLock, selectedChain, address])
 
-  // Sync lockTime when invalid (e.g. before lock end when extending)
+  // Sync lockTime when invalid (e.g. before lock end when extending).
+  // Only relevant in extend mode — in add mode we keep the existing lock end.
   useEffect(() => {
-    if (hasLock && VMOONEYLock && lockTime?.formatted) {
+    if (hasLock && lockMode === 'extend' && VMOONEYLock && lockTime?.formatted) {
       const lockEnd = bigNumberToDate(BigNumber.from(VMOONEYLock[1]))
       if (!lockEnd) return
       const minExtendDate = new Date(lockEnd.getTime())
@@ -164,7 +170,7 @@ export default function Lock() {
         })
       }
     }
-  }, [hasLock, VMOONEYLock, lockTime?.formatted])
+  }, [hasLock, lockMode, VMOONEYLock, lockTime?.formatted])
 
   //Lock time min/max
   useEffect(() => {
@@ -203,6 +209,58 @@ export default function Lock() {
       })
     }
   }, [hasLock, lockAmount, lockTime, VMOONEYLock, address])
+
+  const currentLockedAmount =
+    hasLock && VMOONEYLock
+      ? parseFloat(ethers.utils.formatEther(VMOONEYLock[0]))
+      : 0
+  const currentLockEndDate =
+    hasLock && VMOONEYLock
+      ? bigNumberToDate(BigNumber.from(VMOONEYLock[1]))
+      : null
+
+  // Max amount the user can lock in total (already-locked + wallet balance).
+  const maxAmountValue = MOONEYBalance
+    ? hasLock && VMOONEYLock
+      ? parseFloat(
+          ethers.utils.formatEther(
+            BigNumber.from(VMOONEYLock[0]).add(MOONEYBalance)
+          )
+        )
+      : parseFloat(ethers.utils.formatEther(MOONEYBalance.toString()))
+    : undefined
+
+  function selectAddMode() {
+    if (lockMode === 'add') return
+    setLockMode('add')
+    setWantsToIncrease(false)
+    // Keep the existing lock end so we don't accidentally extend the duration.
+    if (VMOONEYLock) {
+      setLockTime((prev: any) => ({
+        ...prev,
+        value: BigNumber.from(VMOONEYLock[1]).mul(1000),
+        formatted: dateToReadable(bigNumberToDate(BigNumber.from(VMOONEYLock[1]))),
+      }))
+    }
+  }
+
+  function selectExtendMode() {
+    if (lockMode === 'extend') return
+    setLockMode('extend')
+    setWantsToIncrease(false)
+    // Keep the current amount so we don't accidentally add more MOONEY.
+    if (VMOONEYLock) {
+      setLockAmount(ethers.utils.formatEther(VMOONEYLock[0]))
+    }
+  }
+
+  const showPreview =
+    wantsToIncrease &&
+    (!hasLock
+      ? canIncrease.amount && canIncrease.time
+      : lockMode === 'add'
+      ? canIncrease.amount
+      : canIncrease.time)
 
   const { t } = useTranslation('common')
 
@@ -271,7 +329,38 @@ export default function Lock() {
 
                         {/* Lock Configuration */}
                         <div className="p-5 space-y-5">
+                          {/* Mode Toggle (existing lock only) */}
+                          {hasLock && (
+                            <div className="space-y-2">
+                              <div className="grid grid-cols-2 gap-2 p-1 bg-black/30 rounded-xl border border-white/10">
+                                <button
+                                  type="button"
+                                  onClick={selectAddMode}
+                                  className={`py-2.5 px-3 rounded-lg text-sm font-semibold transition-all duration-200 ${
+                                    lockMode === 'add'
+                                      ? 'bg-gradient-to-r from-blue-500 to-purple-600 text-white shadow'
+                                      : 'text-gray-400 hover:text-white'
+                                  }`}
+                                >
+                                  Add MOONEY
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={selectExtendMode}
+                                  className={`py-2.5 px-3 rounded-lg text-sm font-semibold transition-all duration-200 ${
+                                    lockMode === 'extend'
+                                      ? 'bg-gradient-to-r from-blue-500 to-purple-600 text-white shadow'
+                                      : 'text-gray-400 hover:text-white'
+                                  }`}
+                                >
+                                  Extend Lock
+                                </button>
+                              </div>
+                            </div>
+                          )}
+
                           {/* Amount Input */}
+                          {(!hasLock || lockMode === 'add') && (
                           <div className="space-y-2">
                             <label className="text-gray-300 text-sm font-medium">Amount</label>
                             <div className="bg-black/30 rounded-xl p-3 border border-white/10 focus-within:border-blue-400/50 transition-colors">
@@ -293,13 +382,7 @@ export default function Lock() {
                                   disabled={
                                     (!MOONEYBalance || +MOONEYBalance.toString() === 0) && !hasLock
                                   }
-                                  max={
-                                    MOONEYBalance
-                                      ? parseFloat(
-                                          ethers.utils.formatEther(MOONEYBalance.toString())
-                                        )
-                                      : undefined
-                                  }
+                                  max={maxAmountValue}
                                   onFocus={() => {
                                     setIsAmountInputFocused(true)
                                     // Remove formatting when focusing for easier editing
@@ -331,13 +414,10 @@ export default function Lock() {
                                       value = '0'
                                     }
 
-                                    // Enforce max value (available MOONEY balance)
-                                    if (MOONEYBalance) {
-                                      const maxValue = parseFloat(
-                                        ethers.utils.formatEther(MOONEYBalance.toString())
-                                      )
-                                      if (parseFloat(value) > maxValue) {
-                                        value = maxValue.toString()
+                                    // Enforce max value (already-locked + wallet balance)
+                                    if (maxAmountValue !== undefined) {
+                                      if (parseFloat(value) > maxAmountValue) {
+                                        value = maxAmountValue.toString()
                                       }
                                     }
 
@@ -418,11 +498,31 @@ export default function Lock() {
                                 </div>
                               </div>
                             </div>
+                            {hasLock && currentLockEndDate && (
+                              <p className="text-gray-400 text-xs flex items-center gap-1.5">
+                                <InformationCircleIcon className="h-4 w-4 flex-shrink-0" aria-hidden />
+                                Unlock date stays {dateToReadable(currentLockEndDate)}. Switch to
+                                &nbsp;Extend Lock&nbsp;to change it.
+                              </p>
+                            )}
                           </div>
+                          )}
 
                           {/* Duration Selection */}
+                          {(!hasLock || lockMode === 'extend') && (
                           <div className="space-y-3">
                             <label className="text-gray-300 text-sm font-medium">Lock Until</label>
+                            {hasLock && (
+                              <p className="text-gray-400 text-xs flex items-center gap-1.5">
+                                <InformationCircleIcon className="h-4 w-4 flex-shrink-0" aria-hidden />
+                                Locked amount stays{' '}
+                                {currentLockedAmount.toLocaleString('en-US', {
+                                  minimumFractionDigits: 2,
+                                  maximumFractionDigits: 2,
+                                })}{' '}
+                                MOONEY. Switch to Add MOONEY to change it.
+                              </p>
+                            )}
 
                             {(() => {
                               const now = new Date()
@@ -496,9 +596,10 @@ export default function Lock() {
                               )
                             })()}
                           </div>
+                          )}
 
                           {/* Voting Power Preview */}
-                          {(canIncrease.time || canIncrease.amount) && wantsToIncrease && (
+                          {showPreview && (
                             <div className="bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-xl p-4 border border-blue-400/20 space-y-3">
                               <p className="text-gray-300 text-xs">
                                 Locking MOONEY gives you vMOONEY tokens. Your voting power is
@@ -585,13 +686,9 @@ export default function Lock() {
                             label={
                               !hasLock
                                 ? 'Lock MOONEY'
-                                : canIncrease.amount && canIncrease.time
-                                ? 'Increase Lock'
-                                : canIncrease.amount && !canIncrease.time
-                                ? 'Increase Amount'
-                                : !canIncrease.amount && canIncrease.time
-                                ? 'Extend Duration'
-                                : 'Update Lock'
+                                : lockMode === 'add'
+                                ? 'Add MOONEY'
+                                : 'Extend Lock'
                             }
                             action={async () => {
                               try {
@@ -674,8 +771,10 @@ export default function Lock() {
                                   lockAmount === '' ||
                                   lockAmount === '0' ||
                                   !canIncrease.time
-                                : // For existing locks, allow if either amount or time can be increased
-                                  !canIncrease.amount && !canIncrease.time
+                                : // For existing locks, only the active mode's change is required
+                                lockMode === 'add'
+                                ? !canIncrease.amount
+                                : !canIncrease.time
                             }
                           />
 


### PR DESCRIPTION
## Summary

Fixes UX issues across the **buy (get-mooney)**, **bridge**, and **lock** pages. This PR is stacked on top of `fix/citizen-profile-page`.

### Buy / Get MOONEY (`components/uniswap/NativeToMooney.tsx`)
- **MAX button no longer breaks the swap.** It now reserves gas (`effectiveGasPrice × 350k`, fallback `0.002 ETH`) before filling the amount, so the route quote no longer fails with "No Route Available" because there's no ETH left for fees.
- **Fixed the cursor/deletion bug** when typing more than your balance. Removed the double max-clamping (the `Input` `max` prop + the manual `onChange` clamp) that snapped the value down mid-edit and left the cursor misplaced. Instead, the button now shows **"Not Enough ETH"** and is disabled when over balance, and the quote is skipped.
- 🎉 **Confetti** fires on a successful swap (same pattern as citizen creation).

### Bridge (`components/bridge/ArbitrumBridge.tsx`)
- Same clamping/cursor fix as the buy page. Removed the double clamp; the button now shows **"Not Enough ETH/MOONEY"** (and "Enter Amount" when empty) and is disabled instead of silently snapping the number down.

### Lock (`pages/lock.tsx`)
- **Resolved the "two confusing elements" problem.** For an existing lock, the amount and duration controls were shown together, but the contract's `increaseLock` can only do **one** operation per transaction (it silently prioritizes amount over time). A user changing both thought they were doing both, but the time extension was dropped.
- Added an explicit **"Add MOONEY" / "Extend Lock"** toggle so the user makes one clear choice; the form shows only the relevant control plus a hint stating what stays unchanged. The button label is now simply "Add MOONEY" or "Extend Lock".
- New locks are unchanged (combined amount + duration, since `createLock` needs both).
- Fixed the amount `max` to account for already-locked + wallet balance, and gated the time-sync effect to extend mode only.

## Test plan
- [ ] Buy: click MAX with a low ETH balance → route resolves and swap is enabled (gas reserved).
- [ ] Buy: type more than balance → cursor/deletion behaves normally; button shows "Not Enough ETH".
- [ ] Buy: complete a swap → confetti fires.
- [ ] Bridge: type more than balance (ETH and MOONEY) → cursor/deletion normal; button shows "Not Enough …".
- [ ] Lock (new lock): amount + duration both required; "Lock MOONEY" works.
- [ ] Lock (existing lock): toggle between "Add MOONEY" and "Extend Lock"; each runs only its own transaction.

Made with [Cursor](https://cursor.com)