### PR TITLE
fix: marketplace listing price shows NaN for values over 999

### DIFF
--- a/ui/components/layout/StandardDetailCard.tsx
+++ b/ui/components/layout/StandardDetailCard.tsx
@@ -65,12 +65,12 @@ export default function StandardDetailCard({
                     {`${
                       isCitizen
                         ? truncateTokenValue(price, currency)
-                        : truncateTokenValue(+price * 1.1, currency)
+                        : truncateTokenValue(parseFloat(price.replace(/,/g, '')) * 1.1, currency)
                     } ${currency}`}
                   </p>
                   {isCitizen && (
                     <p className="line-through text-xs opacity-70 text-slate-400">
-                      {`${truncateTokenValue(+price * 1.1, currency)} ${currency}`}
+                      {`${truncateTokenValue(parseFloat(price.replace(/,/g, '')) * 1.1, currency)} ${currency}`}
                     </p>
                   )}
                 </div>

--- a/ui/components/subscription/BuyTeamListingModal.tsx
+++ b/ui/components/subscription/BuyTeamListingModal.tsx
@@ -123,11 +123,12 @@ export default function BuyTeamListingModal({
   async function buyListing() {
     if (!account) return
 
+    const numericPrice = parseFloat(listing.price.replace(/,/g, ''))
     let price
     if (citizen) {
-      price = +listing.price
+      price = numericPrice
     } else {
-      price = +listing.price + +listing.price * 0.1 // 10% upcharge for non-citizens
+      price = numericPrice * 1.1 // 10% upcharge for non-citizens
     }
 
     setIsLoading(true)
@@ -135,7 +136,7 @@ export default function BuyTeamListingModal({
 
     try {
       // Execute the transaction
-      if (+listing.price <= 0) {
+      if (numericPrice <= 0) {
         transactionHash = 'none'
       } else if (listing.currency === 'ETH') {
         // buy with eth
@@ -165,7 +166,7 @@ export default function BuyTeamListingModal({
             ? 'https://arbiscan.io/tx/'
             : 'https://sepolia.etherscan.io/tx/'
 
-        const transactionLink = +listing.price <= 0 ? 'none' : etherscanUrl + transactionHash
+        const transactionLink = numericPrice <= 0 ? 'none' : etherscanUrl + transactionHash
 
         const shipping = Object.values(shippingInfo).join(', ')
 
@@ -179,7 +180,7 @@ export default function BuyTeamListingModal({
             email,
             item: listing.title,
             value: price,
-            originalValue: +listing.price,
+            originalValue: numericPrice,
             currency: listing.currency,
             decimals: currencyDecimals[listing.currency],
             quantity: 1,
@@ -247,7 +248,7 @@ export default function BuyTeamListingModal({
             <p id="listing-price" className="font-bold">{`${
               citizen
                 ? truncateTokenValue(listing.price, listing.currency)
-                : truncateTokenValue(+listing.price * 1.1, listing.currency)
+                : truncateTokenValue(parseFloat(listing.price.replace(/,/g, '')) * 1.1, listing.currency)
             } ${listing.currency}`}</p>
           </div>
         </div>

--- a/ui/components/subscription/TeamListing.tsx
+++ b/ui/components/subscription/TeamListing.tsx
@@ -193,17 +193,17 @@ export default function TeamListing({
                 <span id="listing-price" className="text-white font-bold text-sm">
                   {`${isCitizen
                     ? truncateTokenValue(listing.price, listing.currency)
-                    : truncateTokenValue(+listing.price * 1.1, listing.currency)
+                    : truncateTokenValue(parseFloat(listing.price.replace(/,/g, '')) * 1.1, listing.currency)
                   } ${listing.currency}`}
                 </span>
                 {isCitizen && (
                   <span id="listing-original-price" className="text-white/30 text-xs line-through ml-1.5">
-                    {`${truncateTokenValue(+listing.price * 1.1, listing.currency)} ${listing.currency}`}
+                    {`${truncateTokenValue(parseFloat(listing.price.replace(/,/g, '')) * 1.1, listing.currency)} ${listing.currency}`}
                   </span>
                 )}
                 {!isCitizen && listing.price && (
                   <p id="listing-savings" className="text-white/40 text-xs mt-0.5">
-                    {`Save ${+listing.price * 0.1} ${listing.currency} with citizenship`}
+                    {`Save ${truncateTokenValue(parseFloat(listing.price.replace(/,/g, '')) * 0.1, listing.currency)} ${listing.currency} with citizenship`}
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- Marketplace listing prices over 999 USDC (or any currency) were displaying as `NaN`
- The price `Input` component formats numbers with comma separators (e.g. `1000` → `"1,000"`) and that string is persisted to Tableland
- Casting `"1,000"` with the unary `+` operator returns `NaN` in JavaScript; all arithmetic on the price then propagates `NaN` to the display

## Changes
- Replaced all unguarded `+listing.price` / `+price` casts with `parseFloat(price.replace(/,/g, ''))` in:
  - `components/subscription/TeamListing.tsx` — citizen/non-citizen price display and savings line
  - `components/layout/StandardDetailCard.tsx` — marketplace card price display
  - `components/subscription/BuyTeamListingModal.tsx` — modal price display and actual on-chain transaction amount

## Test plan
- [ ] Create a marketplace listing with a price ≥ 1,000 USDC
- [ ] Verify the price displays correctly (not `NaN`) on the listing card and marketplace page
- [ ] Verify the citizen discount price (×1.1) and savings line also render correctly
- [ ] Verify the buy modal shows the correct price and the transaction sends the correct amount

Made with [Cursor](https://cursor.com)