### PR TITLE
feat: send gas stipend to new citizens after free mint

### DIFF
--- a/ui/lib/google/hsm-signer.ts
+++ b/ui/lib/google/hsm-signer.ts
@@ -560,6 +560,16 @@ export async function createHSMWallet(): Promise<any> {
 }
 
 /**
+ * Send ETH from the HSM wallet to a recipient address.
+ * Intended for small gas stipends (e.g. topping up new citizens after a free mint).
+ * Throws on failure — callers should catch and treat as non-critical.
+ */
+export async function sendEthFromHSM(to: string, amountWei: bigint): Promise<string> {
+  const config = getHSMConfig()
+  return sendTransaction(config, { to, value: amountWei, data: '0x' })
+}
+
+/**
  * Convert a secp256k1 public key to Ethereum address using proper keccak256 derivation
  * @param publicKeyHex - The public key as a hex string (with or without 0x prefix)
  * @returns The derived Ethereum address

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -16,7 +16,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { readContract, prepareContractCall, sendAndConfirmTransaction, getContract } from 'thirdweb'
 import { cacheExchange, createClient, fetchExchange } from 'urql'
 import { CitizenInvite, consumeInvite, peekInvite, restoreInvite } from '@/lib/citizen/inviteTokens'
-import { createHSMWallet } from '@/lib/google/hsm-signer'
+import { createHSMWallet, sendEthFromHSM } from '@/lib/google/hsm-signer'
 import { addressBelongsToPrivyUser } from '@/lib/privy'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -286,6 +286,15 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         account,
       })
       mintSucceeded = true
+
+      // Send a small gas stipend (~$0.05 worth of ETH) so new citizens can
+      // interact on-chain right away without needing to fund their wallet first.
+      // 0.00002 ETH ≈ $0.06 at $3 000/ETH on Arbitrum.
+      const GAS_STIPEND_WEI = BigInt('20000000000000') // 0.00002 ETH
+      sendEthFromHSM(address, GAS_STIPEND_WEI).catch((err) =>
+        console.error('Gas stipend transfer failed (non-critical):', err)
+      )
+
       const jsonReceipt = JSON.stringify(receipt, (key, value) => {
         if (typeof value === 'bigint') {
           return value.toString()


### PR DESCRIPTION
## Summary

- After a successful free/sponsored citizen mint, the HSM signer now sends **~0.00002 ETH (~$0.06)** directly to the new citizen's wallet on Arbitrum
- Implemented via a new `sendEthFromHSM(to, amountWei)` helper in `lib/google/hsm-signer.ts` that reuses the existing GCP KMS config
- The transfer is **fire-and-forget** — failure is logged but never blocks the mint response, so a depleted HSM balance cannot break the citizen-creation flow

## Why

New citizens who mint for free have no ETH in their wallet and can't do anything on-chain (vote, update profile, etc.) until they manually fund it. This stipend removes that friction.

## How it works

1. `freeMint.ts` POST handler mints the NFT as before
2. Immediately after `mintSucceeded = true`, it calls `sendEthFromHSM(address, 20000000000000n)` — a plain ETH transfer from the HSM wallet to the new citizen
3. Any error is caught and logged; the mint receipt is still returned to the client

## Test plan

- [ ] Trigger a free mint (via whitelist or invite link) and confirm the recipient wallet receives ~0.00002 ETH on Arbitrum shortly after minting
- [ ] Deliberately exhaust the HSM ETH balance (testnet only) and confirm the mint still completes successfully and the stipend failure is only logged, not surfaced to the user
- [ ] Confirm paid mints are unaffected (stipend code only runs in the `POST /api/mission/freeMint` route after `mintSucceeded`)

## Notes

- The HSM wallet (`moon-dao-signer`) must maintain an ETH balance on Arbitrum to cover both mint costs and stipends. Ops should monitor this.
- The stipend amount (`GAS_STIPEND_WEI = 20000000000000n`) is defined as a named constant inline — easy to adjust if ETH price changes significantly.

Made with [Cursor](https://cursor.com)