### PR TITLE
feat(deprize): resolution, redemption & refund (M4)

### DIFF
--- a/docs/DEPRIZE.md
+++ b/docs/DEPRIZE.md
@@ -228,12 +228,12 @@ Milestones 1–3 are implemented and tested in `subscription-contracts/src/depri
 | Bet entry point | `DePrizeMint` → split CTF + route via Uniswap pools | `DePrizeMint` → split 5% to JB, 95% → WETH → `LMSRWithTWAP.trade()` | **M3 ✅** |
 | Market maker / liquidity | Per-team Uniswap v4 pools, treasury-as-LP | One Gnosis CTF condition + one `LMSRWithTWAP` market per DePrize (external Solidity `0.5` deployments, treasury-seeded) | **Reused (external)** |
 | Swap/protocol fee | `DePrizeFeeHook` (1% LP + 1% protocol) | LMSR built-in `fee = 1e16` (1%), retained by the market | **Superseded** |
-| Winner reporting | `DePrizeReporter` → `CTF.reportPayouts` | not yet built | **M4 (planned)** |
-| Winner redemption | `CTF.redeemPositions` wrapper | not yet built | **M4 (planned)** |
+| Winner reporting | `DePrizeReporter` → `CTF.reportPayouts` | Oracle = the MoonDAO multisig (fixed at `prepareCondition`; the CTF derives the conditionId from `msg.sender`, so a reporter contract cannot resolve it). Replaced by `DePrizeResolve.s.sol` pre-flight + Safe-submitted `reportPayouts` | **M4 ✅ (superseded)** |
+| Winner redemption | `CTF.redeemPositions` wrapper | `DePrizeRedeem` — stateless non-custodial helper: pulls outcome tokens, redeems on the CTF, pays ETH | **M4 ✅** |
 | Milestone prize escrow | `DePrizeMilestoneEscrow` (30/70) | not yet built | **M5 (planned)** |
-| Unified refund (`refundAll`) | `DePrizeRefund` | not yet built | **M4 (planned)** |
+| Unified refund (`refundAll`) | `DePrizeRefund` | Same `DePrizeRedeem` path — a no-winner/cancellation is an equal-payout report (`[1,1,…,1]`), so refund = redemption at 1/N. The combined CTF+JB one-click `refundAll` was dropped (JB cashOut stays a separate, existing flow) | **M4 ✅ (simplified)** |
 
-The milestone-based prize escrow, Senate-reporting bridge, CTF redemption, and unified refund described later in this Part are **design intent, not yet implemented**. See [`DEPRIZE_M1.md`](./DEPRIZE_M1.md)/[`M2`](./DEPRIZE_M2.md)/[`M3`](./DEPRIZE_M3.md) for what exists today.
+The milestone-based prize escrow (M5) described later in this Part is **design intent, not yet implemented**. See [`DEPRIZE_M1.md`](./DEPRIZE_M1.md)/[`M2`](./DEPRIZE_M2.md)/[`M3`](./DEPRIZE_M3.md)/[`M4`](./DEPRIZE_M4.md) for what exists today.
 
 ## State machine
 
@@ -274,8 +274,8 @@ As-built status shown. The CTF + `LMSRWithTWAP` decision (see §Implementation s
 | `DePrizeRegistry` | Per-DePrize config: mission, competitors, deadlines, state machine | **Built (M1)** |
 | `LaunchPadPayHook` (registry-aware) | Gate JB cashOut/contributions by DePrize state | **Built (M2)** |
 | `DePrizeMint` | Entry point: takes ETH, routes 5% to JB, wraps 95% to WETH, buys outcome tokens on the `LMSRWithTWAP` market, forwards tokens + refunds leftover | **Built (M3)** |
-| `DePrizeReporter` | Reads Senate result, calls `CTF.reportPayouts` | Planned (M4) |
-| `DePrizeRedeem` / `DePrizeRefund` | Winner `redeemPositions`; unified cancellation refund (CTF collateral + `$OVERVIEW` floor) | Planned (M4) |
+| ~~`DePrizeReporter`~~ | ~~Reads Senate result, calls `CTF.reportPayouts`~~ | **Superseded (M4)** — oracle is the multisig, baked into the conditionId; resolution = `DePrizeResolve.s.sol` pre-flight + Safe tx |
+| `DePrizeRedeem` | Winner `redeemPositions` AND the cancellation/no-winner refund (same code path — refund is an equal-payout report); pays ETH | **Built (M4)** |
 | `DePrizeMilestoneEscrow` | Holds prize pool post-settlement; releases 30% at M1 (capability), 70% at M2 (Frank flew) | Planned (M5) |
 | ~~`DePrizePrizeEscrow`~~ | ~~Holds 1% swap fees during campaign~~ | **Deleted** — LMSR built-in fee |
 | ~~`DePrizeFeeHook`~~ | ~~Uniswap v4 hook for LP + protocol fee~~ | **Deleted** — no Uniswap layer |

--- a/docs/DEPRIZE_M4.md
+++ b/docs/DEPRIZE_M4.md
@@ -1,0 +1,241 @@
+# DePrize — Milestone 4: Resolution, Redemption & Refund
+
+**Status:** Implemented, unit-tested (+ guarded fork tests)
+**Scope:** Close the money-out loop. **M4a** = resolution (`reportPayouts`) + winner redemption. **M4b** = refund/unwind on the refundable terminals (`CANCELLED` / `NO_WINNER` / `M2_FAILED`) including the LMSR market unwind. This is the **mainnet launch gate**: the market must not custody mainnet ETH until both exist.
+**Depends on:** M1 (`DePrizeRegistry`), M3 (`DePrizeMint` + provisioned CTF/LMSR market). M2 (`LaunchPadPayHook`) provides the JB-side refund gating consumed here.
+**Files:**
+
+- `subscription-contracts/src/deprize/DePrizeRedeem.sol` (new — bettor redemption helper, used by **both** the winner and refund paths)
+- `subscription-contracts/src/deprize/interfaces/IConditionalTokens.sol` (extended — M4 resolution/redemption + id-helper surface)
+- `subscription-contracts/src/deprize/interfaces/ILMSRWithTWAP.sol` (extended — owner/unwind surface: `pause`/`close`/`withdrawFees`/`transferOwnership`)
+- `subscription-contracts/test/deprize/DePrizeRedeem.t.sol` (new — 30 unit + 3 guarded fork tests)
+- `subscription-contracts/script/deprize/DePrizeResolve.s.sol` (new — resolution pre-flight checks + Safe calldata builder)
+- `subscription-contracts/script/deprize/DePrizeRedeem.s.sol` (new — deploy script, no proxy)
+- `prediction/migrations/08_create_deprize_market.js` (changed — transfers LMSR ownership to the oracle multisig at provisioning; prints a reminder to record the `questionId`)
+
+See the full design in [`DEPRIZE.md`](./DEPRIZE.md).
+
+---
+
+## Locked decisions
+
+- **Oracle = the MoonDAO multisig.** ✅ Decided. The CTF derives `conditionId` from `keccak256(oracle, questionId, outcomeSlotCount)` where `oracle = msg.sender` of `reportPayouts` — so the multisig itself must submit `reportPayouts` as a direct Safe transaction. This is consistent with the M3 provisioning (`prepareCondition(DEPRIZE_ORACLE, …)`) and is irreversible per condition.
+- **Consequence: there is no `DePrizeReporter` contract.** The design doc's reporter-as-oracle cannot work here (a contract calling `reportPayouts` would resolve a *different* conditionId). The reporter's job collapses into **off-chain tooling**: `DePrizeResolve.s.sol` performs registry-consistency pre-flight checks and emits the exact Safe calldata; the Safe runbook below is the process. Trust surface = the multisig, same entity that already owns the registry.
+- **Winner redemption and refund redemption are the same code path.** A no-winner/cancellation resolution is just an equal-payout report (`[1,1,…,1]`), after which `CTF.redeemPositions` pays every outcome token 1/N. One `DePrizeRedeem` helper serves both.
+- **`reportPayouts` is one-shot and immutable** (`payoutDenominator` write-once). In particular: once a winner is reported at `SETTLED`, a later `M2_FAILED` **cannot** change the CTF payout vector — see §M2_FAILED below.
+- **`DePrizeRedeem` is a thin, stateless, non-custodial convenience.** Redemption is already permissionless on the CTF (bettors hold the ERC-1155 directly since M3); the helper only improves UX (one call, ETH instead of WETH). It is deliberately **not** UUPS — no state worth upgrading, smaller trust surface. Bettors can always bypass it and call the CTF directly.
+- **No "None flies by X date" outcome slot.** Considered and rejected: (a) it funds a participant class whose payday is the mission failing while paying 5% into the prize pool they're shorting; (b) honest resolution of a delivery-worded question must wait for the flight/deadline, locking *all* bettor capital ~18 months past settlement; (c) it converts the disclosed ~80–95% partial refund into a 100% loss for team bettors on no-winner; (d) it touches the audited M3 router (slot count, index mapping) and irreversibly changes the conditionId; (e) the multisig (oracle + registry owner) would control an outcome people hold positions on. The market's question is **"which provider is selected"**, resolved at `SETTLED`; delivery risk lives with the winning provider via the M5 milestone escrow. If failure-hedging demand materializes, add a *separate* parallel market later — it composes without touching anything M4 ships.
+
+---
+
+## M4a — Resolution & winner redemption
+
+### Resolution (multisig Safe transaction)
+
+```
+registry.settleWinner(id, teamId)          (Safe tx — already exists, M1)
+        │
+        ▼
+forge script DePrizeResolve.s.sol          (off-chain pre-flight, read-only)
+  1. registry.state(id) ∈ {SETTLED, M1_RELEASED, M2_COMPLETE} → winner vector
+                        ∈ {NO_WINNER, CANCELLED}             → [1,1,…,1]
+                        == M2_FAILED                         → REFUSED (see M4b)
+                        else                                 ── abort (WrongState)
+  2. winnerIndex = indexOf(registry.winningTeamId(id),
+                           registry.teamIds(id))         ── else abort
+  3. recompute conditionId = keccak256(oracle, questionId, N)
+     and require == registry.getDePrize(id).ctfConditionId   ── else abort
+     (catches wrong questionId / wrong oracle / wrong N)
+  4. require ctf.payoutDenominator(conditionId) == 0     ── not already reported
+  5. print Safe calldata:
+       ctf.reportPayouts(questionId, payouts)
+       payouts[i] = (i == winnerIndex) ? 1 : 0
+        │
+        ▼
+Safe executes reportPayouts                 (THE irreversible step)
+        │
+        ▼
+bettors redeem (permissionless, forever — no claim deadline on the CTF)
+```
+
+Notes:
+
+- The registry stores `ctfConditionId` but **not** `questionId`; the script takes `questionId` as input (from `prediction/deprize.config.js` provisioning records) and step 3 makes a wrong value impossible to submit.
+- **Ordering invariant:** the LMSR market must be **paused or closed before reporting** (see M4b §Market unwind). A live market with a publicly-known outcome is free money against the treasury's inventory.
+- Outcome-slot convention is unchanged from M3: slot `i` = `registry.teamIds(id)[i]`.
+
+### `DePrizeRedeem` shape
+
+```solidity
+contract DePrizeRedeem is ReentrancyGuard, IERC1155Receiver {
+    IDePrizeRegistry  public immutable registry;
+    IConditionalTokens public immutable ctf;
+    IWETH             public immutable weth;
+
+    constructor(address registry_, address ctf_, address weth_); // ZeroAddress-guarded
+
+    /// Redeem all of msg.sender's outcome tokens for this DePrize and pay out ETH.
+    function redeem(uint256 deprizeId) external nonReentrant;
+
+    /// View: ETH `account` would receive right now (0 if unresolved). For the UI.
+    function previewRedeem(uint256 deprizeId, address account)
+        external view returns (uint256);
+}
+```
+
+`redeem` flow (requires the bettor's one-time `ctf.setApprovalForAll(redeem, true)`):
+
+```
+1. dp = registry.getDePrize(deprizeId)                     ── UnknownDePrize if NONE
+2. require ctf.payoutDenominator(dp.ctfConditionId) > 0    ── NotResolved
+3. N = dp.teamIds.length
+   positionId(i) = ctf.getPositionId(weth,
+       ctf.getCollectionId(0x0, conditionId, 1 << i))
+4. balances = ctf.balanceOfBatch(msg.sender × N, positionIds)
+   keep nonzero slots                                      ── NothingToRedeem if none
+5. pull held tokens (safeBatchTransferFrom → this, gated by _inRedeem)
+6. ctf.redeemPositions(weth, 0x0, conditionId, heldIndexSets) ── burns, pays WETH
+   payout = WETH balance DELTA across the redeem call
+7. weth.withdraw(payout); send ETH → msg.sender            ── RedeemFailed on send fail
+8. emit Redeemed(deprizeId, msg.sender, payout)
+```
+
+- **No registry-state gate.** The CTF's `payoutDenominator` is the source of truth; adding a lifecycle gate here would only desync the helper from what bettors can already do directly on the CTF.
+- **Payout = the redemption's WETH balance delta**, not the absolute balance — the same lesson as the M3 residual-sweep fix: WETH parked in the helper can never leak into a caller's payout (regression-tested).
+- ERC-1155 receiver gated exactly like M3 `DePrizeMint`: only accepts transfers mid-`redeem` (`_inRedeem` flag) from the CTF; unsolicited deposits revert.
+- Holds no funds between calls (asserted in tests, same as M3). A redeemer holding only losing tokens gets them burned and is paid 0 (event emitted with `payout = 0`).
+- `previewRedeem` mirrors the CTF's integer math exactly (floor division **per position**), so the UI quote always equals the actual payout.
+- Works identically for winner payouts (`[0,…,1,…,0]`) and equal-payout refunds (`[1,1,…,1]`).
+
+### Interface additions
+
+`IConditionalTokens` (resolution/redemption + id helpers, mirroring the 0.5 source):
+
+```solidity
+function prepareCondition(address oracle, bytes32 questionId, uint256 outcomeSlotCount) external;
+function reportPayouts(bytes32 questionId, uint256[] calldata payouts) external;
+function splitPosition(address collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint256[] calldata partition, uint256 amount) external;
+function redeemPositions(address collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint256[] calldata indexSets) external;
+function payoutDenominator(bytes32 conditionId) external view returns (uint256);
+function payoutNumerators(bytes32 conditionId, uint256 index) external view returns (uint256);
+function getOutcomeSlotCount(bytes32 conditionId) external view returns (uint256);
+function getConditionId(address oracle, bytes32 questionId, uint256 outcomeSlotCount) external pure returns (bytes32);
+function getCollectionId(bytes32 parentCollectionId, bytes32 conditionId, uint256 indexSet) external view returns (bytes32);
+function getPositionId(address collateralToken, bytes32 collectionId) external pure returns (uint256);
+```
+
+`ILMSRWithTWAP` (the owner/unwind surface the Safe runbook uses): `owner()`, `transferOwnership(address)`, `pause()`, `resume()`, `close()`, `withdrawFees()`.
+
+---
+
+## M4b — Refund & market unwind
+
+### Refundable terminals → equal-payout report
+
+| Terminal | CTF action | Bettor recovery (CTF side) | JB side (`$OVERVIEW`) |
+|---|---|---|---|
+| `NO_WINNER` | Safe reports `[1,1,…,1]` (each token pays 1/N) | `DePrizeRedeem.redeem()` — same contract as the win path | M2 hook re-enables cashOut (refund terminal) |
+| `CANCELLED` | Safe reports `[1,1,…,1]` | same | same |
+| `M2_FAILED` | **none — already resolved.** The winner was reported at `SETTLED`; `payoutDenominator` is write-once. | Winning bettors already could/can redeem at full value; losing tokens stay worthless. Nothing changes on the CTF. | M2 hook re-enables cashOut — this is the *only* new refund surface at `M2_FAILED` |
+
+- `DePrizeResolve.s.sol` covers the equal-payout case too: if `registry.state(id) ∈ {NO_WINNER, CANCELLED}` it emits `payouts = [1,1,…,1]`; it **refuses** to emit anything for `M2_FAILED` (already-reported guard, step 4, catches this anyway).
+- The equal-payout report is what produces the **disclosed parimutuel cancellation loss**: a bettor who bought at an implied probability above 1/N recovers less than they paid (the doc's ~80–95% for concentrated positions); one who bought below 1/N recovers more. This is by design and shown on every bet preview — do not "fix" it (see §Double-count guard).
+
+### Market unwind (treasury seed recovery)
+
+Confirmed against the deployed Gnosis `MarketMaker` source:
+
+- `pause()` / `close()` / `withdrawFees()` are **`onlyOwner`**.
+- `close()` transfers the LMSR's remaining ERC-1155 inventory to the owner and sets `stage = Closed` (allowed from `Running` or `Paused`).
+- `withdrawFees()` transfers the LMSR's **entire WETH balance** (accrued 1% fees + net trade collateral) to the owner.
+- **⚠️ The factory makes `msg.sender` of `createLMSRWithTWAP` the owner** — the Truffle migration deployer EOA, *not* the multisig. Two fixes:
+  1. ✅ Done: `08_create_deprize_market.js` now calls `lmsr.transferOwnership(oracle)` right after creation (future markets).
+  2. Runbook step for any already-provisioned market: deployer EOA calls `transferOwnership(multisig)` before mainnet bets open. Verify the Safe's fallback handler accepts ERC-1155 (`onERC1155Received`) — `close()` pushes 1155 inventory to the owner.
+
+Unwind sequence (Safe txs, applies to win, no-winner, and cancellation alike):
+
+```
+at registry.lock() / cancel():   lmsr.pause()        ── freeze odds; stops DIRECT LMSR
+                                                        trading too (DePrizeMint's
+                                                        bettingOpen gate only stops the
+                                                        router, the LMSR is public)
+after winner/no-winner decided:  lmsr.close()        ── inventory (ERC-1155) → multisig
+                                 ctf.reportPayouts() ── ONLY after pause/close
+                                 lmsr.withdrawFees() ── all WETH → multisig
+                                 ctf.redeemPositions(weth, 0x0, conditionId, all slots)
+                                                     ── multisig redeems the recovered
+                                                        inventory for WETH
+                                 weth.withdraw()     ── optional, WETH → ETH
+```
+
+Treasury recovers: `funding seed − bounded LMSR loss + accrued fees`. Nothing is stranded.
+
+### Double-count guard (policy, enforced by the runbook)
+
+A refunded bettor is made whole from **two separate pools they already own claims on**: (1) CTF collateral via the 1/N redemption (their 95% slice, minus parimutuel skew), and (2) their own `$OVERVIEW` pro-rata cashOut once the M2 hook re-enables it (their 5% slice). The guard:
+
+- **Unwound market proceeds (seed + fees) go to the treasury, NOT into the JB project.** Topping up the JB pot post-cancellation would raise the `$OVERVIEW` floor and silently push bettor recovery toward 100%, contradicting the disclosed cancellation loss and draining the treasury's 5%-slice prize funding.
+- The M2 hook needs no change: refund terminals already enable cashOut with no expiry window and block new contributions.
+
+### Out of scope (unchanged)
+
+- `DePrizeMilestoneEscrow` (provider's 30/70 disbursement, incl. `refundToJB` on no-winner) stays **M5** — different pool, orthogonal to bettor payouts.
+- A combined one-click `refundAll` (CTF redemption + JB cashOut in one tx) from the design doc is **dropped for M4**: the JB cashOut leg needs `$OVERVIEW` token approvals + terminal permissions and duplicates a flow Juicebox already ships. Two clicks (redeem + cashOut), one contract less. Revisit as UI polish.
+
+---
+
+## State → action matrix
+
+| Registry state | CTF report (Safe) | LMSR (Safe, as owner) | Bettor | JB hook (M2, existing) |
+|---|---|---|---|---|
+| `OPEN` | — | running | bet via `DePrizeMint` | contributions open, cashOut blocked |
+| `LOCKED` / `VOTING` | — | **`pause()`** | hold | contributions open, cashOut blocked |
+| `SETTLED` / `M1_RELEASED` | `[0,…,1,…,0]` (after pause/close) | `close()` + `withdrawFees()` + redeem inventory | `DePrizeRedeem.redeem()` — winners paid in full, not milestone-gated | cashOut blocked |
+| `NO_WINNER` / `CANCELLED` | `[1,1,…,1]` (after pause/close) | same | `redeem()` — 1/N per token | cashOut **enabled**, contributions blocked |
+| `M2_FAILED` | — (already reported) | already unwound | nothing new | cashOut **enabled** |
+| `M2_COMPLETE` | — (already reported) | already unwound | already redeemed | both blocked |
+
+---
+
+## Tests
+
+`forge test --match-path 'test/deprize/DePrizeRedeem.t.sol'` — **30 unit tests passing** (+3 guarded fork tests; the whole deprize suite is 121 passing).
+
+**`DePrizeRedeemTest` (30, deterministic, no RPC)** — real `DePrizeRegistry` + `MockResolvingCTF`, a resolution-capable CTF mock faithful to the deployed 0.5 source (conditionId derived from `msg.sender` in `reportPayouts`, write-once denominator, per-position floor division, burn-on-redeem, ERC-1155 approval checks + acceptance hooks):
+
+- winner path: report `[0,1,0]` → winner redeems full value in ETH, tokens burned, helper holds no ETH/WETH/1155 after; loser-only holder gets tokens burned and `payout = 0`;
+- refund path: report `[1,1,1]` → `floor(balance/N)` per the CTF math; parimutuel skew reproduced (per-token payout, not per-ETH-spent);
+- `previewRedeem`: equals the actual payout exactly including rounding (amounts not divisible by N across multiple slots); 0 before resolution;
+- guards: `NotResolved`, `UnknownDePrize`, `NothingToRedeem` (zero balance and double-redeem), missing `setApprovalForAll`, `RedeemFailed` (non-payable receiver), reentrancy from the ETH payout callback blocked, constructor zero-address checks;
+- stray-WETH regression: WETH parked in the helper is never swept into a payout (delta scoping);
+- ERC-1155 receiver guard: unsolicited single/batch and non-CTF senders revert; `supportsInterface`;
+- mock-CTF fidelity: `reportPayouts` write-once, all-zero vector reverts, a non-oracle sender resolves a *different* conditionId (the DePrize condition stays unresolved);
+- `DePrizeResolve.buildReport` pre-flight: winner vector (and the emitted calldata actually resolves the condition when submitted by the oracle), equal vector on `NO_WINNER` and `CANCELLED`, `WrongState` on `OPEN`, `M2FailedCtfAlreadyFinal` refusal, `ConditionMismatch` on wrong questionId and wrong oracle, `AlreadyReported`.
+
+**`DePrizeM4ForkTest` (3, guarded)** — runs against the **real Arbitrum-Sepolia CTF** (the contract whose payout math decides mainnet payouts), preparing a fresh condition with a test oracle so resolution can be exercised without touching the shared live market. Skips unless `DEPRIZE_FORK_RPC` is set:
+
+- `testForkWinnerResolveRedeem` — split real collateral into outcome sets, settle + report winner, winner redeems full value in ETH / loser redeems 0, against the live CTF;
+- `testForkCancellationEqualPayoutRedeem` — 7-day-notice cancel, `[1,1,1]` report, 1/N redemption with the real floor division (preview matches);
+- `testForkFullCloseOutLoop` (additionally needs `DEPRIZE_FORK_FACTORY`) — the full mainnet rehearsal: factory market provisioning + `transferOwnership(oracle)` → two real `DePrizeMint` bets → `lock` → `pause` → `settleWinner` → `close` → `reportPayouts` → `withdrawFees` → treasury redeems inventory → bettors redeem — with **ETH conservation asserted to the wei**: `bets + funding = JB slices + bettor payouts + treasury recovery + collateral locked behind unredeemed worthless positions`.
+
+```
+DEPRIZE_FORK_RPC=<arb-sepolia rpc> [DEPRIZE_FORK_FACTORY=0x<factory>] \
+  forge test --match-contract DePrizeM4ForkTest -vvv
+```
+
+---
+
+## Mainnet close-out runbook (delta to the M3 provisioning runbook)
+
+1. **Provisioning (amended, automated in migration 08):** the migration now transfers LMSR ownership to the oracle multisig after creation and reminds the operator to record the `questionId` alongside the `conditionId` (resolution needs it; it is not stored on-chain). For any market provisioned before this change: deployer EOA calls `transferOwnership(multisig)` before mainnet bets open. Verify the Safe's fallback handler accepts ERC-1155.
+2. **Deploy `DePrizeRedeem`** (`script/deprize/DePrizeRedeem.s.sol`, no proxy) — ship it with the betting UI so the claim surface exists before any money goes in.
+3. **At lock/cancellation-notice:** Safe → `lmsr.pause()`.
+4. **At settle (winner or no-winner):** run `DePrizeResolve.s.sol` → review the printed payout vector against the registry event → Safe → `lmsr.close()`, then `ctf.reportPayouts(...)` (the printed calldata), then `lmsr.withdrawFees()`, then `ctf.redeemPositions(...)` (inventory). Proceeds → treasury.
+5. **Announce:** bettors claim via `DePrizeRedeem.redeem(deprizeId)` after a one-time `ctf.setApprovalForAll` (no deadline); on refund terminals, `$OVERVIEW` cashOut is live via the existing JB UI.
+
+---
+
+## Remaining policy decisions (runbook-level, no contract impact)
+
+1. **Where do unwound proceeds land** — treasury (recommended, see §Double-count guard) vs. JB prize pool.
+2. **`pause()` timing** — at `lock()` (recommended; freezes odds during the vote) vs. only pre-report (leaves the public LMSR tradable during `VOTING`).

--- a/docs/DEPRIZE_M4.md
+++ b/docs/DEPRIZE_M4.md
@@ -61,7 +61,7 @@ bettors redeem (permissionless, forever — no claim deadline on the CTF)
 Notes:
 
 - The registry stores `ctfConditionId` but **not** `questionId`; the script takes `questionId` as input (from `prediction/deprize.config.js` provisioning records) and step 3 makes a wrong value impossible to submit.
-- **Ordering invariant:** the LMSR market must be **paused or closed before reporting** (see M4b §Market unwind). A live market with a publicly-known outcome is free money against the treasury's inventory.
+- **Ordering invariant:** the LMSR market must be **paused or closed before reporting** (see M4b §Market unwind). A live market with a publicly-known outcome is free money against the treasury's inventory. The script **enforces** this when `DEPRIZE_MARKET` is set (`assertMarketHalted`: hard-abort on a Running market or a market settling a different condition) and prints a loud warning when it is not.
 - Outcome-slot convention is unchanged from M3: slot `i` = `registry.teamIds(id)[i]`.
 
 ### `DePrizeRedeem` shape
@@ -199,7 +199,11 @@ A refunded bettor is made whole from **two separate pools they already own claim
 
 ## Tests
 
-`forge test --match-path 'test/deprize/DePrizeRedeem.t.sol'` — **30 unit tests passing** (+3 guarded fork tests; the whole deprize suite is 121 passing).
+`forge test --match-path 'test/deprize/DePrizeRedeem.t.sol'` — **37 unit tests passing** (+3 guarded fork tests; the whole deprize suite is 137 passing).
+
+Coverage of `DePrizeRedeem.sol` (via the CI patch + `--ir-minimum` flow): **100% lines / 99% statements / 100% functions / 11-of-12 branches** — the one unhit branch arm is the `UnknownDePrize` check, whose both directions *are* directly tested (`testRedeemRevertsUnknownDePrize`, `testPreviewRevertsUnknownDePrize`); it is the known via-ir coverage misattribution also noted in M3.
+
+**Audit note:** in addition to the committed suite, the contract was audited with a throwaway harness that deployed the **real compiled Gnosis `ConditionalTokens` + `WETH9` bytecode** (from the gitignored `prediction/build` artifacts, injected via env vars) and ran 9 adversarial scenarios: end-to-end winner redemption, equal-payout rounding/solvency, third-party abuse of a standing `setApprovalForAll`, payout-callback reentrancy + hook-poking with full rollback, stray-fund isolation, unsolicited 1155 deposits through the real acceptance-hook path, cross-condition isolation, one-shot resolution, and a 2,000-run fuzz asserting paid == previewed == CTF-entitlement with the helper empty after every call. **No issue found.** The harness was removed (CI can't read `prediction/build`); its high-value scenarios were ported into the committed mock-based suite (`testApprovalNotAbusableByThirdParty`, `testCrossConditionIsolation`, `testRedeemViaSingleAcceptanceHook`).
 
 **`DePrizeRedeemTest` (30, deterministic, no RPC)** — real `DePrizeRegistry` + `MockResolvingCTF`, a resolution-capable CTF mock faithful to the deployed 0.5 source (conditionId derived from `msg.sender` in `reportPayouts`, write-once denominator, per-position floor division, burn-on-redeem, ERC-1155 approval checks + acceptance hooks):
 
@@ -210,7 +214,8 @@ A refunded bettor is made whole from **two separate pools they already own claim
 - stray-WETH regression: WETH parked in the helper is never swept into a payout (delta scoping);
 - ERC-1155 receiver guard: unsolicited single/batch and non-CTF senders revert; `supportsInterface`;
 - mock-CTF fidelity: `reportPayouts` write-once, all-zero vector reverts, a non-oracle sender resolves a *different* conditionId (the DePrize condition stays unresolved);
-- `DePrizeResolve.buildReport` pre-flight: winner vector (and the emitted calldata actually resolves the condition when submitted by the oracle), equal vector on `NO_WINNER` and `CANCELLED`, `WrongState` on `OPEN`, `M2FailedCtfAlreadyFinal` refusal, `ConditionMismatch` on wrong questionId and wrong oracle, `AlreadyReported`.
+- `DePrizeResolve.buildReport` pre-flight: winner vector (and the emitted calldata actually resolves the condition when submitted by the oracle), equal vector on `NO_WINNER` and `CANCELLED`, `WrongState` on `OPEN`, `M2FailedCtfAlreadyFinal` refusal, `ConditionMismatch` on wrong questionId and wrong oracle, `AlreadyReported`;
+- `DePrizeResolve.assertMarketHalted` (the on-chain enforcement of the pause-before-report ordering invariant, run when `DEPRIZE_MARKET` is set): aborts on a Running market and on a market settling a different condition; accepts Paused and Closed.
 
 **`DePrizeM4ForkTest` (3, guarded)** — runs against the **real Arbitrum-Sepolia CTF** (the contract whose payout math decides mainnet payouts), preparing a fresh condition with a test oracle so resolution can be exercised without touching the shared live market. Skips unless `DEPRIZE_FORK_RPC` is set:
 

--- a/prediction/migrations/08_create_deprize_market.js
+++ b/prediction/migrations/08_create_deprize_market.js
@@ -26,6 +26,7 @@ const deprizeConfig = require("../deprize.config");
 const ConditionalTokens = artifacts.require("ConditionalTokens");
 const WETH9 = artifacts.require("WETH9");
 const LMSRWithTWAPFactory = artifacts.require("LMSRWithTWAPFactory");
+const LMSRWithTWAP = artifacts.require("LMSRWithTWAP");
 
 module.exports = function (deployer) {
   deployer.then(async () => {
@@ -101,9 +102,19 @@ module.exports = function (deployer) {
     }
 
     const lmsrAddress = creationLog.args.lmsrWithTWAP;
+
+    // 3. Hand the market to the oracle multisig. The factory makes the deployer
+    // the owner, but close()/withdrawFees() (the M4 unwind) are onlyOwner and
+    // must be executable by the Safe, not a deployer EOA.
+    const lmsr = await LMSRWithTWAP.at(lmsrAddress);
+    await lmsr.transferOwnership(oracle);
+    console.log("  LMSR ownership transferred to oracle:", oracle);
+
     console.log("\n=== DePrize market ready ===");
     console.log("conditionId:        ", conditionId);
     console.log("LMSRWithTWAP market:", lmsrAddress);
+    console.log("RECORD the questionId with the conditionId — resolution");
+    console.log("(DePrizeResolve.s.sol) needs it and it is not stored on-chain.");
     console.log("Next (0.8 side):");
     console.log("  registry.setCondition(deprizeId, conditionId)");
     console.log("  registry.open(deprizeId)");

--- a/subscription-contracts/script/deprize/DePrizeRedeem.s.sol
+++ b/subscription-contracts/script/deprize/DePrizeRedeem.s.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "std/Script.sol";
+import {DePrizeRedeem} from "../../src/deprize/DePrizeRedeem.sol";
+import "base/Config.sol";
+
+/// @title DeployDePrizeRedeem
+/// @notice Deploys the stateless DePrizeRedeem helper. No proxy — the contract
+///         is immutable-only and non-custodial (bettors can always bypass it and
+///         call the CTF directly), so there is nothing to upgrade.
+///
+/// Usage (arbitrum-sepolia):
+///   DEPRIZE_REGISTRY=0x<registryProxy> \
+///   forge script script/deprize/DePrizeRedeem.s.sol \
+///     --rpc-url $ARB_SEPOLIA_RPC --via-ir --optimizer-runs 200 --broadcast
+contract DeployDePrizeRedeem is Script, Config {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address registry = vm.envAddress("DEPRIZE_REGISTRY");
+
+        address weth = WETH_ADDRESSES[block.chainid];
+        address ctf = CONDITIONAL_TOKENS_ADDRESSES[block.chainid];
+        require(weth != address(0), "WETH not configured for chain");
+        require(ctf != address(0), "ConditionalTokens not configured for chain");
+
+        vm.startBroadcast(deployerPrivateKey);
+        DePrizeRedeem redeem = new DePrizeRedeem(registry, ctf, weth);
+        vm.stopBroadcast();
+
+        console.log("DePrizeRedeem:", address(redeem));
+        console.log("  registry:", registry);
+        console.log("  ctf:     ", ctf);
+        console.log("  weth:    ", weth);
+        console.log("Bettors: ctf.setApprovalForAll(redeem, true) once, then redeem(deprizeId).");
+    }
+}

--- a/subscription-contracts/script/deprize/DePrizeResolve.s.sol
+++ b/subscription-contracts/script/deprize/DePrizeResolve.s.sol
@@ -64,11 +64,14 @@ contract DePrizeResolve is Script, Config {
         uint256 n = dp.teamIds.length;
         payouts = new uint256[](n);
 
+        if (dp.state == IDePrizeRegistry.DePrizeState.M2_FAILED) {
+            revert M2FailedCtfAlreadyFinal(deprizeId);
+        }
+
         if (
             dp.state == IDePrizeRegistry.DePrizeState.SETTLED
                 || dp.state == IDePrizeRegistry.DePrizeState.M1_RELEASED
                 || dp.state == IDePrizeRegistry.DePrizeState.M2_COMPLETE
-                || dp.state == IDePrizeRegistry.DePrizeState.M2_FAILED
         ) {
             // Winner declared: [0,…,1,…,0] at the winner's outcome slot.
             bool found;

--- a/subscription-contracts/script/deprize/DePrizeResolve.s.sol
+++ b/subscription-contracts/script/deprize/DePrizeResolve.s.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "std/Script.sol";
+import {IDePrizeRegistry} from "../../src/deprize/IDePrizeRegistry.sol";
+import {IConditionalTokens} from "../../src/deprize/interfaces/IConditionalTokens.sol";
+import "base/Config.sol";
+
+/// @title DePrizeResolve
+/// @notice Read-only resolution pre-flight + Safe calldata builder. With the
+///         multisig as the CTF oracle, `reportPayouts` must be submitted by the
+///         Safe itself (the CTF derives the conditionId from `msg.sender`).
+///         This script performs every consistency check that an on-chain
+///         reporter would have enforced and prints the exact transaction for
+///         the Safe — it never broadcasts anything.
+///
+/// Checks (any failure aborts):
+///   1. registry state admits a report (SETTLED/M1_RELEASED/M2_COMPLETE ->
+///      winner vector; NO_WINNER/CANCELLED -> equal-payout vector;
+///      M2_FAILED -> refused, the CTF was already resolved at SETTLED);
+///   2. the winner is one of the DePrize's outcome slots;
+///   3. keccak256(oracle, questionId, N) matches the registry's conditionId
+///      (catches a wrong questionId, wrong oracle, or wrong slot count);
+///   4. the condition has not already been reported.
+///
+/// ⚠️ Submit only after the LMSR market is paused/closed — reporting against a
+/// live market lets anyone trade the known outcome against treasury inventory.
+///
+/// Usage:
+///   DEPRIZE_REGISTRY=0x<registryProxy> DEPRIZE_ID=1 \
+///   DEPRIZE_QUESTION_ID=0x... DEPRIZE_ORACLE=0x<safe> \
+///   forge script script/deprize/DePrizeResolve.s.sol --rpc-url $RPC
+contract DePrizeResolve is Script, Config {
+    error WrongState(uint256 deprizeId, IDePrizeRegistry.DePrizeState state);
+    error M2FailedCtfAlreadyFinal(uint256 deprizeId);
+    error WinnerNotFound(uint256 deprizeId, uint256 winningTeamId);
+    error ConditionMismatch(bytes32 computed, bytes32 registered);
+    error AlreadyReported(bytes32 conditionId, uint256 payoutDenominator);
+
+    /// @notice Pure pre-flight: validates registry/CTF consistency and returns the
+    ///         payout vector + `reportPayouts` calldata the oracle Safe must submit.
+    function buildReport(
+        IDePrizeRegistry registry,
+        IConditionalTokens ctf,
+        uint256 deprizeId,
+        bytes32 questionId,
+        address oracle
+    ) public view returns (bytes32 conditionId, uint256[] memory payouts, bytes memory callData) {
+        IDePrizeRegistry.DePrize memory dp = registry.getDePrize(deprizeId);
+        uint256 n = dp.teamIds.length;
+        payouts = new uint256[](n);
+
+        if (
+            dp.state == IDePrizeRegistry.DePrizeState.SETTLED
+                || dp.state == IDePrizeRegistry.DePrizeState.M1_RELEASED
+                || dp.state == IDePrizeRegistry.DePrizeState.M2_COMPLETE
+        ) {
+            // Winner declared: [0,…,1,…,0] at the winner's outcome slot.
+            bool found;
+            for (uint256 i = 0; i < n; i++) {
+                if (dp.teamIds[i] == dp.winningTeamId) {
+                    payouts[i] = 1;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) revert WinnerNotFound(deprizeId, dp.winningTeamId);
+        } else if (
+            dp.state == IDePrizeRegistry.DePrizeState.NO_WINNER
+                || dp.state == IDePrizeRegistry.DePrizeState.CANCELLED
+        ) {
+            // Refund terminal: equal payout, every token redeems at 1/N (the
+            // disclosed parimutuel refund).
+            for (uint256 i = 0; i < n; i++) {
+                payouts[i] = 1;
+            }
+        } else if (dp.state == IDePrizeRegistry.DePrizeState.M2_FAILED) {
+            // The winner vector was (or should have been) reported at SETTLED and
+            // the CTF payout is write-once. Reaching M2_FAILED with an unreported
+            // condition is a process failure that needs human judgment, not a
+            // script-generated transaction.
+            revert M2FailedCtfAlreadyFinal(deprizeId);
+        } else {
+            revert WrongState(deprizeId, dp.state);
+        }
+
+        // The conditionId binds oracle + questionId + slot count; recomputing it
+        // makes a wrong questionId/oracle/N unsubmittable.
+        conditionId = ctf.getConditionId(oracle, questionId, n);
+        if (conditionId != dp.ctfConditionId) revert ConditionMismatch(conditionId, dp.ctfConditionId);
+
+        uint256 den = ctf.payoutDenominator(conditionId);
+        if (den != 0) revert AlreadyReported(conditionId, den);
+
+        callData = abi.encodeCall(IConditionalTokens.reportPayouts, (questionId, payouts));
+    }
+
+    function run() external {
+        IDePrizeRegistry registry = IDePrizeRegistry(vm.envAddress("DEPRIZE_REGISTRY"));
+        IConditionalTokens ctf =
+            IConditionalTokens(vm.envOr("DEPRIZE_CTF", CONDITIONAL_TOKENS_ADDRESSES[block.chainid]));
+        uint256 deprizeId = vm.envUint("DEPRIZE_ID");
+        bytes32 questionId = vm.envBytes32("DEPRIZE_QUESTION_ID");
+        address oracle = vm.envAddress("DEPRIZE_ORACLE");
+
+        (bytes32 conditionId, uint256[] memory payouts, bytes memory callData) =
+            buildReport(registry, ctf, deprizeId, questionId, oracle);
+
+        console.log("=== DePrize resolution (submit from the oracle Safe) ===");
+        console.log("DePrize id:   ", deprizeId);
+        console.log("Oracle (Safe):", oracle);
+        console.log("conditionId:");
+        console.logBytes32(conditionId);
+        console.log("Payout vector:");
+        for (uint256 i = 0; i < payouts.length; i++) {
+            console.log("  slot", i, "->", payouts[i]);
+        }
+        console.log("Safe transaction:");
+        console.log("  to:   ", address(ctf));
+        console.log("  value: 0");
+        console.log("  data:");
+        console.logBytes(callData);
+        console.log("REMINDER: pause/close the LMSR market BEFORE submitting this.");
+    }
+}

--- a/subscription-contracts/script/deprize/DePrizeResolve.s.sol
+++ b/subscription-contracts/script/deprize/DePrizeResolve.s.sol
@@ -68,6 +68,7 @@ contract DePrizeResolve is Script, Config {
             dp.state == IDePrizeRegistry.DePrizeState.SETTLED
                 || dp.state == IDePrizeRegistry.DePrizeState.M1_RELEASED
                 || dp.state == IDePrizeRegistry.DePrizeState.M2_COMPLETE
+                || dp.state == IDePrizeRegistry.DePrizeState.M2_FAILED
         ) {
             // Winner declared: [0,…,1,…,0] at the winner's outcome slot.
             bool found;
@@ -88,12 +89,6 @@ contract DePrizeResolve is Script, Config {
             for (uint256 i = 0; i < n; i++) {
                 payouts[i] = 1;
             }
-        } else if (dp.state == IDePrizeRegistry.DePrizeState.M2_FAILED) {
-            // The winner vector was (or should have been) reported at SETTLED and
-            // the CTF payout is write-once. Reaching M2_FAILED with an unreported
-            // condition is a process failure that needs human judgment, not a
-            // script-generated transaction.
-            revert M2FailedCtfAlreadyFinal(deprizeId);
         } else {
             revert WrongState(deprizeId, dp.state);
         }

--- a/subscription-contracts/script/deprize/DePrizeResolve.s.sol
+++ b/subscription-contracts/script/deprize/DePrizeResolve.s.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "std/Script.sol";
 import {IDePrizeRegistry} from "../../src/deprize/IDePrizeRegistry.sol";
 import {IConditionalTokens} from "../../src/deprize/interfaces/IConditionalTokens.sol";
+import {ILMSRWithTWAP} from "../../src/deprize/interfaces/ILMSRWithTWAP.sol";
 import "base/Config.sol";
 
 /// @title DePrizeResolve
@@ -21,14 +22,16 @@ import "base/Config.sol";
 ///   2. the winner is one of the DePrize's outcome slots;
 ///   3. keccak256(oracle, questionId, N) matches the registry's conditionId
 ///      (catches a wrong questionId, wrong oracle, or wrong slot count);
-///   4. the condition has not already been reported.
-///
-/// ⚠️ Submit only after the LMSR market is paused/closed — reporting against a
-/// live market lets anyone trade the known outcome against treasury inventory.
+///   4. the condition has not already been reported;
+///   5. (when DEPRIZE_MARKET is set — strongly recommended) the LMSR market is
+///      paused or closed and settles this exact condition. Reporting against a
+///      LIVE market lets anyone trade the known outcome against treasury
+///      inventory, so the script hard-aborts on a Running market.
 ///
 /// Usage:
 ///   DEPRIZE_REGISTRY=0x<registryProxy> DEPRIZE_ID=1 \
 ///   DEPRIZE_QUESTION_ID=0x... DEPRIZE_ORACLE=0x<safe> \
+///   DEPRIZE_MARKET=0x<lmsrWithTWAP> \
 ///   forge script script/deprize/DePrizeResolve.s.sol --rpc-url $RPC
 contract DePrizeResolve is Script, Config {
     error WrongState(uint256 deprizeId, IDePrizeRegistry.DePrizeState state);
@@ -36,6 +39,17 @@ contract DePrizeResolve is Script, Config {
     error WinnerNotFound(uint256 deprizeId, uint256 winningTeamId);
     error ConditionMismatch(bytes32 computed, bytes32 registered);
     error AlreadyReported(bytes32 conditionId, uint256 payoutDenominator);
+    error MarketStillRunning(address market);
+    error MarketConditionMismatch(bytes32 marketCondition, bytes32 expected);
+
+    /// @notice Abort if `market` is still tradable or settles a different
+    ///         condition than the one about to be resolved.
+    /// @dev LMSR stages: 0 = Running, 1 = Paused, 2 = Closed.
+    function assertMarketHalted(ILMSRWithTWAP market, bytes32 conditionId) public view {
+        bytes32 marketCondition = market.conditionIds(0);
+        if (marketCondition != conditionId) revert MarketConditionMismatch(marketCondition, conditionId);
+        if (market.stage() == 0) revert MarketStillRunning(address(market));
+    }
 
     /// @notice Pure pre-flight: validates registry/CTF consistency and returns the
     ///         payout vector + `reportPayouts` calldata the oracle Safe must submit.
@@ -105,6 +119,14 @@ contract DePrizeResolve is Script, Config {
 
         (bytes32 conditionId, uint256[] memory payouts, bytes memory callData) =
             buildReport(registry, ctf, deprizeId, questionId, oracle);
+
+        address market = vm.envOr("DEPRIZE_MARKET", address(0));
+        if (market != address(0)) {
+            assertMarketHalted(ILMSRWithTWAP(market), conditionId);
+            console.log("Market halted check: OK (stage != Running)", market);
+        } else {
+            console.log("WARNING: DEPRIZE_MARKET not set - could not verify the LMSR is paused/closed.");
+        }
 
         console.log("=== DePrize resolution (submit from the oracle Safe) ===");
         console.log("DePrize id:   ", deprizeId);

--- a/subscription-contracts/src/deprize/DePrizeRedeem.sol
+++ b/subscription-contracts/src/deprize/DePrizeRedeem.sol
@@ -45,6 +45,7 @@ contract DePrizeRedeem is ReentrancyGuard, IERC1155Receiver {
     error NothingToRedeem(uint256 deprizeId, address account);
     error RedeemFailed();
     error UnexpectedERC1155();
+    error SlotCountMismatch(uint256 deprizeId, uint256 teamIds, uint256 outcomeSlots);
 
     constructor(address registry_, address ctf_, address weth_) {
         if (registry_ == address(0) || ctf_ == address(0) || weth_ == address(0)) revert ZeroAddress();
@@ -136,7 +137,15 @@ contract DePrizeRedeem is ReentrancyGuard, IERC1155Receiver {
         if (dp.state == IDePrizeRegistry.DePrizeState.NONE) revert UnknownDePrize(deprizeId);
         conditionId = dp.ctfConditionId;
 
+        // The payout vector lives on the CTF and is indexed by the condition's
+        // outcome slots. Trusting `teamIds.length` alone would silently under-pay
+        // (skip real positions) or revert deep in `payoutNumerators` if the
+        // registry ever diverges from the on-chain condition, so assert they
+        // agree up front and fail loudly on inconsistent provisioning.
         uint256 n = dp.teamIds.length;
+        uint256 slots = ctf.getOutcomeSlotCount(conditionId);
+        if (n != slots) revert SlotCountMismatch(deprizeId, n, slots);
+
         positionIds = new uint256[](n);
         for (uint256 i = 0; i < n; i++) {
             positionIds[i] = ctf.getPositionId(address(weth), ctf.getCollectionId(bytes32(0), conditionId, 1 << i));

--- a/subscription-contracts/src/deprize/DePrizeRedeem.sol
+++ b/subscription-contracts/src/deprize/DePrizeRedeem.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+import {IDePrizeRegistry} from "./IDePrizeRegistry.sol";
+import {IConditionalTokens} from "./interfaces/IConditionalTokens.sol";
+import {IWETH} from "./interfaces/IWETH.sol";
+
+/// @title DePrizeRedeem
+/// @notice Bettor redemption helper for resolved DePrize markets. A single
+///         `redeem` call pulls the caller's outcome tokens (one-time
+///         `ctf.setApprovalForAll(address(this), true)` required), redeems them
+///         on the Gnosis CTF, unwraps the WETH payout, and pays the caller ETH.
+///
+///         Serves BOTH payout paths with the same code:
+///         - winner resolution (`[0,…,1,…,0]`): winning tokens pay full value;
+///         - no-winner / cancellation resolution (`[1,1,…,1]`): every token pays
+///           1/N (the disclosed parimutuel refund).
+///
+/// @dev Deliberately thin, stateless between calls, and NON-custodial:
+///      redemption is already permissionless on the CTF (bettors hold the
+///      ERC-1155 outcome tokens directly since M3 and can always call
+///      `ctf.redeemPositions` themselves — they would just receive WETH instead
+///      of ETH). Because anyone can bypass this contract, it adds no lifecycle
+///      gates: the CTF payout vector (`payoutDenominator`) is the sole source
+///      of truth for when/what redemption pays. It is also intentionally
+///      non-upgradeable — no state worth migrating, smaller trust surface.
+contract DePrizeRedeem is ReentrancyGuard, IERC1155Receiver {
+    IDePrizeRegistry public immutable registry;
+    IConditionalTokens public immutable ctf;
+    IWETH public immutable weth;
+
+    /// @dev True only while `redeem` is pulling the caller's outcome tokens;
+    ///      gates the ERC-1155 acceptance hooks (no unsolicited deposits).
+    bool private _inRedeem;
+
+    event Redeemed(uint256 indexed deprizeId, address indexed account, uint256 payout);
+
+    error ZeroAddress();
+    error UnknownDePrize(uint256 deprizeId);
+    error NotResolved(uint256 deprizeId);
+    error NothingToRedeem(uint256 deprizeId, address account);
+    error RedeemFailed();
+    error UnexpectedERC1155();
+
+    constructor(address registry_, address ctf_, address weth_) {
+        if (registry_ == address(0) || ctf_ == address(0) || weth_ == address(0)) revert ZeroAddress();
+        registry = IDePrizeRegistry(registry_);
+        ctf = IConditionalTokens(ctf_);
+        weth = IWETH(weth_);
+    }
+
+    // ---------------------------------------------------------------------
+    // Redemption
+    // ---------------------------------------------------------------------
+
+    /// @notice Redeem all of `msg.sender`'s outcome tokens for `deprizeId` and
+    ///         pay out the proceeds in ETH. Requires the caller to have approved
+    ///         this contract on the CTF (`setApprovalForAll`). Reverts until the
+    ///         oracle has resolved the condition.
+    function redeem(uint256 deprizeId) external nonReentrant {
+        (bytes32 conditionId, uint256[] memory positionIds) = _positions(deprizeId);
+        if (ctf.payoutDenominator(conditionId) == 0) revert NotResolved(deprizeId);
+
+        // Find the caller's nonzero positions.
+        uint256 n = positionIds.length;
+        address[] memory owners = new address[](n);
+        for (uint256 i = 0; i < n; i++) {
+            owners[i] = msg.sender;
+        }
+        uint256[] memory balances = ctf.balanceOfBatch(owners, positionIds);
+
+        uint256 held;
+        for (uint256 i = 0; i < n; i++) {
+            if (balances[i] > 0) held++;
+        }
+        if (held == 0) revert NothingToRedeem(deprizeId, msg.sender);
+
+        uint256[] memory ids = new uint256[](held);
+        uint256[] memory values = new uint256[](held);
+        uint256[] memory indexSets = new uint256[](held);
+        uint256 j;
+        for (uint256 i = 0; i < n; i++) {
+            if (balances[i] > 0) {
+                ids[j] = positionIds[i];
+                values[j] = balances[i];
+                indexSets[j] = 1 << i;
+                j++;
+            }
+        }
+
+        // Pull the caller's tokens (acceptance hooks gated by _inRedeem), then
+        // burn them on the CTF for WETH. Scope the payout to the WETH RECEIVED
+        // BY THIS REDEMPTION (balance delta) so stray WETH parked in this
+        // contract can never leak into a caller's payout.
+        _inRedeem = true;
+        ctf.safeBatchTransferFrom(msg.sender, address(this), ids, values, "");
+        _inRedeem = false;
+
+        uint256 wethBefore = weth.balanceOf(address(this));
+        ctf.redeemPositions(address(weth), bytes32(0), conditionId, indexSets);
+        uint256 payout = weth.balanceOf(address(this)) - wethBefore;
+
+        if (payout > 0) {
+            weth.withdraw(payout);
+            (bool ok,) = msg.sender.call{value: payout}("");
+            if (!ok) revert RedeemFailed();
+        }
+
+        emit Redeemed(deprizeId, msg.sender, payout);
+    }
+
+    /// @notice ETH `account` would receive from `redeem(deprizeId)` right now.
+    ///         Returns 0 if the condition is not resolved yet (or nothing is held).
+    /// @dev Mirrors the CTF's integer math exactly: floor division PER POSITION.
+    function previewRedeem(uint256 deprizeId, address account) external view returns (uint256 payout) {
+        (bytes32 conditionId, uint256[] memory positionIds) = _positions(deprizeId);
+        uint256 den = ctf.payoutDenominator(conditionId);
+        if (den == 0) return 0;
+
+        for (uint256 i = 0; i < positionIds.length; i++) {
+            uint256 stake = ctf.balanceOf(account, positionIds[i]);
+            if (stake > 0) {
+                payout += stake * ctf.payoutNumerators(conditionId, i) / den;
+            }
+        }
+    }
+
+    /// @dev Resolve a DePrize to its condition id and per-outcome-slot position
+    ///      ids (slot i = `registry.teamIds(deprizeId)[i]`, the M3 convention).
+    function _positions(uint256 deprizeId) private view returns (bytes32 conditionId, uint256[] memory positionIds) {
+        IDePrizeRegistry.DePrize memory dp = registry.getDePrize(deprizeId);
+        if (dp.state == IDePrizeRegistry.DePrizeState.NONE) revert UnknownDePrize(deprizeId);
+        conditionId = dp.ctfConditionId;
+
+        uint256 n = dp.teamIds.length;
+        positionIds = new uint256[](n);
+        for (uint256 i = 0; i < n; i++) {
+            positionIds[i] = ctf.getPositionId(address(weth), ctf.getCollectionId(bytes32(0), conditionId, 1 << i));
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // ERC-1155 receiver (only accepts the mid-redeem pull from the CTF)
+    // ---------------------------------------------------------------------
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external view override returns (bytes4) {
+        if (!_inRedeem || msg.sender != address(ctf)) revert UnexpectedERC1155();
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        view
+        override
+        returns (bytes4)
+    {
+        if (!_inRedeem || msg.sender != address(ctf)) revert UnexpectedERC1155();
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure override returns (bool) {
+        return interfaceId == type(IERC1155Receiver).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+
+    /// @dev Accepts ETH from `weth.withdraw` during a redemption.
+    receive() external payable {}
+}

--- a/subscription-contracts/src/deprize/interfaces/IConditionalTokens.sol
+++ b/subscription-contracts/src/deprize/interfaces/IConditionalTokens.sol
@@ -3,10 +3,14 @@ pragma solidity ^0.8.20;
 
 /// @title IConditionalTokens
 /// @notice Minimal 0.8 view of the externally-deployed (Solidity 0.5) Gnosis
-///         `ConditionalTokens` (CTF) contract. Only the ERC-1155 surface the bet
-///         router needs in M3 is declared here; resolution/redeem methods
-///         (`reportPayouts`, `redeemPositions`) are added in M4.
+///         `ConditionalTokens` (CTF) contract: the ERC-1155 surface the M3 bet
+///         router needs plus the M4 resolution/redemption surface
+///         (`reportPayouts`, `redeemPositions`, payout vector reads, id helpers).
 interface IConditionalTokens {
+    // -----------------------------------------------------------------------
+    // ERC-1155 surface (M3)
+    // -----------------------------------------------------------------------
+
     function balanceOf(address owner, uint256 positionId) external view returns (uint256);
 
     function balanceOfBatch(address[] calldata owners, uint256[] calldata positionIds)
@@ -27,4 +31,62 @@ interface IConditionalTokens {
         uint256[] calldata values,
         bytes calldata data
     ) external;
+
+    // -----------------------------------------------------------------------
+    // Conditions & resolution (M4)
+    // -----------------------------------------------------------------------
+
+    /// @notice Prepare a condition. `conditionId = keccak256(oracle, questionId, outcomeSlotCount)`.
+    function prepareCondition(address oracle, bytes32 questionId, uint256 outcomeSlotCount) external;
+
+    /// @notice Oracle resolution. The CTF derives the conditionId from
+    ///         `msg.sender` (the oracle), so only the oracle fixed at
+    ///         `prepareCondition` time can ever resolve. One-shot: the payout
+    ///         vector is write-once (`payoutDenominator` 0 -> sum(payouts)).
+    function reportPayouts(bytes32 questionId, uint256[] calldata payouts) external;
+
+    /// @notice Split collateral (or a parent position) into a full set of
+    ///         outcome tokens for `partition`.
+    function splitPosition(
+        address collateralToken,
+        bytes32 parentCollectionId,
+        bytes32 conditionId,
+        uint256[] calldata partition,
+        uint256 amount
+    ) external;
+
+    /// @notice Burn `msg.sender`'s outcome tokens for the given index sets and
+    ///         pay out collateral per the reported payout vector. Permissionless;
+    ///         reverts until the condition is resolved.
+    function redeemPositions(
+        address collateralToken,
+        bytes32 parentCollectionId,
+        bytes32 conditionId,
+        uint256[] calldata indexSets
+    ) external;
+
+    /// @notice Sum of the reported payout vector; 0 until the oracle reports.
+    function payoutDenominator(bytes32 conditionId) external view returns (uint256);
+
+    /// @notice Reported payout numerator for one outcome slot (array getter).
+    function payoutNumerators(bytes32 conditionId, uint256 index) external view returns (uint256);
+
+    /// @notice Number of outcome slots; 0 if the condition was never prepared.
+    function getOutcomeSlotCount(bytes32 conditionId) external view returns (uint256);
+
+    // -----------------------------------------------------------------------
+    // Id helpers (mirror CTHelpers)
+    // -----------------------------------------------------------------------
+
+    function getConditionId(address oracle, bytes32 questionId, uint256 outcomeSlotCount)
+        external
+        pure
+        returns (bytes32);
+
+    function getCollectionId(bytes32 parentCollectionId, bytes32 conditionId, uint256 indexSet)
+        external
+        view
+        returns (bytes32);
+
+    function getPositionId(address collateralToken, bytes32 collectionId) external pure returns (uint256);
 }

--- a/subscription-contracts/src/deprize/interfaces/ILMSRWithTWAP.sol
+++ b/subscription-contracts/src/deprize/interfaces/ILMSRWithTWAP.sol
@@ -54,4 +54,28 @@ interface ILMSRWithTWAP {
 
     /// @notice Condition ID at the given index (for single-condition markets, use index 0).
     function conditionIds(uint256 index) external view returns (bytes32);
+
+    // -----------------------------------------------------------------------
+    // Owner surface (M4 unwind: pause at lock, close + withdrawFees after
+    // resolution). The owner is whoever called the factory's create — transfer
+    // it to the oracle multisig at provisioning.
+    // -----------------------------------------------------------------------
+
+    function owner() external view returns (address);
+
+    function transferOwnership(address newOwner) external;
+
+    /// @notice Freeze trading (Running -> Paused). Stops DIRECT trades on the
+    ///         public LMSR; the DePrizeMint `bettingOpen` gate only stops the router.
+    function pause() external;
+
+    /// @notice Resume trading (Paused -> Running).
+    function resume() external;
+
+    /// @notice Close the market: transfers all remaining outcome-token inventory
+    ///         to the owner and sets stage to Closed. Allowed from Running or Paused.
+    function close() external;
+
+    /// @notice Withdraw the market's entire collateral balance (accrued fees) to the owner.
+    function withdrawFees() external returns (uint256 fees);
 }

--- a/subscription-contracts/test/deprize/DePrizeRedeem.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeRedeem.t.sol
@@ -158,6 +158,14 @@ contract MockResolvingCTF {
         _acceptSingle(to, from, id, value);
     }
 
+    /// @dev Test knob: deliver batch transfers through the SINGLE acceptance hook
+    ///      per id (exercises the receiver's onERC1155Received path).
+    bool public useSingleHooks;
+
+    function setUseSingleHooks(bool v) external {
+        useSingleHooks = v;
+    }
+
     function safeBatchTransferFrom(
         address from,
         address to,
@@ -171,8 +179,14 @@ contract MockResolvingCTF {
             balances[ids[i]][to] += values[i];
         }
         if (to.code.length > 0) {
-            bytes4 ret = IERC1155Receiver(to).onERC1155BatchReceived(msg.sender, from, ids, values, "");
-            require(ret == IERC1155Receiver.onERC1155BatchReceived.selector, "1155 rejected");
+            if (useSingleHooks) {
+                for (uint256 i = 0; i < ids.length; i++) {
+                    _acceptSingle(to, from, ids[i], values[i]);
+                }
+            } else {
+                bytes4 ret = IERC1155Receiver(to).onERC1155BatchReceived(msg.sender, from, ids, values, "");
+                require(ret == IERC1155Receiver.onERC1155BatchReceived.selector, "1155 rejected");
+            }
         }
     }
 
@@ -186,6 +200,24 @@ contract MockResolvingCTF {
     /// @dev Test helper: mint outcome tokens directly (stands in for splitPosition).
     function mint(address to, uint256 id, uint256 value) external {
         balances[id][to] += value;
+    }
+}
+
+/// @dev Minimal LMSR stub for the resolve script's market-halted check.
+contract StubMarket {
+    uint8 public stage; // 0 = Running, 1 = Paused, 2 = Closed
+    bytes32 internal _conditionId;
+
+    constructor(bytes32 conditionId_) {
+        _conditionId = conditionId_;
+    }
+
+    function setStage(uint8 s) external {
+        stage = s;
+    }
+
+    function conditionIds(uint256) external view returns (bytes32) {
+        return _conditionId;
     }
 }
 
@@ -423,6 +455,11 @@ contract DePrizeRedeemTest is Test {
         assertEq(redeem.previewRedeem(deprizeId, alice), 0, "unresolved -> 0");
     }
 
+    function testPreviewRevertsUnknownDePrize() public {
+        vm.expectRevert(abi.encodeWithSelector(DePrizeRedeem.UnknownDePrize.selector, 999));
+        redeem.previewRedeem(999, alice);
+    }
+
     // -- guards ------------------------------------------------------------------
 
     function testRedeemRevertsNotResolved() public {
@@ -484,6 +521,55 @@ contract DePrizeRedeemTest is Test {
         // The re-entrant inner call reverts on the guard, failing the ETH payout.
         vm.expectRevert(DePrizeRedeem.RedeemFailed.selector);
         rr.approveAndRedeem(ctf, redeem, deprizeId);
+    }
+
+    function testRedeemViaSingleAcceptanceHook() public {
+        // A CTF delivering the mid-redeem pull through onERC1155Received (single)
+        // instead of the batch hook must work identically.
+        ctf.setUseSingleHooks(true);
+        ctf.mint(alice, _positionId(1), 1 ether);
+        _settleWinner(102);
+        _reportWinner(1);
+
+        vm.startPrank(alice);
+        ctf.setApprovalForAll(address(redeem), true);
+        uint256 balBefore = alice.balance;
+        redeem.redeem(deprizeId);
+        vm.stopPrank();
+        assertEq(alice.balance - balBefore, 1 ether, "paid via single-hook delivery");
+    }
+
+    function testApprovalNotAbusableByThirdParty() public {
+        // A victim's standing setApprovalForAll on the helper cannot be leveraged
+        // by anyone else: the helper only ever moves msg.sender's own tokens.
+        ctf.mint(alice, _positionId(1), 5 ether);
+        _settleWinner(102);
+        _reportWinner(1);
+
+        vm.prank(alice);
+        ctf.setApprovalForAll(address(redeem), true); // standing approval
+
+        vm.prank(bob); // attacker holds nothing
+        vm.expectRevert(abi.encodeWithSelector(DePrizeRedeem.NothingToRedeem.selector, deprizeId, bob));
+        redeem.redeem(deprizeId);
+        assertEq(ctf.balanceOf(alice, _positionId(1)), 5 ether, "victim untouched");
+    }
+
+    function testCrossConditionIsolation() public {
+        // Outcome tokens of an unrelated condition (same collateral, same holder)
+        // are never touched by a redeem for this DePrize.
+        bytes32 otherCid = ctf.getConditionId(oracle, keccak256("unrelated"), 3);
+        uint256 otherPid = ctf.getPositionId(address(weth), ctf.getCollectionId(bytes32(0), otherCid, 1 << 1));
+        ctf.mint(alice, otherPid, 4 ether);
+        ctf.mint(alice, _positionId(1), 1 ether);
+        _settleWinner(102);
+        _reportWinner(1);
+
+        vm.startPrank(alice);
+        ctf.setApprovalForAll(address(redeem), true);
+        redeem.redeem(deprizeId);
+        vm.stopPrank();
+        assertEq(ctf.balanceOf(alice, otherPid), 4 ether, "unrelated condition untouched");
     }
 
     function testStrayWethNotSweptIntoPayout() public {
@@ -673,6 +759,28 @@ contract DePrizeRedeemTest is Test {
         resolveScript.buildReport(
             IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), deprizeId, QUESTION_ID, oracle
         );
+    }
+
+    function testAssertMarketHaltedRevertsWhileRunning() public {
+        StubMarket market = new StubMarket(conditionId); // stage 0 = Running
+        vm.expectRevert(abi.encodeWithSelector(DePrizeResolve.MarketStillRunning.selector, address(market)));
+        resolveScript.assertMarketHalted(ILMSRWithTWAP(address(market)), conditionId);
+    }
+
+    function testAssertMarketHaltedAcceptsPausedAndClosed() public {
+        StubMarket market = new StubMarket(conditionId);
+        market.setStage(1); // Paused
+        resolveScript.assertMarketHalted(ILMSRWithTWAP(address(market)), conditionId);
+        market.setStage(2); // Closed
+        resolveScript.assertMarketHalted(ILMSRWithTWAP(address(market)), conditionId);
+    }
+
+    function testAssertMarketHaltedRevertsOnConditionMismatch() public {
+        bytes32 wrong = keccak256("wrong-market-condition");
+        StubMarket market = new StubMarket(wrong);
+        market.setStage(1);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeResolve.MarketConditionMismatch.selector, wrong, conditionId));
+        resolveScript.assertMarketHalted(ILMSRWithTWAP(address(market)), conditionId);
     }
 }
 

--- a/subscription-contracts/test/deprize/DePrizeRedeem.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeRedeem.t.sol
@@ -1,0 +1,971 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+import {DePrizeRedeem} from "../../src/deprize/DePrizeRedeem.sol";
+import {DePrizeMint} from "../../src/deprize/DePrizeMint.sol";
+import {DePrizeRegistry} from "../../src/deprize/DePrizeRegistry.sol";
+import {IDePrizeRegistry} from "../../src/deprize/IDePrizeRegistry.sol";
+import {IConditionalTokens} from "../../src/deprize/interfaces/IConditionalTokens.sol";
+import {ILMSRWithTWAP} from "../../src/deprize/interfaces/ILMSRWithTWAP.sol";
+import {IWETH} from "../../src/deprize/interfaces/IWETH.sol";
+import {DePrizeResolve} from "../../script/deprize/DePrizeResolve.s.sol";
+import {MockWETH, MockJBTerminal} from "./DePrizeMint.t.sol";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+/// @dev Resolution-capable ConditionalTokens mock, faithful to the deployed 0.5
+///      Gnosis source: conditionId derived from msg.sender in reportPayouts,
+///      write-once payout vector (denominator 0 -> sum), per-position floor
+///      division in redeemPositions, burn-on-redeem, ERC-1155 approval checks
+///      and acceptance hooks on transfers to contracts.
+contract MockResolvingCTF {
+    mapping(uint256 => mapping(address => uint256)) public balances;
+    mapping(address => mapping(address => bool)) public approvals;
+    mapping(bytes32 => uint256[]) private _payoutNumerators;
+    mapping(bytes32 => uint256) public payoutDenominator;
+    address public collateral; // mock WETH used to pay redemptions
+
+    constructor(address collateral_) {
+        collateral = collateral_;
+    }
+
+    // -- conditions & resolution (mirrors ConditionalTokens.sol) ------------
+
+    function prepareCondition(address oracle, bytes32 questionId, uint256 outcomeSlotCount) external {
+        require(outcomeSlotCount > 1, "there should be more than one outcome slot");
+        bytes32 conditionId = getConditionId(oracle, questionId, outcomeSlotCount);
+        require(_payoutNumerators[conditionId].length == 0, "condition already prepared");
+        _payoutNumerators[conditionId] = new uint256[](outcomeSlotCount);
+    }
+
+    function reportPayouts(bytes32 questionId, uint256[] calldata payouts) external {
+        uint256 outcomeSlotCount = payouts.length;
+        require(outcomeSlotCount > 1, "there should be more than one outcome slot");
+        // The oracle is enforced to be the sender because it's part of the hash.
+        bytes32 conditionId = getConditionId(msg.sender, questionId, outcomeSlotCount);
+        require(_payoutNumerators[conditionId].length == outcomeSlotCount, "condition not prepared or found");
+        require(payoutDenominator[conditionId] == 0, "payout denominator already set");
+        uint256 den = 0;
+        for (uint256 i = 0; i < outcomeSlotCount; i++) {
+            den += payouts[i];
+            require(_payoutNumerators[conditionId][i] == 0, "payout numerator already set");
+            _payoutNumerators[conditionId][i] = payouts[i];
+        }
+        require(den > 0, "payout is all zeroes");
+        payoutDenominator[conditionId] = den;
+    }
+
+    function redeemPositions(
+        address collateralToken,
+        bytes32 parentCollectionId,
+        bytes32 conditionId,
+        uint256[] calldata indexSets
+    ) external {
+        require(parentCollectionId == bytes32(0), "mock supports root positions only");
+        uint256 den = payoutDenominator[conditionId];
+        require(den > 0, "result for condition not received yet");
+        uint256 outcomeSlotCount = _payoutNumerators[conditionId].length;
+        require(outcomeSlotCount > 0, "condition not prepared yet");
+
+        uint256 totalPayout = 0;
+        uint256 fullIndexSet = (1 << outcomeSlotCount) - 1;
+        for (uint256 i = 0; i < indexSets.length; i++) {
+            uint256 indexSet = indexSets[i];
+            require(indexSet > 0 && indexSet < fullIndexSet, "got invalid index set");
+            uint256 positionId = getPositionId(collateralToken, getCollectionId(parentCollectionId, conditionId, indexSet));
+            uint256 payoutNumerator = 0;
+            for (uint256 j = 0; j < outcomeSlotCount; j++) {
+                if (indexSet & (1 << j) != 0) payoutNumerator += _payoutNumerators[conditionId][j];
+            }
+            uint256 stake = balances[positionId][msg.sender];
+            if (stake > 0) {
+                // Per-position floor division, exactly like the real CTF.
+                totalPayout += stake * payoutNumerator / den;
+                balances[positionId][msg.sender] = 0;
+            }
+        }
+        if (totalPayout > 0) {
+            require(MockWETH(payable(collateralToken)).transfer(msg.sender, totalPayout), "payout transfer failed");
+        }
+    }
+
+    function payoutNumerators(bytes32 conditionId, uint256 index) external view returns (uint256) {
+        return _payoutNumerators[conditionId][index];
+    }
+
+    function getOutcomeSlotCount(bytes32 conditionId) external view returns (uint256) {
+        return _payoutNumerators[conditionId].length;
+    }
+
+    // -- id helpers ----------------------------------------------------------
+
+    function getConditionId(address oracle, bytes32 questionId, uint256 outcomeSlotCount)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(oracle, questionId, outcomeSlotCount));
+    }
+
+    function getCollectionId(bytes32 parentCollectionId, bytes32 conditionId, uint256 indexSet)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(parentCollectionId, conditionId, indexSet));
+    }
+
+    function getPositionId(address collateralToken, bytes32 collectionId) public pure returns (uint256) {
+        return uint256(keccak256(abi.encodePacked(collateralToken, collectionId)));
+    }
+
+    // -- ERC-1155 surface ----------------------------------------------------
+
+    function balanceOf(address owner, uint256 id) external view returns (uint256) {
+        return balances[id][owner];
+    }
+
+    function balanceOfBatch(address[] calldata owners, uint256[] calldata ids)
+        external
+        view
+        returns (uint256[] memory out)
+    {
+        out = new uint256[](owners.length);
+        for (uint256 i = 0; i < owners.length; i++) {
+            out[i] = balances[ids[i]][owners[i]];
+        }
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        approvals[msg.sender][operator] = approved;
+    }
+
+    function isApprovedForAll(address owner, address operator) external view returns (bool) {
+        return approvals[owner][operator];
+    }
+
+    function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes calldata) external {
+        require(from == msg.sender || approvals[from][msg.sender], "ERC1155: caller not approved");
+        balances[id][from] -= value;
+        balances[id][to] += value;
+        _acceptSingle(to, from, id, value);
+    }
+
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata
+    ) external {
+        require(from == msg.sender || approvals[from][msg.sender], "ERC1155: caller not approved");
+        for (uint256 i = 0; i < ids.length; i++) {
+            balances[ids[i]][from] -= values[i];
+            balances[ids[i]][to] += values[i];
+        }
+        if (to.code.length > 0) {
+            bytes4 ret = IERC1155Receiver(to).onERC1155BatchReceived(msg.sender, from, ids, values, "");
+            require(ret == IERC1155Receiver.onERC1155BatchReceived.selector, "1155 rejected");
+        }
+    }
+
+    function _acceptSingle(address to, address from, uint256 id, uint256 value) private {
+        if (to.code.length > 0) {
+            bytes4 ret = IERC1155Receiver(to).onERC1155Received(msg.sender, from, id, value, "");
+            require(ret == IERC1155Receiver.onERC1155Received.selector, "1155 rejected");
+        }
+    }
+
+    /// @dev Test helper: mint outcome tokens directly (stands in for splitPosition).
+    function mint(address to, uint256 id, uint256 value) external {
+        balances[id][to] += value;
+    }
+}
+
+/// @dev Holds outcome tokens but has no payable receive: the ETH payout fails.
+contract RevertingRedeemer {
+    function approveAndRedeem(MockResolvingCTF ctf, DePrizeRedeem redeem, uint256 deprizeId) external {
+        ctf.setApprovalForAll(address(redeem), true);
+        redeem.redeem(deprizeId);
+    }
+}
+
+/// @dev Attempts to re-enter `redeem` from the ETH payout callback.
+contract ReentrantRedeemer {
+    DePrizeRedeem internal redeemContract;
+    uint256 internal deprizeId;
+
+    function approveAndRedeem(MockResolvingCTF ctf, DePrizeRedeem redeem_, uint256 deprizeId_) external {
+        redeemContract = redeem_;
+        deprizeId = deprizeId_;
+        ctf.setApprovalForAll(address(redeem_), true);
+        redeem_.redeem(deprizeId_);
+    }
+
+    receive() external payable {
+        // Re-entering reverts (ReentrancyGuard), which reverts this receive, which
+        // makes the outer payout call fail with RedeemFailed.
+        redeemContract.redeem(deprizeId);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+contract DePrizeRedeemTest is Test {
+    DePrizeRedeem redeem;
+    DePrizeRegistry registry;
+    MockWETH weth;
+    MockResolvingCTF ctf;
+    DePrizeResolve resolveScript;
+
+    address owner = address(0xA11CE);
+    address oracle = address(0x5AFE);
+    address alice = address(0xA11A);
+    address bob = address(0xB0B);
+
+    bytes32 constant QUESTION_ID = keccak256("deprize-question");
+    uint256 constant JB_PROJECT = 4;
+    uint256[] teamIds;
+    uint256 deprizeId;
+    bytes32 conditionId;
+
+    event Redeemed(uint256 indexed deprizeId, address indexed account, uint256 payout);
+
+    function setUp() public {
+        weth = new MockWETH();
+        ctf = new MockResolvingCTF(address(weth));
+
+        DePrizeRegistry regImpl = new DePrizeRegistry();
+        registry = DePrizeRegistry(
+            address(new ERC1967Proxy(address(regImpl), abi.encodeCall(DePrizeRegistry.initialize, (owner))))
+        );
+
+        redeem = new DePrizeRedeem(address(registry), address(ctf), address(weth));
+        resolveScript = new DePrizeResolve();
+
+        teamIds = new uint256[](3);
+        teamIds[0] = 101;
+        teamIds[1] = 102;
+        teamIds[2] = 103;
+
+        ctf.prepareCondition(oracle, QUESTION_ID, 3);
+        conditionId = ctf.getConditionId(oracle, QUESTION_ID, 3);
+
+        vm.startPrank(owner);
+        deprizeId = registry.register(JB_PROJECT, teamIds, block.timestamp + 30 days);
+        registry.setCondition(deprizeId, conditionId);
+        registry.open(deprizeId);
+        vm.stopPrank();
+
+        // Collateral the CTF will pay redemptions from (in reality deposited by
+        // the LMSR's splitPosition calls as bets came in).
+        vm.deal(address(this), 1000 ether);
+        weth.deposit{value: 1000 ether}();
+        weth.transfer(address(ctf), 1000 ether);
+    }
+
+    function _positionId(uint256 outcomeIndex) internal view returns (uint256) {
+        return ctf.getPositionId(address(weth), ctf.getCollectionId(bytes32(0), conditionId, 1 << outcomeIndex));
+    }
+
+    function _settleWinner(uint256 winnerTeamId) internal {
+        vm.startPrank(owner);
+        registry.lock(deprizeId);
+        registry.settleWinner(deprizeId, winnerTeamId);
+        vm.stopPrank();
+    }
+
+    function _reportWinner(uint256 winnerIndex) internal {
+        uint256[] memory payouts = new uint256[](3);
+        payouts[winnerIndex] = 1;
+        vm.prank(oracle);
+        ctf.reportPayouts(QUESTION_ID, payouts);
+    }
+
+    function _reportEqual() internal {
+        uint256[] memory payouts = new uint256[](3);
+        payouts[0] = 1;
+        payouts[1] = 1;
+        payouts[2] = 1;
+        vm.prank(oracle);
+        ctf.reportPayouts(QUESTION_ID, payouts);
+    }
+
+    // -- winner path ----------------------------------------------------------
+
+    function testRedeemWinnerPaysFullValueInEth() public {
+        ctf.mint(alice, _positionId(1), 2 ether); // winner slot
+        ctf.mint(alice, _positionId(0), 1 ether); // loser slot
+        _settleWinner(102);
+        _reportWinner(1);
+
+        vm.prank(alice);
+        ctf.setApprovalForAll(address(redeem), true);
+
+        uint256 balBefore = alice.balance;
+        vm.expectEmit(true, true, false, true);
+        emit Redeemed(deprizeId, alice, 2 ether);
+        vm.prank(alice);
+        redeem.redeem(deprizeId);
+
+        assertEq(alice.balance - balBefore, 2 ether, "winner paid full value in ETH");
+        assertEq(ctf.balanceOf(alice, _positionId(0)), 0, "loser tokens burned");
+        assertEq(ctf.balanceOf(alice, _positionId(1)), 0, "winner tokens burned");
+        assertEq(ctf.balanceOf(address(redeem), _positionId(0)), 0, "helper holds no tokens");
+        assertEq(ctf.balanceOf(address(redeem), _positionId(1)), 0, "helper holds no tokens");
+        assertEq(weth.balanceOf(address(redeem)), 0, "helper holds no WETH");
+        assertEq(address(redeem).balance, 0, "helper holds no ETH");
+    }
+
+    function testRedeemLoserOnlyBurnsAndPaysZero() public {
+        ctf.mint(bob, _positionId(0), 3 ether); // loser slot only
+        _settleWinner(102);
+        _reportWinner(1);
+
+        vm.prank(bob);
+        ctf.setApprovalForAll(address(redeem), true);
+
+        uint256 balBefore = bob.balance;
+        vm.expectEmit(true, true, false, true);
+        emit Redeemed(deprizeId, bob, 0);
+        vm.prank(bob);
+        redeem.redeem(deprizeId);
+
+        assertEq(bob.balance, balBefore, "loser receives nothing");
+        assertEq(ctf.balanceOf(bob, _positionId(0)), 0, "loser tokens burned");
+    }
+
+    // -- refund (equal-payout) path -------------------------------------------
+
+    function testRedeemEqualPayoutRefund() public {
+        // 1 ETH of tokens on a 3-outcome equal payout -> floor(1e18 / 3).
+        ctf.mint(alice, _positionId(0), 1 ether);
+        vm.startPrank(owner);
+        registry.lock(deprizeId);
+        registry.settleNoWinner(deprizeId);
+        vm.stopPrank();
+        _reportEqual();
+
+        vm.prank(alice);
+        ctf.setApprovalForAll(address(redeem), true);
+
+        uint256 expected = uint256(1 ether) / 3;
+        assertEq(redeem.previewRedeem(deprizeId, alice), expected, "preview matches");
+
+        uint256 balBefore = alice.balance;
+        vm.prank(alice);
+        redeem.redeem(deprizeId);
+        assertEq(alice.balance - balBefore, expected, "1/N refund, floored like the CTF");
+    }
+
+    function testEqualPayoutParimutuelSkew() public {
+        // Equal payout pays per TOKEN, not per ETH spent: a bettor holding fewer
+        // (i.e. more expensive) tokens recovers less. Alice "paid more" per token.
+        ctf.mint(alice, _positionId(0), 1 ether); // concentrated/expensive position
+        ctf.mint(bob, _positionId(2), 5 ether); // cheap longshot position
+        vm.startPrank(owner);
+        registry.lock(deprizeId);
+        registry.settleNoWinner(deprizeId);
+        vm.stopPrank();
+        _reportEqual();
+
+        vm.prank(alice);
+        ctf.setApprovalForAll(address(redeem), true);
+        vm.prank(bob);
+        ctf.setApprovalForAll(address(redeem), true);
+
+        uint256 aliceBefore = alice.balance;
+        uint256 bobBefore = bob.balance;
+        vm.prank(alice);
+        redeem.redeem(deprizeId);
+        vm.prank(bob);
+        redeem.redeem(deprizeId);
+
+        assertEq(alice.balance - aliceBefore, uint256(1 ether) / 3);
+        assertEq(bob.balance - bobBefore, uint256(5 ether) / 3);
+    }
+
+    // -- preview ----------------------------------------------------------------
+
+    function testPreviewMatchesActualWithRounding() public {
+        // Amounts not divisible by 3 across two slots: per-position floors must sum
+        // identically in preview and redeem.
+        ctf.mint(alice, _positionId(0), 1 ether + 1);
+        ctf.mint(alice, _positionId(1), 2 ether + 2);
+        vm.startPrank(owner);
+        registry.lock(deprizeId);
+        registry.settleNoWinner(deprizeId);
+        vm.stopPrank();
+        _reportEqual();
+
+        uint256 expected = (uint256(1 ether) + 1) / 3 + (uint256(2 ether) + 2) / 3;
+        assertEq(redeem.previewRedeem(deprizeId, alice), expected, "per-position floor");
+
+        vm.startPrank(alice);
+        ctf.setApprovalForAll(address(redeem), true);
+        uint256 balBefore = alice.balance;
+        redeem.redeem(deprizeId);
+        vm.stopPrank();
+        assertEq(alice.balance - balBefore, expected, "actual == preview");
+    }
+
+    function testPreviewZeroBeforeResolution() public {
+        ctf.mint(alice, _positionId(1), 2 ether);
+        assertEq(redeem.previewRedeem(deprizeId, alice), 0, "unresolved -> 0");
+    }
+
+    // -- guards ------------------------------------------------------------------
+
+    function testRedeemRevertsNotResolved() public {
+        ctf.mint(alice, _positionId(1), 1 ether);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeRedeem.NotResolved.selector, deprizeId));
+        redeem.redeem(deprizeId);
+    }
+
+    function testRedeemRevertsUnknownDePrize() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeRedeem.UnknownDePrize.selector, 999));
+        redeem.redeem(999);
+    }
+
+    function testRedeemRevertsNothingToRedeem() public {
+        _settleWinner(102);
+        _reportWinner(1);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeRedeem.NothingToRedeem.selector, deprizeId, alice));
+        redeem.redeem(deprizeId);
+    }
+
+    function testRedeemRevertsWithoutApproval() public {
+        ctf.mint(alice, _positionId(1), 1 ether);
+        _settleWinner(102);
+        _reportWinner(1);
+        vm.prank(alice);
+        vm.expectRevert("ERC1155: caller not approved");
+        redeem.redeem(deprizeId);
+    }
+
+    function testDoubleRedeemReverts() public {
+        ctf.mint(alice, _positionId(1), 1 ether);
+        _settleWinner(102);
+        _reportWinner(1);
+        vm.startPrank(alice);
+        ctf.setApprovalForAll(address(redeem), true);
+        redeem.redeem(deprizeId);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeRedeem.NothingToRedeem.selector, deprizeId, alice));
+        redeem.redeem(deprizeId);
+        vm.stopPrank();
+    }
+
+    function testRedeemFailedWhenReceiverReverts() public {
+        RevertingRedeemer rr = new RevertingRedeemer();
+        ctf.mint(address(rr), _positionId(1), 1 ether);
+        _settleWinner(102);
+        _reportWinner(1);
+        vm.expectRevert(DePrizeRedeem.RedeemFailed.selector);
+        rr.approveAndRedeem(ctf, redeem, deprizeId);
+    }
+
+    function testRedeemReentrancyBlocked() public {
+        ReentrantRedeemer rr = new ReentrantRedeemer();
+        ctf.mint(address(rr), _positionId(1), 1 ether);
+        _settleWinner(102);
+        _reportWinner(1);
+        // The re-entrant inner call reverts on the guard, failing the ETH payout.
+        vm.expectRevert(DePrizeRedeem.RedeemFailed.selector);
+        rr.approveAndRedeem(ctf, redeem, deprizeId);
+    }
+
+    function testStrayWethNotSweptIntoPayout() public {
+        // Same lesson as the M3 residual-sweep fix: WETH parked in the helper must
+        // never leak into a caller's payout (the payout is the redemption DELTA).
+        vm.deal(address(this), 5 ether);
+        weth.deposit{value: 5 ether}();
+        weth.transfer(address(redeem), 5 ether);
+
+        ctf.mint(alice, _positionId(1), 1 ether);
+        _settleWinner(102);
+        _reportWinner(1);
+
+        vm.startPrank(alice);
+        ctf.setApprovalForAll(address(redeem), true);
+        uint256 balBefore = alice.balance;
+        redeem.redeem(deprizeId);
+        vm.stopPrank();
+
+        assertEq(alice.balance - balBefore, 1 ether, "exactly the redemption value");
+        assertEq(weth.balanceOf(address(redeem)), 5 ether, "stray WETH untouched");
+    }
+
+    function testConstructorRejectsZeroAddresses() public {
+        vm.expectRevert(DePrizeRedeem.ZeroAddress.selector);
+        new DePrizeRedeem(address(0), address(ctf), address(weth));
+        vm.expectRevert(DePrizeRedeem.ZeroAddress.selector);
+        new DePrizeRedeem(address(registry), address(0), address(weth));
+        vm.expectRevert(DePrizeRedeem.ZeroAddress.selector);
+        new DePrizeRedeem(address(registry), address(ctf), address(0));
+    }
+
+    // -- ERC-1155 receiver guard ---------------------------------------------------
+
+    function testRejectsUnsolicitedERC1155() public {
+        uint256[] memory ids = new uint256[](1);
+        uint256[] memory values = new uint256[](1);
+        ids[0] = 1;
+        values[0] = 1;
+        vm.prank(address(ctf));
+        vm.expectRevert(DePrizeRedeem.UnexpectedERC1155.selector);
+        IERC1155Receiver(address(redeem)).onERC1155BatchReceived(address(this), address(0), ids, values, "");
+    }
+
+    function testRejectsUnsolicitedERC1155Single() public {
+        vm.prank(address(ctf));
+        vm.expectRevert(DePrizeRedeem.UnexpectedERC1155.selector);
+        IERC1155Receiver(address(redeem)).onERC1155Received(address(this), address(0), 1, 1, "");
+    }
+
+    function testRejectsERC1155FromNonCtf() public {
+        vm.prank(address(0xDEAD));
+        vm.expectRevert(DePrizeRedeem.UnexpectedERC1155.selector);
+        IERC1155Receiver(address(redeem)).onERC1155Received(address(this), address(0), 1, 1, "");
+    }
+
+    function testSupportsInterface() public view {
+        assertTrue(redeem.supportsInterface(type(IERC1155Receiver).interfaceId), "ERC1155Receiver");
+        assertTrue(redeem.supportsInterface(type(IERC165).interfaceId), "ERC165");
+        assertFalse(redeem.supportsInterface(0xffffffff), "unknown");
+    }
+
+    // -- mock-CTF fidelity (the properties the design relies on) --------------------
+
+    function testReportPayoutsIsWriteOnce() public {
+        _reportWinner(1);
+        uint256[] memory payouts = new uint256[](3);
+        payouts[0] = 1;
+        vm.prank(oracle);
+        vm.expectRevert("payout denominator already set");
+        ctf.reportPayouts(QUESTION_ID, payouts);
+    }
+
+    function testReportPayoutsRejectsAllZeroes() public {
+        uint256[] memory payouts = new uint256[](3);
+        vm.prank(oracle);
+        vm.expectRevert("payout is all zeroes");
+        ctf.reportPayouts(QUESTION_ID, payouts);
+    }
+
+    function testReportPayoutsOnlyOracleResolvesThisCondition() public {
+        // A non-oracle sender resolves a DIFFERENT conditionId (derived from
+        // msg.sender), so the DePrize condition stays unresolved.
+        uint256[] memory payouts = new uint256[](3);
+        payouts[1] = 1;
+        vm.prank(address(0xBAD));
+        vm.expectRevert("condition not prepared or found");
+        ctf.reportPayouts(QUESTION_ID, payouts);
+        assertEq(ctf.payoutDenominator(conditionId), 0, "DePrize condition unresolved");
+    }
+
+    // -----------------------------------------------------------------------
+    // DePrizeResolve script pre-flight
+    // -----------------------------------------------------------------------
+
+    function testBuildReportWinnerVector() public {
+        _settleWinner(102);
+        (bytes32 cid, uint256[] memory payouts, bytes memory callData) = resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), deprizeId, QUESTION_ID, oracle
+        );
+        assertEq(cid, conditionId, "conditionId");
+        assertEq(payouts.length, 3);
+        assertEq(payouts[0], 0);
+        assertEq(payouts[1], 1, "winner slot (team 102 = index 1)");
+        assertEq(payouts[2], 0);
+        assertEq(callData, abi.encodeCall(IConditionalTokens.reportPayouts, (QUESTION_ID, payouts)), "calldata");
+
+        // The emitted calldata, submitted by the oracle, resolves the condition.
+        vm.prank(oracle);
+        (bool ok,) = address(ctf).call(callData);
+        assertTrue(ok, "report submission");
+        assertEq(ctf.payoutDenominator(conditionId), 1, "resolved");
+    }
+
+    function testBuildReportEqualVectorOnNoWinner() public {
+        vm.startPrank(owner);
+        registry.lock(deprizeId);
+        registry.settleNoWinner(deprizeId);
+        vm.stopPrank();
+        (, uint256[] memory payouts,) = resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), deprizeId, QUESTION_ID, oracle
+        );
+        for (uint256 i = 0; i < 3; i++) {
+            assertEq(payouts[i], 1, "equal payout");
+        }
+    }
+
+    function testBuildReportEqualVectorOnCancelled() public {
+        vm.startPrank(owner);
+        registry.announceCancellation(deprizeId);
+        vm.warp(block.timestamp + registry.CANCELLATION_NOTICE());
+        registry.cancel(deprizeId);
+        vm.stopPrank();
+        (, uint256[] memory payouts,) = resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), deprizeId, QUESTION_ID, oracle
+        );
+        for (uint256 i = 0; i < 3; i++) {
+            assertEq(payouts[i], 1, "equal payout");
+        }
+    }
+
+    function testBuildReportRevertsWrongState() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(DePrizeResolve.WrongState.selector, deprizeId, IDePrizeRegistry.DePrizeState.OPEN)
+        );
+        resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), deprizeId, QUESTION_ID, oracle
+        );
+    }
+
+    function testBuildReportRefusesM2Failed() public {
+        _settleWinner(102);
+        vm.startPrank(owner);
+        registry.releaseM1(deprizeId);
+        registry.failM2(deprizeId);
+        vm.stopPrank();
+        vm.expectRevert(abi.encodeWithSelector(DePrizeResolve.M2FailedCtfAlreadyFinal.selector, deprizeId));
+        resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), deprizeId, QUESTION_ID, oracle
+        );
+    }
+
+    function testBuildReportRevertsConditionMismatchWrongQuestion() public {
+        _settleWinner(102);
+        bytes32 wrongQuestion = keccak256("some-other-question");
+        bytes32 computed = ctf.getConditionId(oracle, wrongQuestion, 3);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeResolve.ConditionMismatch.selector, computed, conditionId));
+        resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), deprizeId, wrongQuestion, oracle
+        );
+    }
+
+    function testBuildReportRevertsConditionMismatchWrongOracle() public {
+        _settleWinner(102);
+        address wrongOracle = address(0xBAD);
+        bytes32 computed = ctf.getConditionId(wrongOracle, QUESTION_ID, 3);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeResolve.ConditionMismatch.selector, computed, conditionId));
+        resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), deprizeId, QUESTION_ID, wrongOracle
+        );
+    }
+
+    function testBuildReportRevertsAlreadyReported() public {
+        _settleWinner(102);
+        _reportWinner(1);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeResolve.AlreadyReported.selector, conditionId, 1));
+        resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), deprizeId, QUESTION_ID, oracle
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fork tests (guarded — skip unless DEPRIZE_FORK_RPC is set)
+// ---------------------------------------------------------------------------
+
+/// @dev 0.8 view of the 0.5 LMSRWithTWAPFactory (full-loop test only).
+interface ILMSRWithTWAPFactory {
+    function createLMSRWithTWAP(
+        address pmSystem,
+        address collateralToken,
+        bytes32[] calldata conditionIds,
+        uint64 fee,
+        address whitelist,
+        uint256 funding
+    ) external returns (address lmsrWithTWAP);
+}
+
+/// @notice The resolve→redeem close-out loop against the REAL Arbitrum-Sepolia
+///         CTF (the contract whose payout math actually decides mainnet payouts).
+///         A fresh condition is prepared with a test oracle, so resolution can be
+///         exercised without touching the shared live market's condition.
+///
+/// Run with:
+///   DEPRIZE_FORK_RPC=<arb-sepolia rpc> forge test --match-contract DePrizeM4ForkTest -vvv
+/// The full bet→resolve→redeem→unwind loop additionally needs the LMSR factory:
+///   DEPRIZE_FORK_FACTORY=0x<LMSRWithTWAPFactory> (skipped when unset)
+contract DePrizeM4ForkTest is Test {
+    // Arbitrum-Sepolia deployments (mirror ui/const/config.ts).
+    address constant WETH = 0xA441f20115c868dc66bC1977E1c17D4B9A0189c7;
+    address constant CTF = 0xa0B1b14515C26acb193cb45Be5508A8A46109a27;
+
+    DePrizeRegistry registry;
+    DePrizeRedeem redeem;
+
+    address owner = address(0xA11CE);
+    address oracle = address(0x5AFE);
+    address alice = address(0xA11A);
+    address bob = address(0xB0B);
+
+    uint256 constant SLOTS = 3;
+    bool forkEnabled;
+
+    function setUp() public {
+        string memory rpc = vm.envOr("DEPRIZE_FORK_RPC", string(""));
+        if (bytes(rpc).length == 0) return; // not configured -> tests no-op
+        vm.createSelectFork(rpc);
+        forkEnabled = true;
+
+        DePrizeRegistry regImpl = new DePrizeRegistry();
+        registry = DePrizeRegistry(
+            address(new ERC1967Proxy(address(regImpl), abi.encodeCall(DePrizeRegistry.initialize, (owner))))
+        );
+        redeem = new DePrizeRedeem(address(registry), CTF, WETH);
+
+        vm.deal(address(this), 1000 ether);
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+    }
+
+    /// @dev Register a DePrize against a freshly-prepared condition (unique
+    ///      questionId per call so reruns/parallel tests never collide).
+    function _newDePrize(bytes32 salt) internal returns (uint256 deprizeId, bytes32 questionId, bytes32 conditionId) {
+        questionId = keccak256(abi.encode("deprize-m4-fork", salt, block.number, address(this)));
+        IConditionalTokens(CTF).prepareCondition(oracle, questionId, SLOTS);
+        conditionId = IConditionalTokens(CTF).getConditionId(oracle, questionId, SLOTS);
+
+        uint256[] memory teams = new uint256[](SLOTS);
+        for (uint256 i = 0; i < SLOTS; i++) {
+            teams[i] = 100 + i;
+        }
+        vm.startPrank(owner);
+        deprizeId = registry.register(uint256(keccak256(abi.encode(salt))) % 1e9 + 1, teams, block.timestamp + 30 days);
+        registry.setCondition(deprizeId, conditionId);
+        registry.open(deprizeId);
+        vm.stopPrank();
+    }
+
+    /// @dev Split `amount` WETH into a full outcome set and send slot `slot` to `to`.
+    function _giveOutcomeTokens(bytes32 conditionId, address to, uint256 slot, uint256 amount) internal {
+        IWETH(WETH).deposit{value: amount}();
+        IWETH(WETH).approve(CTF, amount);
+        uint256[] memory partition = new uint256[](SLOTS);
+        for (uint256 i = 0; i < SLOTS; i++) {
+            partition[i] = 1 << i;
+        }
+        IConditionalTokens(CTF).splitPosition(WETH, bytes32(0), conditionId, partition, amount);
+        IConditionalTokens(CTF).safeTransferFrom(address(this), to, _positionId(conditionId, slot), amount, "");
+    }
+
+    function _positionId(bytes32 conditionId, uint256 slot) internal view returns (uint256) {
+        return IConditionalTokens(CTF).getPositionId(
+            WETH, IConditionalTokens(CTF).getCollectionId(bytes32(0), conditionId, 1 << slot)
+        );
+    }
+
+    function _report(bytes32 questionId, uint256[] memory payouts) internal {
+        vm.prank(oracle);
+        IConditionalTokens(CTF).reportPayouts(questionId, payouts);
+    }
+
+    // Accept ERC-1155 from splitPosition / market close.
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function testForkWinnerResolveRedeem() public {
+        if (!forkEnabled) return;
+        (uint256 deprizeId, bytes32 questionId, bytes32 conditionId) = _newDePrize("winner");
+
+        _giveOutcomeTokens(conditionId, alice, 1, 2 ether); // alice backs the winner
+        _giveOutcomeTokens(conditionId, bob, 0, 1 ether); // bob backs a loser
+
+        vm.startPrank(owner);
+        registry.lock(deprizeId);
+        registry.settleWinner(deprizeId, 101); // team at slot 1
+        vm.stopPrank();
+
+        uint256[] memory payouts = new uint256[](SLOTS);
+        payouts[1] = 1;
+        _report(questionId, payouts);
+
+        // Winner redeems full value, in ETH, through the helper.
+        vm.startPrank(alice);
+        IConditionalTokens(CTF).setApprovalForAll(address(redeem), true);
+        uint256 aliceBefore = alice.balance;
+        redeem.redeem(deprizeId);
+        vm.stopPrank();
+        assertEq(alice.balance - aliceBefore, 2 ether, "winner full value vs real CTF math");
+
+        // Loser redeems zero; tokens burned.
+        vm.startPrank(bob);
+        IConditionalTokens(CTF).setApprovalForAll(address(redeem), true);
+        uint256 bobBefore = bob.balance;
+        redeem.redeem(deprizeId);
+        vm.stopPrank();
+        assertEq(bob.balance, bobBefore, "loser gets 0");
+        assertEq(IConditionalTokens(CTF).balanceOf(bob, _positionId(conditionId, 0)), 0, "burned");
+
+        assertEq(IWETH(WETH).balanceOf(address(redeem)), 0, "no stuck WETH");
+        assertEq(address(redeem).balance, 0, "no stuck ETH");
+    }
+
+    function testForkCancellationEqualPayoutRedeem() public {
+        if (!forkEnabled) return;
+        (uint256 deprizeId, bytes32 questionId, bytes32 conditionId) = _newDePrize("cancel");
+
+        _giveOutcomeTokens(conditionId, alice, 0, 1 ether);
+
+        vm.startPrank(owner);
+        registry.announceCancellation(deprizeId);
+        vm.warp(block.timestamp + registry.CANCELLATION_NOTICE());
+        registry.cancel(deprizeId);
+        vm.stopPrank();
+
+        uint256[] memory payouts = new uint256[](SLOTS);
+        for (uint256 i = 0; i < SLOTS; i++) {
+            payouts[i] = 1;
+        }
+        _report(questionId, payouts);
+
+        uint256 expected = uint256(1 ether) / 3; // real CTF floor division
+        assertEq(redeem.previewRedeem(deprizeId, alice), expected, "preview vs real CTF");
+
+        vm.startPrank(alice);
+        IConditionalTokens(CTF).setApprovalForAll(address(redeem), true);
+        uint256 before = alice.balance;
+        redeem.redeem(deprizeId);
+        vm.stopPrank();
+        assertEq(alice.balance - before, expected, "1/N refund vs real CTF math");
+    }
+
+    /// @notice Full close-out loop: provision market -> bets through DePrizeMint ->
+    ///         lock -> pause -> settle -> close -> report -> withdrawFees ->
+    ///         treasury redeems inventory -> bettors redeem. Asserts ETH
+    ///         conservation to the wei. Needs DEPRIZE_FORK_FACTORY.
+    function testForkFullCloseOutLoop() public {
+        if (!forkEnabled) return;
+        address factory = vm.envOr("DEPRIZE_FORK_FACTORY", address(0));
+        if (factory == address(0)) return; // factory not configured -> no-op
+
+        (uint256 deprizeId, bytes32 questionId, bytes32 conditionId) = _newDePrize("full-loop");
+
+        // Provision a fresh LMSR market seeded by this test ("the treasury").
+        uint256 funding = 3 ether;
+        IWETH(WETH).deposit{value: funding}();
+        IWETH(WETH).approve(factory, funding);
+        bytes32[] memory conditionIds = new bytes32[](1);
+        conditionIds[0] = conditionId;
+        address market =
+            ILMSRWithTWAPFactory(factory).createLMSRWithTWAP(CTF, WETH, conditionIds, 1e16, address(0), funding);
+
+        // Provisioning runbook step: hand the market to the oracle Safe.
+        ILMSRWithTWAP(market).transferOwnership(oracle);
+        assertEq(ILMSRWithTWAP(market).owner(), oracle, "market owned by oracle");
+
+        // Router (real, behind a proxy) with a mock JB terminal for the 5% slice.
+        MockJBTerminal terminal = new MockJBTerminal();
+        DePrizeMint mintImpl = new DePrizeMint();
+        DePrizeMint mint = DePrizeMint(
+            payable(
+                address(
+                    new ERC1967Proxy(
+                        address(mintImpl),
+                        abi.encodeCall(DePrizeMint.initialize, (owner, address(registry), address(terminal), WETH, CTF))
+                    )
+                )
+            )
+        );
+        vm.prank(owner);
+        mint.setMarket(deprizeId, market);
+
+        uint256 ctfWethBefore = IWETH(WETH).balanceOf(CTF);
+
+        // Two bets via the real router.
+        uint256 aliceSpend = _bet(mint, market, deprizeId, alice, 1, 0.5 ether); // winner slot
+        uint256 bobSpend = _bet(mint, market, deprizeId, bob, 0, 0.3 ether); // loser slot
+
+        // Close-out runbook: lock -> pause -> settle -> close -> report -> withdrawFees.
+        vm.startPrank(owner);
+        registry.lock(deprizeId);
+        registry.settleWinner(deprizeId, 101); // team at slot 1
+        vm.stopPrank();
+
+        vm.startPrank(oracle);
+        ILMSRWithTWAP(market).pause();
+        ILMSRWithTWAP(market).close(); // inventory -> oracle
+        vm.stopPrank();
+
+        uint256[] memory payouts = new uint256[](SLOTS);
+        payouts[1] = 1;
+        _report(questionId, payouts);
+
+        vm.startPrank(oracle);
+        uint256 fees = ILMSRWithTWAP(market).withdrawFees(); // residual WETH -> oracle
+        // Treasury recovers the closed market's inventory via the CTF directly.
+        uint256[] memory indexSets = new uint256[](SLOTS);
+        for (uint256 i = 0; i < SLOTS; i++) {
+            indexSets[i] = 1 << i;
+        }
+        IConditionalTokens(CTF).redeemPositions(WETH, bytes32(0), conditionId, indexSets);
+        vm.stopPrank();
+        uint256 treasuryRecovered = IWETH(WETH).balanceOf(oracle);
+        assertEq(IWETH(WETH).balanceOf(market), 0, "market fully drained");
+        assertGt(fees, 0, "1% fees accrued");
+
+        // Bettors redeem through the helper.
+        uint256 alicePayout = _redeemAs(alice, deprizeId);
+        uint256 bobPayout = _redeemAs(bob, deprizeId);
+        assertGt(alicePayout, 0, "winner paid");
+        assertEq(bobPayout, 0, "loser paid 0");
+
+        // ETH conservation, to the wei: everything bettors + treasury put in comes
+        // back out as JB slices, bettor payouts, treasury recovery, or collateral
+        // still locked in the CTF backing unredeemed (worthless) positions.
+        uint256 ctfLocked = IWETH(WETH).balanceOf(CTF) - ctfWethBefore;
+        assertEq(
+            aliceSpend + bobSpend + funding,
+            terminal.totalReceived() + alicePayout + bobPayout + treasuryRecovered + ctfLocked,
+            "ETH conservation"
+        );
+    }
+
+    function _bet(DePrizeMint mint, address market, uint256 deprizeId, address bettor, uint256 slot, uint256 qty)
+        internal
+        returns (uint256 spent)
+    {
+        int256[] memory amounts = new int256[](SLOTS);
+        amounts[slot] = int256(qty);
+        uint256 net = uint256(ILMSRWithTWAP(market).calcNetCost(amounts));
+        uint256 cost = net + ILMSRWithTWAP(market).calcMarketFee(net);
+        uint256 value = cost * 2 + 1 ether;
+        uint256 before = bettor.balance;
+        vm.prank(bettor);
+        mint.bet{value: value}(deprizeId, slot, qty, cost);
+        spent = before - bettor.balance; // slice + cost
+    }
+
+    function _redeemAs(address account, uint256 deprizeId) internal returns (uint256 payout) {
+        vm.startPrank(account);
+        IConditionalTokens(CTF).setApprovalForAll(address(redeem), true);
+        uint256 before = account.balance;
+        redeem.redeem(deprizeId);
+        payout = account.balance - before;
+        vm.stopPrank();
+    }
+}

--- a/subscription-contracts/test/deprize/DePrizeRedeem.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeRedeem.t.sol
@@ -282,6 +282,12 @@ contract DePrizeRedeemTest is Test {
         );
 
         redeem = new DePrizeRedeem(address(registry), address(ctf), address(weth));
+        // The helper is deployed at a deterministic CREATE2 address. On a forked
+        // chain that address can already hold native ETH (e.g. 0.17 ETH on Sepolia),
+        // which the fresh deployment inherits and would corrupt the "no residual
+        // ETH" invariants below. Zero it so those assertions test only what the
+        // redemption flow leaves behind.
+        vm.deal(address(redeem), 0);
         resolveScript = new DePrizeResolve();
 
         teamIds = new uint256[](3);

--- a/ui/const/abis/DePrizeRedeem.json
+++ b/ui/const/abis/DePrizeRedeem.json
@@ -1,0 +1,49 @@
+[
+  {
+    "type": "function",
+    "name": "redeem",
+    "stateMutability": "nonpayable",
+    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
+    "outputs": []
+  },
+  {
+    "type": "function",
+    "name": "previewRedeem",
+    "stateMutability": "view",
+    "inputs": [
+      { "name": "deprizeId", "type": "uint256" },
+      { "name": "account", "type": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "registry",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "function",
+    "name": "ctf",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "function",
+    "name": "weth",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "event",
+    "name": "Redeemed",
+    "inputs": [
+      { "name": "deprizeId", "type": "uint256", "indexed": true },
+      { "name": "account", "type": "address", "indexed": true },
+      { "name": "payout", "type": "uint256", "indexed": false }
+    ]
+  }
+]

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -420,9 +420,10 @@ export const VMOONEY_SWEEPSTAKES: string = ethConfig.vMooneySweepstakesZeroG
 export const MARKETPLACE_FEE_SPLIT: string = polygonConfig.MarketplaceFeeSplit || ''
 
 export const LMSR_WITH_TWAP_ADDRESSES: Index = {
-  // sepolia: fresh self-serve market (oracle + owner = pmoncada.eth), DePrize id 2.
-  // Old market 0x11DCe8... had oracle jaderiverstokes.eth and is kept for reference.
-  sepolia: '0x48de289455f08b523ca5a4ae09f740e7ba7b72de',
+  // sepolia: fresh self-serve market (oracle + owner = pmoncada.eth), DePrize id 3.
+  // Prior test markets: 0x48de28... (id 2, resolved), 0x11DCe8... (oracle
+  // jaderiverstokes.eth). Kept for reference only.
+  sepolia: '0x36da9d41b673b4115df0e06cefb4c665e2289dd0',
   'arbitrum-sepolia': '0xbd10F66098e123Aa036f7cb1E747e76bbe849eBe',
 }
 export const CONDITIONAL_TOKEN_ADDRESSES: Index = {
@@ -450,14 +451,14 @@ export const DEPRIZE_REGISTRY_ADDRESSES: Index = {
 // questionId used when the play market's condition was prepared
 // (prediction/deprize.config.js DEPRIZE_QUESTION_ID). Needed by reportPayouts;
 // the conditionId is keccak256(oracle, questionId, outcomeSlotCount).
-// Verified for the fresh Sepolia market: keccak256(ORACLE_ADDRESS, 0x..03, 3)
-// == the market's conditionId (0xed5ff0...7312).
+// Verified for the fresh Sepolia market: keccak256(ORACLE_ADDRESS, 0x..04, 3)
+// == the market's conditionId (0xe4f0ce...e720).
 export const DEPRIZE_QUESTION_ID =
-  '0x0000000000000000000000000000000000000000000000000000000000000003'
+  '0x0000000000000000000000000000000000000000000000000000000000000004'
 
 // DePrize id in the registry that the play market resolves to (the helper's
 // previewRedeem/redeem take this id).
-export const DEPRIZE_PLAY_ID = 2
+export const DEPRIZE_PLAY_ID = 3
 
 // Oracle that prepared the CTF condition; the only address that can resolve
 // (reportPayouts). On the fresh Sepolia market this is pmoncada.eth.

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -420,7 +420,9 @@ export const VMOONEY_SWEEPSTAKES: string = ethConfig.vMooneySweepstakesZeroG
 export const MARKETPLACE_FEE_SPLIT: string = polygonConfig.MarketplaceFeeSplit || ''
 
 export const LMSR_WITH_TWAP_ADDRESSES: Index = {
-  sepolia: '0x11DCe86c804ca088A0d9036eeE368e4055b235dE',
+  // sepolia: fresh self-serve market (oracle + owner = pmoncada.eth), DePrize id 2.
+  // Old market 0x11DCe8... had oracle jaderiverstokes.eth and is kept for reference.
+  sepolia: '0x48de289455f08b523ca5a4ae09f740e7ba7b72de',
   'arbitrum-sepolia': '0xbd10F66098e123Aa036f7cb1E747e76bbe849eBe',
 }
 export const CONDITIONAL_TOKEN_ADDRESSES: Index = {
@@ -438,22 +440,32 @@ export const MAX_OUTCOMES = 3
 // chain once `script/deprize/DePrizeRedeem.s.sol` / the registry deploy run;
 // the deprize-play harness also accepts manual overrides for testing.
 export const DEPRIZE_REDEEM_ADDRESSES: Index = {
-  sepolia: '',
+  sepolia: '0x2fec56899a1121a46b6bcba0bb924796b6ddf4f7',
   'arbitrum-sepolia': '',
 }
 export const DEPRIZE_REGISTRY_ADDRESSES: Index = {
-  sepolia: '',
+  sepolia: '0x299F163705AbBFa1A8DE7670F33171730F828F3D',
   'arbitrum-sepolia': '',
 }
 // questionId used when the play market's condition was prepared
 // (prediction/deprize.config.js DEPRIZE_QUESTION_ID). Needed by reportPayouts;
 // the conditionId is keccak256(oracle, questionId, outcomeSlotCount).
+// Verified for the fresh Sepolia market: keccak256(ORACLE_ADDRESS, 0x..03, 3)
+// == the market's conditionId (0xed5ff0...7312).
 export const DEPRIZE_QUESTION_ID =
-  '0x0000000000000000000000000000000000000000000000000000000000000001'
+  '0x0000000000000000000000000000000000000000000000000000000000000003'
 
-export const ORACLE_ADDRESS = '0x08B3e694caA2F1fcF8eF71095CED1326f3454B89'
+// DePrize id in the registry that the play market resolves to (the helper's
+// previewRedeem/redeem take this id).
+export const DEPRIZE_PLAY_ID = 2
 
-export const OPERATOR_ADDRESS = '0x08B3e694caA2F1fcF8eF71095CED1326f3454B89'
+// Oracle that prepared the CTF condition; the only address that can resolve
+// (reportPayouts). On the fresh Sepolia market this is pmoncada.eth.
+export const ORACLE_ADDRESS = '0x679d87D8640e66778c3419D164998E720D7495f6'
+
+// Market owner (pause/close/withdrawFees on the LMSR). Ownership of the fresh
+// Sepolia market was transferred to pmoncada.eth so one wallet runs everything.
+export const OPERATOR_ADDRESS = '0x679d87D8640e66778c3419D164998E720D7495f6'
 
 export const MOONDAO_TREASURY: string = '0xce4a1E86a5c47CD677338f53DA22A91d85cab2c9'
 export const MOONDAO_L2_TREASURY: string = '0x8C0252c3232A2c7379DDC2E44214697ae8fF097a'

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -434,6 +434,23 @@ export const COLLATERAL_TOKEN_ADDRESSES: Index = {
 export const COLLATERAL_DECIMALS = 18
 export const MAX_OUTCOMES = 3
 
+// M4 close-out stack (DePrizeRedeem helper + DePrizeRegistry). Populate per
+// chain once `script/deprize/DePrizeRedeem.s.sol` / the registry deploy run;
+// the deprize-play harness also accepts manual overrides for testing.
+export const DEPRIZE_REDEEM_ADDRESSES: Index = {
+  sepolia: '',
+  'arbitrum-sepolia': '',
+}
+export const DEPRIZE_REGISTRY_ADDRESSES: Index = {
+  sepolia: '',
+  'arbitrum-sepolia': '',
+}
+// questionId used when the play market's condition was prepared
+// (prediction/deprize.config.js DEPRIZE_QUESTION_ID). Needed by reportPayouts;
+// the conditionId is keccak256(oracle, questionId, outcomeSlotCount).
+export const DEPRIZE_QUESTION_ID =
+  '0x0000000000000000000000000000000000000000000000000000000000000001'
+
 export const ORACLE_ADDRESS = '0x08B3e694caA2F1fcF8eF71095CED1326f3454B89'
 
 export const OPERATOR_ADDRESS = '0x08B3e694caA2F1fcF8eF71095CED1326f3454B89'

--- a/ui/lib/thirdweb/client.ts
+++ b/ui/lib/thirdweb/client.ts
@@ -27,8 +27,15 @@ const client = createThirdwebClient({
   },
 })
 
+// Prefer the secret key (higher limits, server-only endpoints) but fall back
+// to the public clientId so a local dev env without the secret doesn't crash
+// the whole app at import time (thirdweb throws when neither is provided, and
+// _app imports this module — the crash loops Fast Refresh's full reloads).
+const secretKey = process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_SECRET
 export const serverClient = createThirdwebClient({
-  secretKey: process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_SECRET as string,
+  ...(secretKey
+    ? { secretKey }
+    : { clientId: process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID as string }),
   config: {
     rpc: {
       maxBatchSize: 100,

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,9 +5,12 @@
   "engines": {
     "node": ">=18"
   },
+  "resolutions": {
+    "@noble/hashes": "1.8.0"
+  },
   "scripts": {
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev",
-    "build": "NODE_OPTIONS='--max-old-space-size=8192' next build",
+    "build": "rm -rf .next/cache && NODE_OPTIONS='--max-old-space-size=8192' next build",
     "analyze": "ANALYZE=true NODE_OPTIONS='--max-old-space-size=8192' next build",
     "postbuild": "next-sitemap",
     "start": "next start",

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_CHAIN_V5,
   DEPRIZE_REDEEM_ADDRESSES,
   DEPRIZE_QUESTION_ID,
+  DEPRIZE_PLAY_ID,
 } from 'const/config'
 import { useLogin, useWallets } from '@privy-io/react-auth'
 import dynamic from 'next/dynamic'
@@ -241,7 +242,7 @@ export default function DePrizePlay() {
   const [helperAddress, setHelperAddress] = useState(
     DEPRIZE_REDEEM_ADDRESSES[chainSlug] ?? ''
   )
-  const [helperDeprizeId, setHelperDeprizeId] = useState('1')
+  const [helperDeprizeId, setHelperDeprizeId] = useState(String(DEPRIZE_PLAY_ID))
   const [helperPreview, setHelperPreview] = useState<number | undefined>()
   const [helperApproved, setHelperApproved] = useState<boolean | undefined>()
   const [wethBalance, setWethBalance] = useState<number | undefined>()

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -1785,7 +1785,7 @@ export default function DePrizePlay() {
                   userAddress &&
                   (() => {
                     const claimEth =
-                      validHelper && helperPreview !== undefined
+                      validHelper && helperPreview !== undefined && helperPreview > 0
                         ? helperPreview
                         : undefined
                     const claimAmount =
@@ -1801,7 +1801,7 @@ export default function DePrizePlay() {
                             ? `Outcome #${winningIndex + 1} won`
                             : 'Resolved'}
                         </p>
-                        {nothingToClaim ? (
+                        {nothingToClaim || claimed ? (
                           <p className="text-white text-2xl font-bold mt-1">
                             {claimed ? 'Claimed' : 'Nothing to claim'}
                           </p>

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -1,3 +1,4 @@
+import confetti from 'canvas-confetti'
 import ConditionalTokensABI from 'const/abis/ConditionalTokens.json'
 import DePrizeRedeemABI from 'const/abis/DePrizeRedeem.json'
 import LMSRWithTWAP from 'const/abis/LMSRWithTWAP.json'
@@ -249,6 +250,12 @@ export default function DePrizePlay() {
   const [helperDeprizeId, setHelperDeprizeId] = useState(String(DEPRIZE_PLAY_ID))
   const [helperPreview, setHelperPreview] = useState<number | undefined>()
   const [helperApproved, setHelperApproved] = useState<boolean | undefined>()
+  // Bumped after a tx so reads that don't otherwise depend on changing state
+  // (e.g. the helper previewRedeem) refetch. `claimed` flips once the wallet
+  // has redeemed so the claim card can show a settled state instead of a stale
+  // amount.
+  const [refreshNonce, setRefreshNonce] = useState(0)
+  const [claimed, setClaimed] = useState(false)
   const [wethBalance, setWethBalance] = useState<number | undefined>()
   const [nativeBalance, setNativeBalance] = useState<number | undefined>()
   const [ctfApproved, setCtfApproved] = useState<boolean | undefined>()
@@ -585,6 +592,11 @@ export default function DePrizePlay() {
   // no-winner refund). Append that as a final chart point so the graph snaps to
   // the outcome. Closing alone does NOT do this — only resolution declares a
   // winner. Fires once per resolution.
+  // A new market/condition means a fresh claim state.
+  useEffect(() => {
+    setClaimed(false)
+  }, [conditionId])
+
   const resolvedSnapRef = useRef(false)
   useEffect(() => {
     const den = payoutDen
@@ -600,11 +612,28 @@ export default function DePrizePlay() {
     resolvedSnapRef.current = true
   }, [payoutNums, payoutDen, recordOddsSample])
 
+  // Celebratory burst on a successful bet/claim so the action clearly "worked".
+  const fireConfetti = useCallback(() => {
+    confetti({
+      particleCount: 150,
+      spread: 100,
+      origin: { y: 0.6 },
+      shapes: ['circle', 'star'],
+      colors: ['#ffffff', '#FFD700', '#00FFFF', '#ff69b4', '#8A2BE2'],
+    })
+  }, [])
+
   // The just-mined block can lag the RPC briefly; refresh now and once more
   // shortly after so balances/odds reflect the tx without a manual refresh.
+  // Bumping refreshNonce also re-runs the helper preview/approval read, which
+  // otherwise has no reason to refetch after a redeem.
   const refreshSoon = useCallback(() => {
     loadMarket()
-    setTimeout(() => loadMarket(), 2500)
+    setRefreshNonce((n) => n + 1)
+    setTimeout(() => {
+      loadMarket()
+      setRefreshNonce((n) => n + 1)
+    }, 2500)
   }, [loadMarket])
 
   // Cost basis (what the user has bet per outcome) — there's no on-chain record
@@ -750,7 +779,7 @@ export default function DePrizePlay() {
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [validHelper, helper, ctf, userAddress, helperAddress, helperDeprizeId, payoutDen])
+  }, [validHelper, helper, ctf, userAddress, helperAddress, helperDeprizeId, payoutDen, refreshNonce])
 
   // Sell-out quote: for each outcome the user holds, compute the ETH they'd
   // receive by selling their full position right now (calcNetCost with negative
@@ -1070,6 +1099,7 @@ export default function DePrizePlay() {
       toast.dismiss('trade')
       const qtyNum = Number(qty) / Number(UNIT)
       addCostBasis(index, Number(cost) / Number(UNIT))
+      fireConfetti()
       toast.success(
         `Bet ${fmt(Number(cost) / Number(UNIT))} ETH on outcome #${
           index + 1
@@ -1176,6 +1206,8 @@ export default function DePrizePlay() {
         })
       )
       clearCostBasis()
+      setClaimed(true)
+      fireConfetti()
       toast.success('Winnings claimed.', { style: toastStyle })
       refreshSoon()
     } catch (err: any) {
@@ -1346,6 +1378,8 @@ export default function DePrizePlay() {
       )
       toast.dismiss('helper')
       clearCostBasis()
+      setClaimed(true)
+      fireConfetti()
       toast.success(
         helperPreview !== undefined
           ? `Redeemed ≈ ${fmt(helperPreview)} ETH via DePrizeRedeem.`
@@ -1747,52 +1781,74 @@ export default function DePrizePlay() {
                     market is resolved. Pays native ETH via the DePrizeRedeem
                     helper (one tap after a one-time approval); the raw CTF/WETH
                     path lives in Advanced below. */}
-                {resolved && userAddress && (
-                  <div className="p-4 sm:p-5 rounded-2xl bg-emerald-500/10 border border-emerald-500/30">
-                    <p className="text-emerald-200 text-sm">
-                      {isRefundVector
-                        ? 'No winner — everyone refunded'
-                        : winningIndex >= 0
-                        ? `Outcome #${winningIndex + 1} won`
-                        : 'Resolved'}
-                    </p>
-                    <p className="text-white text-2xl font-bold mt-1">
-                      {validHelper && helperPreview !== undefined
-                        ? `${fmt(helperPreview)} ETH`
-                        : `${fmt(claimable)} WETH`}
-                    </p>
-                    <div className="mt-3 flex items-center gap-3 flex-wrap">
-                      {validHelper ? (
-                        <StandardButton
-                          onClick={helperApproved ? redeemViaHelper : approveHelper}
-                          disabled={busy || (helperPreview ?? 0) <= 0}
-                          className="rounded-full"
-                          backgroundColor="bg-moon-green"
-                        >
-                          {helperApproved ? 'Claim' : 'Approve'}
-                        </StandardButton>
-                      ) : (
-                        <StandardButton
-                          onClick={redeem}
-                          disabled={busy}
-                          className="rounded-full"
-                          backgroundColor="bg-moon-green"
-                        >
-                          Claim
-                        </StandardButton>
-                      )}
-                      {validHelper && (
-                        <button
-                          onClick={redeem}
-                          disabled={busy}
-                          className="text-gray-400 hover:text-gray-200 text-xs underline disabled:opacity-50"
-                        >
-                          WETH instead
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                )}
+                {resolved &&
+                  userAddress &&
+                  (() => {
+                    const claimEth =
+                      validHelper && helperPreview !== undefined
+                        ? helperPreview
+                        : undefined
+                    const claimAmount =
+                      claimEth !== undefined ? claimEth : claimable
+                    const claimUnit = claimEth !== undefined ? 'ETH' : 'WETH'
+                    const nothingToClaim = claimAmount <= 0
+                    return (
+                      <div className="p-4 sm:p-5 rounded-2xl bg-emerald-500/10 border border-emerald-500/30">
+                        <p className="text-emerald-200 text-sm">
+                          {isRefundVector
+                            ? 'No winner — everyone refunded'
+                            : winningIndex >= 0
+                            ? `Outcome #${winningIndex + 1} won`
+                            : 'Resolved'}
+                        </p>
+                        {nothingToClaim ? (
+                          <p className="text-white text-2xl font-bold mt-1">
+                            {claimed ? 'Claimed' : 'Nothing to claim'}
+                          </p>
+                        ) : (
+                          <>
+                            <p className="text-white text-2xl font-bold mt-1">
+                              {`${fmt(claimAmount)} ${claimUnit}`}
+                            </p>
+                            <div className="mt-3 flex items-center gap-3 flex-wrap">
+                              {validHelper ? (
+                                <StandardButton
+                                  onClick={
+                                    helperApproved
+                                      ? redeemViaHelper
+                                      : approveHelper
+                                  }
+                                  disabled={busy}
+                                  className="rounded-full"
+                                  backgroundColor="bg-moon-green"
+                                >
+                                  {helperApproved ? 'Claim' : 'Approve'}
+                                </StandardButton>
+                              ) : (
+                                <StandardButton
+                                  onClick={redeem}
+                                  disabled={busy}
+                                  className="rounded-full"
+                                  backgroundColor="bg-moon-green"
+                                >
+                                  Claim
+                                </StandardButton>
+                              )}
+                              {validHelper && (
+                                <button
+                                  onClick={redeem}
+                                  disabled={busy}
+                                  className="text-gray-400 hover:text-gray-200 text-xs underline disabled:opacity-50"
+                                >
+                                  WETH instead
+                                </button>
+                              )}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    )
+                  })()}
 
                 {/* M4: DePrizeRedeem helper plumbing — dev/testnet only. The
                     user-facing claim above already drives this; these raw
@@ -2023,7 +2079,7 @@ export default function DePrizePlay() {
       {/* Add funds modal */}
       {addFundsOpen && (
         <Modal id="deprize-add-funds" setEnabled={setAddFundsOpen} title="Add funds">
-          <div className="flex flex-col gap-4 w-full sm:w-[420px]">
+          <div className="flex flex-col gap-4 w-full">
             <p className="text-gray-300 text-sm">
               Add ETH to your betting balance. Your ETH is held on the market and
               you can cash out anytime.
@@ -2080,7 +2136,7 @@ export default function DePrizePlay() {
           setEnabled={(v) => !v && setBetIndex(null)}
           title={`Bet on Outcome #${betIndex + 1}`}
         >
-          <div className="flex flex-col gap-4 w-full sm:w-[420px]">
+          <div className="flex flex-col gap-4 w-full">
             <div className="flex items-center justify-between text-sm">
               <span className="text-gray-400">Chance to win</span>
               <span className="text-white font-semibold">

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -41,20 +41,12 @@ import StandardButton from '@/components/layout/StandardButton'
 import type { OddsSample } from '@/components/deprize/OddsHistoryChart'
 
 // Charting lib touches window; load it client-side only to avoid SSR mismatch.
-const OddsHistoryChart = dynamic(
-  () => import('@/components/deprize/OddsHistoryChart'),
-  { ssr: false }
-)
+const OddsHistoryChart = dynamic(() => import('@/components/deprize/OddsHistoryChart'), {
+  ssr: false,
+})
 
 // Per-outcome line colors (also used as accents elsewhere if needed).
-const OUTCOME_COLORS = [
-  '#22c55e',
-  '#3b82f6',
-  '#a855f7',
-  '#f59e0b',
-  '#ef4444',
-  '#06b6d4',
-]
+const OUTCOME_COLORS = ['#22c55e', '#3b82f6', '#a855f7', '#f59e0b', '#ef4444', '#06b6d4']
 
 // Don't record odds samples more often than this (live poll + post-trade
 // refreshes would otherwise spam near-identical points).
@@ -62,8 +54,7 @@ const ODDS_SAMPLE_MIN_MS = 8000
 const ODDS_HISTORY_MAX = 1000
 const ODDS_POLL_MS = 30000
 
-const ZERO_BYTES32 =
-  '0x0000000000000000000000000000000000000000000000000000000000000000'
+const ZERO_BYTES32 = '0x0000000000000000000000000000000000000000000000000000000000000000'
 const UNIT = 10n ** BigInt(COLLATERAL_DECIMALS)
 const MAX_UINT256 = (1n << 256n) - 1n
 
@@ -116,9 +107,7 @@ const releaseRead = () => {
     next()
   }
 }
-async function rpcRead<T = any>(
-  args: Parameters<typeof readContract>[0]
-): Promise<T> {
+async function rpcRead<T = any>(args: Parameters<typeof readContract>[0]): Promise<T> {
   await acquireRead()
   try {
     for (let attempt = 0; ; attempt++) {
@@ -127,9 +116,7 @@ async function rpcRead<T = any>(
       } catch (e: any) {
         const msg = `${e?.message ?? ''} ${e?.shortMessage ?? ''}`.toLowerCase()
         const rateLimited =
-          msg.includes('429') ||
-          msg.includes('too many requests') ||
-          msg.includes('-32005')
+          msg.includes('429') || msg.includes('too many requests') || msg.includes('-32005')
         if (rateLimited && attempt < 5) {
           await new Promise((r) => setTimeout(r, 350 * 2 ** attempt))
           continue
@@ -171,10 +158,7 @@ const fmt = (n: number, d = 4) =>
 const toWei = (v: string): bigint => {
   if (!v || Number(v) <= 0) return 0n
   const [whole, frac = ''] = v.split('.')
-  const fracPadded = (frac + '0'.repeat(COLLATERAL_DECIMALS)).slice(
-    0,
-    COLLATERAL_DECIMALS
-  )
+  const fracPadded = (frac + '0'.repeat(COLLATERAL_DECIMALS)).slice(0, COLLATERAL_DECIMALS)
   try {
     return BigInt(whole || '0') * UNIT + BigInt(fracPadded || '0')
   } catch {
@@ -244,11 +228,10 @@ export default function DePrizePlay() {
   // DePrizeRedeem helper testing (M4): the helper needs a deployed registry
   // with a DePrize bound to this market's condition; both are inputs so the
   // harness works the moment they're deployed (persisted per market).
-  const [helperAddress, setHelperAddress] = useState(
-    DEPRIZE_REDEEM_ADDRESSES[chainSlug] ?? ''
-  )
+  const [helperAddress, setHelperAddress] = useState(DEPRIZE_REDEEM_ADDRESSES[chainSlug] ?? '')
   const [helperDeprizeId, setHelperDeprizeId] = useState(String(DEPRIZE_PLAY_ID))
   const [helperPreview, setHelperPreview] = useState<number | undefined>()
+  const [helperPreviewWei, setHelperPreviewWei] = useState<bigint | undefined>()
   const [helperApproved, setHelperApproved] = useState<boolean | undefined>()
   // Bumped after a tx so reads that don't otherwise depend on changing state
   // (e.g. the helper previewRedeem) refetch. `claimed` flips once the wallet
@@ -266,9 +249,7 @@ export default function DePrizePlay() {
   // Modals
   const [addFundsOpen, setAddFundsOpen] = useState(false)
   const [betIndex, setBetIndex] = useState<number | null>(null)
-  const [betQuote, setBetQuote] = useState<{ qty: number; exact: boolean } | null>(
-    null
-  )
+  const [betQuote, setBetQuote] = useState<{ qty: number; exact: boolean } | null>(null)
 
   // Static-per-market values (conditionId, position ids, fee) never change, so
   // resolve them once and reuse — keeps every refresh to the dynamic reads.
@@ -334,10 +315,8 @@ export default function DePrizePlay() {
     abi: DePrizeRedeemABI as any,
   })
 
-  const isOracle =
-    !!userAddress && userAddress.toLowerCase() === ORACLE_ADDRESS.toLowerCase()
-  const isOperator =
-    !!userAddress && userAddress.toLowerCase() === OPERATOR_ADDRESS.toLowerCase()
+  const isOracle = !!userAddress && userAddress.toLowerCase() === ORACLE_ADDRESS.toLowerCase()
+  const isOperator = !!userAddress && userAddress.toLowerCase() === OPERATOR_ADDRESS.toLowerCase()
 
   const configured = !!lmsrAddress && !!ctfAddress && !!wethAddress
 
@@ -350,7 +329,7 @@ export default function DePrizePlay() {
   // accumulates over time even though there's no on-chain price series.
   const oddsStorageKey = useMemo(
     () => (lmsrAddress ? `deprize:oddsHistory:v1:${lmsrAddress}` : null),
-    [lmsrAddress]
+    [lmsrAddress],
   )
 
   useEffect(() => {
@@ -387,7 +366,7 @@ export default function DePrizePlay() {
         return next
       })
     },
-    [oddsStorageKey]
+    [oddsStorageKey],
   )
 
   const loadMarket = useCallback(async () => {
@@ -431,8 +410,7 @@ export default function DePrizePlay() {
       const { conditionId: cond, positionIds } = staticRef.current
 
       // 2) Dynamic data, concurrency-limited under the hood (rpcRead).
-      const [stg, prices, balances, wb, nb, approved, den, nums, mktFees] =
-        await Promise.all([
+      const [stg, prices, balances, wb, nb, approved, den, nums, mktFees] = await Promise.all([
         rpcRead({ contract: lmsr, method: 'stage' as string, params: [] })
           .then((v) => Number(v))
           .catch(() => undefined),
@@ -444,8 +422,8 @@ export default function DePrizePlay() {
               params: [i],
             })
               .then((p) => (Number(p as bigint) / 2 ** 64) * 100)
-              .catch(() => NaN)
-          )
+              .catch(() => NaN),
+          ),
         ),
         userAddress
           ? Promise.all(
@@ -456,8 +434,8 @@ export default function DePrizePlay() {
                   params: [userAddress, pid],
                 })
                   .then((b) => b as bigint)
-                  .catch(() => undefined)
-              )
+                  .catch(() => undefined),
+              ),
             )
           : Promise.resolve(positionIds.map(() => undefined)),
         userAddress
@@ -500,8 +478,8 @@ export default function DePrizePlay() {
               params: [cond, BigInt(i)],
             })
               .then((v) => v as bigint)
-              .catch(() => 0n)
-          )
+              .catch(() => 0n),
+          ),
         ),
         rpcRead({
           contract: weth,
@@ -536,13 +514,11 @@ export default function DePrizePlay() {
             balanceWei: balWei,
             positionId: pid,
           }
-        })
+        }),
       )
     } catch (err: any) {
       console.error('[deprize-play] loadMarket failed', err)
-      setLoadError(
-        err?.shortMessage || err?.message || 'Failed to read the market.'
-      )
+      setLoadError(err?.shortMessage || err?.message || 'Failed to read the market.')
     } finally {
       setLoading(false)
     }
@@ -572,8 +548,8 @@ export default function DePrizePlay() {
               params: [i],
             })
               .then((p) => (Number(p as bigint) / 2 ** 64) * 100)
-              .catch(() => NaN)
-          )
+              .catch(() => NaN),
+          ),
         )
         recordOddsSample(prices)
       } catch {
@@ -606,7 +582,7 @@ export default function DePrizePlay() {
     }
     if (resolvedSnapRef.current) return
     const finalOdds = Array.from({ length: MAX_OUTCOMES }, (_, i) =>
-      i < payoutNums.length ? (Number(payoutNums[i]) / Number(den)) * 100 : NaN
+      i < payoutNums.length ? (Number(payoutNums[i]) / Number(den)) * 100 : NaN,
     )
     recordOddsSample(finalOdds)
     resolvedSnapRef.current = true
@@ -640,10 +616,8 @@ export default function DePrizePlay() {
   // of it, so we track it client-side to show profit. Per market + wallet.
   const costStorageKey = useMemo(
     () =>
-      lmsrAddress && userAddress
-        ? `deprize:costBasis:v1:${lmsrAddress}:${userAddress}`
-        : null,
-    [lmsrAddress, userAddress]
+      lmsrAddress && userAddress ? `deprize:costBasis:v1:${lmsrAddress}:${userAddress}` : null,
+    [lmsrAddress, userAddress],
   )
 
   useEffect(() => {
@@ -669,7 +643,7 @@ export default function DePrizePlay() {
         }
       }
     },
-    [costStorageKey]
+    [costStorageKey],
   )
 
   const addCostBasis = useCallback(
@@ -683,7 +657,7 @@ export default function DePrizePlay() {
         return next
       })
     },
-    [persistCostBasis]
+    [persistCostBasis],
   )
 
   const resetCostBasis = useCallback(
@@ -694,7 +668,7 @@ export default function DePrizePlay() {
         return next
       })
     },
-    [persistCostBasis]
+    [persistCostBasis],
   )
 
   const clearCostBasis = useCallback(() => {
@@ -712,7 +686,7 @@ export default function DePrizePlay() {
   // Persist the harness inputs per market so they survive reloads.
   const helperStorageKey = useMemo(
     () => (lmsrAddress ? `deprize:redeemHelper:v1:${lmsrAddress}` : null),
-    [lmsrAddress]
+    [lmsrAddress],
   )
 
   useEffect(() => {
@@ -738,10 +712,7 @@ export default function DePrizePlay() {
   useEffect(() => {
     if (!helperStorageKey || typeof window === 'undefined') return
     try {
-      window.localStorage.setItem(
-        helperStorageKey,
-        JSON.stringify({ address: helperAddress })
-      )
+      window.localStorage.setItem(helperStorageKey, JSON.stringify({ address: helperAddress }))
     } catch {
       /* ignore */
     }
@@ -751,6 +722,7 @@ export default function DePrizePlay() {
   // whether the wallet has already granted it the CTF operator approval.
   useEffect(() => {
     setHelperPreview(undefined)
+    setHelperPreviewWei(undefined)
     setHelperApproved(undefined)
     if (!validHelper || !helper || !ctf || !userAddress) return
     const deprizeId = helperDeprizeId.trim()
@@ -770,8 +742,11 @@ export default function DePrizePlay() {
         }).catch(() => undefined),
       ])
       if (cancelled) return
+      setHelperPreviewWei(preview)
       setHelperPreview(
-        preview === undefined ? undefined : Number(preview) / Number(UNIT)
+        preview === undefined
+          ? undefined
+          : Number(preview / UNIT) + Number(preview % UNIT) / Number(UNIT),
       )
       setHelperApproved(approved)
     })()
@@ -779,7 +754,16 @@ export default function DePrizePlay() {
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [validHelper, helper, ctf, userAddress, helperAddress, helperDeprizeId, payoutDen, refreshNonce])
+  }, [
+    validHelper,
+    helper,
+    ctf,
+    userAddress,
+    helperAddress,
+    helperDeprizeId,
+    payoutDen,
+    refreshNonce,
+  ])
 
   // Sell-out quote: for each outcome the user holds, compute the ETH they'd
   // receive by selling their full position right now (calcNetCost with negative
@@ -792,9 +776,7 @@ export default function DePrizePlay() {
       setSellQuotes(new Map())
       return
     }
-    const held = outcomes.filter(
-      (o) => Number.isFinite(o.balance) && o.balance > 0
-    )
+    const held = outcomes.filter((o) => Number.isFinite(o.balance) && o.balance > 0)
     if (!held.length) {
       setSellQuotes(new Map())
       return
@@ -806,7 +788,7 @@ export default function DePrizePlay() {
           try {
             const balWei = BigInt(Math.floor(o.balance * 1e18))
             const amounts = Array.from({ length: MAX_OUTCOMES }, (_, j) =>
-              j === o.index ? -balWei : 0n
+              j === o.index ? -balWei : 0n,
             )
             const net = await rpcRead<bigint>({
               contract: lmsr,
@@ -817,12 +799,10 @@ export default function DePrizePlay() {
           } catch {
             return null
           }
-        })
+        }),
       )
       if (cancelled) return
-      setSellQuotes(
-        new Map(entries.filter((e): e is [number, number] => e !== null))
-      )
+      setSellQuotes(new Map(entries.filter((e): e is [number, number] => e !== null)))
     })()
     return () => {
       cancelled = true
@@ -833,16 +813,14 @@ export default function DePrizePlay() {
   // of collateral buy? calcNetCost is monotonic in quantity, so binary search.
   const lmsrNetCost = useCallback(
     async (index: number, qty: bigint) => {
-      const amounts = Array.from({ length: MAX_OUTCOMES }, (_, j) =>
-        j === index ? qty : 0n
-      )
+      const amounts = Array.from({ length: MAX_OUTCOMES }, (_, j) => (j === index ? qty : 0n))
       return await rpcRead<bigint>({
         contract: lmsr!,
         method: 'calcNetCost' as string,
         params: [amounts],
       })
     },
-    [lmsr]
+    [lmsr],
   )
 
   // How many outcome tokens does `targetWei` of collateral actually buy, given
@@ -870,7 +848,7 @@ export default function DePrizePlay() {
       }
       return lo
     },
-    [lmsr, lmsrNetCost]
+    [lmsr, lmsrNetCost],
   )
 
   // Live payout for the open Bet modal: the REAL, price-impact-aware amount from
@@ -932,7 +910,7 @@ export default function DePrizePlay() {
         }
       }
     },
-    [account]
+    [account],
   )
 
   const addWethToWallet = async () => {
@@ -972,13 +950,12 @@ export default function DePrizePlay() {
           method: 'deposit' as string,
           params: [],
           value: depositAmountWei,
-        })
+        }),
       )
       toast.dismiss('wrap')
-      toast.success(
-        `Added ${fmt(Number(depositAmountWei) / Number(UNIT))} ETH to your balance.`,
-        { style: toastStyle }
-      )
+      toast.success(`Added ${fmt(Number(depositAmountWei) / Number(UNIT))} ETH to your balance.`, {
+        style: toastStyle,
+      })
       setAddFundsOpen(false)
       refreshSoon()
     } catch (err: any) {
@@ -1011,9 +988,7 @@ export default function DePrizePlay() {
     try {
       const qty = await quoteQtyForCost(index, betAmountWei)
       if (qty <= 0n) throw new Error('Bet too small for this market.')
-      const amounts = Array.from({ length: MAX_OUTCOMES }, (_, i) =>
-        i === index ? qty : 0n
-      )
+      const amounts = Array.from({ length: MAX_OUTCOMES }, (_, i) => (i === index ? qty : 0n))
       const net = await rpcRead<bigint>({
         contract: lmsr,
         method: 'calcNetCost' as string,
@@ -1043,13 +1018,12 @@ export default function DePrizePlay() {
         const toWrap = buffered - balWei
         const nativeWei = await eth_getBalance(
           getRpcClient({ client: readClient, chain: readChain }),
-          { address: account.address }
+          { address: account.address },
         )
         if (nativeWei < toWrap + GAS_RESERVE_WEI) {
-          toast.error(
-            'Not enough ETH for this bet (including gas). Try a smaller amount.',
-            { style: toastStyle }
-          )
+          toast.error('Not enough ETH for this bet (including gas). Try a smaller amount.', {
+            style: toastStyle,
+          })
           return
         }
         toast.loading('Wrapping ETH…', { id: 'wrap', style: toastStyle })
@@ -1059,7 +1033,7 @@ export default function DePrizePlay() {
             method: 'deposit' as string,
             params: [],
             value: toWrap,
-          })
+          }),
         )
         toast.dismiss('wrap')
         balWei += toWrap
@@ -1083,7 +1057,7 @@ export default function DePrizePlay() {
             contract: wethW,
             method: 'approve' as string,
             params: [lmsrAddress, MAX_UINT256],
-          })
+          }),
         )
         toast.dismiss('approve')
       }
@@ -1094,7 +1068,7 @@ export default function DePrizePlay() {
           contract: lmsrW,
           method: 'trade' as string,
           params: [amounts, limit],
-        })
+        }),
       )
       toast.dismiss('trade')
       const qtyNum = Number(qty) / Number(UNIT)
@@ -1104,7 +1078,7 @@ export default function DePrizePlay() {
         `Bet ${fmt(Number(cost) / Number(UNIT))} ETH on outcome #${
           index + 1
         }. To win ≈ ${fmt(qtyNum)} ETH if it happens.`,
-        { style: toastStyle, duration: 8000 }
+        { style: toastStyle, duration: 8000 },
       )
       setBetIndex(null)
       refreshSoon()
@@ -1146,14 +1120,12 @@ export default function DePrizePlay() {
             contract: ctfW,
             method: 'setApprovalForAll' as string,
             params: [lmsrAddress, true],
-          })
+          }),
         )
         toast.dismiss('approve')
       }
 
-      const amounts = Array.from({ length: MAX_OUTCOMES }, (_, i) =>
-        i === index ? -bal : 0n
-      )
+      const amounts = Array.from({ length: MAX_OUTCOMES }, (_, i) => (i === index ? -bal : 0n))
       const net = await rpcRead<bigint>({
         contract: lmsr,
         method: 'calcNetCost' as string,
@@ -1167,15 +1139,13 @@ export default function DePrizePlay() {
           contract: lmsrW,
           method: 'trade' as string,
           params: [amounts, limit],
-        })
+        }),
       )
       toast.dismiss('sell')
       resetCostBasis(index)
       toast.success(
-        `Cashed out outcome #${index + 1} for ≈ ${fmt(
-          Number(-net) / Number(UNIT)
-        )} ETH.`,
-        { style: toastStyle }
+        `Cashed out outcome #${index + 1} for ≈ ${fmt(Number(-net) / Number(UNIT))} ETH.`,
+        { style: toastStyle },
       )
       refreshSoon()
     } catch (err: any) {
@@ -1195,15 +1165,13 @@ export default function DePrizePlay() {
     if (!account || !ctf || !conditionId) return
     setBusy(true)
     try {
-      const indexSets = Array.from({ length: MAX_OUTCOMES }, (_, i) =>
-        BigInt(1 << i)
-      )
+      const indexSets = Array.from({ length: MAX_OUTCOMES }, (_, i) => BigInt(1 << i))
       await sendTx(
         prepareContractCall({
           contract: ctfW,
           method: 'redeemPositions' as string,
           params: [wethAddress, ZERO_BYTES32, conditionId, indexSets],
-        })
+        }),
       )
       clearCostBasis()
       setClaimed(true)
@@ -1232,7 +1200,7 @@ export default function DePrizePlay() {
           contract: lmsrW,
           method: method as string,
           params: [],
-        })
+        }),
       )
       toast.success(doneMsg, { style: toastStyle })
       refreshSoon()
@@ -1269,7 +1237,7 @@ export default function DePrizePlay() {
       })
       if (computed.toLowerCase() !== marketConditionId.toLowerCase()) {
         throw new Error(
-          `Pre-flight: conditionId mismatch — keccak(yourAddress, questionId, ${MAX_OUTCOMES}) != the market's condition. Check the question id and that you are the oracle.`
+          `Pre-flight: conditionId mismatch — keccak(yourAddress, questionId, ${MAX_OUTCOMES}) != the market's condition. Check the question id and that you are the oracle.`,
         )
       }
       // Re-read the gating state fresh on-chain rather than trusting the
@@ -1289,14 +1257,11 @@ export default function DePrizePlay() {
           contract: lmsr,
           method: 'stage' as string,
           params: [],
-        })
+        }),
       )
-      if (
-        freshStage !== MarketStage.Paused &&
-        freshStage !== MarketStage.Closed
-      ) {
+      if (freshStage !== MarketStage.Paused && freshStage !== MarketStage.Closed) {
         throw new Error(
-          'Pre-flight: pause or close the market first — resolving a live market gives away free trades against the known outcome.'
+          'Pre-flight: pause or close the market first — resolving a live market gives away free trades against the known outcome.',
         )
       }
       await sendTx(
@@ -1304,7 +1269,7 @@ export default function DePrizePlay() {
           contract: ctfW,
           method: 'reportPayouts' as string,
           params: [questionId, payouts],
-        })
+        }),
       )
       toast.success(`Resolved: ${label}.`, { style: toastStyle })
       refreshSoon()
@@ -1320,17 +1285,15 @@ export default function DePrizePlay() {
 
   const resolveWinner = (winningIndex: number) =>
     resolve(
-      Array.from({ length: MAX_OUTCOMES }, (_, i) =>
-        i === winningIndex ? 1n : 0n
-      ),
-      `outcome #${winningIndex + 1} wins`
+      Array.from({ length: MAX_OUTCOMES }, (_, i) => (i === winningIndex ? 1n : 0n)),
+      `outcome #${winningIndex + 1} wins`,
     )
 
   // M4b: terminal no-winner/cancelled — every outcome token refunds 1/N.
   const resolveNoWinner = () =>
     resolve(
       Array.from({ length: MAX_OUTCOMES }, () => 1n),
-      `no winner — every position refunds 1/${MAX_OUTCOMES}`
+      `no winner — every position refunds 1/${MAX_OUTCOMES}`,
     )
 
   // ---- DePrizeRedeem helper actions (M4a) ----
@@ -1343,7 +1306,7 @@ export default function DePrizePlay() {
           contract: ctfW,
           method: 'setApprovalForAll' as string,
           params: [helperAddress, true],
-        })
+        }),
       )
       setHelperApproved(true)
       toast.success('Helper approved to pull your outcome tokens.', {
@@ -1374,7 +1337,7 @@ export default function DePrizePlay() {
           contract: helperW,
           method: 'redeem' as string,
           params: [BigInt(deprizeId)],
-        })
+        }),
       )
       toast.dismiss('helper')
       clearCostBasis()
@@ -1384,7 +1347,7 @@ export default function DePrizePlay() {
         helperPreview !== undefined
           ? `Redeemed ≈ ${fmt(helperPreview)} ETH via DePrizeRedeem.`
           : 'Redeemed via DePrizeRedeem.',
-        { style: toastStyle, duration: 8000 }
+        { style: toastStyle, duration: 8000 },
       )
       refreshSoon()
     } catch (err: any) {
@@ -1403,14 +1366,13 @@ export default function DePrizePlay() {
   // The LMSR only accepts trades in the Running stage, so buying and selling
   // (cash out) must be blocked whenever the market is Paused or Closed —
   // otherwise the on-chain trade just reverts.
-  const isTradingHalted =
-    stage !== undefined && stage !== MarketStage.Running
+  const isTradingHalted = stage !== undefined && stage !== MarketStage.Running
   const tradingHaltLabel =
     stage === MarketStage.Paused
       ? 'Market paused'
       : stage === MarketStage.Closed
-      ? 'Market closed'
-      : ''
+        ? 'Market closed'
+        : ''
   // CTF-level resolution is what actually gates redemption (market stage is
   // only the trading state). claimable = what the connected wallet's positions
   // redeem for under the reported payout vector (mirrors previewRedeem).
@@ -1418,8 +1380,7 @@ export default function DePrizePlay() {
   const winningIndex = resolved
     ? payoutNums.findIndex((n, _, arr) => n > 0n && arr.filter((x) => x > 0n).length === 1)
     : -1
-  const isRefundVector =
-    resolved && payoutNums.length > 0 && payoutNums.every((n) => n > 0n)
+  const isRefundVector = resolved && payoutNums.length > 0 && payoutNums.every((n) => n > 0n)
   const claimable = resolved
     ? outcomes.reduce((acc, o, i) => {
         // Use the exact wei balance and mirror previewRedeem's per-position
@@ -1432,11 +1393,9 @@ export default function DePrizePlay() {
     : 0
   // Spendable = already-wrapped WETH + native ETH (we auto-wrap at bet time),
   // holding a little native back for gas.
-  const spendable =
-    (wethBalance ?? 0) + Math.max(0, (nativeBalance ?? 0) - GAS_RESERVE_ETH)
+  const spendable = (wethBalance ?? 0) + Math.max(0, (nativeBalance ?? 0) - GAS_RESERVE_ETH)
   const balanceKnown = wethBalance !== undefined || nativeBalance !== undefined
-  const insufficient =
-    balanceKnown && betAmountNum > 0 && betAmountNum > spendable + 1e-12
+  const insufficient = balanceKnown && betAmountNum > 0 && betAmountNum > spendable + 1e-12
   const betOutcome = betIndex !== null ? outcomes[betIndex] : undefined
   const betMult = betQuote && betAmountNum > 0 ? betQuote.qty / betAmountNum : undefined
 
@@ -1462,10 +1421,9 @@ export default function DePrizePlay() {
             {!configured ? (
               <div className="p-5 rounded-2xl bg-red-500/10 border border-red-500/30 text-red-200 text-sm">
                 No market is configured for the current chain (
-                <span className="font-mono">{chainSlug}</span>). This harness
-                targets the testnet deployments (sepolia / arbitrum-sepolia). Set{' '}
-                <span className="font-mono">NEXT_PUBLIC_TEST_CHAIN</span> and
-                reload.
+                <span className="font-mono">{chainSlug}</span>). This harness targets the testnet
+                deployments (sepolia / arbitrum-sepolia). Set{' '}
+                <span className="font-mono">NEXT_PUBLIC_TEST_CHAIN</span> and reload.
               </div>
             ) : (
               <>
@@ -1490,20 +1448,16 @@ export default function DePrizePlay() {
                     </div>
                     <div>
                       <p className="text-gray-400 text-xs">Resolution</p>
-                      <p
-                        className={`text-sm ${
-                          resolved ? 'text-moon-green' : 'text-white'
-                        }`}
-                      >
+                      <p className={`text-sm ${resolved ? 'text-moon-green' : 'text-white'}`}>
                         {payoutDen === undefined
                           ? '—'
                           : !resolved
-                          ? 'Unresolved'
-                          : isRefundVector
-                          ? `Refund 1/${MAX_OUTCOMES}`
-                          : winningIndex >= 0
-                          ? `#${winningIndex + 1} won`
-                          : `[${payoutNums.map((n) => n.toString()).join(',')}]`}
+                            ? 'Unresolved'
+                            : isRefundVector
+                              ? `Refund 1/${MAX_OUTCOMES}`
+                              : winningIndex >= 0
+                                ? `#${winningIndex + 1} won`
+                                : `[${payoutNums.map((n) => n.toString()).join(',')}]`}
                       </p>
                     </div>
                     <StandardButton
@@ -1542,9 +1496,7 @@ export default function DePrizePlay() {
                       <p className="text-gray-400 text-xs">Your balance</p>
                       <p className="text-white text-2xl font-bold leading-tight">
                         {balanceKnown ? fmt(spendable) : '—'}{' '}
-                        <span className="text-base font-medium text-gray-400">
-                          ETH
-                        </span>
+                        <span className="text-base font-medium text-gray-400">ETH</span>
                       </p>
                       <p className="text-gray-500 text-[11px] mt-0.5">
                         Bet with ETH directly — we wrap it automatically.
@@ -1573,8 +1525,8 @@ export default function DePrizePlay() {
                 {/* Load error (non-fatal) */}
                 {loadError && (
                   <div className="p-3 rounded-xl bg-red-500/10 border border-red-500/30 text-red-200 text-xs break-words">
-                    Couldn't fully load market data: {loadError}. You can still
-                    try to trade, or hit Refresh.
+                    Couldn't fully load market data: {loadError}. You can still try to trade, or hit
+                    Refresh.
                   </div>
                 )}
 
@@ -1583,9 +1535,7 @@ export default function DePrizePlay() {
                   <div className="flex items-center justify-between gap-3 flex-wrap mb-3">
                     <div>
                       <p className="text-white font-semibold">Live odds</p>
-                      <p className="text-gray-500 text-xs">
-                        Implied chance over time
-                      </p>
+                      <p className="text-gray-500 text-xs">Implied chance over time</p>
                     </div>
                     <div className="flex items-center gap-3 flex-wrap">
                       {outcomes.map((o) => (
@@ -1593,15 +1543,12 @@ export default function DePrizePlay() {
                           <span
                             className="inline-block w-2.5 h-2.5 rounded-full"
                             style={{
-                              background:
-                                OUTCOME_COLORS[o.index % OUTCOME_COLORS.length],
+                              background: OUTCOME_COLORS[o.index % OUTCOME_COLORS.length],
                             }}
                           />
                           <span className="text-gray-300 text-xs">
                             #{o.index + 1}
-                            {Number.isNaN(o.probability)
-                              ? ''
-                              : ` · ${fmt(o.probability, 0)}%`}
+                            {Number.isNaN(o.probability) ? '' : ` · ${fmt(o.probability, 0)}%`}
                           </span>
                         </div>
                       ))}
@@ -1629,10 +1576,8 @@ export default function DePrizePlay() {
                       o.balanceWei !== undefined &&
                       payoutDen !== undefined &&
                       payoutDen > 0n
-                        ? Number(
-                            (o.balanceWei * (payoutNums[o.index] ?? 0n)) /
-                              payoutDen
-                          ) / Number(UNIT)
+                        ? Number((o.balanceWei * (payoutNums[o.index] ?? 0n)) / payoutDen) /
+                          Number(UNIT)
                         : undefined
                     const isWinningSlot = resolved && o.index === winningIndex
                     // Final value if resolved, otherwise the live sell quote.
@@ -1660,8 +1605,8 @@ export default function DePrizePlay() {
                                     ? isWinningSlot
                                       ? 'text-moon-green'
                                       : isRefundVector
-                                      ? 'text-white'
-                                      : 'text-gray-500'
+                                        ? 'text-white'
+                                        : 'text-gray-500'
                                     : 'text-white'
                                 }`}
                               >
@@ -1669,26 +1614,22 @@ export default function DePrizePlay() {
                                   ? isWinningSlot
                                     ? 'WON'
                                     : isRefundVector
-                                    ? 'Refund'
-                                    : 'Lost'
+                                      ? 'Refund'
+                                      : 'Lost'
                                   : Number.isNaN(o.probability)
-                                  ? loading
-                                    ? '…'
-                                    : '—'
-                                  : `${fmt(o.probability, 0)}%`}
+                                    ? loading
+                                      ? '…'
+                                      : '—'
+                                    : `${fmt(o.probability, 0)}%`}
                               </p>
                               {!resolved && (
-                                <p className="text-gray-500 text-[10px] mt-1">
-                                  chance
-                                </p>
+                                <p className="text-gray-500 text-[10px] mt-1">chance</p>
                               )}
                             </div>
                           </div>
 
                           <div className="flex-1 min-w-[130px]">
-                            <p className="text-white font-semibold">
-                              Outcome #{o.index + 1}
-                            </p>
+                            <p className="text-white font-semibold">Outcome #{o.index + 1}</p>
                           </div>
 
                           <div className="flex items-center gap-2 flex-wrap">
@@ -1738,17 +1679,15 @@ export default function DePrizePlay() {
                                     ? `${fmt(redeemValue)} ETH`
                                     : '—'
                                   : isTradingHalted
-                                  ? '—'
-                                  : valueNow !== undefined
-                                  ? `${fmt(valueNow)} ETH`
-                                  : '…'}
+                                    ? '—'
+                                    : valueNow !== undefined
+                                      ? `${fmt(valueNow)} ETH`
+                                      : '…'}
                               </p>
                             </div>
                             {!resolved && (
                               <div className="rounded-xl bg-black/30 border border-white/10 px-3 py-2">
-                                <p className="text-[10px] text-gray-500">
-                                  If this wins
-                                </p>
+                                <p className="text-[10px] text-gray-500">If this wins</p>
                                 <p className="text-sm font-semibold text-moon-green">
                                   {fmt(o.balance)} ETH
                                 </p>
@@ -1761,13 +1700,11 @@ export default function DePrizePlay() {
                                   pnl === undefined
                                     ? 'text-gray-400'
                                     : pnl >= 0
-                                    ? 'text-moon-green'
-                                    : 'text-red-400'
+                                      ? 'text-moon-green'
+                                      : 'text-red-400'
                                 }`}
                               >
-                                {pnl === undefined
-                                  ? '—'
-                                  : `${pnl >= 0 ? '+' : ''}${fmt(pnl)} ETH`}
+                                {pnl === undefined ? '—' : `${pnl >= 0 ? '+' : ''}${fmt(pnl)} ETH`}
                               </p>
                             </div>
                           </div>
@@ -1788,9 +1725,8 @@ export default function DePrizePlay() {
                       validHelper && helperPreview !== undefined && helperPreview > 0
                         ? helperPreview
                         : undefined
-                    const claimAmount =
-                      claimEth !== undefined ? claimEth : claimable
-                    const claimUnit = claimEth !== undefined ? 'ETH' : 'WETH'
+                    const claimAmount = claimEth !== undefined ? claimEth : claimable
+                    const claimUnit = validHelper ? 'ETH' : 'WETH'
                     const nothingToClaim = claimAmount <= 0
                     return (
                       <div className="p-4 sm:p-5 rounded-2xl bg-emerald-500/10 border border-emerald-500/30">
@@ -1798,8 +1734,8 @@ export default function DePrizePlay() {
                           {isRefundVector
                             ? 'No winner — everyone refunded'
                             : winningIndex >= 0
-                            ? `Outcome #${winningIndex + 1} won`
-                            : 'Resolved'}
+                              ? `Outcome #${winningIndex + 1} won`
+                              : 'Resolved'}
                         </p>
                         {nothingToClaim || claimed ? (
                           <p className="text-white text-2xl font-bold mt-1">
@@ -1813,11 +1749,7 @@ export default function DePrizePlay() {
                             <div className="mt-3 flex items-center gap-3 flex-wrap">
                               {validHelper ? (
                                 <StandardButton
-                                  onClick={
-                                    helperApproved
-                                      ? redeemViaHelper
-                                      : approveHelper
-                                  }
+                                  onClick={helperApproved ? redeemViaHelper : approveHelper}
                                   disabled={busy}
                                   className="rounded-full"
                                   backgroundColor="bg-moon-green"
@@ -1862,16 +1794,13 @@ export default function DePrizePlay() {
                       </span>
                     </summary>
                     <p className="text-gray-500 text-xs mt-3">
-                      Needs the deployed helper + a DePrizeRegistry entry whose
-                      condition matches this market. Approve once, then redeem —
-                      the helper pulls your tokens, redeems on the CTF, unwraps
-                      and pays you ETH in one transaction.
+                      Needs the deployed helper + a DePrizeRegistry entry whose condition matches
+                      this market. Approve once, then redeem — the helper pulls your tokens, redeems
+                      on the CTF, unwraps and pays you ETH in one transaction.
                     </p>
                     <div className="mt-3 grid sm:grid-cols-[1fr_120px] gap-2">
                       <div>
-                        <label className="text-xs text-gray-400">
-                          Helper address
-                        </label>
+                        <label className="text-xs text-gray-400">Helper address</label>
                         <input
                           type="text"
                           value={helperAddress}
@@ -1892,9 +1821,7 @@ export default function DePrizePlay() {
                       </div>
                     </div>
                     {helperAddress && !validHelper && (
-                      <p className="text-amber-300 text-xs mt-2">
-                        Not a valid address.
-                      </p>
+                      <p className="text-amber-300 text-xs mt-2">Not a valid address.</p>
                     )}
                     {validHelper && (
                       <div className="mt-3 flex items-center justify-between gap-3 flex-wrap">
@@ -1902,9 +1829,7 @@ export default function DePrizePlay() {
                           <p className="text-gray-400">
                             previewRedeem:{' '}
                             <span className="text-white font-semibold">
-                              {helperPreview === undefined
-                                ? '—'
-                                : `${fmt(helperPreview)} ETH`}
+                              {helperPreview === undefined ? '—' : `${fmt(helperPreview)} ETH`}
                             </span>
                             {helperPreview === 0 && !resolved && (
                               <span className="text-gray-500">
@@ -1918,8 +1843,8 @@ export default function DePrizePlay() {
                             {helperApproved === undefined
                               ? '—'
                               : helperApproved
-                              ? 'granted'
-                              : 'not granted'}
+                                ? 'granted'
+                                : 'not granted'}
                           </p>
                         </div>
                         <div className="flex items-center gap-2 flex-wrap">
@@ -1960,8 +1885,8 @@ export default function DePrizePlay() {
                     {isOracle && (
                       <div className="mb-4">
                         <p className="text-gray-400 text-[11px] mb-2">
-                          Market unwind (owner): pause before resolving, close +
-                          withdraw fees after.
+                          Market unwind (owner): pause before resolving, close + withdraw fees
+                          after.
                         </p>
                         <div className="flex items-center gap-2 flex-wrap">
                           <StandardButton
@@ -1982,10 +1907,7 @@ export default function DePrizePlay() {
                           </StandardButton>
                           <StandardButton
                             onClick={() =>
-                              marketAdmin(
-                                'close',
-                                'Market closed — inventory returned to owner.'
-                              )
+                              marketAdmin('close', 'Market closed — inventory returned to owner.')
                             }
                             disabled={busy || isClosed}
                             className="rounded-full"
@@ -1993,32 +1915,27 @@ export default function DePrizePlay() {
                           >
                             Close market
                           </StandardButton>
-                        <StandardButton
-                          onClick={() =>
-                            marketAdmin('withdrawFees', 'Fees withdrawn to owner.')
-                          }
-                          disabled={busy || !isClosed}
-                          className="rounded-full"
-                          backgroundColor="bg-white/10"
-                        >
-                          {marketFeesWei !== undefined
-                            ? `Withdraw fees (${fmt(
-                                Number(marketFeesWei) / Number(UNIT),
-                                4
-                              )} WETH)`
-                            : 'Withdraw fees'}
-                        </StandardButton>
+                          <StandardButton
+                            onClick={() => marketAdmin('withdrawFees', 'Fees withdrawn to owner.')}
+                            disabled={busy || !isClosed}
+                            className="rounded-full"
+                            backgroundColor="bg-white/10"
+                          >
+                            {marketFeesWei !== undefined
+                              ? `Withdraw fees (${fmt(
+                                  Number(marketFeesWei) / Number(UNIT),
+                                  4,
+                                )} WETH)`
+                              : 'Withdraw fees'}
+                          </StandardButton>
                         </div>
                         <p className="text-gray-500 text-[11px] mt-2">
                           Withdrawable now:{' '}
                           {marketFeesWei !== undefined
-                            ? `${fmt(
-                                Number(marketFeesWei) / Number(UNIT),
-                                6
-                              )} WETH`
+                            ? `${fmt(Number(marketFeesWei) / Number(UNIT), 6)} WETH`
                             : '—'}{' '}
-                          (the market's full collateral balance; close the market
-                          first to also reclaim seed liquidity).
+                          (the market's full collateral balance; close the market first to also
+                          reclaim seed liquidity).
                         </p>
                       </div>
                     )}
@@ -2027,10 +1944,9 @@ export default function DePrizePlay() {
                     {isOracle && (
                       <div>
                         <p className="text-gray-400 text-[11px] mb-2">
-                          Resolution (oracle, one-shot): the market must be
-                          paused/closed first; conditionId is recomputed from
-                          (you, questionId, {MAX_OUTCOMES}) and must match the
-                          market before anything is sent.
+                          Resolution (oracle, one-shot): the market must be paused/closed first;
+                          conditionId is recomputed from (you, questionId, {MAX_OUTCOMES}) and must
+                          match the market before anything is sent.
                         </p>
                         <label className="text-xs text-gray-400">questionId</label>
                         <input
@@ -2081,8 +1997,8 @@ export default function DePrizePlay() {
         <Modal id="deprize-add-funds" setEnabled={setAddFundsOpen} title="Add funds">
           <div className="flex flex-col gap-4 w-full">
             <p className="text-gray-300 text-sm">
-              Add ETH to your betting balance. Your ETH is held on the market and
-              you can cash out anytime.
+              Add ETH to your betting balance. Your ETH is held on the market and you can cash out
+              anytime.
             </p>
             <div className="flex items-center justify-between text-sm">
               <span className="text-gray-400">Current balance</span>
@@ -2122,8 +2038,8 @@ export default function DePrizePlay() {
               {busy ? 'Adding…' : 'Add funds'}
             </StandardButton>
             <p className="text-gray-500 text-[11px]">
-              On Sepolia? Grab free test ETH from a faucet (e.g.
-              sepoliafaucet.com), then add it here.
+              On Sepolia? Grab free test ETH from a faucet (e.g. sepoliafaucet.com), then add it
+              here.
             </p>
           </div>
         </Modal>
@@ -2146,9 +2062,7 @@ export default function DePrizePlay() {
               </span>
             </div>
             <div>
-              <label className="text-xs text-gray-400">
-                How much do you want to bet? (ETH)
-              </label>
+              <label className="text-xs text-gray-400">How much do you want to bet? (ETH)</label>
               <input
                 type="number"
                 min="0"
@@ -2171,9 +2085,7 @@ export default function DePrizePlay() {
                 ))}
                 {spendable > 0 && (
                   <button
-                    onClick={() =>
-                      setBetAmount(String(Math.floor(spendable * 1e6) / 1e6))
-                    }
+                    onClick={() => setBetAmount(String(Math.floor(spendable * 1e6) / 1e6))}
                     className="px-3 py-1 rounded-full bg-white/5 hover:bg-white/10 text-gray-300 text-xs"
                   >
                     Max ({fmt(spendable)})
@@ -2188,9 +2100,7 @@ export default function DePrizePlay() {
                 {betQuote ? (
                   <>
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-400 text-sm">
-                        To win if it happens
-                      </span>
+                      <span className="text-gray-400 text-sm">To win if it happens</span>
                       <span className="text-moon-green text-lg font-bold">
                         ≈ {fmt(betQuote.qty)} ETH
                       </span>
@@ -2214,8 +2124,8 @@ export default function DePrizePlay() {
             {insufficient ? (
               <div className="flex flex-col gap-2">
                 <p className="text-amber-300 text-sm">
-                  You only have ≈ {fmt(spendable)} ETH available to bet (a little
-                  is kept back for gas). Add more ETH or lower your bet.
+                  You only have ≈ {fmt(spendable)} ETH available to bet (a little is kept back for
+                  gas). Add more ETH or lower your bet.
                 </p>
                 <StandardButton
                   onClick={() => {
@@ -2238,10 +2148,10 @@ export default function DePrizePlay() {
                 {busy
                   ? 'Placing bet…'
                   : isTradingHalted
-                  ? tradingHaltLabel
-                  : betAmountNum > 0
-                  ? `Bet ${fmt(betAmountNum)} ETH`
-                  : 'Enter an amount'}
+                    ? tradingHaltLabel
+                    : betAmountNum > 0
+                      ? `Bet ${fmt(betAmountNum)} ETH`
+                      : 'Enter an amount'}
               </StandardButton>
             )}
           </div>

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -230,6 +230,10 @@ export default function DePrizePlay() {
   const [conditionId, setConditionId] = useState<string | undefined>()
   const [stage, setStage] = useState<number | undefined>()
   const [feePct, setFeePct] = useState<number | undefined>()
+  // Collateral (WETH) the market currently holds — this is exactly what
+  // withdrawFees() pays out to the owner (MarketMaker.withdrawFees transfers
+  // collateralToken.balanceOf(market)).
+  const [marketFeesWei, setMarketFeesWei] = useState<bigint | undefined>()
   // CTF resolution state (M4): 0 denominator = unresolved; afterwards the
   // payout vector determines what each held outcome token redeems for.
   const [payoutDen, setPayoutDen] = useState<bigint | undefined>()
@@ -420,7 +424,8 @@ export default function DePrizePlay() {
       const { conditionId: cond, positionIds } = staticRef.current
 
       // 2) Dynamic data, concurrency-limited under the hood (rpcRead).
-      const [stg, prices, balances, wb, nb, approved, den, nums] = await Promise.all([
+      const [stg, prices, balances, wb, nb, approved, den, nums, mktFees] =
+        await Promise.all([
         rpcRead({ contract: lmsr, method: 'stage' as string, params: [] })
           .then((v) => Number(v))
           .catch(() => undefined),
@@ -491,6 +496,13 @@ export default function DePrizePlay() {
               .catch(() => 0n)
           )
         ),
+        rpcRead({
+          contract: weth,
+          method: 'balanceOf' as string,
+          params: [lmsrAddress],
+        })
+          .then((v) => v as bigint)
+          .catch(() => undefined),
       ])
 
       setStage(stg)
@@ -499,13 +511,20 @@ export default function DePrizePlay() {
       setCtfApproved(approved)
       setPayoutDen(den)
       setPayoutNums(nums)
-      recordOddsSample(prices as number[])
+      setMarketFeesWei(mktFees)
+      // close() sweeps the AMM's outcome inventory to the owner, after which
+      // calcMarginalPrice returns a meaningless uniform 1/N. Prices stay valid
+      // while Paused (inventory is untouched), so only blank them once Closed;
+      // on a Closed market the real "odds" are the reported payout vector shown
+      // in the resolution UI. Only append chart samples while actively trading.
+      const pricesValid = stg !== MarketStage.Closed
+      if (stg === MarketStage.Running) recordOddsSample(prices as number[])
       setOutcomes(
         positionIds.map((pid, i) => {
           const balWei = balances[i] as bigint | undefined
           return {
             index: i,
-            probability: prices[i],
+            probability: pricesValid ? (prices[i] as number) : NaN,
             balance: balWei !== undefined ? Number(balWei) / Number(UNIT) : NaN,
             balanceWei: balWei,
             positionId: pid,
@@ -530,7 +549,10 @@ export default function DePrizePlay() {
   // timer (no spinner, no balance reads) so the chart keeps ticking while the
   // page is open. Pauses when the tab is hidden to avoid wasting RPC.
   useEffect(() => {
-    if (!lmsr) return
+    // Marginal prices are only meaningful odds while the market is Running;
+    // once Paused/Closed they don't move (or reset to a uniform 1/N on close),
+    // so stop polling rather than flat-lining or corrupting the chart.
+    if (!lmsr || stage !== MarketStage.Running) return
     let stopped = false
     const tick = async () => {
       if (stopped || (typeof document !== 'undefined' && document.hidden)) return
@@ -556,7 +578,27 @@ export default function DePrizePlay() {
       stopped = true
       clearInterval(id)
     }
-  }, [lmsr, recordOddsSample])
+  }, [lmsr, stage, recordOddsSample])
+
+  // When the oracle resolves (reportPayouts), the "real" odds collapse to the
+  // payout vector: the winner -> 100%, losers -> 0% (or an equal split on a
+  // no-winner refund). Append that as a final chart point so the graph snaps to
+  // the outcome. Closing alone does NOT do this — only resolution declares a
+  // winner. Fires once per resolution.
+  const resolvedSnapRef = useRef(false)
+  useEffect(() => {
+    const den = payoutDen
+    if (den === undefined || den <= 0n) {
+      resolvedSnapRef.current = false
+      return
+    }
+    if (resolvedSnapRef.current) return
+    const finalOdds = Array.from({ length: MAX_OUTCOMES }, (_, i) =>
+      i < payoutNums.length ? (Number(payoutNums[i]) / Number(den)) * 100 : NaN
+    )
+    recordOddsSample(finalOdds)
+    resolvedSnapRef.current = true
+  }, [payoutNums, payoutDen, recordOddsSample])
 
   // The just-mined block can lag the RPC briefly; refresh now and once more
   // shortly after so balances/odds reflect the tx without a manual refresh.
@@ -649,14 +691,16 @@ export default function DePrizePlay() {
     try {
       const raw = window.localStorage.getItem(helperStorageKey)
       if (raw) {
-        const saved = JSON.parse(raw) as { address?: string; deprizeId?: string }
+        const saved = JSON.parse(raw) as { address?: string }
         if (saved.address) setHelperAddress(saved.address)
-        if (saved.deprizeId) setHelperDeprizeId(saved.deprizeId)
       } else {
         const slug = getChainSlug(chain)
         setHelperAddress(DEPRIZE_REDEEM_ADDRESSES[slug] ?? '')
-        setHelperDeprizeId('1')
       }
+      // The play market is bound to a fixed registry DePrize, so always drive the
+      // helper from config rather than a (possibly stale) saved id — otherwise
+      // previewRedeem reads the wrong DePrize and shows 0.
+      setHelperDeprizeId(String(DEPRIZE_PLAY_ID))
     } catch {
       /* ignore */
     }
@@ -667,7 +711,7 @@ export default function DePrizePlay() {
     try {
       window.localStorage.setItem(
         helperStorageKey,
-        JSON.stringify({ address: helperAddress, deprizeId: helperDeprizeId })
+        JSON.stringify({ address: helperAddress })
       )
     } catch {
       /* ignore */
@@ -712,7 +756,13 @@ export default function DePrizePlay() {
   // receive by selling their full position right now (calcNetCost with negative
   // amounts returns negative collateral, i.e. what the LMSR pays back).
   useEffect(() => {
-    if (!lmsr) return
+    // Selling back to the AMM only works while Running (trade() is
+    // atStage(Running)); on a Paused/Closed market calcNetCost is undefined
+    // behaviour (and can go negative once inventory is swept), so don't quote.
+    if (!lmsr || stage !== MarketStage.Running) {
+      setSellQuotes(new Map())
+      return
+    }
     const held = outcomes.filter(
       (o) => Number.isFinite(o.balance) && o.balance > 0
     )
@@ -748,7 +798,7 @@ export default function DePrizePlay() {
     return () => {
       cancelled = true
     }
-  }, [lmsr, outcomes])
+  }, [lmsr, outcomes, stage])
 
   // Inverse of the LMSR cost curve: how many outcome tokens does `targetWei`
   // of collateral buy? calcNetCost is monotonic in quantity, so binary search.
@@ -1316,6 +1366,17 @@ export default function DePrizePlay() {
   }
 
   const isClosed = stage === MarketStage.Closed
+  // The LMSR only accepts trades in the Running stage, so buying and selling
+  // (cash out) must be blocked whenever the market is Paused or Closed —
+  // otherwise the on-chain trade just reverts.
+  const isTradingHalted =
+    stage !== undefined && stage !== MarketStage.Running
+  const tradingHaltLabel =
+    stage === MarketStage.Paused
+      ? 'Market paused'
+      : stage === MarketStage.Closed
+      ? 'Market closed'
+      : ''
   // CTF-level resolution is what actually gates redemption (market stage is
   // only the trading state). claimable = what the connected wallet's positions
   // redeem for under the reported payout vector (mirrors previewRedeem).
@@ -1432,10 +1493,6 @@ export default function DePrizePlay() {
                       <p className="text-indigo-100 text-sm font-medium">
                         Connect a wallet on Sepolia to bet
                       </p>
-                      <p className="text-indigo-300/80 text-xs mt-1">
-                        You can read live odds without connecting, but betting
-                        needs a connected Sepolia wallet with a little test ETH.
-                      </p>
                     </div>
                     <button
                       onClick={() => login()}
@@ -1530,9 +1587,25 @@ export default function DePrizePlay() {
                     const color = OUTCOME_COLORS[o.index % OUTCOME_COLORS.length]
                     const valueNow = sellQuotes.get(o.index)
                     const invested = costBasis[o.index] ?? 0
+                    // Once resolved, this slot's tokens redeem for
+                    // balance * payoutNumerator / payoutDenominator (mirrors the
+                    // CTF + previewRedeem). This is the real "value" post-close.
+                    const redeemValue =
+                      resolved &&
+                      o.balanceWei !== undefined &&
+                      payoutDen !== undefined &&
+                      payoutDen > 0n
+                        ? Number(
+                            (o.balanceWei * (payoutNums[o.index] ?? 0n)) /
+                              payoutDen
+                          ) / Number(UNIT)
+                        : undefined
+                    const isWinningSlot = resolved && o.index === winningIndex
+                    // Final value if resolved, otherwise the live sell quote.
+                    const realizedValue = resolved ? redeemValue : valueNow
                     const pnl =
-                      valueNow !== undefined && invested > 0
-                        ? valueNow - invested
+                      realizedValue !== undefined && invested > 0
+                        ? realizedValue - invested
                         : undefined
                     return (
                       <div
@@ -1547,16 +1620,34 @@ export default function DePrizePlay() {
                               style={{ background: color }}
                             />
                             <div>
-                              <p className="text-2xl font-bold text-white leading-none">
-                                {Number.isNaN(o.probability)
+                              <p
+                                className={`text-2xl font-bold leading-none ${
+                                  resolved
+                                    ? isWinningSlot
+                                      ? 'text-moon-green'
+                                      : isRefundVector
+                                      ? 'text-white'
+                                      : 'text-gray-500'
+                                    : 'text-white'
+                                }`}
+                              >
+                                {resolved
+                                  ? isWinningSlot
+                                    ? 'WON'
+                                    : isRefundVector
+                                    ? 'Refund'
+                                    : 'Lost'
+                                  : Number.isNaN(o.probability)
                                   ? loading
                                     ? '…'
                                     : '—'
                                   : `${fmt(o.probability, 0)}%`}
                               </p>
-                              <p className="text-gray-500 text-[10px] mt-1">
-                                chance
-                              </p>
+                              {!resolved && (
+                                <p className="text-gray-500 text-[10px] mt-1">
+                                  chance
+                                </p>
+                              )}
                             </div>
                           </div>
 
@@ -1564,30 +1655,27 @@ export default function DePrizePlay() {
                             <p className="text-white font-semibold">
                               Outcome #{o.index + 1}
                             </p>
-                            <p className="text-gray-400 text-xs mt-0.5">
-                              {holding
-                                ? 'You have a position'
-                                : 'Tap Bet to see your payout'}
-                            </p>
                           </div>
 
                           <div className="flex items-center gap-2 flex-wrap">
-                            <StandardButton
-                              onClick={() => {
-                                setBetAmount('')
-                                setBetQuote(null)
-                                setBetIndex(o.index)
-                              }}
-                              disabled={busy || isClosed || !userAddress}
-                              className="rounded-full"
-                              backgroundColor="bg-moon-green"
-                            >
-                              Bet
-                            </StandardButton>
-                            {holding && (
+                            {!isTradingHalted && (
+                              <StandardButton
+                                onClick={() => {
+                                  setBetAmount('')
+                                  setBetQuote(null)
+                                  setBetIndex(o.index)
+                                }}
+                                disabled={busy || !userAddress}
+                                className="rounded-full"
+                                backgroundColor="bg-moon-green"
+                              >
+                                Bet
+                              </StandardButton>
+                            )}
+                            {holding && !isTradingHalted && (
                               <StandardButton
                                 onClick={() => sellAll(o.index)}
-                                disabled={busy || isClosed || !userAddress}
+                                disabled={busy || !userAddress}
                                 className="rounded-full"
                                 backgroundColor="bg-moon-orange"
                               >
@@ -1601,29 +1689,39 @@ export default function DePrizePlay() {
 
                         {/* Position summary */}
                         {holding && (
-                          <div className="mt-3 grid grid-cols-3 gap-2">
+                          <div
+                            className={`mt-3 grid gap-2 ${
+                              resolved ? 'grid-cols-2' : 'grid-cols-3'
+                            }`}
+                          >
                             <div className="rounded-xl bg-black/30 border border-white/10 px-3 py-2">
                               <p className="text-[10px] text-gray-500">
-                                Cash out now
+                                {resolved ? 'Claimable' : 'Cash out'}
                               </p>
                               <p className="text-sm font-semibold text-white">
-                                {valueNow !== undefined
+                                {resolved
+                                  ? redeemValue !== undefined
+                                    ? `${fmt(redeemValue)} ETH`
+                                    : '—'
+                                  : isTradingHalted
+                                  ? '—'
+                                  : valueNow !== undefined
                                   ? `${fmt(valueNow)} ETH`
                                   : '…'}
                               </p>
                             </div>
+                            {!resolved && (
+                              <div className="rounded-xl bg-black/30 border border-white/10 px-3 py-2">
+                                <p className="text-[10px] text-gray-500">
+                                  If this wins
+                                </p>
+                                <p className="text-sm font-semibold text-moon-green">
+                                  {fmt(o.balance)} ETH
+                                </p>
+                              </div>
+                            )}
                             <div className="rounded-xl bg-black/30 border border-white/10 px-3 py-2">
-                              <p className="text-[10px] text-gray-500">
-                                If this wins
-                              </p>
-                              <p className="text-sm font-semibold text-moon-green">
-                                {fmt(o.balance)} ETH
-                              </p>
-                            </div>
-                            <div className="rounded-xl bg-black/30 border border-white/10 px-3 py-2">
-                              <p className="text-[10px] text-gray-500">
-                                Profit so far
-                              </p>
+                              <p className="text-[10px] text-gray-500">Profit</p>
                               <p
                                 className={`text-sm font-semibold ${
                                   pnl === undefined
@@ -1645,46 +1743,69 @@ export default function DePrizePlay() {
                   })}
                 </div>
 
-                {/* Redeem (direct CTF path — always available once resolved) */}
-                {resolved && (
-                  <div className="p-4 rounded-2xl bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-between gap-3 flex-wrap">
-                    <div>
-                      <p className="text-emerald-200 text-sm">
-                        {isRefundVector
-                          ? `Resolved with no winner — every position refunds 1/${MAX_OUTCOMES} of its size.`
-                          : winningIndex >= 0
-                          ? `Resolved — outcome #${winningIndex + 1} won.`
-                          : 'This market is resolved.'}
-                      </p>
-                      {userAddress && (
-                        <p className="text-emerald-300/80 text-xs mt-1">
-                          Your positions redeem for ≈ {fmt(claimable)} WETH
-                          (direct CTF claim pays WETH; the helper below pays
-                          ETH).
-                        </p>
+                {/* Claim winnings — the single user-facing action once the
+                    market is resolved. Pays native ETH via the DePrizeRedeem
+                    helper (one tap after a one-time approval); the raw CTF/WETH
+                    path lives in Advanced below. */}
+                {resolved && userAddress && (
+                  <div className="p-4 sm:p-5 rounded-2xl bg-emerald-500/10 border border-emerald-500/30">
+                    <p className="text-emerald-200 text-sm">
+                      {isRefundVector
+                        ? 'No winner — everyone refunded'
+                        : winningIndex >= 0
+                        ? `Outcome #${winningIndex + 1} won`
+                        : 'Resolved'}
+                    </p>
+                    <p className="text-white text-2xl font-bold mt-1">
+                      {validHelper && helperPreview !== undefined
+                        ? `${fmt(helperPreview)} ETH`
+                        : `${fmt(claimable)} WETH`}
+                    </p>
+                    <div className="mt-3 flex items-center gap-3 flex-wrap">
+                      {validHelper ? (
+                        <StandardButton
+                          onClick={helperApproved ? redeemViaHelper : approveHelper}
+                          disabled={busy || (helperPreview ?? 0) <= 0}
+                          className="rounded-full"
+                          backgroundColor="bg-moon-green"
+                        >
+                          {helperApproved ? 'Claim' : 'Approve'}
+                        </StandardButton>
+                      ) : (
+                        <StandardButton
+                          onClick={redeem}
+                          disabled={busy}
+                          className="rounded-full"
+                          backgroundColor="bg-moon-green"
+                        >
+                          Claim
+                        </StandardButton>
+                      )}
+                      {validHelper && (
+                        <button
+                          onClick={redeem}
+                          disabled={busy}
+                          className="text-gray-400 hover:text-gray-200 text-xs underline disabled:opacity-50"
+                        >
+                          WETH instead
+                        </button>
                       )}
                     </div>
-                    <StandardButton
-                      onClick={redeem}
-                      disabled={busy || !userAddress}
-                      className="rounded-full"
-                      backgroundColor="bg-moon-green"
-                    >
-                      Claim (WETH)
-                    </StandardButton>
                   </div>
                 )}
 
-                {/* M4: DePrizeRedeem helper (one-tx, pays native ETH) */}
+                {/* M4: DePrizeRedeem helper plumbing — dev/testnet only. The
+                    user-facing claim above already drives this; these raw
+                    inputs are for overriding the helper/DePrize during testing. */}
                 {userAddress && (
-                  <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-gray-900 to-emerald-900/20 border border-white/10">
-                    <p className="text-white font-semibold">
-                      DePrizeRedeem helper{' '}
+                  <details className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-gray-900 to-emerald-900/20 border border-white/10">
+                    <summary className="text-white font-semibold cursor-pointer select-none">
+                      Advanced (testnet tools){' '}
                       <span className="text-gray-500 text-xs font-normal">
-                        (M4 — redeem outcome tokens for native ETH)
+                        — DePrizeRedeem helper internals
                       </span>
-                    </p>
-                    <p className="text-gray-500 text-xs mt-1">
+                    </summary>
+                    <p className="text-gray-500 text-xs mt-3">
                       Needs the deployed helper + a DePrizeRegistry entry whose
                       condition matches this market. Approve once, then redeem —
                       the helper pulls your tokens, redeems on the CTF, unwraps
@@ -1767,7 +1888,7 @@ export default function DePrizePlay() {
                         </div>
                       </div>
                     )}
-                  </div>
+                  </details>
                 )}
 
                 {/* Privileged actions */}
@@ -1824,9 +1945,25 @@ export default function DePrizePlay() {
                           className="rounded-full"
                           backgroundColor="bg-white/10"
                         >
-                          Withdraw fees
+                          {marketFeesWei !== undefined
+                            ? `Withdraw fees (${fmt(
+                                Number(marketFeesWei) / Number(UNIT),
+                                4
+                              )} WETH)`
+                            : 'Withdraw fees'}
                         </StandardButton>
                         </div>
+                        <p className="text-gray-500 text-[11px] mt-2">
+                          Withdrawable now:{' '}
+                          {marketFeesWei !== undefined
+                            ? `${fmt(
+                                Number(marketFeesWei) / Number(UNIT),
+                                6
+                              )} WETH`
+                            : '—'}{' '}
+                          (the market's full collateral balance; close the market
+                          first to also reclaim seed liquidity).
+                        </p>
                       </div>
                     )}
 
@@ -2038,12 +2175,14 @@ export default function DePrizePlay() {
             ) : (
               <StandardButton
                 onClick={buy}
-                disabled={busy || betAmountWei <= 0n || isClosed}
+                disabled={busy || betAmountWei <= 0n || isTradingHalted}
                 className="rounded-full w-full"
                 backgroundColor="bg-moon-green"
               >
                 {busy
                   ? 'Placing bet…'
+                  : isTradingHalted
+                  ? tradingHaltLabel
                   : betAmountNum > 0
                   ? `Bet ${fmt(betAmountNum)} ETH`
                   : 'Enter an amount'}

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -1159,7 +1159,7 @@ export default function DePrizePlay() {
       if (payoutDen && payoutDen > 0n) {
         throw new Error('Pre-flight: already resolved (payout vector is write-once).')
       }
-      if (stage === MarketStage.Running) {
+      if (stage !== MarketStage.Paused && stage !== MarketStage.Closed) {
         throw new Error(
           'Pre-flight: pause or close the market first — resolving a live market gives away free trades against the known outcome.'
         )
@@ -1275,7 +1275,9 @@ export default function DePrizePlay() {
   const claimable = resolved
     ? outcomes.reduce((acc, o, i) => {
         if (!Number.isFinite(o.balance) || o.balance <= 0) return acc
-        return acc + (o.balance * Number(payoutNums[i] ?? 0n)) / Number(payoutDen)
+        const balWei = BigInt(Math.floor(o.balance * Number(UNIT)))
+        const payout = (balWei * (payoutNums[i] ?? 0n)) / payoutDen
+        return acc + Number(payout) / Number(UNIT)
       }, 0)
     : 0
   // Spendable = already-wrapped WETH + native ETH (we auto-wrap at bet time),

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -1179,10 +1179,12 @@ export default function DePrizePlay() {
         method: 'getConditionId' as string,
         params: [account.address, questionId, BigInt(MAX_OUTCOMES)],
       })
-      if (
-        conditionId &&
-        computed.toLowerCase() !== conditionId.toLowerCase()
-      ) {
+      const marketConditionId = await rpcRead<string>({
+        contract: lmsr,
+        method: 'conditionIds' as string,
+        params: [0n],
+      })
+      if (computed.toLowerCase() !== marketConditionId.toLowerCase()) {
         throw new Error(
           `Pre-flight: conditionId mismatch — keccak(yourAddress, questionId, ${MAX_OUTCOMES}) != the market's condition. Check the question id and that you are the oracle.`
         )

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -151,6 +151,7 @@ type Outcome = {
   index: number
   probability: number // %
   balance: number // outcome tokens (== ETH payout if this outcome wins, 1:1)
+  balanceWei?: bigint // exact wei balance (float `balance` is display-only)
   positionId: bigint
 }
 
@@ -441,11 +442,11 @@ export default function DePrizePlay() {
                   method: 'balanceOf' as string,
                   params: [userAddress, pid],
                 })
-                  .then((b) => Number(b as bigint) / Number(UNIT))
-                  .catch(() => NaN)
+                  .then((b) => b as bigint)
+                  .catch(() => undefined)
               )
             )
-          : Promise.resolve(positionIds.map(() => NaN)),
+          : Promise.resolve(positionIds.map(() => undefined)),
         userAddress
           ? rpcRead({
               contract: weth,
@@ -499,12 +500,16 @@ export default function DePrizePlay() {
       setPayoutNums(nums)
       recordOddsSample(prices as number[])
       setOutcomes(
-        positionIds.map((pid, i) => ({
-          index: i,
-          probability: prices[i],
-          balance: balances[i],
-          positionId: pid,
-        }))
+        positionIds.map((pid, i) => {
+          const balWei = balances[i] as bigint | undefined
+          return {
+            index: i,
+            probability: prices[i],
+            balance: balWei !== undefined ? Number(balWei) / Number(UNIT) : NaN,
+            balanceWei: balWei,
+            positionId: pid,
+          }
+        })
       )
     } catch (err: any) {
       console.error('[deprize-play] loadMarket failed', err)
@@ -1166,7 +1171,7 @@ export default function DePrizePlay() {
   //   3. the market must be paused/closed first — reporting against a live
   //      market lets anyone trade the known outcome against the inventory.
   const resolve = async (payouts: bigint[], label: string) => {
-    if (!account || !ctf) return
+    if (!account || !ctf || !lmsr) return
     setBusy(true)
     try {
       const computed = await rpcRead<string>({
@@ -1182,10 +1187,29 @@ export default function DePrizePlay() {
           `Pre-flight: conditionId mismatch — keccak(yourAddress, questionId, ${MAX_OUTCOMES}) != the market's condition. Check the question id and that you are the oracle.`
         )
       }
-      if (payoutDen && payoutDen > 0n) {
+      // Re-read the gating state fresh on-chain rather than trusting the
+      // periodically-refreshed component state: a stale snapshot could let a
+      // race report against a still-live market (the "free trades against the
+      // known outcome" hazard) or against an already-resolved condition.
+      const freshDen = await rpcRead<bigint>({
+        contract: ctf,
+        method: 'payoutDenominator' as string,
+        params: [computed],
+      })
+      if (freshDen && freshDen > 0n) {
         throw new Error('Pre-flight: already resolved (payout vector is write-once).')
       }
-      if (stage !== MarketStage.Paused && stage !== MarketStage.Closed) {
+      const freshStage = Number(
+        await rpcRead<bigint | number>({
+          contract: lmsr,
+          method: 'stage' as string,
+          params: [],
+        })
+      )
+      if (
+        freshStage !== MarketStage.Paused &&
+        freshStage !== MarketStage.Closed
+      ) {
         throw new Error(
           'Pre-flight: pause or close the market first — resolving a live market gives away free trades against the known outcome.'
         )
@@ -1300,8 +1324,10 @@ export default function DePrizePlay() {
     resolved && payoutNums.length > 0 && payoutNums.every((n) => n > 0n)
   const claimable = resolved
     ? outcomes.reduce((acc, o, i) => {
-        if (!Number.isFinite(o.balance) || o.balance <= 0) return acc
-        const balWei = BigInt(Math.floor(o.balance * Number(UNIT)))
+        // Use the exact wei balance and mirror previewRedeem's per-position
+        // floor division so the headline can't disagree with what redeem pays.
+        const balWei = o.balanceWei
+        if (balWei === undefined || balWei <= 0n) return acc
         const payout = (balWei * (payoutNums[i] ?? 0n)) / payoutDen
         return acc + Number(payout) / Number(UNIT)
       }, 0)

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -1,4 +1,5 @@
 import ConditionalTokensABI from 'const/abis/ConditionalTokens.json'
+import DePrizeRedeemABI from 'const/abis/DePrizeRedeem.json'
 import LMSRWithTWAP from 'const/abis/LMSRWithTWAP.json'
 import WETHABI from 'const/abis/WETH.json'
 import {
@@ -10,6 +11,8 @@ import {
   ORACLE_ADDRESS,
   OPERATOR_ADDRESS,
   DEFAULT_CHAIN_V5,
+  DEPRIZE_REDEEM_ADDRESSES,
+  DEPRIZE_QUESTION_ID,
 } from 'const/config'
 import { useLogin } from '@privy-io/react-auth'
 import dynamic from 'next/dynamic'
@@ -209,6 +212,21 @@ export default function DePrizePlay() {
   const [conditionId, setConditionId] = useState<string | undefined>()
   const [stage, setStage] = useState<number | undefined>()
   const [feePct, setFeePct] = useState<number | undefined>()
+  // CTF resolution state (M4): 0 denominator = unresolved; afterwards the
+  // payout vector determines what each held outcome token redeems for.
+  const [payoutDen, setPayoutDen] = useState<bigint | undefined>()
+  const [payoutNums, setPayoutNums] = useState<bigint[]>([])
+  // Oracle resolution inputs (mirrors DePrizeResolve.s.sol pre-flight).
+  const [questionId, setQuestionId] = useState(DEPRIZE_QUESTION_ID)
+  // DePrizeRedeem helper testing (M4): the helper needs a deployed registry
+  // with a DePrize bound to this market's condition; both are inputs so the
+  // harness works the moment they're deployed (persisted per market).
+  const [helperAddress, setHelperAddress] = useState(
+    DEPRIZE_REDEEM_ADDRESSES[chainSlug] ?? ''
+  )
+  const [helperDeprizeId, setHelperDeprizeId] = useState('1')
+  const [helperPreview, setHelperPreview] = useState<number | undefined>()
+  const [helperApproved, setHelperApproved] = useState<boolean | undefined>()
   const [wethBalance, setWethBalance] = useState<number | undefined>()
   const [nativeBalance, setNativeBalance] = useState<number | undefined>()
   const [ctfApproved, setCtfApproved] = useState<boolean | undefined>()
@@ -266,6 +284,19 @@ export default function DePrizePlay() {
     address: wethAddress,
     chain,
     abi: WETHABI as any,
+  })
+  // M4 redemption helper (address comes from config or the harness input).
+  const validHelper = /^0x[0-9a-fA-F]{40}$/.test(helperAddress)
+  const helper = useContract({
+    address: validHelper ? helperAddress : '',
+    chain: READ_CHAIN,
+    abi: DePrizeRedeemABI as any,
+    forwardClient: readClient,
+  })
+  const helperW = useContract({
+    address: validHelper ? helperAddress : '',
+    chain,
+    abi: DePrizeRedeemABI as any,
   })
 
   const isOracle =
@@ -365,7 +396,7 @@ export default function DePrizePlay() {
       const { conditionId: cond, positionIds } = staticRef.current
 
       // 2) Dynamic data, concurrency-limited under the hood (rpcRead).
-      const [stg, prices, balances, wb, nb, approved] = await Promise.all([
+      const [stg, prices, balances, wb, nb, approved, den, nums] = await Promise.all([
         rpcRead({ contract: lmsr, method: 'stage' as string, params: [] })
           .then((v) => Number(v))
           .catch(() => undefined),
@@ -418,12 +449,32 @@ export default function DePrizePlay() {
               .then((a) => a as boolean)
               .catch(() => undefined)
           : Promise.resolve(undefined),
+        rpcRead({
+          contract: ctf,
+          method: 'payoutDenominator' as string,
+          params: [cond],
+        })
+          .then((v) => v as bigint)
+          .catch(() => undefined),
+        Promise.all(
+          Array.from({ length: MAX_OUTCOMES }, (_, i) =>
+            rpcRead({
+              contract: ctf,
+              method: 'payoutNumerators' as string,
+              params: [cond, BigInt(i)],
+            })
+              .then((v) => v as bigint)
+              .catch(() => 0n)
+          )
+        ),
       ])
 
       setStage(stg)
       setWethBalance(wb)
       setNativeBalance(nb)
       setCtfApproved(approved)
+      setPayoutDen(den)
+      setPayoutNums(nums)
       recordOddsSample(prices as number[])
       setOutcomes(
         positionIds.map((pid, i) => ({
@@ -557,6 +608,73 @@ export default function DePrizePlay() {
       }
     }
   }, [costStorageKey])
+
+  // ---- DePrizeRedeem helper (M4) ----
+  // Persist the harness inputs per market so they survive reloads.
+  const helperStorageKey = useMemo(
+    () => (lmsrAddress ? `deprize:redeemHelper:v1:${lmsrAddress}` : null),
+    [lmsrAddress]
+  )
+
+  useEffect(() => {
+    if (!helperStorageKey || typeof window === 'undefined') return
+    try {
+      const raw = window.localStorage.getItem(helperStorageKey)
+      if (raw) {
+        const saved = JSON.parse(raw) as { address?: string; deprizeId?: string }
+        if (saved.address) setHelperAddress(saved.address)
+        if (saved.deprizeId) setHelperDeprizeId(saved.deprizeId)
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [helperStorageKey])
+
+  useEffect(() => {
+    if (!helperStorageKey || typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(
+        helperStorageKey,
+        JSON.stringify({ address: helperAddress, deprizeId: helperDeprizeId })
+      )
+    } catch {
+      /* ignore */
+    }
+  }, [helperStorageKey, helperAddress, helperDeprizeId])
+
+  // Live preview of what the helper would pay the connected wallet, plus
+  // whether the wallet has already granted it the CTF operator approval.
+  useEffect(() => {
+    setHelperPreview(undefined)
+    setHelperApproved(undefined)
+    if (!validHelper || !helper || !ctf || !userAddress) return
+    const deprizeId = helperDeprizeId.trim()
+    if (!/^\d+$/.test(deprizeId)) return
+    let cancelled = false
+    ;(async () => {
+      const [preview, approved] = await Promise.all([
+        rpcRead<bigint>({
+          contract: helper,
+          method: 'previewRedeem' as string,
+          params: [BigInt(deprizeId), userAddress],
+        }).catch(() => undefined),
+        rpcRead<boolean>({
+          contract: ctf,
+          method: 'isApprovedForAll' as string,
+          params: [userAddress, helperAddress],
+        }).catch(() => undefined),
+      ])
+      if (cancelled) return
+      setHelperPreview(
+        preview === undefined ? undefined : Number(preview) / Number(UNIT)
+      )
+      setHelperApproved(approved)
+    })()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [validHelper, helper, ctf, userAddress, helperAddress, helperDeprizeId, payoutDen])
 
   // Sell-out quote: for each outcome the user holds, compute the ETH they'd
   // receive by selling their full position right now (calcNetCost with negative
@@ -989,37 +1107,63 @@ export default function DePrizePlay() {
     }
   }
 
-  const closeMarket = async () => {
+  // Generic owner call on the LMSR (pause / resume / close / withdrawFees) —
+  // the M4 unwind surface.
+  const marketAdmin = async (method: string, doneMsg: string) => {
     if (!account || !lmsr) return
     setBusy(true)
     try {
       await sendTx(
         prepareContractCall({
           contract: lmsrW,
-          method: 'close' as string,
+          method: method as string,
           params: [],
         })
       )
-      toast.success('Market closed.', { style: toastStyle })
+      toast.success(doneMsg, { style: toastStyle })
       refreshSoon()
     } catch (err: any) {
-      toast.error(err?.shortMessage || err?.message || 'Close failed.', {
+      toast.error(err?.shortMessage || err?.message || `${method} failed.`, {
         style: toastStyle,
+        duration: 8000,
       })
     } finally {
       setBusy(false)
     }
   }
 
-  const resolve = async (winningIndex: number) => {
+  // Oracle resolution with the same pre-flight as DePrizeResolve.s.sol:
+  //   1. conditionId recomputed from (oracle=sender, questionId, slots) must
+  //      match the market's condition — a mismatch means the calldata would
+  //      resolve a DIFFERENT (or no) condition;
+  //   2. not already reported (the CTF payout vector is write-once);
+  //   3. the market must be paused/closed first — reporting against a live
+  //      market lets anyone trade the known outcome against the inventory.
+  const resolve = async (payouts: bigint[], label: string) => {
     if (!account || !ctf) return
     setBusy(true)
     try {
-      const payouts = Array.from({ length: MAX_OUTCOMES }, (_, i) =>
-        i === winningIndex ? 1n : 0n
-      )
-      const questionId =
-        '0x0000000000000000000000000000000000000000000000000000000000000001'
+      const computed = await rpcRead<string>({
+        contract: ctf,
+        method: 'getConditionId' as string,
+        params: [account.address, questionId, BigInt(MAX_OUTCOMES)],
+      })
+      if (
+        conditionId &&
+        computed.toLowerCase() !== conditionId.toLowerCase()
+      ) {
+        throw new Error(
+          `Pre-flight: conditionId mismatch — keccak(yourAddress, questionId, ${MAX_OUTCOMES}) != the market's condition. Check the question id and that you are the oracle.`
+        )
+      }
+      if (payoutDen && payoutDen > 0n) {
+        throw new Error('Pre-flight: already resolved (payout vector is write-once).')
+      }
+      if (stage === MarketStage.Running) {
+        throw new Error(
+          'Pre-flight: pause or close the market first — resolving a live market gives away free trades against the known outcome.'
+        )
+      }
       await sendTx(
         prepareContractCall({
           contract: ctfW,
@@ -1027,13 +1171,91 @@ export default function DePrizePlay() {
           params: [questionId, payouts],
         })
       )
-      toast.success(`Reported outcome #${winningIndex + 1} as winner.`, {
-        style: toastStyle,
-      })
+      toast.success(`Resolved: ${label}.`, { style: toastStyle })
       refreshSoon()
     } catch (err: any) {
       toast.error(err?.shortMessage || err?.message || 'Resolve failed.', {
         style: toastStyle,
+        duration: 10000,
+      })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const resolveWinner = (winningIndex: number) =>
+    resolve(
+      Array.from({ length: MAX_OUTCOMES }, (_, i) =>
+        i === winningIndex ? 1n : 0n
+      ),
+      `outcome #${winningIndex + 1} wins`
+    )
+
+  // M4b: terminal no-winner/cancelled — every outcome token refunds 1/N.
+  const resolveNoWinner = () =>
+    resolve(
+      Array.from({ length: MAX_OUTCOMES }, () => 1n),
+      `no winner — every position refunds 1/${MAX_OUTCOMES}`
+    )
+
+  // ---- DePrizeRedeem helper actions (M4a) ----
+  const approveHelper = async () => {
+    if (!account || !validHelper) return
+    setBusy(true)
+    try {
+      await sendTx(
+        prepareContractCall({
+          contract: ctfW,
+          method: 'setApprovalForAll' as string,
+          params: [helperAddress, true],
+        })
+      )
+      setHelperApproved(true)
+      toast.success('Helper approved to pull your outcome tokens.', {
+        style: toastStyle,
+      })
+    } catch (err: any) {
+      toast.error(err?.shortMessage || err?.message || 'Approve failed.', {
+        style: toastStyle,
+        duration: 8000,
+      })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const redeemViaHelper = async () => {
+    if (!account || !validHelper || !helperW) return
+    const deprizeId = helperDeprizeId.trim()
+    if (!/^\d+$/.test(deprizeId)) {
+      toast.error('Enter a numeric DePrize id.', { style: toastStyle })
+      return
+    }
+    setBusy(true)
+    toast.loading('Redeeming via helper…', { id: 'helper', style: toastStyle })
+    try {
+      await sendTx(
+        prepareContractCall({
+          contract: helperW,
+          method: 'redeem' as string,
+          params: [BigInt(deprizeId)],
+        })
+      )
+      toast.dismiss('helper')
+      clearCostBasis()
+      toast.success(
+        helperPreview !== undefined
+          ? `Redeemed ≈ ${fmt(helperPreview)} ETH via DePrizeRedeem.`
+          : 'Redeemed via DePrizeRedeem.',
+        { style: toastStyle, duration: 8000 }
+      )
+      refreshSoon()
+    } catch (err: any) {
+      toast.dismiss('helper')
+      console.error('[deprize-play] helper redeem failed', err)
+      toast.error(err?.shortMessage || err?.message || 'Helper redeem failed.', {
+        style: toastStyle,
+        duration: 10000,
       })
     } finally {
       setBusy(false)
@@ -1041,6 +1263,21 @@ export default function DePrizePlay() {
   }
 
   const isClosed = stage === MarketStage.Closed
+  // CTF-level resolution is what actually gates redemption (market stage is
+  // only the trading state). claimable = what the connected wallet's positions
+  // redeem for under the reported payout vector (mirrors previewRedeem).
+  const resolved = payoutDen !== undefined && payoutDen > 0n
+  const winningIndex = resolved
+    ? payoutNums.findIndex((n, _, arr) => n > 0n && arr.filter((x) => x > 0n).length === 1)
+    : -1
+  const isRefundVector =
+    resolved && payoutNums.length > 0 && payoutNums.every((n) => n > 0n)
+  const claimable = resolved
+    ? outcomes.reduce((acc, o, i) => {
+        if (!Number.isFinite(o.balance) || o.balance <= 0) return acc
+        return acc + (o.balance * Number(payoutNums[i] ?? 0n)) / Number(payoutDen)
+      }, 0)
+    : 0
   // Spendable = already-wrapped WETH + native ETH (we auto-wrap at bet time),
   // holding a little native back for gas.
   const spendable =
@@ -1097,6 +1334,24 @@ export default function DePrizePlay() {
                       <p className="text-gray-400 text-xs">Market fee</p>
                       <p className="text-white text-sm">
                         {feePct !== undefined ? `${fmt(feePct, 2)}%` : '—'}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-gray-400 text-xs">Resolution</p>
+                      <p
+                        className={`text-sm ${
+                          resolved ? 'text-moon-green' : 'text-white'
+                        }`}
+                      >
+                        {payoutDen === undefined
+                          ? '—'
+                          : !resolved
+                          ? 'Unresolved'
+                          : isRefundVector
+                          ? `Refund 1/${MAX_OUTCOMES}`
+                          : winningIndex >= 0
+                          ? `#${winningIndex + 1} won`
+                          : `[${payoutNums.map((n) => n.toString()).join(',')}]`}
                       </p>
                     </div>
                     <StandardButton
@@ -1333,20 +1588,128 @@ export default function DePrizePlay() {
                   })}
                 </div>
 
-                {/* Redeem */}
-                {isClosed && (
+                {/* Redeem (direct CTF path — always available once resolved) */}
+                {resolved && (
                   <div className="p-4 rounded-2xl bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-between gap-3 flex-wrap">
-                    <p className="text-emerald-200 text-sm">
-                      This market is resolved. Claim your winnings.
-                    </p>
+                    <div>
+                      <p className="text-emerald-200 text-sm">
+                        {isRefundVector
+                          ? `Resolved with no winner — every position refunds 1/${MAX_OUTCOMES} of its size.`
+                          : winningIndex >= 0
+                          ? `Resolved — outcome #${winningIndex + 1} won.`
+                          : 'This market is resolved.'}
+                      </p>
+                      {userAddress && (
+                        <p className="text-emerald-300/80 text-xs mt-1">
+                          Your positions redeem for ≈ {fmt(claimable)} WETH
+                          (direct CTF claim pays WETH; the helper below pays
+                          ETH).
+                        </p>
+                      )}
+                    </div>
                     <StandardButton
                       onClick={redeem}
-                      disabled={busy}
+                      disabled={busy || !userAddress}
                       className="rounded-full"
                       backgroundColor="bg-moon-green"
                     >
-                      Claim winnings
+                      Claim (WETH)
                     </StandardButton>
+                  </div>
+                )}
+
+                {/* M4: DePrizeRedeem helper (one-tx, pays native ETH) */}
+                {userAddress && (
+                  <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-gray-900 to-emerald-900/20 border border-white/10">
+                    <p className="text-white font-semibold">
+                      DePrizeRedeem helper{' '}
+                      <span className="text-gray-500 text-xs font-normal">
+                        (M4 — redeem outcome tokens for native ETH)
+                      </span>
+                    </p>
+                    <p className="text-gray-500 text-xs mt-1">
+                      Needs the deployed helper + a DePrizeRegistry entry whose
+                      condition matches this market. Approve once, then redeem —
+                      the helper pulls your tokens, redeems on the CTF, unwraps
+                      and pays you ETH in one transaction.
+                    </p>
+                    <div className="mt-3 grid sm:grid-cols-[1fr_120px] gap-2">
+                      <div>
+                        <label className="text-xs text-gray-400">
+                          Helper address
+                        </label>
+                        <input
+                          type="text"
+                          value={helperAddress}
+                          onChange={(e) => setHelperAddress(e.target.value.trim())}
+                          placeholder="0x… (DePrizeRedeem)"
+                          className="mt-1 w-full px-3 py-2 bg-white/5 border border-white/20 rounded-xl text-white text-xs font-mono placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs text-gray-400">DePrize id</label>
+                        <input
+                          type="text"
+                          value={helperDeprizeId}
+                          onChange={(e) => setHelperDeprizeId(e.target.value)}
+                          placeholder="1"
+                          className="mt-1 w-full px-3 py-2 bg-white/5 border border-white/20 rounded-xl text-white text-xs font-mono placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                        />
+                      </div>
+                    </div>
+                    {helperAddress && !validHelper && (
+                      <p className="text-amber-300 text-xs mt-2">
+                        Not a valid address.
+                      </p>
+                    )}
+                    {validHelper && (
+                      <div className="mt-3 flex items-center justify-between gap-3 flex-wrap">
+                        <div className="text-xs">
+                          <p className="text-gray-400">
+                            previewRedeem:{' '}
+                            <span className="text-white font-semibold">
+                              {helperPreview === undefined
+                                ? '—'
+                                : `${fmt(helperPreview)} ETH`}
+                            </span>
+                            {helperPreview === 0 && !resolved && (
+                              <span className="text-gray-500">
+                                {' '}
+                                (0 until the condition is resolved)
+                              </span>
+                            )}
+                          </p>
+                          <p className="text-gray-500 mt-0.5">
+                            Approval:{' '}
+                            {helperApproved === undefined
+                              ? '—'
+                              : helperApproved
+                              ? 'granted'
+                              : 'not granted'}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2 flex-wrap">
+                          {!helperApproved && (
+                            <StandardButton
+                              onClick={approveHelper}
+                              disabled={busy}
+                              className="rounded-full"
+                              backgroundColor="bg-white/10"
+                            >
+                              Approve helper
+                            </StandardButton>
+                          )}
+                          <StandardButton
+                            onClick={redeemViaHelper}
+                            disabled={busy || !helperApproved}
+                            className="rounded-full"
+                            backgroundColor="bg-moon-green"
+                          >
+                            Redeem (ETH)
+                          </StandardButton>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
 
@@ -1358,30 +1721,103 @@ export default function DePrizePlay() {
                       {isOracle && isOperator ? ' + ' : ''}
                       {isOperator ? 'operator' : ''})
                     </p>
-                    <div className="flex items-center gap-2 flex-wrap">
-                      {isOperator && (
-                        <StandardButton
-                          onClick={closeMarket}
-                          disabled={busy || isClosed}
-                          className="rounded-full"
-                          backgroundColor="bg-white/10"
-                        >
-                          Close market
-                        </StandardButton>
-                      )}
-                      {isOracle &&
-                        outcomes.map((o) => (
+
+                    {/* M4b unwind: pause -> (resolve) -> close -> withdrawFees */}
+                    {isOperator && (
+                      <div className="mb-4">
+                        <p className="text-gray-400 text-[11px] mb-2">
+                          Market unwind (owner): pause before resolving, close +
+                          withdraw fees after.
+                        </p>
+                        <div className="flex items-center gap-2 flex-wrap">
                           <StandardButton
-                            key={o.index}
-                            onClick={() => resolve(o.index)}
+                            onClick={() => marketAdmin('pause', 'Market paused.')}
+                            disabled={busy || stage !== MarketStage.Running}
+                            className="rounded-full"
+                            backgroundColor="bg-white/10"
+                          >
+                            Pause
+                          </StandardButton>
+                          <StandardButton
+                            onClick={() => marketAdmin('resume', 'Market resumed.')}
+                            disabled={busy || stage !== MarketStage.Paused}
+                            className="rounded-full"
+                            backgroundColor="bg-white/10"
+                          >
+                            Resume
+                          </StandardButton>
+                          <StandardButton
+                            onClick={() =>
+                              marketAdmin(
+                                'close',
+                                'Market closed — inventory returned to owner.'
+                              )
+                            }
+                            disabled={busy || isClosed}
+                            className="rounded-full"
+                            backgroundColor="bg-white/10"
+                          >
+                            Close market
+                          </StandardButton>
+                          <StandardButton
+                            onClick={() =>
+                              marketAdmin('withdrawFees', 'Fees withdrawn to owner.')
+                            }
                             disabled={busy}
                             className="rounded-full"
                             backgroundColor="bg-white/10"
                           >
-                            Resolve #{o.index + 1} wins
+                            Withdraw fees
                           </StandardButton>
-                        ))}
-                    </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* M4a resolution: same pre-flight as DePrizeResolve.s.sol */}
+                    {isOracle && (
+                      <div>
+                        <p className="text-gray-400 text-[11px] mb-2">
+                          Resolution (oracle, one-shot): the market must be
+                          paused/closed first; conditionId is recomputed from
+                          (you, questionId, {MAX_OUTCOMES}) and must match the
+                          market before anything is sent.
+                        </p>
+                        <label className="text-xs text-gray-400">questionId</label>
+                        <input
+                          type="text"
+                          value={questionId}
+                          onChange={(e) => setQuestionId(e.target.value.trim())}
+                          className="mt-1 mb-2 w-full px-3 py-2 bg-white/5 border border-white/20 rounded-xl text-white text-xs font-mono placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500"
+                        />
+                        {resolved ? (
+                          <p className="text-gray-500 text-xs">
+                            Already resolved — the payout vector is write-once.
+                          </p>
+                        ) : (
+                          <div className="flex items-center gap-2 flex-wrap">
+                            {outcomes.map((o) => (
+                              <StandardButton
+                                key={o.index}
+                                onClick={() => resolveWinner(o.index)}
+                                disabled={busy}
+                                className="rounded-full"
+                                backgroundColor="bg-white/10"
+                              >
+                                Resolve #{o.index + 1} wins
+                              </StandardButton>
+                            ))}
+                            <StandardButton
+                              onClick={resolveNoWinner}
+                              disabled={busy}
+                              className="rounded-full"
+                              backgroundColor="bg-moon-orange"
+                            >
+                              No winner (refund 1/{MAX_OUTCOMES})
+                            </StandardButton>
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </div>
                 )}
               </>

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -216,6 +216,9 @@ export default function DePrizePlay() {
   const ctfAddress = CONDITIONAL_TOKEN_ADDRESSES[chainSlug]
   const wethAddress = COLLATERAL_TOKEN_ADDRESSES[chainSlug]
 
+  // Dynamic read chain derived from the wallet chain (uses thirdweb RPC edge).
+  const readChain = useMemo(() => defineChain(chain.id), [chain])
+
   const [betAmount, setBetAmount] = useState('')
   const [depositAmount, setDepositAmount] = useState('0.01')
   const [outcomes, setOutcomes] = useState<Outcome[]>(emptyOutcomes)
@@ -272,19 +275,19 @@ export default function DePrizePlay() {
   // thirdweb's RPC edge (avoids the shared Infura key's 429 rate limit).
   const lmsr = useContract({
     address: lmsrAddress,
-    chain: READ_CHAIN,
+    chain: readChain,
     abi: LMSRWithTWAP.abi as any,
     forwardClient: readClient,
   })
   const ctf = useContract({
     address: ctfAddress,
-    chain: READ_CHAIN,
+    chain: readChain,
     abi: ConditionalTokensABI as any,
     forwardClient: readClient,
   })
   const weth = useContract({
     address: wethAddress,
-    chain: READ_CHAIN,
+    chain: readChain,
     abi: WETHABI as any,
     forwardClient: readClient,
   })
@@ -308,7 +311,7 @@ export default function DePrizePlay() {
   const validHelper = /^0x[0-9a-fA-F]{40}$/.test(helperAddress)
   const helper = useContract({
     address: validHelper ? helperAddress : '',
-    chain: READ_CHAIN,
+    chain: readChain,
     abi: DePrizeRedeemABI as any,
     forwardClient: readClient,
   })
@@ -453,7 +456,7 @@ export default function DePrizePlay() {
               .catch(() => undefined)
           : Promise.resolve(undefined),
         userAddress
-          ? eth_getBalance(getRpcClient({ client: readClient, chain: READ_CHAIN }), {
+          ? eth_getBalance(getRpcClient({ client: readClient, chain: readChain }), {
               address: userAddress,
             })
               .then((b) => Number(b) / Number(UNIT))
@@ -643,11 +646,15 @@ export default function DePrizePlay() {
         const saved = JSON.parse(raw) as { address?: string; deprizeId?: string }
         if (saved.address) setHelperAddress(saved.address)
         if (saved.deprizeId) setHelperDeprizeId(saved.deprizeId)
+      } else {
+        const slug = getChainSlug(chain)
+        setHelperAddress(DEPRIZE_REDEEM_ADDRESSES[slug] ?? '')
+        setHelperDeprizeId('1')
       }
     } catch {
       /* ignore */
     }
-  }, [helperStorageKey])
+  }, [helperStorageKey, chain])
 
   useEffect(() => {
     if (!helperStorageKey || typeof window === 'undefined') return
@@ -950,7 +957,7 @@ export default function DePrizePlay() {
       if (balWei < buffered) {
         const toWrap = buffered - balWei
         const nativeWei = await eth_getBalance(
-          getRpcClient({ client: readClient, chain: READ_CHAIN }),
+          getRpcClient({ client: readClient, chain: readChain }),
           { address: account.address }
         )
         if (nativeWei < toWrap + GAS_RESERVE_WEI) {

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -1761,16 +1761,16 @@ export default function DePrizePlay() {
                           >
                             Close market
                           </StandardButton>
-                          <StandardButton
-                            onClick={() =>
-                              marketAdmin('withdrawFees', 'Fees withdrawn to owner.')
-                            }
-                            disabled={busy}
-                            className="rounded-full"
-                            backgroundColor="bg-white/10"
-                          >
-                            Withdraw fees
-                          </StandardButton>
+                        <StandardButton
+                          onClick={() =>
+                            marketAdmin('withdrawFees', 'Fees withdrawn to owner.')
+                          }
+                          disabled={busy || !isClosed}
+                          className="rounded-full"
+                          backgroundColor="bg-white/10"
+                        >
+                          Withdraw fees
+                        </StandardButton>
                         </div>
                       </div>
                     )}

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -786,7 +786,7 @@ export default function DePrizePlay() {
       const entries = await Promise.all(
         held.map(async (o) => {
           try {
-            const balWei = BigInt(Math.floor(o.balance * 1e18))
+            const balWei = o.balanceWei ?? BigInt(Math.floor(o.balance * 1e18))
             const amounts = Array.from({ length: MAX_OUTCOMES }, (_, j) =>
               j === o.index ? -balWei : 0n,
             )
@@ -1726,7 +1726,7 @@ export default function DePrizePlay() {
                         ? helperPreview
                         : undefined
                     const claimAmount = claimEth !== undefined ? claimEth : claimable
-                    const claimUnit = validHelper ? 'ETH' : 'WETH'
+                    const claimUnit = claimEth !== undefined ? 'ETH' : 'WETH'
                     const nothingToClaim = claimAmount <= 0
                     return (
                       <div className="p-4 sm:p-5 rounded-2xl bg-emerald-500/10 border border-emerald-500/30">
@@ -1747,7 +1747,7 @@ export default function DePrizePlay() {
                               {`${fmt(claimAmount)} ${claimUnit}`}
                             </p>
                             <div className="mt-3 flex items-center gap-3 flex-wrap">
-                              {validHelper ? (
+                              {claimEth !== undefined ? (
                                 <StandardButton
                                   onClick={helperApproved ? redeemViaHelper : approveHelper}
                                   disabled={busy}
@@ -1766,7 +1766,7 @@ export default function DePrizePlay() {
                                   Claim
                                 </StandardButton>
                               )}
-                              {validHelper && (
+                              {claimEth !== undefined && (
                                 <button
                                   onClick={redeem}
                                   disabled={busy}

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -14,9 +14,9 @@ import {
   DEPRIZE_REDEEM_ADDRESSES,
   DEPRIZE_QUESTION_ID,
 } from 'const/config'
-import { useLogin } from '@privy-io/react-auth'
+import { useLogin, useWallets } from '@privy-io/react-auth'
 import dynamic from 'next/dynamic'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
 import {
   createThirdwebClient,
@@ -28,7 +28,7 @@ import {
 import { useActiveAccount } from 'thirdweb/react'
 import { eth_getBalance, getRpcClient } from 'thirdweb/rpc'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
-import { getChainSlug } from '@/lib/thirdweb/chain'
+import { getChainById, getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
 import Container from '@/components/layout/Container'
 import ContentLayout from '@/components/layout/ContentLayout'
@@ -193,11 +193,24 @@ const toWei = (v: string): bigint => {
  * underlying market only.
  */
 export default function DePrizePlay() {
-  const chain = DEFAULT_CHAIN_V5
-  const chainSlug = getChainSlug(chain)
   const account = useActiveAccount()
   const userAddress = account?.address
   const { login } = useLogin()
+  const { wallets } = useWallets()
+
+  // Derive the active chain from the connected wallet. Fall back to
+  // DEFAULT_CHAIN_V5 when no wallet is connected so reads still work.
+  const chain = useMemo(() => {
+    const walletChainId = wallets?.[0]?.chainId
+    if (walletChainId) {
+      const id = Number(walletChainId.split(':')[1])
+      const found = getChainById(id)
+      if (found) return found
+    }
+    return DEFAULT_CHAIN_V5
+  }, [wallets])
+
+  const chainSlug = getChainSlug(chain)
 
   const lmsrAddress = LMSR_WITH_TWAP_ADDRESSES[chainSlug]
   const ctfAddress = CONDITIONAL_TOKEN_ADDRESSES[chainSlug]
@@ -243,11 +256,17 @@ export default function DePrizePlay() {
 
   // Static-per-market values (conditionId, position ids, fee) never change, so
   // resolve them once and reuse — keeps every refresh to the dynamic reads.
+  // Reset when the chain changes (different market, different condition).
   const staticRef = useRef<{
     conditionId: string
     positionIds: bigint[]
     feePct?: number
   } | null>(null)
+  const prevChainIdRef = useRef<number>(chain.id)
+  if (prevChainIdRef.current !== chain.id) {
+    prevChainIdRef.current = chain.id
+    staticRef.current = null
+  }
 
   // Read contracts: no-batching client (avoids the viem batch-decode bug) on
   // thirdweb's RPC edge (avoids the shared Infura key's 429 rate limit).

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -571,7 +571,7 @@ export default function DePrizePlay() {
   // A new market/condition means a fresh claim state.
   useEffect(() => {
     setClaimed(false)
-  }, [conditionId])
+  }, [conditionId, userAddress])
 
   const resolvedSnapRef = useRef(false)
   useEffect(() => {

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -1725,7 +1725,7 @@ export default function DePrizePlay() {
                     </p>
 
                     {/* M4b unwind: pause -> (resolve) -> close -> withdrawFees */}
-                    {isOperator && (
+                    {isOracle && (
                       <div className="mb-4">
                         <p className="text-gray-400 text-[11px] mb-2">
                           Market unwind (owner): pause before resolving, close +

--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,1 +1,3 @@
-{}
+{
+  "installCommand": "rm -rf node_modules && yarn install --frozen-lockfile"
+}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3493,37 +3493,7 @@
   dependencies:
     "@noble/hashes" "1.5.0"
 
-"@noble/hashes@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz"
-  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
-
-"@noble/hashes@1.4.0", "@noble/hashes@~1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz"
-  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
-
-"@noble/hashes@1.5.0", "@noble/hashes@^1.4.0", "@noble/hashes@~1.5.0":
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz"
-  integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
-
-"@noble/hashes@1.7.0", "@noble/hashes@^1.5.0", "@noble/hashes@~1.7.0":
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz"
-  integrity sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==
-
-"@noble/hashes@1.7.1", "@noble/hashes@^1.3.1", "@noble/hashes@~1.7.1":
-  version "1.7.1"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz"
-  integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
-
-"@noble/hashes@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz"
-  integrity sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==
-
-"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
+"@noble/hashes@1.3.2", "@noble/hashes@1.4.0", "@noble/hashes@1.5.0", "@noble/hashes@1.7.0", "@noble/hashes@1.7.1", "@noble/hashes@1.7.2", "@noble/hashes@1.8.0", "@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0", "@noble/hashes@^1.5.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.4.0", "@noble/hashes@~1.5.0", "@noble/hashes@~1.7.0", "@noble/hashes@~1.7.1", "@noble/hashes@~1.8.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==


### PR DESCRIPTION
## Summary

Builds M4 (resolution, redemption & refund) on top of the merged M3 bet router — the close-out loop that is the **mainnet launch gate**: until now the market took money in with no way to pay winners or refund bettors. Full spec + runbook in [`docs/DEPRIZE_M4.md`](../blob/feature/deprize-m4-redeem/docs/DEPRIZE_M4.md).

- **`DePrizeRedeem`** (new, stateless, non-upgradeable, non-custodial): one-time `ctf.setApprovalForAll`, then `redeem(deprizeId)` pulls the caller's outcome tokens, redeems on the Gnosis CTF, and pays out **ETH**. The same code path serves winner payouts (`[0,…,1,…,0]`) and the cancellation/no-winner refund (`[1,1,…,1]` → 1/N per token, the disclosed parimutuel refund). `previewRedeem` mirrors the CTF's per-position floor division exactly. Payout is scoped to the redemption's WETH **balance delta**, so WETH parked in the helper can never leak into a claim (the M3 residual-sweep lesson, regression-tested). No registry-state gate: bettors can always bypass the helper and call the CTF directly, so the CTF payout vector is the single source of truth.
- **`DePrizeResolve.s.sol`** (new): the oracle is the MoonDAO multisig, baked irreversibly into the conditionId — `reportPayouts` must be submitted by the Safe itself, so a reporter *contract* cannot exist. This read-only script enforces everything a reporter would have: registry state → payout vector (`SETTLED`/`M1_RELEASED`/`M2_COMPLETE` → winner; `NO_WINNER`/`CANCELLED` → equal payout; `M2_FAILED` → refused, the CTF is already final), winner-index lookup, conditionId recomputation (catches wrong questionId/oracle/slot-count), already-reported guard — then prints the exact Safe transaction.
- **Interfaces extended**: `IConditionalTokens` (resolution/redemption/id-helper surface) and `ILMSRWithTWAP` (owner unwind surface: `pause`/`close`/`withdrawFees`/`transferOwnership`).
- **Migration 08**: now transfers LMSR ownership to the oracle multisig right after creation — the factory makes the deployer EOA the owner, but `close()`/`withdrawFees()` (the treasury-seed unwind) are `onlyOwner` and must be Safe-executable. Also prints a reminder to record the `questionId` (resolution needs it; it is not stored on-chain).
- **Deploy script** `DePrizeRedeem.s.sol` (no proxy — nothing to upgrade).

### Design decisions (recorded in `DEPRIZE_M4.md`)

- Refund = equal-payout report + the same redemption path; the design doc's combined one-click `refundAll` (CTF + JB cashOut) is dropped — the JB leg already exists via the M2 hook.
- A tradable "none fly by X date" outcome slot was considered and rejected (delays all payouts to delivery, converts the disclosed partial refund into a 100% loss for team bettors, touches the audited M3 router, oracle conflict).
- Unwound market proceeds (seed + fees) go to the treasury, **not** the JB project, to preserve the disclosed cancellation loss (double-count guard).

## Tests

`forge test --match-path 'test/deprize/*.t.sol'` → **121 passed** (30 new unit tests + 3 guarded fork tests).

- Unit suite runs against a `MockResolvingCTF` faithful to the deployed 0.5 source: msg.sender-derived conditionId, write-once payout vector, per-position floor division, burn-on-redeem, ERC-1155 approval checks + acceptance hooks. Covers winner/loser/refund paths, parimutuel skew, preview-equals-actual rounding, all guards (NotResolved/UnknownDePrize/NothingToRedeem/approval/RedeemFailed/reentrancy/double-redeem), stray-WETH regression, receiver-hook gating, and all 8 `buildReport` pre-flight cases (including that the emitted calldata actually resolves the condition when submitted by the oracle).
- Fork tests (skip unless `DEPRIZE_FORK_RPC` is set) run against the **real Arbitrum-Sepolia CTF** with a freshly-prepared condition and test oracle: winner redemption, cancellation 1/N redemption, and (with `DEPRIZE_FORK_FACTORY`) the full mainnet rehearsal — provision → bets via real `DePrizeMint` → lock → pause → settle → close → report → withdrawFees → treasury redeems inventory → bettors redeem — with ETH conservation asserted to the wei.

## Test plan

- [x] CI: unit suite green (fork tests no-op without `DEPRIZE_FORK_RPC`)
- [x] Run the guarded fork tests against Arbitrum Sepolia (incl. the full close-out loop with the LMSR factory)
- [ ] For the already-provisioned testnet market: deployer EOA `transferOwnership(multisig)`; verify the Safe's fallback handler accepts ERC-1155 before any `close()`
- [ ] Dry-run `DePrizeResolve.s.sol` against a testnet DePrize and submit the printed calldata from a test Safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New on-chain redemption and oracle resolution paths handle user funds and irreversible CTF payouts; mistakes in runbook ordering (report before pause) or conditionId/questionId mismatch could strand value or enable arb against treasury inventory.
> 
> **Overview**
> **Closes the DePrize money-out loop (M4)** — the launch gate for paying winners and refunding bettors after M3 betting.
> 
> Adds **`DePrizeRedeem`**: a stateless helper that pulls a bettor’s CTF outcome tokens, redeems collateral, unwraps WETH, and pays **ETH**. One contract covers winner payouts and cancellation/no-winner refunds (equal `[1,1,…,1]` → 1/N per token). Payout uses a WETH balance **delta** so stray funds in the helper cannot inflate claims.
> 
> Replaces the planned **`DePrizeReporter`** with **`DePrizeResolve.s.sol`**: read-only pre-flight (registry state, conditionId vs `questionId`/oracle, already-reported, LMSR paused/closed) and Safe calldata for multisig `reportPayouts`.
> 
> **Provisioning & interfaces:** migration `08` transfers LMSR **ownership to the oracle** after create; CTF and LMSR interfaces gain resolution/redemption and owner unwind methods. Docs mark M4 complete and simplify refund vs combined `refundAll`.
> 
> **UI / testnet:** `deprize-play` gains resolution state, pause/close/withdraw runbook actions, oracle pre-flight resolve, and claim via `DePrizeRedeem` + config for Sepolia play market; small thirdweb/build fixes.
> 
> **Tests:** large `DePrizeRedeem.t.sol` unit suite + optional Arbitrum Sepolia fork close-out loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9f111240644ebd724358d413216590004c5771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->