### PR TITLE
Add Cursor project rules

### DIFF
--- a/.cursor/rules/00-context-discipline.mdc
+++ b/.cursor/rules/00-context-discipline.mdc
@@ -1,12 +1,18 @@
 ---
-description: Context discipline — never blindly scan the monorepo
+description: Context discipline — no speculative scanning
 alwaysApply: true
 ---
 # Context Discipline (HIGHEST PRIORITY)
 
-- DO NOT scan, glob, or traverse the repository. This is a large monorepo; broad scans waste context and cause wrong assumptions.
-- Work ONLY with files the user names in their prompt, files already open/attached in the editor, and files those directly import.
-- The user prompts in plain text and does not use file-mentions. When you need a file, ask the user to paste it or state its path in text — do not go hunting for it.
-- If required context is missing, STOP and ask one precise question naming what you need. Never guess a path and start reading around.
-- NEVER read `node_modules`, `.next`, `yarn.lock`, `package-lock.json`, `archive/`, `public/`, generated artifacts, or ABI JSON unless explicitly asked.
-- Keep edits surgical — change only what the task requires; no unrelated refactors or "tidying".
+- DO NOT speculatively scan or explore the repository to "build context". Never read a file
+  unless you already know why you need it.
+- Targeted lookups are fine: if you know a specific file, symbol, or path you need, go get it
+  directly. What is forbidden is exploratory reading — opening files just to see what is there.
+- Do not read whole directories as discovery. If you need to know what exists in a folder, ask
+  the user rather than listing and reading everything inside.
+- If you are missing context and cannot infer the right file from what is already provided,
+  ask one precise question (e.g. "can you share the path or contents of the file that handles X?")
+  rather than going on a broad search.
+- NEVER read `node_modules`, `.next`, `yarn.lock`, `package-lock.json`, `archive/`, `public/`,
+  or generated artifacts unless explicitly asked.
+- Keep edits surgical — change only what the task requires; no unrelated refactors or tidying.

--- a/.cursor/rules/00-context-discipline.mdc
+++ b/.cursor/rules/00-context-discipline.mdc
@@ -1,18 +1,20 @@
 ---
-description: Context discipline — no speculative scanning
+description: Context discipline — purposeful lookup only, no aimless scanning
 alwaysApply: true
 ---
 # Context Discipline (HIGHEST PRIORITY)
 
-- DO NOT speculatively scan or explore the repository to "build context". Never read a file
-  unless you already know why you need it.
-- Targeted lookups are fine: if you know a specific file, symbol, or path you need, go get it
-  directly. What is forbidden is exploratory reading — opening files just to see what is there.
-- Do not read whole directories as discovery. If you need to know what exists in a folder, ask
-  the user rather than listing and reading everything inside.
-- If you are missing context and cannot infer the right file from what is already provided,
-  ask one precise question (e.g. "can you share the path or contents of the file that handles X?")
-  rather than going on a broad search.
+- You are expected to locate files autonomously when given a high-level task (e.g. "the profile
+  page is broken, fix it"). Search for the relevant files, trace the code, and resolve the issue
+  without requiring the user to specify paths.
+- Every file you open must serve the current task. Ask yourself: "do I need this to complete
+  what was asked?" If the answer is no, don't open it.
+- What is forbidden is aimless exploration — reading files to "understand the codebase" or
+  "get context" with no specific goal tied to the task at hand.
+- Do not read entire directories speculatively. Search or grep for what you need; open only
+  the files the results point to.
+- If you are genuinely blocked and cannot locate something, ask one precise question rather
+  than broadening your search indiscriminately.
 - NEVER read `node_modules`, `.next`, `yarn.lock`, `package-lock.json`, `archive/`, `public/`,
   or generated artifacts unless explicitly asked.
 - Keep edits surgical — change only what the task requires; no unrelated refactors or tidying.

--- a/.cursor/rules/00-context-discipline.mdc
+++ b/.cursor/rules/00-context-discipline.mdc
@@ -1,20 +1,39 @@
 ---
-description: Context discipline — purposeful lookup only, no aimless scanning
+description: Context discipline — scale reading depth to task complexity
 alwaysApply: true
 ---
 # Context Discipline (HIGHEST PRIORITY)
 
-- You are expected to locate files autonomously when given a high-level task (e.g. "the profile
-  page is broken, fix it"). Search for the relevant files, trace the code, and resolve the issue
-  without requiring the user to specify paths.
-- Every file you open must serve the current task. Ask yourself: "do I need this to complete
-  what was asked?" If the answer is no, don't open it.
-- What is forbidden is aimless exploration — reading files to "understand the codebase" or
-  "get context" with no specific goal tied to the task at hand.
-- Do not read entire directories speculatively. Search or grep for what you need; open only
-  the files the results point to.
-- If you are genuinely blocked and cannot locate something, ask one precise question rather
-  than broadening your search indiscriminately.
+## Core principle
+Read with purpose. Every file you open must have a clear reason tied to the current task.
+Aimless exploration — opening files to "understand the codebase" with no specific goal — is
+forbidden. But complex tasks genuinely require reading more, and that is expected.
+
+## Scale your reading to the task
+
+**Targeted fix** (bug in a named component or file)
+→ Read that file + its direct imports. Fix. Done.
+
+**Cross-cutting bug** (stale data, broken state, wrong value across pages)
+→ Trace freely across all files in the call chain. Read as many as needed to find the root cause.
+  Don't stop at the first plausible fix if the real cause may be upstream.
+
+**New feature in an existing domain** (adding to marketplace, subscription, etc.)
+→ Read 1–2 existing files in the same feature folder as a pattern reference, then implement.
+  Prefer `lib/<feature>/` and `components/<feature>/` for the relevant domain.
+
+**Refactor or migration**
+→ Read all files you intend to touch before writing a single line. Understand the full blast
+  radius before starting.
+
+**Unfamiliar area**
+→ Read one representative page + its primary component + the lib module it calls. That is
+  enough to understand the pattern. Do not read the entire feature folder.
+
+## Hard limits — always apply regardless of task type
 - NEVER read `node_modules`, `.next`, `yarn.lock`, `package-lock.json`, `archive/`, `public/`,
-  or generated artifacts unless explicitly asked.
+  or generated artifacts.
+- Do not read files outside the task's domain without a specific reason.
+- If genuinely blocked after targeted searching, ask one precise question rather than
+  broadening the search indiscriminately.
 - Keep edits surgical — change only what the task requires; no unrelated refactors or tidying.

--- a/.cursor/rules/00-context-discipline.mdc
+++ b/.cursor/rules/00-context-discipline.mdc
@@ -1,0 +1,12 @@
+---
+description: Context discipline — never blindly scan the monorepo
+alwaysApply: true
+---
+# Context Discipline (HIGHEST PRIORITY)
+
+- DO NOT scan, glob, or traverse the repository. This is a large monorepo; broad scans waste context and cause wrong assumptions.
+- Work ONLY with files the user names in their prompt, files already open/attached in the editor, and files those directly import.
+- The user prompts in plain text and does not use file-mentions. When you need a file, ask the user to paste it or state its path in text — do not go hunting for it.
+- If required context is missing, STOP and ask one precise question naming what you need. Never guess a path and start reading around.
+- NEVER read `node_modules`, `.next`, `yarn.lock`, `package-lock.json`, `archive/`, `public/`, generated artifacts, or ABI JSON unless explicitly asked.
+- Keep edits surgical — change only what the task requires; no unrelated refactors or "tidying".

--- a/.cursor/rules/10-stack.mdc
+++ b/.cursor/rules/10-stack.mdc
@@ -1,12 +1,44 @@
 ---
-description: MoonDAO monorepo layout and stack overview
+description: MoonDAO monorepo layout, stack, and file location reference
 alwaysApply: true
 ---
 # Repo & Stack
 
-- Monorepo. Web app: `ui/` (Next.js). Solidity: `contracts/`, `fee-hook/`, `prediction/`, `subscription-contracts/`, `xp/`. Services: `dispatcher/`, `townhall-summarizer/`, `tui/`.
-- Default to `ui/` unless another package is named. Don't edit across packages in one task unasked.
-- `ui/`: Next.js 13 **Pages Router** (no `app/`), React 18, TypeScript 5 `strict`.
-- Package manager **Yarn**, Node ≥18. Never suggest npm/pnpm.
-- Web3: thirdweb v5 (primary), wagmi v2 + viem v2, ethers 5.7 (legacy). Auth: Privy. Also Safe, Hats, Juicebox, Uniswap v4, Tableland, LayerZero.
-- Data: react-query, SWR, urql/graphql-request, axios. Forms: react-hook-form. Toasts: react-hot-toast. i18n: next-translate. Styling: Tailwind 3 + daisyUI, `darkMode: 'class'`.
+## Monorepo packages
+- `ui/` — Next.js web app (primary). Default here unless another package is named.
+- `contracts/`, `fee-hook/`, `prediction/`, `subscription-contracts/`, `xp/` — Solidity packages.
+- `dispatcher/`, `townhall-summarizer/`, `tui/` — supporting services.
+- Do not edit across packages in one task unless explicitly asked.
+
+## ui/ tech stack
+- **Framework**: Next.js 13 Pages Router (`pages/` only — no `app/`, no RSC).
+- **Language**: TypeScript 5, `strict: true`. React 18.
+- **Package manager**: Yarn, Node ≥18. Never suggest npm or pnpm.
+- **Web3**: thirdweb v5 (primary for all on-chain reads/writes), wagmi v2 + viem v2, ethers 5.7 (legacy — v5 API). Auth via Privy (`@privy-io/react-auth`). Also: Safe, Hats Protocol, Juicebox, Uniswap v4, Tableland, LayerZero.
+- **Data fetching**: `@tanstack/react-query` and SWR for client side; urql / graphql-request for subgraphs; axios for REST.
+- **Forms**: `react-hook-form`. **Toasts**: `react-hot-toast`. **i18n**: `next-translate`.
+- **Styling**: Tailwind 3 + daisyUI + `@tailwindcss/typography`. `darkMode: 'class'`. Custom theme in `tailwind.config.js`.
+
+## Quick file location reference
+Use this before searching — go directly to the right place.
+
+| What you need | Where it lives |
+|---|---|
+| Chain IDs, contract addresses, env-gated flags | `const/config.ts` |
+| Contract ABIs | `const/abis/<ContractName>.json` |
+| Feature flags | `const/flags.ts` |
+| On-chain read/write hooks | `lib/thirdweb/hooks/` |
+| Chain utilities, default chain | `lib/thirdweb/chain.ts` |
+| thirdweb client | `lib/thirdweb/client.ts` |
+| IPFS pin / unpin helpers | `lib/ipfs/` |
+| Tableland helpers | `lib/tableland/` |
+| Snapshot / governance helpers | `lib/snapshot/` |
+| Safe multisig helpers | `lib/safe/` |
+| Auth / session helpers | `lib/privy/` |
+| Shared UI components (modals, inputs, buttons) | `components/layout/` |
+| Feature components | `components/<feature>/` |
+| Feature logic & data helpers | `lib/<feature>/` |
+| API route for a domain | `pages/api/<domain>/` |
+| Composable API middleware | `middleware/` |
+| Global styles | `styles/globals.css` |
+| One-off scripts | `scripts/` |

--- a/.cursor/rules/10-stack.mdc
+++ b/.cursor/rules/10-stack.mdc
@@ -1,0 +1,12 @@
+---
+description: MoonDAO monorepo layout and stack overview
+alwaysApply: true
+---
+# Repo & Stack
+
+- Monorepo. Web app: `ui/` (Next.js). Solidity: `contracts/`, `fee-hook/`, `prediction/`, `subscription-contracts/`, `xp/`. Services: `dispatcher/`, `townhall-summarizer/`, `tui/`.
+- Default to `ui/` unless another package is named. Don't edit across packages in one task unasked.
+- `ui/`: Next.js 13 **Pages Router** (no `app/`), React 18, TypeScript 5 `strict`.
+- Package manager **Yarn**, Node ≥18. Never suggest npm/pnpm.
+- Web3: thirdweb v5 (primary), wagmi v2 + viem v2, ethers 5.7 (legacy). Auth: Privy. Also Safe, Hats, Juicebox, Uniswap v4, Tableland, LayerZero.
+- Data: react-query, SWR, urql/graphql-request, axios. Forms: react-hook-form. Toasts: react-hot-toast. i18n: next-translate. Styling: Tailwind 3 + daisyUI, `darkMode: 'class'`.

--- a/.cursor/rules/20-conventions.mdc
+++ b/.cursor/rules/20-conventions.mdc
@@ -4,15 +4,30 @@ globs: ui/**/*.{ts,tsx}
 ---
 # Style, Imports & Naming
 
-## Prettier (do not fight it)
-- Single quotes, **no semicolons**, 2-space indent, width 100, `arrowParens: always`.
-- ESLint: `next/core-web-vitals` + `prettier` + `cypress`. Don't introduce lint errors.
+## Prettier — do not fight it
+- Single quotes, **no semicolons**, 2-space indent, print width 100, `arrowParens: always`.
+- ESLint extends `next/core-web-vitals` + `prettier` + `cypress`. Do not introduce lint errors.
+- Run `yarn lint` to verify before declaring a task done.
 
-## Imports (these are code path aliases, not prompt mentions)
-- Aliases: `@/components/*`, `@/lib/*`, `@/pages/*`, `@/cypress/*`. Bare `const/...` and `components/...` also resolve.
-- Import order (auto-sorted): `lib/*` -> `components/*` -> `pages/*` -> relative -> css.
-- ABIs from `const/abis/<Name>.json`; addresses/chains from `const/config`.
+## Import aliases (these are TypeScript path aliases, not prompt mentions)
+- `@/components/*` → `components/`
+- `@/lib/*` → `lib/`
+- `@/pages/*` → `pages/`
+- `@/cypress/*` → `cypress/`
+- Bare `const/...` and `components/...` also resolve (baseUrl is `./`).
+- ABIs: always from `const/abis/<Name>.json`.
+- Addresses and chain config: always from `const/config`.
+
+## Import order (auto-sorted by prettier-plugin-sort-imports)
+`lib/*` → `components/*` → `pages/*` → relative → css.
+Do not manually reorder against this — let the formatter handle it.
 
 ## Naming
-- Components: PascalCase `.tsx`. Hooks: `useXxx.tsx` in `lib/**/hooks/`.
-- Utils: camelCase `.ts` named by action. Constants: SCREAMING_SNAKE_CASE. ABIs: PascalCase `.json`.
+| Thing | Convention | Extension |
+|---|---|---|
+| React component | PascalCase | `.tsx` |
+| Hook | `useXxx` | `.tsx` (in `lib/**/hooks/`) |
+| Utility / helper | camelCase, named by action | `.ts` |
+| Constant | SCREAMING_SNAKE_CASE | — |
+| Contract ABI | PascalCase | `.json` |
+| API route file | camelCase or kebab-case | `.ts` |

--- a/.cursor/rules/20-conventions.mdc
+++ b/.cursor/rules/20-conventions.mdc
@@ -1,0 +1,18 @@
+---
+description: Style, imports, and naming conventions for ui
+globs: ui/**/*.{ts,tsx}
+---
+# Style, Imports & Naming
+
+## Prettier (do not fight it)
+- Single quotes, **no semicolons**, 2-space indent, width 100, `arrowParens: always`.
+- ESLint: `next/core-web-vitals` + `prettier` + `cypress`. Don't introduce lint errors.
+
+## Imports (these are code path aliases, not prompt mentions)
+- Aliases: `@/components/*`, `@/lib/*`, `@/pages/*`, `@/cypress/*`. Bare `const/...` and `components/...` also resolve.
+- Import order (auto-sorted): `lib/*` -> `components/*` -> `pages/*` -> relative -> css.
+- ABIs from `const/abis/<Name>.json`; addresses/chains from `const/config`.
+
+## Naming
+- Components: PascalCase `.tsx`. Hooks: `useXxx.tsx` in `lib/**/hooks/`.
+- Utils: camelCase `.ts` named by action. Constants: SCREAMING_SNAKE_CASE. ABIs: PascalCase `.json`.

--- a/.cursor/rules/30-architecture.mdc
+++ b/.cursor/rules/30-architecture.mdc
@@ -1,0 +1,20 @@
+---
+description: Architecture, folders, and recurring patterns in ui
+globs: ui/**/*.{ts,tsx}
+---
+# Architecture & Patterns
+
+## Folders (ui/)
+- `pages/` routes; `pages/api/**` domain-grouped API routes.
+- `components/` feature-grouped React components.
+- `lib/` feature-grouped logic; hooks in `lib/**/hooks/`.
+- `const/` config + ABIs + static data. `middleware/` composable API middleware.
+
+## Patterns
+- API routes compose middleware: `export default withMiddleware(handler, rateLimit, secureHeaders, ...)`. Reuse existing `middleware/*`.
+- Read on-chain via thirdweb v5 hooks (`useContract`, `useRead`) from the thirdweb hooks lib.
+- Use chain helpers (`DEFAULT_CHAIN_V5`, chain utils); never hardcode RPCs/chains.
+- Pin media via the ipfs lib; user feedback via `react-hot-toast`.
+
+## Don'ts
+- No App Router/RSC. No new global-state libs (use react-query/SWR/context). No narrating comments. No new top-level folders/config unasked. No committing secrets (`.env.local`, `.pem`).

--- a/.cursor/rules/30-architecture.mdc
+++ b/.cursor/rules/30-architecture.mdc
@@ -4,17 +4,68 @@ globs: ui/**/*.{ts,tsx}
 ---
 # Architecture & Patterns
 
-## Folders (ui/)
-- `pages/` routes; `pages/api/**` domain-grouped API routes.
-- `components/` feature-grouped React components.
-- `lib/` feature-grouped logic; hooks in `lib/**/hooks/`.
-- `const/` config + ABIs + static data. `middleware/` composable API middleware.
+## Folder roles (ui/)
+- `pages/` — file-system routes. `pages/api/<domain>/` — API routes grouped by domain.
+- `components/<feature>/` — React components scoped to a feature. Shared primitives in `components/layout/`.
+- `lib/<feature>/` — data fetching, business logic, utilities scoped to a feature.
+- `lib/<feature>/hooks/` — React hooks for that feature.
+- `const/` — addresses, ABIs, flags, static config. Read-only at runtime.
+- `middleware/` — composable Express-style middleware for API routes.
 
-## Patterns
-- API routes compose middleware: `export default withMiddleware(handler, rateLimit, secureHeaders, ...)`. Reuse existing `middleware/*`.
-- Read on-chain via thirdweb v5 hooks (`useContract`, `useRead`) from the thirdweb hooks lib.
-- Use chain helpers (`DEFAULT_CHAIN_V5`, chain utils); never hardcode RPCs/chains.
-- Pin media via the ipfs lib; user feedback via `react-hot-toast`.
+## API route pattern
+Every API route applies middleware via `withMiddleware`. Always follow this shape:
+
+```ts
+import withMiddleware from 'middleware/withMiddleware'
+import rateLimit from 'middleware/rateLimit'
+import secureHeaders from 'middleware/secureHeaders'
+
+async function handler(req, res) { ... }
+
+export default withMiddleware(handler, rateLimit, secureHeaders)
+```
+
+Reuse existing middleware from `middleware/` — do not inline equivalent logic in the handler.
+
+## On-chain read pattern (thirdweb v5)
+```ts
+import useContract from '@/lib/thirdweb/hooks/useContract'
+import { useRead } from '@/lib/thirdweb/hooks/useRead'
+import { DEFAULT_CHAIN_V5 } from 'const/config'
+import FooABI from 'const/abis/Foo.json'
+
+const contract = useContract({ address: FOO_ADDRESS, abi: FooABI, chain: DEFAULT_CHAIN_V5 })
+const { data } = useRead({ contract, method: 'someMethod', params: [...] })
+```
+
+Never hardcode RPC URLs or chain IDs. Always pull from `const/config` or `lib/thirdweb/chain.ts`.
+
+## On-chain write pattern (thirdweb v5)
+```ts
+import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
+// prepare → send → await confirmation → toast result
+```
+
+## Data fetching pattern (react-query)
+Use `useQuery` / `useMutation` from `@tanstack/react-query` for client-side async state.
+SWR is also present — prefer whichever the surrounding code already uses in the same feature.
+
+## IPFS media
+Pin via `@/lib/ipfs/pinBlobOrFile`. Unpin via `@/lib/ipfs/unpin`. Never call a pinning service
+directly from a component.
+
+## User feedback
+Always use `react-hot-toast` (`import toast from 'react-hot-toast'`).
+Show loading → success/error. Never use `alert()` or custom notification state.
+
+## Tableland writes
+After a write, call `waitForRow` from `@/lib/tableland/waitForRow` before treating the
+mutation as complete.
 
 ## Don'ts
-- No App Router/RSC. No new global-state libs (use react-query/SWR/context). No narrating comments. No new top-level folders/config unasked. No committing secrets (`.env.local`, `.pem`).
+- No App Router, RSC, or `use client` / `use server` directives.
+- No new global state libraries — use react-query, SWR, or React context.
+- No narrating code comments ("// increment counter"). Comments explain intent only.
+- No new top-level folders in `ui/` without discussion.
+- Never commit `.env.local`, `.pem`, or any secrets.
+- Never hardcode contract addresses, chain IDs, or RPC URLs outside of `const/config`.


### PR DESCRIPTION
## Summary
Adds `.cursor/rules/` so the whole team and Cursor background agents inherit consistent AI guidance from the repo automatically — no opt-in required.

### Files added
- **`00-context-discipline.mdc`** (always-on): Agent is expected to locate files autonomously for high-level tasks (e.g. "the profile page is broken, fix it"). Every file opened must serve the current task. Aimless exploration — reading files with no specific goal — is forbidden. Blocked forever: `node_modules`, `.next`, `yarn.lock`, `archive/`, generated artifacts.
- **`10-stack.mdc`** (always-on): Monorepo layout + `ui/` stack reference (Next.js 13 Pages Router, React 18, TS strict, Yarn, thirdweb v5, wagmi/viem, Privy, etc.).
- **`20-conventions.mdc`** (scoped to `ui/**/*.{ts,tsx}`): Prettier config, import aliases/ordering, file and symbol naming conventions.
- **`30-architecture.mdc`** (scoped to `ui/**/*.{ts,tsx}`): Folder layout, middleware composition pattern, on-chain read patterns, don'ts.

### Design intent
`alwaysApply` rules are intentionally small. Convention and architecture rules auto-attach only when `ui` TS/TSX files are in context, keeping baseline token usage low.

No application code changed.

## Test plan
- [ ] Confirm rules appear under Cursor Settings → Rules after pull
- [ ] Open a `ui/**/*.tsx` file and verify the `ui`-scoped rules attach
- [ ] Give a high-level task (e.g. "X page shows the wrong data, fix it") and confirm the agent finds files on its own without requiring explicit paths