### PR TITLE
fix(citizen): ReferenceError gasToUse is not defined breaks all mints

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -1278,8 +1278,9 @@ export default function CreateCitizen({
     // For paid mints, the user may have just signed in at this step, so the
     // gas-estimation effect may not have run yet. Estimate inline and use the
     // returned value rather than erroring out and forcing a retry.
+    let gasToUse = BigInt(0)
     if (!freeMint) {
-      let gasToUse = estimatedGas
+      gasToUse = estimatedGas ?? BigInt(0)
       if (!gasToUse || gasToUse === BigInt(0)) {
         gasToUse = (await estimateMintGas()) ?? BigInt(0)
       }
@@ -1303,16 +1304,25 @@ export default function CreateCitizen({
         params: [address, 365 * 24 * 60 * 60],
       })
 
-      const totalCost = calculateTotalCost(cost, gasToUse, effectiveGasPrice, isCrossChain)
+      // Balance check only applies to paid mints; sponsored mints cost the
+      // user nothing and may not have a gas price loaded at all.
+      if (!freeMint) {
+        const totalCost = calculateTotalCost(
+          cost,
+          gasToUse,
+          effectiveGasPrice ?? BigInt(0),
+          isCrossChain
+        )
 
-      if (!freeMint && +(nativeBalance ?? '0') < totalCost) {
-        const shortfall = totalCost - +(nativeBalance ?? '0')
-        const requiredAmount = shortfall * 1.15
+        if (+(nativeBalance ?? '0') < totalCost) {
+          const shortfall = totalCost - +(nativeBalance ?? '0')
+          const requiredAmount = shortfall * 1.15
 
-        setRequiredEthAmount(requiredAmount)
-        setOnrampModalOpen(true)
-        setIsLoadingMint(false)
-        return
+          setRequiredEthAmount(requiredAmount)
+          setOnrampModalOpen(true)
+          setIsLoadingMint(false)
+          return
+        }
       }
 
       // Upload to IPFS


### PR DESCRIPTION
## Summary

Hotfix for `ReferenceError: gasToUse is not defined`, which currently breaks **every** citizen mint in production (normal flow and invite links). Reported by a user on MetaMask/Chrome.

## Root cause

`b7dbf816` ("skip gas checks for free mints") wrapped the gas-estimation block in `if (!freeMint) { ... }`, moving the `let gasToUse` declaration inside the block — but the `calculateTotalCost(cost, gasToUse, ...)` call further down remained outside it:

```ts
if (!freeMint) {
  let gasToUse = estimatedGas   // block-scoped
  ...
}
...
const totalCost = calculateTotalCost(cost, gasToUse, effectiveGasPrice, isCrossChain) // ReferenceError
```

Since `calculateTotalCost` runs unconditionally before any mint path, every click on Mint threw. TypeScript flags this ("Cannot find name 'gasToUse'"), but the build ships anyway because `next.config.js` sets `typescript.ignoreBuildErrors: true`.

## Fix

- Hoist `let gasToUse = BigInt(0)` to function scope; paid mints still estimate inline as before.
- Move the `totalCost` / balance / onramp check inside `if (!freeMint)` — it only ever applied to paid mints (`if (!freeMint && balance < totalCost)`), and sponsored mints may legitimately have no gas price loaded, which would have made `gasEstimate * gasPrice` throw on `undefined`.

Behavior preserved from the original intent of `b7dbf816`: sponsored mints skip all gas/balance checks; paid mints behave exactly as before.

## Test plan

- [ ] Paid mint on Arbitrum: checkout shows cost, mint succeeds.
- [ ] Paid mint with insufficient balance: onramp modal opens (no error).
- [ ] Sponsored mint via invite link: mint succeeds with no gas estimation required.
- [ ] Sponsored mint via whitelist/contribution threshold: mint succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix in the mint handler that restores intended paid vs sponsored behavior with no auth or contract changes.
> 
> **Overview**
> Fixes a **production-breaking** bug in `callMint` where **`gasToUse` was block-scoped** inside the paid-mint gas path but **`calculateTotalCost` still referenced it unconditionally**, causing `ReferenceError: gasToUse is not defined` on every Mint click.
> 
> **`gasToUse`** is now declared at function scope (default `BigInt(0)`); paid mints still inline-estimate gas when needed. **Total cost, balance check, and onramp modal** run only when **`!freeMint`**, so sponsored mints skip gas/balance logic and avoid failures when **`effectiveGasPrice`** is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a418b38041752d3aea20ab47e8bf4513b21269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->