### PR TITLE
fix: NaN price display still broken — root cause in truncateTokenValue

### DIFF
--- a/ui/components/subscription/TeamMarketplaceListingModal.tsx
+++ b/ui/components/subscription/TeamMarketplaceListingModal.tsx
@@ -161,7 +161,10 @@ export default function TeamMarketplaceListingModal({
 
           setIsLoading(true)
 
-          const cleanedData = cleanData(listingData)
+          const cleanedData = cleanData({
+            ...listingData,
+            price: listingData.price.replace(/,/g, ''),
+          })
 
           let imageIpfsLink
 

--- a/ui/lib/utils/numbers.ts
+++ b/ui/lib/utils/numbers.ts
@@ -6,19 +6,20 @@ export function stringToNumber(string: any, decimals: any) {
 }
 
 export function truncateTokenValue(value: number | string, token: string) {
+  const normalized = typeof value === 'string' ? value.replace(/,/g, '') : value
   let truncatedValue
-  const decimalPlaces = value.toString().split('.')[1]?.length || 0
+  const decimalPlaces = normalized.toString().split('.')[1]?.length || 0
   if (token === 'ETH') {
-    truncatedValue = Number(value).toFixed(Math.min(decimalPlaces, 5))
+    truncatedValue = Number(normalized).toFixed(Math.min(decimalPlaces, 5))
   } else if (
     token === 'USDC' ||
     token === 'USDT' ||
     token === 'DAI' ||
     token === 'MOONEY'
   ) {
-    truncatedValue = Number(value).toFixed(Math.min(decimalPlaces, 2))
+    truncatedValue = Number(normalized).toFixed(Math.min(decimalPlaces, 2))
   } else {
-    truncatedValue = Number(value)
+    truncatedValue = Number(normalized)
   }
   const numericValue = parseFloat(String(truncatedValue))
   return formatNumberWithCommas(numericValue.toString())


### PR DESCRIPTION
## What was missed in #1364

The previous fix only patched the non-citizen `×1.1` arithmetic paths. But the real root cause is that `truncateTokenValue` itself calls `Number("1,000")` on comma-formatted strings from Tableland, which returns `NaN`. This broke **all** price display — including the citizen base price — across every page.

## Root cause

The price `Input` uses `formatNumbers={true}`, formatting values as `"1,000"` in React state. That string was passed directly to `cleanData` and stored in Tableland unchanged. On read-back, `truncateTokenValue("1,000", "USDC")` → `Number("1,000")` → `NaN`.

## Changes

**`lib/utils/numbers.ts`** — `truncateTokenValue`  
Strip commas from string values at the top of the function before any numeric conversion. This is the single source-of-truth fix that covers every call site (citizen price, non-citizen price, savings line, modal, marketplace card) and handles existing Tableland rows that already have commas stored.

**`components/subscription/TeamMarketplaceListingModal.tsx`** — save path  
Strip commas from price before inserting/updating in Tableland so future listings are stored as plain numeric strings (e.g. `"1000"` not `"1,000"`).

## Test plan
- [ ] Create a listing with price ≥ 1,000 — verify it saves and displays correctly
- [ ] View an existing listing with price ≥ 1,000 (bad data in Tableland) — verify it now displays correctly
- [ ] Check citizen view (base price) and non-citizen view (×1.1 price + savings line) both render correctly
- [ ] Check the buy modal shows the correct amount

Made with [Cursor](https://cursor.com)