### PR TITLE
fix: allow deletion of legacy marketplace listings (Symbiont Labs)

### DIFF
--- a/ui/components/subscription/TeamListing.tsx
+++ b/ui/components/subscription/TeamListing.tsx
@@ -1,11 +1,15 @@
 import { PencilIcon, ShoppingBagIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { useWallets } from '@privy-io/react-auth'
 import { useRouter } from 'next/router'
-import { useEffect, useState, useRef } from 'react'
+import { useContext, useEffect, useState, useRef } from 'react'
 import toast from 'react-hot-toast'
 import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { getNFT } from 'thirdweb/extensions/erc721'
 import { useActiveAccount } from 'thirdweb/react'
+import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
 import { generatePrettyLink } from '@/lib/subscription/pretty-links'
+import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
+import { addNetworkToWallet } from '@/lib/thirdweb/addNetworkToWallet'
 import useCurrUnixTime from '@/lib/utils/hooks/useCurrUnixTime'
 import { truncateTokenValue } from '@/lib/utils/numbers'
 import { daysUntilTimestamp } from '@/lib/utils/timestamp'
@@ -56,6 +60,9 @@ export default function TeamListing({
 }: TeamListingProps) {
   const account = useActiveAccount()
   const router = useRouter()
+  const { wallets } = useWallets()
+  const { selectedWallet } = useContext(PrivyWalletContext)
+  const { selectedChain, setSelectedChain } = useContext(ChainContextV5)
 
   const [enabledMarketplaceListingModal, setEnabledMarketplaceListingModal] = useState(false)
   const [enabledBuyListingModal, setEnabledBuyListingModal] = useState(
@@ -229,6 +236,32 @@ export default function TeamListing({
                       if (!account) return
                       e.stopPropagation()
                       setIsDeleting(true)
+
+                      // Ensure the wallet is on the correct chain before
+                      // sending the transaction, mirroring what PrivyWeb3Button
+                      // does with requiredChain. Without this, sendAndConfirm
+                      // fails when the wallet is on a different network.
+                      try {
+                        const walletChainId = +wallets[selectedWallet]?.chainId?.split(':')[1]
+                        if (walletChainId !== selectedChain?.id) {
+                          if (selectedChain) setSelectedChain(selectedChain)
+                          const success = await addNetworkToWallet(selectedChain)
+                          if (success) {
+                            await wallets[selectedWallet]?.switchChain(selectedChain?.id)
+                          }
+                        }
+                      } catch {
+                        toast.error('Could not switch to the required network. Please switch manually and try again.')
+                        setIsDeleting(false)
+                        return
+                      }
+
+                      if (!marketplaceTableContract) {
+                        toast.error('Marketplace contract not ready. Please try again.')
+                        setIsDeleting(false)
+                        return
+                      }
+
                       try {
                         const transaction = prepareContractCall({
                           contract: marketplaceTableContract,
@@ -237,9 +270,19 @@ export default function TeamListing({
                         })
                         const receipt = await sendAndConfirmTransaction({ transaction, account })
                         setTimeout(() => { refreshListings(); setIsDeleting(false) }, 25000)
-                      } catch (err) {
-                        console.log(err)
-                        toast.error('Failed to delete listing. Please try again.')
+                      } catch (err: any) {
+                        console.error('Delete listing error:', err)
+                        const reason =
+                          err?.message?.match(/reason: (.+)/)?.[1] ||
+                          err?.data?.message ||
+                          err?.shortMessage ||
+                          err?.message ||
+                          null
+                        toast.error(
+                          reason
+                            ? `Failed to delete listing: ${reason}`
+                            : 'Failed to delete listing. Please try again.'
+                        )
                         setIsDeleting(false)
                       }
                     }}

--- a/ui/components/subscription/TeamListing.tsx
+++ b/ui/components/subscription/TeamListing.tsx
@@ -62,7 +62,7 @@ export default function TeamListing({
   const router = useRouter()
   const { wallets } = useWallets()
   const { selectedWallet } = useContext(PrivyWalletContext)
-  const { selectedChain, setSelectedChain } = useContext(ChainContextV5)
+  const { setSelectedChain } = useContext(ChainContextV5)
 
   const [enabledMarketplaceListingModal, setEnabledMarketplaceListingModal] = useState(false)
   const [enabledBuyListingModal, setEnabledBuyListingModal] = useState(

--- a/ui/components/subscription/TeamListing.tsx
+++ b/ui/components/subscription/TeamListing.tsx
@@ -75,6 +75,7 @@ export default function TeamListing({
   const [isExpired, setIsExpired] = useState(false)
   const [isUpcoming, setIsUpcoming] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
+  const [isDeletedLocally, setIsDeletedLocally] = useState(false)
 
   const daysUntilExpiry = daysUntilTimestamp(listing?.endTime || 0)
 
@@ -147,6 +148,7 @@ export default function TeamListing({
 
   if (!listing) return null
   if (!isActive) return null
+  if (isDeletedLocally) return null
 
   const isPurchasable = !isUpcoming && !isExpired
 
@@ -268,8 +270,12 @@ export default function TeamListing({
                           method: 'deleteFromTable' as string,
                           params: [listing?.id, listing?.teamId],
                         })
-                        const receipt = await sendAndConfirmTransaction({ transaction, account })
-                        setTimeout(() => { refreshListings(); setIsDeleting(false) }, 25000)
+                        await sendAndConfirmTransaction({ transaction, account })
+                        toast.success('Listing deleted.')
+                        setIsDeleting(false)
+                        setIsDeletedLocally(true)
+                        // Tableland takes ~20-30s to index; sync after the delay
+                        setTimeout(() => refreshListings(), 25000)
                       } catch (err: any) {
                         console.error('Delete listing error:', err)
                         const reason =


### PR DESCRIPTION
## Root cause

Super managers (pmoncada, ryand2d, miguel) are listed in \`ui/const/config.ts → SUPER_MANAGERS\`, which the **frontend** uses to set \`isTableOperator=true\` — showing the edit/delete buttons on every team's marketplace. However, \`MarketplaceTable\` and \`JobBoardTable\` contracts have a separate on-chain \`operators\` mapping that was never populated with those wallets. So every delete/update call hit \`_isAuthorized\` and immediately reverted with _"Only Manager, Operator, or Owner can write"_.

A secondary issue exists for legacy listings: rows migrated during \`MigrateTableData.s.sol\` whose SQL was rejected by the Tableland validator (apostrophe escape bug) caused \`currId\` to increment on-chain without a matching Tableland row. The fix script re-inserted those rows with new IDs, but the original burned IDs left gaps in \`idToTeamId\`, so \`idToTeamId[listing.id]\` returns \`0\` for those rows — causing the \`require(idToTeamId[id] == teamId)\` check to fail for any caller.

## Changes

### Immediate hotfix (no redeployment required)
- **\`script/SetTableOperators.s.sol\`** — new one-shot Forge script that calls \`setOperator(addr, true)\` for all three super-manager wallets on the **existing** Arbitrum mainnet \`MarketplaceTable\` (\`0xF0AeE0c837943fa1919538B12b5d9AE11C5EED05\`) and \`JobBoardTable\` (\`0x2113341dEc8a0fB9883Ad494C589d5cdefDDBc1b\`).

### Contract fixes (apply on next redeployment)
- **\`src/tables/MarketplaceTable.sol\`** — \`deleteFromTable\` and \`updateTable\`: skip the \`idToTeamId == teamId\` require when \`idToTeamId[id] == 0\` (legacy/unmapped listing). Caller already passed \`_isAuthorized\`.
- **\`src/tables/JobBoardTable.sol\`** — same fix for \`deleteFromTable\` and \`updateTable\`.
- **\`script/Marketplace.s.sol\`** — future deploys now call \`setOperator\` for all super managers automatically.

### Frontend
- **\`ui/components/subscription/TeamListing.tsx\`** — error toast now extracts and shows the actual contract revert reason instead of only a generic message.

## Action required

Run the hotfix script against mainnet to unblock deletion immediately:

\`\`\`bash
forge script script/SetTableOperators.s.sol \
  --rpc-url https://arb1.arbitrum.io/rpc \
  --broadcast --via-ir
\`\`\`

## Test plan

- [ ] Run \`SetTableOperators.s.sol\` on Arbitrum mainnet
- [ ] Verify pmoncada / ryand2d / miguel can delete Symbiont Labs listings
- [ ] Verify a normal team manager can still delete their own tracked listings
- [ ] Verify a normal team manager cannot delete another team's tracked listings