### PR TITLE
fix: deleted citizens show as empty cards in network list

### DIFF
--- a/ui/lib/network/useNetworkData.ts
+++ b/ui/lib/network/useNetworkData.ts
@@ -117,7 +117,10 @@ export function useCitizensCount(
   const { citizenTableName } = useTableNames()
   const searchClause = buildSearchClause(search)
   const excludeCondition = buildExcludeIdsCondition(BLOCKED_CITIZENS)
-  const whereClause = appendToWhereClause(searchClause, excludeCondition)
+  const whereClause = appendToWhereClause(
+    appendToWhereClause(searchClause, excludeCondition),
+    "view != ''"
+  )
   const statement = citizenTableName
     ? `SELECT COUNT(*) as count FROM ${citizenTableName} ${whereClause}`
     : null
@@ -194,7 +197,10 @@ export function useCitizens(options: UseNetworkDataOptions = {}): NetworkDataRes
 
   const searchClause = buildSearchClause(search)
   const excludeCondition = buildExcludeIdsCondition(BLOCKED_CITIZENS)
-  const whereClause = appendToWhereClause(searchClause, excludeCondition)
+  const whereClause = appendToWhereClause(
+    appendToWhereClause(searchClause, excludeCondition),
+    "view != ''"
+  )
   const paginationClause = buildPaginationClause(page, pageSize)
   const statement = citizenTableName
     ? `SELECT * FROM ${citizenTableName} ${whereClause} ORDER BY id DESC ${paginationClause}`


### PR DESCRIPTION
## Summary

- Deleted citizens (all fields blanked including `view`) were still returned by the Tableland SQL query and rendered as empty cards in the `/network` citizen list.
- Added `view != ''` to the `WHERE` clause in both `useCitizensCount` and `useCitizens` so deleted profiles are excluded at the database level.
- This also fixes the pagination count, which previously over-counted deleted entries.

## Root cause

When a citizen deletes their profile, `DeleteProfileData.tsx` calls `updateTableDynamic` to blank every Tableland row field (including `view`). The NFT is not burned — the row remains with all fields set to `""`. The `isDeleted` check (`view === ''`) only guarded the individual profile page; there was no equivalent filter in the list query.

## Test plan

- [ ] Verify a deleted citizen no longer appears in the citizen list on `/network`
- [ ] Verify the pagination count does not include deleted citizens
- [ ] Verify active (non-deleted) citizens still appear correctly
- [ ] Verify search still works as expected alongside the new filter

Made with [Cursor](https://cursor.com)