### PR TITLE
Skip cookie consent banner for US users

### DIFF
--- a/ui/components/layout/CookieBanner.tsx
+++ b/ui/components/layout/CookieBanner.tsx
@@ -4,29 +4,56 @@ import { useEffect, useState } from 'react'
 
 export default function CookieBanner() {
   const [cookieConsent, setCookieConsent] = useState<any>(false)
-  const [hasLoadedLocalStorage, setHasLoadedLocalStorage] = useState(false)
+  const [hasResolvedConsent, setHasResolvedConsent] = useState(false)
 
   useEffect(() => {
     const storedCookieConsent = localStorage.getItem('cookie_consent')
 
+    // Respect any decision the user already made.
     if (storedCookieConsent !== null && storedCookieConsent !== undefined) {
       setCookieConsent(JSON.parse(storedCookieConsent))
-    } else {
-      setCookieConsent(null)
+      setHasResolvedConsent(true)
+      return
     }
 
-    setHasLoadedLocalStorage(true)
-  }, [setCookieConsent])
+    // US users don't need to make a cookie decision, so skip the banner and
+    // grant analytics consent automatically. Anyone else (or unknown geo) sees
+    // the banner so the privacy-protective default is to ask.
+    let cancelled = false
+
+    ;(async () => {
+      try {
+        const res = await fetch('/api/geo/country')
+        const data = await res.json()
+        if (!cancelled && data?.country === 'US') {
+          setCookieConsent(true)
+          setHasResolvedConsent(true)
+          return
+        }
+      } catch (err) {
+        // Fall through to showing the banner on any failure.
+      }
+
+      if (!cancelled) {
+        setCookieConsent(null)
+        setHasResolvedConsent(true)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
-    if (cookieConsent != null && hasLoadedLocalStorage) {
+    if (cookieConsent != null && hasResolvedConsent) {
       const newValue = cookieConsent ? 'granted' : 'denied'
 
       window.gtag('consent', 'update', { analytics_storage: newValue })
 
       localStorage.setItem('cookie_consent', JSON.stringify(cookieConsent))
     }
-  }, [cookieConsent, hasLoadedLocalStorage])
+  }, [cookieConsent, hasResolvedConsent])
 
   if (cookieConsent != null) return null
 

--- a/ui/cypress/integration/layout/cookie-banner.cy.tsx
+++ b/ui/cypress/integration/layout/cookie-banner.cy.tsx
@@ -6,11 +6,26 @@ describe('<CookieBanner />', () => {
     cy.window().then((win: any) => {
       win.gtag = cy.stub().as('gtagStub')
     })
+    // Default to a non-US country so the banner renders for most tests.
+    cy.intercept('GET', '/api/geo/country', { body: { country: 'GB' } }).as('geoCountry')
   })
 
   it('Renders when cookie consent is null', () => {
     cy.mount(<CookieBanner />)
     cy.contains('We use cookies for analytics and personalization').should('be.visible')
+  })
+
+  it('Hides the banner and grants consent for US users', () => {
+    cy.intercept('GET', '/api/geo/country', { body: { country: 'US' } }).as('geoCountryUS')
+    cy.mount(<CookieBanner />)
+    cy.wait('@geoCountryUS')
+    cy.contains('We use cookies for analytics and personalization').should('not.exist')
+    cy.get('@gtagStub').should('have.been.calledWith', 'consent', 'update', {
+      analytics_storage: 'granted',
+    })
+    cy.should(() => {
+      expect(localStorage.getItem('cookie_consent')).to.eq('true')
+    })
   })
 
   it('Updates localStorage and calls gtag when Accept is clicked', () => {

--- a/ui/pages/api/geo/country.ts
+++ b/ui/pages/api/geo/country.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import { getCountryFromHeaders } from '../../../lib/geo'
+
+/**
+ * GET /api/geo/country
+ * Returns the requesting user's country code (from Vercel/Cloudflare geo headers).
+ * Used client-side to decide whether to show the cookie consent banner.
+ * Returns `country: null` when the country cannot be determined.
+ */
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const country = getCountryFromHeaders(req)
+
+  // Geo derives only from request headers, so this is safe to cache briefly.
+  res.setHeader('Cache-Control', 'private, max-age=3600')
+  return res.status(200).json({ country })
+}
+
+export default withMiddleware(handler, rateLimit)


### PR DESCRIPTION
## Summary
- US visitors don't legally need to make a cookie/consent decision, so the consent banner is now hidden for them and analytics consent is auto-granted.
- Adds `GET /api/geo/country`, which returns the requester's country from Vercel/Cloudflare geo headers (`getCountryFromHeaders`) for the client to read.
- `CookieBanner` now resolves consent before rendering: respects any stored decision, auto-grants + hides for `US`, and otherwise shows the banner. Any geo lookup failure falls back to showing the banner (privacy-protective default).

## Test plan
- [ ] Non-US / unknown geo: banner renders; Accept/Decline/X update `localStorage` + `gtag` as before.
- [ ] US geo (`/api/geo/country` -> `{ country: 'US' }`): banner does not render, `gtag('consent','update',{analytics_storage:'granted'})` fires, `cookie_consent` stored as `true`.
- [ ] Existing stored consent is respected regardless of country.
- [ ] Cypress: `cypress/integration/layout/cookie-banner.cy.tsx` (geo endpoint stubbed; added US case).

Made with [Cursor](https://cursor.com)