### PR TITLE
feat(contributions): Discord notification for new Community Circle submissions

### DIFF
--- a/.github/workflows/contribution-notifications.yml
+++ b/.github/workflows/contribution-notifications.yml
@@ -1,0 +1,24 @@
+name: Contribution Discord Notifications
+
+# Contributions are submitted through an external Google Form, so there's no
+# server-side hook on submit. This cron polls the deployed site, which diffs the
+# contributions sheet against rows already announced and posts new ones to
+# Discord. Dedup state lives in Upstash Redis, so polling is idempotent.
+on:
+  schedule:
+    - cron: '*/10 * * * *' # every 10 minutes
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger contribution notification poller
+        env:
+          SITE_URL: ${{ secrets.MOONDAO_SITE_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          BASE="${SITE_URL:-https://moondao.com}"
+          curl -fsS -X POST "$BASE/api/cron/contribution-notifications" \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            -H "Content-Type: application/json"

--- a/ui/env.d.ts
+++ b/ui/env.d.ts
@@ -23,5 +23,9 @@ namespace NodeJS {
     S3_UPLOAD_KEY: string
     S3_UPLOAD_SECRET: string
     S3_UPLOAD_BUCKET: string
+    UPSTASH_REDIS_URL: string
+    UPSTASH_REDIS_TOKEN: string
+    CONTRIBUTIONS_SHEET_CSV_URL: string
+    CRON_SECRET: string
   }
 }

--- a/ui/lib/contributions/notifyNewContributions.ts
+++ b/ui/lib/contributions/notifyNewContributions.ts
@@ -28,6 +28,15 @@ import {
 const NOTIFIED_SET_KEY = 'contributions:notified'
 const SEEDED_FLAG_KEY = 'contributions:notified:seeded'
 
+// Per-run lock so overlapping cron invocations can't both read the seen-set and
+// double-post the same row (the gap between SMEMBERS and SADD). The release is a
+// compare-and-delete keyed on a unique token, so a slow run can never delete a
+// lock that a later run has already acquired.
+const LOCK_KEY = 'contributions:notify:lock'
+const LOCK_TTL_SECONDS = 120
+const RELEASE_LOCK_SCRIPT =
+  'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end'
+
 // Cap posts per run so a sudden burst (or a misconfiguration) can't spam the
 // channel or trip Discord's rate limiter. Anything beyond this is picked up on
 // the next poll, since rows are only marked seen after a successful post.
@@ -49,6 +58,8 @@ export type NotifyResult = {
   total?: number
   /** New rows that remain unposted (deferred to the next run / failed). */
   pending?: number
+  /** Set when another run held the lock and this invocation was skipped. */
+  locked?: boolean
   /** Populated when ok is false. */
   reason?: string
 }
@@ -140,45 +151,63 @@ export async function notifyNewContributions(): Promise<NotifyResult> {
     return { ok: false, reason: 'redis-unconfigured' }
   }
 
-  const contributions = await getSheetContributions()
-  // `getSheetContributions` returns newest-first; post oldest-first so the
-  // Discord feed reads chronologically.
-  const ordered = [...contributions].reverse()
-  const keys = ordered.map(contributionKey)
+  const lockToken = crypto.randomBytes(16).toString('hex')
+  const acquired = await redis.set(LOCK_KEY, lockToken, {
+    nx: true,
+    ex: LOCK_TTL_SECONDS,
+  })
+  if (acquired !== 'OK') {
+    // Another run is in flight; skip rather than risk a double-post.
+    return { ok: true, locked: true, posted: 0 }
+  }
 
-  const seeded = await redis.get(SEEDED_FLAG_KEY)
-  if (!seeded) {
-    if (keys.length > 0) {
-      await redis.sadd(NOTIFIED_SET_KEY, keys[0], ...keys.slice(1))
+  try {
+    const contributions = await getSheetContributions()
+    // `getSheetContributions` returns newest-first; post oldest-first so the
+    // Discord feed reads chronologically.
+    const ordered = [...contributions].reverse()
+    const keys = ordered.map(contributionKey)
+
+    const seeded = await redis.get(SEEDED_FLAG_KEY)
+    if (!seeded) {
+      if (keys.length > 0) {
+        await redis.sadd(NOTIFIED_SET_KEY, keys[0], ...keys.slice(1))
+      }
+      await redis.set(SEEDED_FLAG_KEY, '1')
+      return { ok: true, seeded: true, posted: 0, total: keys.length }
     }
-    await redis.set(SEEDED_FLAG_KEY, '1')
-    return { ok: true, seeded: true, posted: 0, total: keys.length }
-  }
 
-  if (ordered.length === 0) {
-    return { ok: true, seeded: false, posted: 0, total: 0 }
-  }
+    if (ordered.length === 0) {
+      return { ok: true, seeded: false, posted: 0, total: 0 }
+    }
 
-  const seen = new Set(await redis.smembers(NOTIFIED_SET_KEY))
-  const newOnes: { c: Contribution; key: string }[] = []
-  for (let i = 0; i < ordered.length; i++) {
-    if (!seen.has(keys[i])) newOnes.push({ c: ordered[i], key: keys[i] })
-  }
+    const seen = new Set(await redis.smembers(NOTIFIED_SET_KEY))
+    const newOnes: { c: Contribution; key: string }[] = []
+    for (let i = 0; i < ordered.length; i++) {
+      if (!seen.has(keys[i])) newOnes.push({ c: ordered[i], key: keys[i] })
+    }
 
-  let posted = 0
-  for (const { c, key } of newOnes.slice(0, MAX_PER_RUN)) {
-    const ok = await postToDiscord(buildContent(c))
-    if (!ok) break // leave unseen so the next run retries
-    await redis.sadd(NOTIFIED_SET_KEY, key)
-    posted++
-    await sleep(400) // be gentle with Discord's rate limiter
-  }
+    let posted = 0
+    for (const { c, key } of newOnes.slice(0, MAX_PER_RUN)) {
+      const ok = await postToDiscord(buildContent(c))
+      if (!ok) break // leave unseen so the next run retries
+      await redis.sadd(NOTIFIED_SET_KEY, key)
+      posted++
+      await sleep(400) // be gentle with Discord's rate limiter
+    }
 
-  return {
-    ok: true,
-    seeded: false,
-    posted,
-    total: keys.length,
-    pending: Math.max(0, newOnes.length - posted),
+    return {
+      ok: true,
+      seeded: false,
+      posted,
+      total: keys.length,
+      pending: Math.max(0, newOnes.length - posted),
+    }
+  } finally {
+    try {
+      await redis.eval(RELEASE_LOCK_SCRIPT, [LOCK_KEY], [lockToken])
+    } catch (err) {
+      console.warn('[contribution-notify] lock release failed:', err)
+    }
   }
 }

--- a/ui/lib/contributions/notifyNewContributions.ts
+++ b/ui/lib/contributions/notifyNewContributions.ts
@@ -1,0 +1,184 @@
+// Posts a Discord notification for each NEW community contribution submitted
+// through the Community Circle Google Form.
+//
+// Why this exists / how it works:
+//   Contributions are submitted via an external Google Form that writes rows to
+//   a Google Sheet. The app only ever *reads* that sheet (see
+//   `getSheetContributions`), so there is no server-side hook we can fire on
+//   submit. Instead this module is polled on a schedule (a GitHub Actions cron
+//   hits `/api/cron/contribution-notifications`), diffs the sheet against the
+//   set of rows we've already announced, and posts the new ones to the same
+//   Discord "network notifications" channel used for citizens/teams/jobs.
+//
+//   Dedup + first-run seeding live in Upstash Redis (the same store used for
+//   citizen invites and rate limiting):
+//     - `contributions:notified`        SET of already-announced row hashes
+//     - `contributions:notified:seeded` flag set after the initial backfill
+//   On the very first run we record every existing row as "seen" WITHOUT
+//   posting, so turning this on doesn't dump the entire historical backlog into
+//   Discord. After that, only genuinely new rows are announced.
+import crypto from 'crypto'
+import { Redis } from '@upstash/redis'
+import { DEPLOYED_ORIGIN, GENERAL_CHANNEL_ID, TEST_CHANNEL_ID } from 'const/config'
+import {
+  getSheetContributions,
+  type Contribution,
+} from '@/lib/contributions/getSheetContributions'
+
+const NOTIFIED_SET_KEY = 'contributions:notified'
+const SEEDED_FLAG_KEY = 'contributions:notified:seeded'
+
+// Cap posts per run so a sudden burst (or a misconfiguration) can't spam the
+// channel or trip Discord's rate limiter. Anything beyond this is picked up on
+// the next poll, since rows are only marked seen after a successful post.
+const MAX_PER_RUN = 8
+
+// Same channel selection the rest of the network notifications use.
+const NOTIFICATION_CHANNEL_ID =
+  process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
+    ? GENERAL_CHANNEL_ID
+    : TEST_CHANNEL_ID
+
+export type NotifyResult = {
+  ok: boolean
+  /** Set when the run only seeded the dedup store (first run). */
+  seeded?: boolean
+  /** Number of contributions posted to Discord this run. */
+  posted?: number
+  /** Total contribution rows currently in the sheet. */
+  total?: number
+  /** New rows that remain unposted (deferred to the next run / failed). */
+  pending?: number
+  /** Populated when ok is false. */
+  reason?: string
+}
+
+let redisClient: Redis | null = null
+
+function getRedis(): Redis | null {
+  if (redisClient) return redisClient
+  const url = process.env.UPSTASH_REDIS_URL
+  const token = process.env.UPSTASH_REDIS_TOKEN
+  if (!url || !token) return null
+  redisClient = new Redis({ url, token })
+  return redisClient
+}
+
+// Stable per-row identity. Timestamp + wallet + description is unique enough to
+// survive sheet re-ordering and never collides for distinct submissions.
+function contributionKey(c: Contribution): string {
+  return crypto
+    .createHash('sha1')
+    .update(`${c.timestamp}|${c.walletAddress}|${c.description}`)
+    .digest('hex')
+}
+
+function truncate(text: string, max: number): string {
+  const t = text.trim()
+  return t.length > max ? `${t.slice(0, max - 1).trimEnd()}…` : t
+}
+
+function buildContent(c: Contribution): string {
+  const who =
+    c.name && c.name !== 'Anonymous'
+      ? `**${c.name}**`
+      : c.walletAddress
+      ? `**${c.walletAddress.slice(0, 6)}…${c.walletAddress.slice(-4)}**`
+      : '**Someone**'
+
+  const lines = [`## 🚀 New Contribution from ${who}`]
+  if (c.area) lines.push(`**Area:** ${c.area}`)
+  if (c.description) lines.push(truncate(c.description, 1500))
+  if (c.links) {
+    const url = c.links.startsWith('http') ? c.links : `https://${c.links}`
+    lines.push(`🔗 ${url}`)
+  }
+  lines.push(`\nView all contributions → ${DEPLOYED_ORIGIN}/contributions`)
+  return lines.join('\n')
+}
+
+async function postToDiscord(content: string): Promise<boolean> {
+  const token = process.env.DISCORD_BOT_TOKEN
+  if (!token) {
+    console.error('[contribution-notify] DISCORD_BOT_TOKEN not set')
+    return false
+  }
+  try {
+    const resp = await fetch(
+      `https://discord.com/api/v10/channels/${NOTIFICATION_CHANNEL_ID}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bot ${token}`,
+        },
+        body: JSON.stringify({ content }),
+      }
+    )
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '')
+      console.error(
+        `[contribution-notify] Discord post failed (${resp.status}): ${body}`
+      )
+      return false
+    }
+    return true
+  } catch (err) {
+    console.error('[contribution-notify] Discord post error:', err)
+    return false
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+export async function notifyNewContributions(): Promise<NotifyResult> {
+  const redis = getRedis()
+  if (!redis) {
+    console.error(
+      '[contribution-notify] Redis not configured (UPSTASH_REDIS_URL / UPSTASH_REDIS_TOKEN)'
+    )
+    return { ok: false, reason: 'redis-unconfigured' }
+  }
+
+  const contributions = await getSheetContributions()
+  // `getSheetContributions` returns newest-first; post oldest-first so the
+  // Discord feed reads chronologically.
+  const ordered = [...contributions].reverse()
+  const keys = ordered.map(contributionKey)
+
+  const seeded = await redis.get(SEEDED_FLAG_KEY)
+  if (!seeded) {
+    if (keys.length > 0) {
+      await redis.sadd(NOTIFIED_SET_KEY, keys[0], ...keys.slice(1))
+    }
+    await redis.set(SEEDED_FLAG_KEY, '1')
+    return { ok: true, seeded: true, posted: 0, total: keys.length }
+  }
+
+  if (ordered.length === 0) {
+    return { ok: true, seeded: false, posted: 0, total: 0 }
+  }
+
+  const seen = new Set(await redis.smembers(NOTIFIED_SET_KEY))
+  const newOnes: { c: Contribution; key: string }[] = []
+  for (let i = 0; i < ordered.length; i++) {
+    if (!seen.has(keys[i])) newOnes.push({ c: ordered[i], key: keys[i] })
+  }
+
+  let posted = 0
+  for (const { c, key } of newOnes.slice(0, MAX_PER_RUN)) {
+    const ok = await postToDiscord(buildContent(c))
+    if (!ok) break // leave unseen so the next run retries
+    await redis.sadd(NOTIFIED_SET_KEY, key)
+    posted++
+    await sleep(400) // be gentle with Discord's rate limiter
+  }
+
+  return {
+    ok: true,
+    seeded: false,
+    posted,
+    total: keys.length,
+    pending: Math.max(0, newOnes.length - posted),
+  }
+}

--- a/ui/lib/contributions/notifyNewContributions.ts
+++ b/ui/lib/contributions/notifyNewContributions.ts
@@ -42,6 +42,15 @@ const RELEASE_LOCK_SCRIPT =
 // the next poll, since rows are only marked seen after a successful post.
 const MAX_PER_RUN = 8
 
+// Discord rejects messages whose `content` exceeds 2000 chars. Keep a margin so
+// a single oversized submission can never become permanently un-postable and
+// stall the queue.
+const MAX_CONTENT_LENGTH = 1900
+
+// Abort a hung Discord request so a single slow call can't run the whole cron
+// past its function time limit.
+const DISCORD_FETCH_TIMEOUT_MS = 10_000
+
 // Same channel selection the rest of the network notifications use.
 const NOTIFICATION_CHANNEL_ID =
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
@@ -105,7 +114,13 @@ function buildContent(c: Contribution): string {
     lines.push(`🔗 ${url}`)
   }
   lines.push(`\nView all contributions → ${DEPLOYED_ORIGIN}/contributions`)
-  return lines.join('\n')
+  const content = lines.join('\n')
+  // Final guard: even with a capped description, `area`/`name`/`links` can push
+  // the total past Discord's 2000-char limit, which would make this row fail
+  // forever and block the queue. Hard-cap the whole message instead.
+  return content.length > MAX_CONTENT_LENGTH
+    ? `${content.slice(0, MAX_CONTENT_LENGTH - 1).trimEnd()}…`
+    : content
 }
 
 async function postToDiscord(content: string): Promise<boolean> {
@@ -114,6 +129,8 @@ async function postToDiscord(content: string): Promise<boolean> {
     console.error('[contribution-notify] DISCORD_BOT_TOKEN not set')
     return false
   }
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), DISCORD_FETCH_TIMEOUT_MS)
   try {
     const resp = await fetch(
       `https://discord.com/api/v10/channels/${NOTIFICATION_CHANNEL_ID}/messages`,
@@ -123,7 +140,11 @@ async function postToDiscord(content: string): Promise<boolean> {
           'Content-Type': 'application/json',
           Authorization: `Bot ${token}`,
         },
-        body: JSON.stringify({ content }),
+        // `allowed_mentions: { parse: [] }` disables ALL mention parsing so an
+        // attacker-controlled form field (name/area/description/links) can't
+        // make the bot ping @everyone/@here or arbitrary roles/users.
+        body: JSON.stringify({ content, allowed_mentions: { parse: [] } }),
+        signal: controller.signal,
       }
     )
     if (!resp.ok) {
@@ -137,6 +158,8 @@ async function postToDiscord(content: string): Promise<boolean> {
   } catch (err) {
     console.error('[contribution-notify] Discord post error:', err)
     return false
+  } finally {
+    clearTimeout(timeout)
   }
 }
 
@@ -170,9 +193,14 @@ export async function notifyNewContributions(): Promise<NotifyResult> {
 
     const seeded = await redis.get(SEEDED_FLAG_KEY)
     if (!seeded) {
-      if (keys.length > 0) {
-        await redis.sadd(NOTIFIED_SET_KEY, keys[0], ...keys.slice(1))
+      // Only seed once we've actually read rows. `getSheetContributions()`
+      // returns `[]` both for a genuinely empty sheet AND for a transient fetch
+      // failure / momentarily-unset CSV URL; flipping the flag in that case
+      // would make the next successful run dump the entire historical backlog.
+      if (keys.length === 0) {
+        return { ok: true, seeded: false, posted: 0, total: 0 }
       }
+      await redis.sadd(NOTIFIED_SET_KEY, keys[0], ...keys.slice(1))
       await redis.set(SEEDED_FLAG_KEY, '1')
       return { ok: true, seeded: true, posted: 0, total: keys.length }
     }

--- a/ui/lib/discord/sendDiscordMessage.tsx
+++ b/ui/lib/discord/sendDiscordMessage.tsx
@@ -1,18 +1,40 @@
+import { getAccessToken } from '@privy-io/react-auth'
+
+/**
+ * POSTs a fire-and-forget network notification to Discord via `/api/discord/send`.
+ *
+ * The `/api/discord/send` route is wrapped in `authMiddleware`, which 401s
+ * unless the request includes either a valid NextAuth session cookie OR an
+ * `Authorization: Bearer ${accessToken}` header. Privy-only flows (the common
+ * case — new citizens, team creation, contributions, job postings, marketplace
+ * listings) don't reliably have a NextAuth cookie, so without the Bearer header
+ * the request silently 401s and the Discord message never posts. We always
+ * attach the Privy access token to avoid that.
+ */
 export default async function sendDiscordMessage(
   type: 'networkNotifications',
   message: string
 ) {
   try {
+    const accessToken = await getAccessToken()
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    if (accessToken) {
+      headers.Authorization = `Bearer ${accessToken}`
+    }
+
     const response = await fetch(`/api/discord/send?type=${type}`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify({ message }),
     })
 
     if (!response.ok) {
-      throw new Error('Failed to send message to discord')
+      throw new Error(
+        `Failed to send message to discord (status ${response.status})`
+      )
     }
   } catch (err) {
     console.error('Error sending message to discord :', err)

--- a/ui/lib/discord/sendDiscordMessage.tsx
+++ b/ui/lib/discord/sendDiscordMessage.tsx
@@ -1,40 +1,18 @@
-import { getAccessToken } from '@privy-io/react-auth'
-
-/**
- * POSTs a fire-and-forget network notification to Discord via `/api/discord/send`.
- *
- * The `/api/discord/send` route is wrapped in `authMiddleware`, which 401s
- * unless the request includes either a valid NextAuth session cookie OR an
- * `Authorization: Bearer ${accessToken}` header. Privy-only flows (the common
- * case — new citizens, team creation, contributions, job postings, marketplace
- * listings) don't reliably have a NextAuth cookie, so without the Bearer header
- * the request silently 401s and the Discord message never posts. We always
- * attach the Privy access token to avoid that.
- */
 export default async function sendDiscordMessage(
   type: 'networkNotifications',
   message: string
 ) {
   try {
-    const accessToken = await getAccessToken()
-
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    }
-    if (accessToken) {
-      headers.Authorization = `Bearer ${accessToken}`
-    }
-
     const response = await fetch(`/api/discord/send?type=${type}`, {
       method: 'POST',
-      headers,
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({ message }),
     })
 
     if (!response.ok) {
-      throw new Error(
-        `Failed to send message to discord (status ${response.status})`
-      )
+      throw new Error('Failed to send message to discord')
     }
   } catch (err) {
     console.error('Error sending message to discord :', err)

--- a/ui/pages/api/cron/contribution-notifications.ts
+++ b/ui/pages/api/cron/contribution-notifications.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { notifyNewContributions } from '@/lib/contributions/notifyNewContributions'
+
+// Polled by the "Contribution Discord Notifications" GitHub Actions cron (and
+// triggerable manually). Diffs the Community Circle contributions sheet against
+// the rows we've already announced and posts the new ones to Discord.
+//
+// Auth: matches the townhall cron — a shared `CRON_SECRET` passed as either an
+// `Authorization: Bearer <secret>` header, an `x-cron-secret` header, or a
+// `?secret=` query param. When `CRON_SECRET` is unset the route is open (parity
+// with the existing cron endpoints); the work is idempotent so repeated calls
+// post nothing once rows are seen.
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  const first = (v: string | string[] | undefined): string | undefined =>
+    Array.isArray(v) ? v[0] : v
+
+  const authHeader = first(req.headers['authorization'])
+  const bearerToken = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7).trim()
+    : null
+  const provided =
+    bearerToken || first(req.headers['x-cron-secret']) || first(req.query.secret)
+  const expectedSecret = process.env.CRON_SECRET
+
+  if (expectedSecret && provided !== expectedSecret) {
+    return res.status(401).json({ message: 'Unauthorized' })
+  }
+
+  try {
+    const result = await notifyNewContributions()
+    const status = result.ok ? 200 : 500
+    return res.status(status).json(result)
+  } catch (error) {
+    console.error('[cron/contribution-notifications]', error)
+    return res.status(500).json({
+      ok: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    })
+  }
+}

--- a/ui/pages/api/cron/contribution-notifications.ts
+++ b/ui/pages/api/cron/contribution-notifications.ts
@@ -1,6 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { notifyNewContributions } from '@/lib/contributions/notifyNewContributions'
 
+// With MAX_PER_RUN=8 posts, ~400ms inter-post sleeps, and per-request fetch
+// timeouts, a slow run can outlast the default serverless limit and be killed
+// mid-loop. Give it explicit headroom so behavior is predictable.
+export const config = {
+  maxDuration: 60,
+}
+
 // Polled by the "Contribution Discord Notifications" GitHub Actions cron (and
 // triggerable manually). Diffs the Community Circle contributions sheet against
 // the rows we've already announced and posts the new ones to Discord.


### PR DESCRIPTION
## Summary

Community Circle contributions are submitted through an **external Google Form** that writes rows to a Google Sheet. The app only ever *reads* that sheet (`getSheetContributions`) to render the feed — there is **no server-side hook on submit**, so the previous Discord notification (an external Form/Sheet automation) is not something this repo could fire. This PR rebuilds the notification entirely in-repo as a scheduled poller.

> Note: an earlier commit on this branch patched `sendDiscordMessage` (the Coordinape `ContributionEditor` path). That flow is **not** used for contributions, so that change was reverted in this branch.

### How it works
- **`ui/lib/contributions/notifyNewContributions.ts`** — reads the contributions sheet, diffs it against rows already announced (tracked in **Upstash Redis**), and posts each new row to the network-notifications Discord channel (`GENERAL_CHANNEL_ID` on mainnet / `TEST_CHANNEL_ID` otherwise) via `DISCORD_BOT_TOKEN`.
  - **First-run seeding:** on the very first run it records all existing rows as "seen" *without* posting, so enabling this doesn't dump the entire historical backlog into Discord.
  - **Idempotent + safe:** rows are only marked seen after a successful Discord post (failures retry next run), capped at 8 posts/run to avoid rate limits.
- **`ui/pages/api/cron/contribution-notifications.ts`** — secret-protected endpoint (`CRON_SECRET` via `Authorization: Bearer`, `x-cron-secret`, or `?secret=`), mirroring the existing townhall cron auth.
- **`.github/workflows/contribution-notifications.yml`** — GitHub Actions cron that polls the endpoint every 10 minutes (matches the repo's existing scheduled-job pattern).

### Required configuration
- `CONTRIBUTIONS_SHEET_CSV_URL`, `UPSTASH_REDIS_URL`, `UPSTASH_REDIS_TOKEN`, `DISCORD_BOT_TOKEN` (env on the deployed site)
- Repo secrets for the workflow: `CRON_SECRET` and optionally `MOONDAO_SITE_URL` (defaults to `https://moondao.com`)

## Test plan
- [ ] Set the env vars above; trigger the workflow manually (`workflow_dispatch`) once — confirm the **first run seeds silently** (no Discord posts) and returns `{ seeded: true }`.
- [ ] Submit a test contribution via the Google Form; on the next poll confirm a Discord message posts to the network-notifications channel.
- [ ] Re-run the cron and confirm the same contribution is **not** re-posted (dedup works).
- [ ] Verify a missing/invalid `CRON_SECRET` returns 401.