### PR TITLE
fix: deleted citizens show as empty cards in dashboard New Citizens section

### DIFF
--- a/ui/pages/dashboard.tsx
+++ b/ui/pages/dashboard.tsx
@@ -267,16 +267,19 @@ export async function getStaticProps() {
       const jobTableNameWithFallback =
         jobTableName || JOBS_TABLE_NAMES[chainSlug] || ''
 
-      const blockedIds = BLOCKED_CITIZENS.size > 0
-        ? ` WHERE id NOT IN (${Array.from(BLOCKED_CITIZENS).join(',')})`
+      const blockedIdsCondition = BLOCKED_CITIZENS.size > 0
+        ? `id NOT IN (${Array.from(BLOCKED_CITIZENS).join(',')})`
         : ''
+      const deletedCondition = "view != ''"
+      const citizenWhereConditions = [blockedIdsCondition, deletedCondition].filter(Boolean).join(' AND ')
+      const citizenWhereClause = citizenWhereConditions ? ` WHERE ${citizenWhereConditions}` : ''
       const [citizens, citizensCountResult, listings, jobs, teams, projects, missionRows] =
         await Promise.all([
-          citizenTableName ? queryTable(chain, `SELECT * FROM ${citizenTableName} ORDER BY id DESC LIMIT 8`).catch((error) => {
+          citizenTableName ? queryTable(chain, `SELECT * FROM ${citizenTableName}${citizenWhereClause} ORDER BY id DESC LIMIT 8`).catch((error) => {
             console.error('Error querying citizen table:', error)
             return []
           }) : Promise.resolve([]),
-          citizenTableName ? queryTable(chain, `SELECT COUNT(*) as count FROM ${citizenTableName}${blockedIds}`).catch((error) => {
+          citizenTableName ? queryTable(chain, `SELECT COUNT(*) as count FROM ${citizenTableName}${citizenWhereClause}`).catch((error) => {
             console.error('Error querying citizen count:', error)
             return [{ count: 0 }]
           }) : Promise.resolve([{ count: 0 }]),
@@ -408,7 +411,7 @@ export async function getStaticProps() {
       }
     }
     newestCitizens = citizens
-      .filter((c: any) => !BLOCKED_CITIZENS.has(c.id))
+      .filter((c: any) => !BLOCKED_CITIZENS.has(c.id) && c.view !== '')
       .map((c: any) => ({ ...c, mintTimestamp: mintTsMap[String(c.id)] ?? null }))
     newestListings = listings
     newestJobs = jobs


### PR DESCRIPTION
## Summary

- Deleted citizens were appearing as empty placeholder cards ("Citizen #208", "Citizen #206") in the dashboard's **New Citizens** section.
- The `getStaticProps` query in `pages/dashboard.tsx` fetched citizens with a bare `SELECT * ... ORDER BY id DESC LIMIT 8` — no `WHERE` clause, no deletion check.
- Added `view != ''` to the SQL `WHERE` clause (alongside the existing blocked-IDs exclusion) so deleted profiles never reach the client.
- Also added `c.view !== ''` to the JS-side `.filter()` as defense in depth.

## Root cause

When a citizen deletes their profile, every Tableland row field (including `view`) is blanked to `""`. The dashboard's server-side query had no filter for this condition, so deleted rows were returned and rendered as cards with an empty name and the default placeholder icon.

The companion PR [#1365](https://github.com/Official-MoonDao/MoonDAO/pull/1365) applied the same fix to the `/network` page's client-side `useCitizens` hook.

## Test plan

- [ ] Verify deleted citizens no longer appear in the **New Citizens** section on the dashboard
- [ ] Verify active citizens still appear correctly
- [ ] Verify the citizen count shown on the dashboard excludes deleted profiles

Made with [Cursor](https://cursor.com)