### PR TITLE
feat(ui): add $OVERVIEW-weighted path vote for Send Frank to Space

### DIFF
--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -225,6 +225,10 @@ export const VOTES_TABLE_NAMES: Index = {
 export const WBA_VOTE_ID = 0
 export const BAIKONUR_VOTE_ID = 1
 export const OVERVIEW_DELEGATION_VOTE_ID = 2
+export const OVERVIEW_PATH_VOTE_ID = 3
+// Optional ISO-8601 deadline for the path vote. When set, the page shows a
+// countdown and disables submissions after it passes. Null = open-ended.
+export const OVERVIEW_PATH_VOTE_DEADLINE: string | null = null
 // TODO: Replace with actual $OVERVIEW token address from team
 export const OVERVIEW_TOKEN_ADDRESS = '0xc868dFc4Ad388F5d7A8A5c3ECa0cff226d77152a'
 export const OVERVIEW_TOKEN_DECIMALS = 18

--- a/ui/lib/navigation/useNavigation.tsx
+++ b/ui/lib/navigation/useNavigation.tsx
@@ -78,6 +78,7 @@ export default function useNavigation(citizen: any) {
         children: [
           { name: 'Fundraiser', href: '/mission/4' },
           { name: 'Fly with Frank Leaderboard', href: '/overview-vote' },
+          { name: 'Path Forward Vote', href: '/overview-path-vote' },
           { name: 'Launchpad Explainer', href: '/launch' },
         ],
       },

--- a/ui/lib/overview-path-vote/fetchResults.ts
+++ b/ui/lib/overview-path-vote/fetchResults.ts
@@ -140,6 +140,7 @@ export async function fetchPathVoteResults(): Promise<PathVoteResults> {
       'option-a': { totalVoted: 0, voterCount: 0 },
       'option-b': { totalVoted: 0, voterCount: 0 },
       'option-c': { totalVoted: 0, voterCount: 0 },
+      abstain: { totalVoted: 0, voterCount: 0 },
     }
 
     for (const v of votes) {

--- a/ui/lib/overview-path-vote/fetchResults.ts
+++ b/ui/lib/overview-path-vote/fetchResults.ts
@@ -1,4 +1,5 @@
 import {
+  CITIZEN_TABLE_NAMES,
   OVERVIEW_PATH_VOTE_ID,
   OVERVIEW_TOKEN_ADDRESS,
   OVERVIEW_TOKEN_DECIMALS,
@@ -8,6 +9,7 @@ import {
 // runtime under Next's Webpack barrel optimizer in ethers v5 (see the same
 // note in lib/overview-delegate/fetchLeaderboard.ts).
 import { formatUnits } from 'ethers/lib/utils'
+import { isValidEthAddress } from '@/lib/overview-delegate/leaderboard'
 import { arbitrum } from '@/lib/rpc/chains'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -32,10 +34,24 @@ export type PathVoteResult = {
   percentage: number
 }
 
+/**
+ * A single participant in the vote. Intentionally carries no `optionId`: the
+ * page mirrors the governance proposal pattern of showing *who* voted and with
+ * how much weight, without revealing each voter's choice until results are
+ * unsealed.
+ */
+export type PathVoteVoter = {
+  address: string
+  votingPower: number
+  citizenName?: string
+  citizenId?: number | string
+}
+
 export type PathVoteResults = {
   results: PathVoteResult[]
   totalVoted: number
   totalVoters: number
+  voters: PathVoteVoter[]
 }
 
 export function emptyPathVoteResults(): PathVoteResults {
@@ -48,6 +64,7 @@ export function emptyPathVoteResults(): PathVoteResults {
     })),
     totalVoted: 0,
     totalVoters: 0,
+    voters: [],
   }
 }
 
@@ -162,6 +179,55 @@ export async function fetchPathVoteResults(): Promise<PathVoteResults> {
       0
     )
 
+    // Per-voter list (no choice attached) — powers the "who voted" panel that
+    // stays visible while the per-option tally is sealed.
+    const voters: PathVoteVoter[] = votes
+      .map((v) => {
+        const bal = balanceMap[v.voterAddress] ?? 0
+        const power = Number.isFinite(bal) ? bal : v.storedAmount
+        return {
+          address: v.voterAddress,
+          votingPower: Math.round(power * 100) / 100,
+        }
+      })
+      .filter((v) => v.votingPower > 0)
+      .sort((a, b) => b.votingPower - a.votingPower)
+
+    // Resolve citizen names for voter addresses (best-effort), mirroring the
+    // leaderboard's owner -> citizen lookup so the list shows names not raw
+    // addresses where possible.
+    if (voters.length > 0) {
+      try {
+        const citizenTableName = CITIZEN_TABLE_NAMES[chainSlug]
+        const safeAddresses = voters
+          .map((v) => v.address)
+          .filter(isValidEthAddress)
+        if (citizenTableName && safeAddresses.length > 0) {
+          const inClause = safeAddresses.map((a) => `'${a}'`).join(',')
+          const citizenStatement = `SELECT id, name, owner FROM ${citizenTableName} WHERE LOWER(owner) IN (${inClause})`
+          const citizenRows = await queryTable(chain, citizenStatement)
+          if (citizenRows) {
+            const citizenByOwner: Record<
+              string,
+              { id: number | string; name: string }
+            > = {}
+            for (const c of citizenRows) {
+              citizenByOwner[c.owner.toLowerCase()] = { id: c.id, name: c.name }
+            }
+            for (const voter of voters) {
+              const match = citizenByOwner[voter.address.toLowerCase()]
+              if (match) {
+                voter.citizenName = match.name
+                voter.citizenId = match.id
+              }
+            }
+          }
+        }
+      } catch (error) {
+        console.error('[fetchPathVoteResults] citizen lookup failed:', error)
+      }
+    }
+
     return {
       results: PATH_VOTE_OPTIONS.map((o) => ({
         optionId: o.id,
@@ -174,6 +240,7 @@ export async function fetchPathVoteResults(): Promise<PathVoteResults> {
       })),
       totalVoted: Math.round(totalVoted * 100) / 100,
       totalVoters,
+      voters,
     }
   } catch (error) {
     console.error('[fetchPathVoteResults] fatal error:', error)

--- a/ui/lib/overview-path-vote/fetchResults.ts
+++ b/ui/lib/overview-path-vote/fetchResults.ts
@@ -1,0 +1,181 @@
+import {
+  OVERVIEW_PATH_VOTE_ID,
+  OVERVIEW_TOKEN_ADDRESS,
+  OVERVIEW_TOKEN_DECIMALS,
+  VOTES_TABLE_NAMES,
+} from 'const/config'
+// Import from the utils sub-path: the named export from 'ethers' breaks at
+// runtime under Next's Webpack barrel optimizer in ethers v5 (see the same
+// note in lib/overview-delegate/fetchLeaderboard.ts).
+import { formatUnits } from 'ethers/lib/utils'
+import { arbitrum } from '@/lib/rpc/chains'
+import queryTable from '@/lib/tableland/queryTable'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import { engineBatchRead } from '@/lib/thirdweb/engine'
+import { isPathVoteOptionId, PATH_VOTE_OPTIONS } from './options'
+import type { PathVoteOptionId } from './options'
+
+const ERC20_BALANCE_OF_ABI = [
+  {
+    inputs: [{ name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
+export type PathVoteResult = {
+  optionId: PathVoteOptionId
+  totalVoted: number
+  voterCount: number
+  percentage: number
+}
+
+export type PathVoteResults = {
+  results: PathVoteResult[]
+  totalVoted: number
+  totalVoters: number
+}
+
+export function emptyPathVoteResults(): PathVoteResults {
+  return {
+    results: PATH_VOTE_OPTIONS.map((o) => ({
+      optionId: o.id,
+      totalVoted: 0,
+      voterCount: 0,
+      percentage: 0,
+    })),
+    totalVoted: 0,
+    totalVoters: 0,
+  }
+}
+
+type ParsedPathVote = {
+  voterAddress: string
+  optionId: PathVoteOptionId
+  storedAmount: number
+}
+
+function parsePathVotes(rows: any[]): ParsedPathVote[] {
+  const votes: ParsedPathVote[] = []
+  for (const row of rows) {
+    try {
+      const vote =
+        typeof row.vote === 'string' ? JSON.parse(row.vote) : row.vote
+      const entries = Object.entries(vote)
+      if (entries.length > 0) {
+        const [optionId, amount] = entries[0]
+        if (!isPathVoteOptionId(optionId)) continue
+        votes.push({
+          voterAddress: (row.address as string).toLowerCase(),
+          optionId,
+          storedAmount: Number(amount) || 0,
+        })
+      }
+    } catch {
+      continue
+    }
+  }
+  return votes
+}
+
+/**
+ * Fetches and tallies the "Send Frank to Space — Path Forward" vote
+ * server-side: reads all rows for OVERVIEW_PATH_VOTE_ID from the Votes
+ * Tableland table, re-weights each vote by the voter's *live* $OVERVIEW
+ * balance (same pipeline as the overview delegation leaderboard), and
+ * aggregates per option.
+ */
+export async function fetchPathVoteResults(): Promise<PathVoteResults> {
+  try {
+    const chain = arbitrum
+    const chainSlug = getChainSlug(chain)
+
+    const votesTableName = VOTES_TABLE_NAMES[chainSlug]
+    if (!votesTableName) return emptyPathVoteResults()
+
+    const statement = `SELECT * FROM ${votesTableName} WHERE voteId = ${OVERVIEW_PATH_VOTE_ID}`
+    const rows = await queryTable(chain, statement)
+    if (!rows || rows.length === 0) return emptyPathVoteResults()
+
+    const votes = parsePathVotes(rows)
+    if (votes.length === 0) return emptyPathVoteResults()
+
+    const uniqueVoters = [...new Set(votes.map((v) => v.voterAddress))]
+
+    const balanceMap: Record<string, number> = {}
+    try {
+      const balances = await engineBatchRead<string>(
+        OVERVIEW_TOKEN_ADDRESS,
+        'balanceOf',
+        uniqueVoters.map((addr) => [addr]),
+        ERC20_BALANCE_OF_ABI,
+        chain.id
+      )
+      for (let i = 0; i < uniqueVoters.length; i++) {
+        const raw = balances[i]
+        const wei = BigInt(raw || '0')
+        balanceMap[uniqueVoters[i]] = parseFloat(
+          formatUnits(wei, OVERVIEW_TOKEN_DECIMALS)
+        )
+      }
+    } catch (error) {
+      // On RPC failure fall back to the stored vote amounts so results never
+      // render empty purely due to a balance-read flake. Infinity sentinel
+      // triggers the storedAmount fallback below.
+      console.error(
+        '[fetchPathVoteResults] balance read failed, using stored amounts:',
+        error
+      )
+      for (const addr of uniqueVoters) {
+        balanceMap[addr] = Infinity
+      }
+    }
+
+    const totals: Record<
+      PathVoteOptionId,
+      { totalVoted: number; voterCount: number }
+    > = {
+      'option-a': { totalVoted: 0, voterCount: 0 },
+      'option-b': { totalVoted: 0, voterCount: 0 },
+      'option-c': { totalVoted: 0, voterCount: 0 },
+    }
+
+    for (const v of votes) {
+      const currentBalance = balanceMap[v.voterAddress] ?? 0
+      const effective = Number.isFinite(currentBalance)
+        ? currentBalance
+        : v.storedAmount
+      if (effective <= 0) continue
+      totals[v.optionId].totalVoted += effective
+      totals[v.optionId].voterCount += 1
+    }
+
+    const totalVoted = Object.values(totals).reduce(
+      (sum, t) => sum + t.totalVoted,
+      0
+    )
+    const totalVoters = Object.values(totals).reduce(
+      (sum, t) => sum + t.voterCount,
+      0
+    )
+
+    return {
+      results: PATH_VOTE_OPTIONS.map((o) => ({
+        optionId: o.id,
+        totalVoted: Math.round(totals[o.id].totalVoted * 100) / 100,
+        voterCount: totals[o.id].voterCount,
+        percentage:
+          totalVoted > 0
+            ? Math.round((totals[o.id].totalVoted / totalVoted) * 1000) / 10
+            : 0,
+      })),
+      totalVoted: Math.round(totalVoted * 100) / 100,
+      totalVoters,
+    }
+  } catch (error) {
+    console.error('[fetchPathVoteResults] fatal error:', error)
+    return emptyPathVoteResults()
+  }
+}

--- a/ui/lib/overview-path-vote/options.ts
+++ b/ui/lib/overview-path-vote/options.ts
@@ -1,0 +1,166 @@
+/**
+ * Static definitions for the one-off "Send Frank to Space — Path Forward"
+ * $OVERVIEW-weighted vote (voteId = OVERVIEW_PATH_VOTE_ID).
+ *
+ * The option `id` is the key written into the Votes Tableland table as
+ * `{ [optionId]: flooredLiveBalance }`, so it must remain stable for the
+ * lifetime of the vote. Display copy can change freely.
+ */
+
+export type PathVoteOptionId = 'option-a' | 'option-b' | 'option-c'
+
+export type PathVoteOption = {
+  id: PathVoteOptionId
+  letter: string
+  title: string
+  subtitle: string
+  summary: string
+  fundsImpact: string
+  candidateImpact: string
+  realRisk: string
+  bestCase: string
+}
+
+export const PATH_VOTE_OPTIONS: PathVoteOption[] = [
+  {
+    id: 'option-a',
+    letter: 'A',
+    title: 'Commit Now to a Stratospheric Balloon',
+    subtitle: 'One seat, Frank only',
+    summary:
+      'Place a deposit today with the stratospheric balloon provider that, based on the diligence framework, is most likely to deliver. Declare the campaign complete and close it out. Frank flies as soon as that provider is ready.',
+    fundsImpact:
+      "Deposit goes out the door under that provider's contract terms (which may or may not be refundable). Remaining funds reserved for the balance.",
+    candidateImpact:
+      'Deferred or dropped unless a follow-on fundraise is approved.',
+    realRisk:
+      "If the chosen provider fails to demonstrate safe crewed flight, our deposit may be partially or fully unrecoverable, and Frank's flight is delayed indefinitely.",
+    bestCase:
+      'Decisive, honors what contributors put in, Frank has a confirmed seat.',
+  },
+  {
+    id: 'option-b',
+    letter: 'B',
+    title: 'Keep Options Open, Continue Fundraising',
+    subtitle: 'Two seats, Frank + Candidate',
+    summary:
+      "Don't commit to a single provider yet. Continue fundraising to expand the budget, with the goal of reserving two seats so a community Candidate can fly with Frank. This keeps the door open for more expensive suborbital options and for any stratospheric provider that demonstrates safe crewed flight in the meantime. Where possible, place fully refundable deposits to hold space without locking in a single provider, so Frank flies as early as possible.",
+    fundsImpact:
+      'Existing funds stay in the launchpad contract. Only fully refundable deposits go out. New fundraising adds to the pot.',
+    candidateImpact: 'Candidate selection process continues toward two seats.',
+    realRisk:
+      'Campaign fatigue. No clean end date. The community may end up in extended purgatory waiting for either funds or provider readiness.',
+    bestCase:
+      'Maximum optionality. We benefit from another 6-18 months of industry maturation and partnership negotiation before committing.',
+  },
+  {
+    id: 'option-c',
+    letter: 'C',
+    title: 'Refunds',
+    subtitle: 'Burn $OVERVIEW for pro-rata ETH',
+    summary:
+      'If neither A nor B feels like a responsible path forward, activate the existing refund mechanism. Per the Overview Effect Flight Terms, the on-chain refund payhook makes a 28-day window available during which $OVERVIEW can be burned for pro-rata ETH. Off-chain contributions would be refunded through the equivalent process. Because no funds have been spent, the full amount raised or pledged is available.',
+    fundsImpact: 'Pro-rata refunds to contributors who choose to redeem.',
+    candidateImpact: 'Process paused indefinitely.',
+    realRisk:
+      'Campaign concludes without Frank flying. Closes the door on partnerships in flight.',
+    bestCase:
+      "Honest acknowledgement if the conditions for a safe, deliverable flight aren't there. Contributors get their funds back.",
+  },
+]
+
+export const PATH_VOTE_OPTION_IDS = PATH_VOTE_OPTIONS.map((o) => o.id)
+
+export function isPathVoteOptionId(value: string): value is PathVoteOptionId {
+  return (PATH_VOTE_OPTION_IDS as string[]).includes(value)
+}
+
+export function getPathVoteOption(
+  id: string
+): PathVoteOption | undefined {
+  return PATH_VOTE_OPTIONS.find((o) => o.id === id)
+}
+
+/** "At a glance" facts shown at the top of the proposal. */
+export const PATH_VOTE_AT_A_GLANCE: { label: string; value: string }[] = [
+  { label: 'Amount raised or pledged', value: '~$172k' },
+  {
+    label: 'Fundable today',
+    value: '1 stratospheric seat for Frank, from multiple providers',
+  },
+  {
+    label: 'Not fundable today',
+    value:
+      '2 stratospheric seats (Frank + Candidate), or any suborbital seat outright',
+  },
+  { label: 'Funds status', value: 'None has been spent to date' },
+  {
+    label: 'Companies engaged',
+    value: '12 (6 stratospheric balloon, 4 suborbital, 2 orbital / other)',
+  },
+]
+
+/** Key findings from the 30-day carrier negotiation phase. */
+export const PATH_VOTE_FINDINGS: { title: string; body: string }[] = [
+  {
+    title: 'We can pay for a seat for Frank today',
+    body: 'Multiple stratospheric balloon providers have either sent a contract or verbally agreed on a price that fits within current funds. If the community decided today, "Pick a provider and book the seat for Frank," we could execute that decision.',
+  },
+  {
+    title: 'We cannot pay for two seats outright',
+    body: 'Our original commitment was to fly Frank plus a community-selected Candidate. With current funds, no single provider gives us two seats outright — neither stratospheric nor suborbital. Flying two seats would require either continued fundraising to close the gap, or a partnership or volume discount that brings the two-seat price into our budget.',
+  },
+  {
+    title: 'No stratospheric balloon provider is operational yet',
+    body: 'This is the most important caveat. Every stratospheric balloon company we spoke to is still in some stage of hardware development and testing. None have a regularly operating commercial crewed service today. Most project first crewed flights no earlier than next year; a few claim they can fly this year but do not yet have operational, human-tested hardware. Any decision here is a decision under genuine uncertainty.',
+  },
+  {
+    title:
+      'We received a suborbital contract from Virgin Galactic, but cannot buy it outright',
+    body: 'The terms are within reach but not within current funding: we have enough to pay the deposit today, but not enough to purchase the seat in full. Going down this path requires continuing to fundraise toward the balance.',
+  },
+  {
+    title: 'Partnership conversations are still active',
+    body: "Several conversations go beyond a straight ticket purchase — joint marketing, discounts in exchange for a longer-term relationship, and other ways to work together. In particular, we are in the process of a deal with a stratospheric balloon company that could dramatically lower the cost and potentially let us fly two people. That conversation is in an early stage; it's on the table but not a concrete option to count on.",
+  },
+  {
+    title: 'Beyond a traditional flight — alternative formats',
+    body: 'While exploring orbital opportunities with Vast, one option that emerged is sending a "Frank White Avatar" to space rather than flying Frank in person. It does not involve Frank physically flying, and it is not the recommended path — we include it so the community knows it exists as a possibility.',
+  },
+]
+
+/** Diligence framework axes used to compare providers. */
+export const PATH_VOTE_DILIGENCE_AXES: { axis: string; criteria: string }[] = [
+  {
+    axis: 'Crewed flight readiness',
+    criteria:
+      'Tethered flights, uncrewed full-altitude, crewed test, repeated crewed',
+  },
+  {
+    axis: 'Regulatory standing',
+    criteria:
+      'FAA / EASA / equivalent approvals; airspace clearances in flight country',
+  },
+  {
+    axis: 'Safety design',
+    criteria:
+      'Redundant systems, abort modes, parachute / emergency descent, prior incident record',
+  },
+  {
+    axis: 'Funding runway',
+    criteria: 'Will they still be operating in 12-24 months?',
+  },
+  {
+    axis: 'Schedule realism',
+    criteria: 'Track record of quoted vs. delivered timelines',
+  },
+  {
+    axis: 'Contract terms',
+    criteria:
+      "Deposit refundability, milestone structure, what happens if they don't fly",
+  },
+  {
+    axis: 'Total cost',
+    criteria: 'Price for 1 seat and 2 seats vs. current and projected funds',
+  },
+]

--- a/ui/lib/overview-path-vote/options.ts
+++ b/ui/lib/overview-path-vote/options.ts
@@ -7,7 +7,7 @@
  * lifetime of the vote. Display copy can change freely.
  */
 
-export type PathVoteOptionId = 'option-a' | 'option-b' | 'option-c'
+export type PathVoteOptionId = 'option-a' | 'option-b' | 'option-c' | 'abstain'
 
 export type PathVoteOption = {
   id: PathVoteOptionId
@@ -15,10 +15,12 @@ export type PathVoteOption = {
   title: string
   subtitle: string
   summary: string
-  fundsImpact: string
-  candidateImpact: string
-  realRisk: string
-  bestCase: string
+  // The impact breakdown only applies to the substantive paths (A/B/C).
+  // Abstain omits these, so the card renders without a "Show details" row.
+  fundsImpact?: string
+  candidateImpact?: string
+  realRisk?: string
+  bestCase?: string
 }
 
 export const PATH_VOTE_OPTIONS: PathVoteOption[] = [
@@ -66,6 +68,14 @@ export const PATH_VOTE_OPTIONS: PathVoteOption[] = [
       'Campaign concludes without Frank flying. Closes the door on partnerships in flight.',
     bestCase:
       "Honest acknowledgement if the conditions for a safe, deliverable flight aren't there. Contributors get their funds back.",
+  },
+  {
+    id: 'abstain',
+    letter: '–',
+    title: 'Abstain',
+    subtitle: 'No preference on the path',
+    summary:
+      'Record your presence without endorsing any of the three paths. Your $OVERVIEW weight is counted toward participation but does not back Option A, B, or C.',
   },
 ]
 

--- a/ui/pages/api/revalidate.ts
+++ b/ui/pages/api/revalidate.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET
-const ALLOWED_PATHS = ['/overview-vote']
+const ALLOWED_PATHS = ['/overview-vote', '/overview-path-vote']
 
 export default async function handler(
   req: NextApiRequest,

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -455,7 +455,16 @@ export default function OverviewPathVote({
           popOverEffect={false}
           isProfile
           maxWidth="900px"
-          logo={<div aria-hidden />}
+          logo={
+            <div className="w-full h-full flex items-center justify-center md:justify-start pt-6 md:pt-0">
+              <img
+                src="/assets/feature-4.svg"
+                alt=""
+                aria-hidden
+                className="w-auto max-h-[160px] md:max-h-[220px] object-contain"
+              />
+            </div>
+          }
           description={
             <p className="text-gray-300 text-base md:text-lg leading-relaxed max-w-3xl">
               A formal $OVERVIEW-weighted vote on the next step for the

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -1,0 +1,844 @@
+import confetti from 'canvas-confetti'
+import VotesTableABI from 'const/abis/Votes.json'
+import {
+  OVERVIEW_PATH_VOTE_DEADLINE,
+  OVERVIEW_PATH_VOTE_ID,
+  OVERVIEW_TOKEN_ADDRESS,
+  TABLELAND_ENDPOINT,
+  VOTES_TABLE_ADDRESSES,
+  VOTES_TABLE_NAMES,
+} from 'const/config'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { useEffect, useMemo, useState } from 'react'
+import toast from 'react-hot-toast'
+import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
+import { useActiveAccount } from 'thirdweb/react'
+import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import {
+  emptyPathVoteResults,
+  fetchPathVoteResults,
+} from '@/lib/overview-path-vote/fetchResults'
+import type { PathVoteResults } from '@/lib/overview-path-vote/fetchResults'
+import {
+  getPathVoteOption,
+  isPathVoteOptionId,
+  PATH_VOTE_AT_A_GLANCE,
+  PATH_VOTE_DILIGENCE_AXES,
+  PATH_VOTE_FINDINGS,
+  PATH_VOTE_OPTIONS,
+} from '@/lib/overview-path-vote/options'
+import type { PathVoteOptionId } from '@/lib/overview-path-vote/options'
+import { arbitrum } from '@/lib/rpc/chains'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import useContract from '@/lib/thirdweb/hooks/useContract'
+import useWatchTokenBalance from '@/lib/tokens/hooks/useWatchTokenBalance'
+import Container from '@/components/layout/Container'
+import ContentLayout from '@/components/layout/ContentLayout'
+import Head from '@/components/layout/Head'
+import { NoticeFooter } from '@/components/layout/NoticeFooter'
+import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
+
+type OverviewPathVoteProps = {
+  voteResults: PathVoteResults
+  tokenAddress: string
+}
+
+const OPTION_ACCENTS: Record<
+  PathVoteOptionId,
+  { border: string; bg: string; badge: string; bar: string }
+> = {
+  'option-a': {
+    border: 'border-blue-400/60',
+    bg: 'bg-blue-500/10',
+    badge: 'bg-blue-500/20 text-blue-300',
+    bar: 'bg-gradient-to-r from-blue-500 to-blue-400',
+  },
+  'option-b': {
+    border: 'border-purple-400/60',
+    bg: 'bg-purple-500/10',
+    badge: 'bg-purple-500/20 text-purple-300',
+    bar: 'bg-gradient-to-r from-purple-500 to-purple-400',
+  },
+  'option-c': {
+    border: 'border-amber-400/60',
+    bg: 'bg-amber-500/10',
+    badge: 'bg-amber-500/20 text-amber-300',
+    bar: 'bg-gradient-to-r from-amber-500 to-amber-400',
+  },
+}
+
+export default function OverviewPathVote({
+  voteResults,
+  tokenAddress,
+}: OverviewPathVoteProps) {
+  const router = useRouter()
+  const overviewChain = arbitrum
+  const overviewChainSlug = getChainSlug(overviewChain)
+  const account = useActiveAccount()
+  const userAddress = account?.address
+
+  const userBalance = useWatchTokenBalance(overviewChain, tokenAddress)
+
+  const [selectedOption, setSelectedOption] =
+    useState<PathVoteOptionId | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [hasExistingVote, setHasExistingVote] = useState(false)
+  const [previousVote, setPreviousVote] = useState<{
+    optionId: PathVoteOptionId
+    amount: number
+  } | null>(null)
+  const [displayResults, setDisplayResults] = useState(voteResults)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  useEffect(() => {
+    setDisplayResults(voteResults)
+  }, [voteResults])
+
+  const deadline = OVERVIEW_PATH_VOTE_DEADLINE
+    ? new Date(OVERVIEW_PATH_VOTE_DEADLINE)
+    : null
+  const votingClosed = deadline != null && Date.now() > deadline.getTime()
+
+  const votesContract = useContract({
+    address: VOTES_TABLE_ADDRESSES[overviewChainSlug],
+    chain: overviewChain,
+    abi: VotesTableABI.abi as any,
+  })
+
+  const votesTableName = VOTES_TABLE_NAMES[overviewChainSlug]
+
+  // Load the connected wallet's existing vote (if any) so we can show it and
+  // route the submit to updateTableCol instead of insertIntoTable.
+  useEffect(() => {
+    if (!userAddress || !votesTableName) {
+      setHasExistingVote(false)
+      setPreviousVote(null)
+      return
+    }
+    const checkExisting = async () => {
+      try {
+        const stmt = `SELECT * FROM ${votesTableName} WHERE voteId = ${OVERVIEW_PATH_VOTE_ID} AND address = '${userAddress.toLowerCase()}'`
+        const res = await fetch(
+          `${TABLELAND_ENDPOINT}?statement=${encodeURIComponent(stmt)}`
+        )
+        if (res.ok) {
+          const data = await res.json()
+          if (Array.isArray(data) && data.length > 0) {
+            setHasExistingVote(true)
+            try {
+              const vote =
+                typeof data[0].vote === 'string'
+                  ? JSON.parse(data[0].vote)
+                  : data[0].vote
+              const entries = Object.entries(vote)
+              if (entries.length > 0) {
+                const [optionId, amount] = entries[0]
+                if (isPathVoteOptionId(optionId)) {
+                  setPreviousVote({
+                    optionId,
+                    amount: Number(amount) || 0,
+                  })
+                  setSelectedOption(optionId)
+                }
+              }
+            } catch {}
+          } else {
+            setHasExistingVote(false)
+            setPreviousVote(null)
+          }
+        }
+      } catch {
+        setHasExistingVote(false)
+      }
+    }
+    checkExisting()
+  }, [userAddress, votesTableName])
+
+  // Overlay the connected user's live balance onto the displayed tallies, so
+  // the totals don't look stale relative to the balance shown right above
+  // them (ISR revalidates every 60s; the balance hook is live).
+  const visibleResults = useMemo(() => {
+    if (
+      !previousVote ||
+      userBalance == null ||
+      !Number.isFinite(userBalance) ||
+      userBalance <= 0
+    ) {
+      return displayResults
+    }
+    const liveAmount = Math.floor(userBalance)
+    const entry = displayResults.results.find(
+      (r) => r.optionId === previousVote.optionId
+    )
+    if (!entry || entry.totalVoted >= liveAmount) return displayResults
+
+    const userServerContribution = Math.min(
+      entry.totalVoted,
+      previousVote.amount
+    )
+    const adjustedResults = displayResults.results.map((r) =>
+      r.optionId === previousVote.optionId
+        ? {
+            ...r,
+            totalVoted: Math.max(
+              0,
+              r.totalVoted - userServerContribution + liveAmount
+            ),
+          }
+        : r
+    )
+    const totalVoted = adjustedResults.reduce((s, r) => s + r.totalVoted, 0)
+    return {
+      ...displayResults,
+      results: adjustedResults.map((r) => ({
+        ...r,
+        percentage:
+          totalVoted > 0
+            ? Math.round((r.totalVoted / totalVoted) * 1000) / 10
+            : 0,
+      })),
+      totalVoted: Math.round(totalVoted * 100) / 100,
+    }
+  }, [displayResults, previousVote, userBalance])
+
+  const handleSubmit = async () => {
+    if (!account) return
+    if (votingClosed) {
+      toast.error('Voting has closed.', { style: toastStyle })
+      return
+    }
+    if (!selectedOption) {
+      toast.error('Please select an option.', { style: toastStyle })
+      return
+    }
+    if (
+      userBalance == null ||
+      !Number.isFinite(userBalance) ||
+      userBalance <= 0
+    ) {
+      toast.error(
+        userBalance == null || !Number.isFinite(userBalance)
+          ? 'Your $OVERVIEW balance is still loading. Please wait a moment and try again.'
+          : 'You need $OVERVIEW tokens to vote.',
+        { style: toastStyle }
+      )
+      return
+    }
+    if (!votesContract) {
+      toast.error(
+        'Voting contract is not ready yet. Please wait a moment and try again.',
+        { style: toastStyle }
+      )
+      return
+    }
+
+    const voteAmount = Math.floor(userBalance)
+    if (!Number.isFinite(voteAmount) || voteAmount <= 0) {
+      toast.error('You do not have enough $OVERVIEW tokens to vote.', {
+        style: toastStyle,
+      })
+      return
+    }
+
+    setIsSubmitting(true)
+    const vote = JSON.stringify({ [selectedOption]: voteAmount })
+
+    try {
+      // Re-check existence right before submitting: the mount-time check can
+      // be stale (vote landed in another tab, wallet hop). Picking the wrong
+      // method fails server-side — insert violates the unique(address,voteId)
+      // constraint, update on a missing row silently no-ops.
+      let existsNow = hasExistingVote
+      try {
+        const stmt = `SELECT id FROM ${votesTableName} WHERE voteId = ${OVERVIEW_PATH_VOTE_ID} AND address = '${userAddress!.toLowerCase()}'`
+        const res = await fetch(
+          `${TABLELAND_ENDPOINT}?statement=${encodeURIComponent(stmt)}`
+        )
+        if (res.ok) {
+          const data = await res.json()
+          existsNow = Array.isArray(data) && data.length > 0
+        }
+      } catch (lookupErr) {
+        console.warn(
+          '[overview-path-vote] pre-submit existence check failed; falling back to cached value',
+          lookupErr
+        )
+      }
+
+      const method = existsNow ? 'updateTableCol' : 'insertIntoTable'
+      const tx = prepareContractCall({
+        contract: votesContract,
+        method: method as string,
+        params: [OVERVIEW_PATH_VOTE_ID, vote],
+      })
+      await sendAndConfirmTransaction({ transaction: tx, account })
+      setHasExistingVote(true)
+
+      confetti({
+        particleCount: 150,
+        spread: 100,
+        origin: { y: 0.6 },
+        shapes: ['circle', 'star'],
+        colors: ['#ffffff', '#FFD700', '#00FFFF', '#ff69b4', '#8A2BE2'],
+      })
+      const optionTitle = getPathVoteOption(selectedOption)?.title
+      toast.success(
+        `Vote submitted for Option ${getPathVoteOption(selectedOption)?.letter}${optionTitle ? ` — ${optionTitle}` : ''}.`,
+        { style: toastStyle }
+      )
+
+      // Optimistic tally update: move the user's weight from their previous
+      // option (if any) onto the newly selected one.
+      setDisplayResults((current) => {
+        const adjusted = current.results.map((r) => {
+          let totalVoted = r.totalVoted
+          let voterCount = r.voterCount
+          if (previousVote && r.optionId === previousVote.optionId) {
+            totalVoted = Math.max(0, totalVoted - previousVote.amount)
+            if (previousVote.optionId !== selectedOption) {
+              voterCount = Math.max(0, voterCount - 1)
+            }
+          }
+          if (r.optionId === selectedOption) {
+            totalVoted += voteAmount
+            if (!previousVote || previousVote.optionId !== selectedOption) {
+              voterCount += 1
+            }
+          }
+          return { ...r, totalVoted, voterCount }
+        })
+        const totalVoted = adjusted.reduce((s, r) => s + r.totalVoted, 0)
+        const totalVoters = adjusted.reduce((s, r) => s + r.voterCount, 0)
+        return {
+          results: adjusted.map((r) => ({
+            ...r,
+            percentage:
+              totalVoted > 0
+                ? Math.round((r.totalVoted / totalVoted) * 1000) / 10
+                : 0,
+          })),
+          totalVoted: Math.round(totalVoted * 100) / 100,
+          totalVoters,
+        }
+      })
+
+      setPreviousVote({ optionId: selectedOption, amount: voteAmount })
+
+      // Poll for real data in the background, mirroring overview-vote.tsx.
+      setIsRefreshing(true)
+      const pollForUpdate = async (retries = 5) => {
+        for (let i = 0; i < retries; i++) {
+          await new Promise((r) => setTimeout(r, 4000 + i * 2000))
+          try {
+            await fetch('/api/revalidate', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                secret: process.env.NEXT_PUBLIC_REVALIDATE_SECRET,
+                path: '/overview-path-vote',
+              }),
+            })
+            const res = await fetch('/overview-path-vote', {
+              headers: { Accept: 'text/html' },
+            })
+            if (res.ok) {
+              router.replace(router.asPath)
+              break
+            }
+          } catch {}
+        }
+        setIsRefreshing(false)
+      }
+      pollForUpdate()
+    } catch (error: any) {
+      console.error('Error submitting vote:', error)
+      const rawMessage: string =
+        error?.shortMessage ||
+        error?.cause?.shortMessage ||
+        error?.cause?.message ||
+        error?.message ||
+        ''
+      const lower = rawMessage.toLowerCase()
+
+      let toastMessage = 'Failed to submit vote. Please try again.'
+      if (
+        lower.includes('user rejected') ||
+        lower.includes('user denied') ||
+        lower.includes('rejected the request') ||
+        lower.includes('action_rejected')
+      ) {
+        toastMessage = 'Transaction cancelled in your wallet.'
+      } else if (
+        lower.includes('insufficient funds') ||
+        lower.includes('insufficient balance')
+      ) {
+        toastMessage =
+          'Not enough ETH on Arbitrum to cover gas. Add a small amount of ETH to your wallet on Arbitrum and try again.'
+      } else if (
+        lower.includes('chain') &&
+        (lower.includes('mismatch') || lower.includes('switch'))
+      ) {
+        toastMessage =
+          'Wallet is on the wrong network. Please switch to Arbitrum and try again.'
+      } else if (
+        lower.includes('invalid bignumber') ||
+        lower.includes('value="nan"') ||
+        lower.includes("value='nan'")
+      ) {
+        toastMessage =
+          'Your wallet returned an unexpected value. Please refresh the page (or disconnect + reconnect your wallet) and try again.'
+      } else if (rawMessage) {
+        toastMessage = `Failed to submit vote: ${rawMessage.slice(0, 160)}`
+      }
+
+      toast.error(toastMessage, { style: toastStyle, duration: 8000 })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const previousOption = previousVote
+    ? getPathVoteOption(previousVote.optionId)
+    : null
+
+  return (
+    <div className="animate-fadeIn flex flex-col items-center">
+      <Head
+        title="Send Frank to Space — Choose the Path Forward"
+        description="A formal $OVERVIEW-weighted vote on the path forward for the Overview Effect Flight: commit to a stratospheric balloon now, keep options open and continue fundraising, or activate refunds."
+      />
+      <Container>
+        <ContentLayout
+          header={
+            <span
+              style={{ fontSize: 'max(22px, min(3vw, 56px))' }}
+              className="sm:whitespace-nowrap"
+            >
+              Choose the Path Forward
+            </span>
+          }
+          mainPadding
+          mode="compact"
+          popOverEffect={false}
+          isProfile
+          description={
+            <>
+              A formal $OVERVIEW-weighted vote on the next step for the
+              Overview Effect Flight (&quot;Send Frank to Space&quot;). ~$172k
+              has been raised or pledged and none of it has been spent. Token
+              holders now decide between three paths.
+            </>
+          }
+          preFooter={<NoticeFooter />}
+        >
+          <div className="flex flex-col gap-6 md:gap-8 w-full max-w-[900px] mx-auto">
+            {/* Proposal */}
+            <div className="p-4 sm:p-6 md:p-8 bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl">
+              <h2 className="text-lg sm:text-xl font-GoodTimes text-white mb-2 sm:mb-3">
+                The Proposal
+              </h2>
+              <div className="text-gray-300 text-xs sm:text-sm leading-relaxed space-y-3">
+                <p>
+                  After 30 days of post-fundraising carrier negotiation, we
+                  engaged 12 companies across the commercial space tourism
+                  industry and collected real quotes, draft contracts, flight
+                  profiles, and timelines. The findings below frame the
+                  decision. The community now chooses one of three paths:
+                  commit to a stratospheric balloon seat for Frank today, keep
+                  options open and continue fundraising toward two seats, or
+                  activate refunds.
+                </p>
+                <p>
+                  Voting weight is your live $OVERVIEW balance. Your tokens
+                  never leave your wallet — only your voting power is
+                  recorded. You can change your vote at any time
+                  {deadline
+                    ? ` until voting closes on ${deadline.toLocaleDateString(
+                        undefined,
+                        { year: 'numeric', month: 'long', day: 'numeric' }
+                      )}`
+                    : ' until the vote is closed'}
+                  .
+                </p>
+              </div>
+
+              {/* At a glance */}
+              <div className="mt-4 sm:mt-6 bg-black/20 border border-white/10 rounded-xl p-3 sm:p-4">
+                <p className="text-white text-xs sm:text-sm font-semibold mb-2 sm:mb-3 uppercase tracking-wide">
+                  At a Glance
+                </p>
+                <dl className="space-y-2">
+                  {PATH_VOTE_AT_A_GLANCE.map((item) => (
+                    <div
+                      key={item.label}
+                      className="flex flex-col sm:flex-row sm:gap-4"
+                    >
+                      <dt className="text-gray-400 text-xs sm:text-sm sm:w-56 flex-shrink-0">
+                        {item.label}
+                      </dt>
+                      <dd className="text-white text-xs sm:text-sm">
+                        {item.value}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+
+              {/* Key findings */}
+              <details className="mt-3 sm:mt-4 group bg-black/20 border border-white/10 rounded-xl">
+                <summary className="cursor-pointer select-none p-3 sm:p-4 text-white text-xs sm:text-sm font-semibold uppercase tracking-wide list-none flex items-center justify-between">
+                  Key Findings from the Last 30 Days
+                  <span className="text-gray-400 transition-transform group-open:rotate-180">
+                    ▾
+                  </span>
+                </summary>
+                <div className="px-3 sm:px-4 pb-3 sm:pb-4 space-y-3">
+                  {PATH_VOTE_FINDINGS.map((finding, i) => (
+                    <div key={finding.title}>
+                      <p className="text-white text-xs sm:text-sm font-medium">
+                        {i + 1}. {finding.title}
+                      </p>
+                      <p className="text-gray-400 text-xs sm:text-sm leading-relaxed mt-1">
+                        {finding.body}
+                      </p>
+                    </div>
+                  ))}
+                  <p className="text-gray-500 text-xs leading-relaxed pt-1">
+                    A portion of what we received is under NDA — specific
+                    quoted prices, draft contract language, and some technical
+                    details are not shared publicly. Provider-by-provider
+                    scoring (within NDA limits) will be published as NDAs
+                    allow.
+                  </p>
+                </div>
+              </details>
+
+              {/* Diligence framework */}
+              <details className="mt-3 sm:mt-4 group bg-black/20 border border-white/10 rounded-xl">
+                <summary className="cursor-pointer select-none p-3 sm:p-4 text-white text-xs sm:text-sm font-semibold uppercase tracking-wide list-none flex items-center justify-between">
+                  How Providers Are Evaluated
+                  <span className="text-gray-400 transition-transform group-open:rotate-180">
+                    ▾
+                  </span>
+                </summary>
+                <div className="px-3 sm:px-4 pb-3 sm:pb-4">
+                  <div className="space-y-2">
+                    {PATH_VOTE_DILIGENCE_AXES.map((row) => (
+                      <div
+                        key={row.axis}
+                        className="flex flex-col sm:flex-row sm:gap-4"
+                      >
+                        <p className="text-white text-xs sm:text-sm font-medium sm:w-56 flex-shrink-0">
+                          {row.axis}
+                        </p>
+                        <p className="text-gray-400 text-xs sm:text-sm">
+                          {row.criteria}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                  <p className="text-gray-500 text-xs leading-relaxed mt-3">
+                    No provider scores top-of-class on every axis today. The
+                    job of the diligence is to surface the trade-offs
+                    honestly, not to declare a winner.
+                  </p>
+                </div>
+              </details>
+
+              {/* Candidate seat */}
+              <details className="mt-3 sm:mt-4 group bg-black/20 border border-white/10 rounded-xl">
+                <summary className="cursor-pointer select-none p-3 sm:p-4 text-white text-xs sm:text-sm font-semibold uppercase tracking-wide list-none flex items-center justify-between">
+                  What Happens to the Candidate Seat
+                  <span className="text-gray-400 transition-transform group-open:rotate-180">
+                    ▾
+                  </span>
+                </summary>
+                <div className="px-3 sm:px-4 pb-3 sm:pb-4 space-y-2">
+                  <p className="text-gray-400 text-xs sm:text-sm leading-relaxed">
+                    The original campaign promised a community-selected
+                    Candidate flying alongside Frank, chosen through a
+                    four-round merit-based process culminating in a $vMOONEY
+                    quadratic vote. That process is not cancelled — its status
+                    depends on the path chosen:
+                  </p>
+                  <ul className="text-gray-400 text-xs sm:text-sm leading-relaxed list-disc pl-5 space-y-1">
+                    <li>
+                      <span className="text-white">Option A:</span> the
+                      Candidate seat is deferred — either dropped or contingent
+                      on a second fundraise.
+                    </li>
+                    <li>
+                      <span className="text-white">Option B:</span> the
+                      Candidate seat remains an active goal.
+                    </li>
+                    <li>
+                      <span className="text-white">Option C:</span> the
+                      Candidate process is paused indefinitely.
+                    </li>
+                  </ul>
+                </div>
+              </details>
+            </div>
+
+            {/* Vote panel */}
+            <div className="relative z-10 p-4 sm:p-6 md:p-8 bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl">
+              <h2 className="text-lg sm:text-xl font-GoodTimes text-white mb-2 sm:mb-3">
+                Cast Your Vote
+              </h2>
+              <p className="text-gray-400 text-xs sm:text-sm mb-4 sm:mb-6 leading-relaxed">
+                Select one of the three paths below and submit. Your full
+                $OVERVIEW balance is pledged as voting weight — tokens stay in
+                your wallet. You can change your vote{' '}
+                {deadline
+                  ? 'until voting closes'
+                  : 'at any time while the vote is open'}
+                .
+              </p>
+
+              {votingClosed && (
+                <div className="mb-4 sm:mb-6 bg-amber-500/10 border border-amber-500/30 rounded-xl p-3 sm:p-4">
+                  <p className="text-amber-300 text-xs sm:text-sm font-medium">
+                    Voting closed on{' '}
+                    {deadline!.toLocaleDateString(undefined, {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })}
+                    . Results below are final.
+                  </p>
+                </div>
+              )}
+
+              {/* Balance */}
+              <div className="mb-4 sm:mb-6 bg-black/20 border border-white/10 rounded-lg p-3 sm:p-4 flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-gray-400 text-xs sm:text-sm">
+                    Your $OVERVIEW Balance
+                  </p>
+                  <p className="text-white text-xl sm:text-2xl font-semibold">
+                    {userAddress
+                      ? userBalance != null && Number.isFinite(userBalance)
+                        ? userBalance.toLocaleString(undefined, {
+                            maximumFractionDigits: 2,
+                          })
+                        : '...'
+                      : 'Connect wallet'}
+                  </p>
+                </div>
+                <Link
+                  href="/mission/4"
+                  className="flex-shrink-0 px-3 sm:px-4 py-2 bg-indigo-500/20 hover:bg-indigo-500/30 text-indigo-300 hover:text-indigo-200 text-xs sm:text-sm font-medium rounded-lg transition-colors"
+                >
+                  Get $OVERVIEW
+                </Link>
+              </div>
+
+              {/* Current vote */}
+              {previousVote && previousOption && (
+                <div className="mb-4 sm:mb-6 bg-indigo-500/10 border border-indigo-500/30 rounded-xl p-3 sm:p-4">
+                  <p className="text-indigo-300 text-xs sm:text-sm font-medium mb-1">
+                    Your Current Vote
+                  </p>
+                  <p className="text-white text-sm sm:text-base font-medium">
+                    Option {previousOption.letter} — {previousOption.title}
+                  </p>
+                  <p className="text-gray-400 text-xs sm:text-sm">
+                    {(userBalance != null && Number.isFinite(userBalance)
+                      ? userBalance
+                      : previousVote.amount
+                    ).toLocaleString(undefined, {
+                      maximumFractionDigits: 2,
+                    })}{' '}
+                    $OVERVIEW pledged
+                  </p>
+                </div>
+              )}
+
+              {/* Option cards */}
+              <div className="space-y-3 sm:space-y-4 mb-4 sm:mb-6">
+                {PATH_VOTE_OPTIONS.map((option) => {
+                  const accents = OPTION_ACCENTS[option.id]
+                  const isSelected = selectedOption === option.id
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() =>
+                        !votingClosed && setSelectedOption(option.id)
+                      }
+                      disabled={votingClosed}
+                      className={`w-full text-left p-3 sm:p-5 rounded-xl border transition-all duration-200 ${
+                        isSelected
+                          ? `${accents.border} ${accents.bg} shadow-lg`
+                          : 'border-white/10 bg-black/20 hover:border-white/30'
+                      } ${votingClosed ? 'cursor-default opacity-80' : ''}`}
+                    >
+                      <div className="flex items-start gap-3">
+                        <span
+                          className={`flex-shrink-0 w-8 h-8 sm:w-9 sm:h-9 rounded-full flex items-center justify-center font-bold text-sm sm:text-base ${accents.badge}`}
+                        >
+                          {option.letter}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex flex-wrap items-baseline gap-x-2">
+                            <h3 className="text-white text-sm sm:text-base font-semibold">
+                              {option.title}
+                            </h3>
+                            <span className="text-gray-400 text-xs sm:text-sm">
+                              {option.subtitle}
+                            </span>
+                          </div>
+                          <p className="text-gray-400 text-xs sm:text-sm leading-relaxed mt-1.5">
+                            {option.summary}
+                          </p>
+                          <div className="mt-2.5 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5">
+                            <p className="text-xs sm:text-sm text-gray-400">
+                              <span className="text-gray-300 font-medium">
+                                Funds:{' '}
+                              </span>
+                              {option.fundsImpact}
+                            </p>
+                            <p className="text-xs sm:text-sm text-gray-400">
+                              <span className="text-gray-300 font-medium">
+                                Candidate seat:{' '}
+                              </span>
+                              {option.candidateImpact}
+                            </p>
+                            <p className="text-xs sm:text-sm text-gray-400">
+                              <span className="text-red-300/80 font-medium">
+                                Real risk:{' '}
+                              </span>
+                              {option.realRisk}
+                            </p>
+                            <p className="text-xs sm:text-sm text-gray-400">
+                              <span className="text-emerald-300/80 font-medium">
+                                Best case:{' '}
+                              </span>
+                              {option.bestCase}
+                            </p>
+                          </div>
+                        </div>
+                        <span
+                          className={`flex-shrink-0 w-5 h-5 rounded-full border-2 mt-1 flex items-center justify-center ${
+                            isSelected
+                              ? 'border-white bg-white/90'
+                              : 'border-white/30'
+                          }`}
+                        >
+                          {isSelected && (
+                            <span className="w-2.5 h-2.5 rounded-full bg-gray-900" />
+                          )}
+                        </span>
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+
+              {/* Submit */}
+              {!votingClosed && (
+                <PrivyWeb3Button
+                  label={
+                    isSubmitting
+                      ? 'Submitting...'
+                      : previousVote
+                        ? 'Update Your Vote'
+                        : 'Submit Your Vote'
+                  }
+                  action={handleSubmit}
+                  requiredChain={overviewChain}
+                  isDisabled={
+                    isSubmitting ||
+                    !selectedOption ||
+                    !userBalance ||
+                    userBalance <= 0
+                  }
+                  className="w-full px-4 sm:px-6 py-2.5 sm:py-3 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white text-sm sm:text-base font-semibold rounded-xl transition-all duration-300 shadow-lg hover:shadow-xl border-0 disabled:opacity-50"
+                />
+              )}
+            </div>
+
+            {/* Live results */}
+            <div className="p-4 sm:p-6 md:p-8 bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl">
+              <div className="flex items-center justify-between mb-2 sm:mb-3">
+                <h2 className="text-lg sm:text-xl font-GoodTimes text-white">
+                  Live Results
+                </h2>
+                {isRefreshing && (
+                  <div className="flex items-center gap-2 text-indigo-400 text-xs sm:text-sm">
+                    <div className="w-3 h-3 border-2 border-indigo-400/30 border-t-indigo-400 rounded-full animate-spin" />
+                    Updating...
+                  </div>
+                )}
+              </div>
+              <p className="text-gray-400 text-xs sm:text-sm mb-4 sm:mb-6 leading-relaxed">
+                {visibleResults.totalVoters > 0 ? (
+                  <>
+                    {visibleResults.totalVoted.toLocaleString(undefined, {
+                      maximumFractionDigits: 0,
+                    })}{' '}
+                    $OVERVIEW pledged across {visibleResults.totalVoters}{' '}
+                    voter
+                    {visibleResults.totalVoters !== 1 ? 's' : ''}. Tallies
+                    re-weight to voters&apos; live balances.
+                  </>
+                ) : (
+                  'No votes yet. Be the first to choose a path.'
+                )}
+              </p>
+
+              <div className="space-y-4 sm:space-y-5">
+                {visibleResults.results.map((result) => {
+                  const option = getPathVoteOption(result.optionId)
+                  if (!option) return null
+                  const accents = OPTION_ACCENTS[result.optionId]
+                  return (
+                    <div key={result.optionId}>
+                      <div className="flex items-baseline justify-between gap-3 mb-1.5">
+                        <p className="text-white text-xs sm:text-sm font-medium truncate">
+                          Option {option.letter} — {option.title}
+                        </p>
+                        <p className="text-gray-400 text-xs sm:text-sm flex-shrink-0">
+                          {result.totalVoted.toLocaleString(undefined, {
+                            maximumFractionDigits: 0,
+                          })}{' '}
+                          $OVERVIEW ({result.percentage}%)
+                        </p>
+                      </div>
+                      <div className="h-2.5 sm:h-3 bg-white/5 rounded-full overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all duration-500 ${accents.bar}`}
+                          style={{
+                            width: `${Math.min(100, result.percentage)}%`,
+                          }}
+                        />
+                      </div>
+                      <p className="text-gray-500 text-xs mt-1">
+                        {result.voterCount} voter
+                        {result.voterCount !== 1 ? 's' : ''}
+                      </p>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+        </ContentLayout>
+      </Container>
+    </div>
+  )
+}
+
+export async function getStaticProps() {
+  let voteResults: PathVoteResults
+  try {
+    voteResults = await fetchPathVoteResults()
+  } catch {
+    voteResults = emptyPathVoteResults()
+  }
+  return {
+    props: { voteResults, tokenAddress: OVERVIEW_TOKEN_ADDRESS },
+    revalidate: 60,
+  }
+}

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -37,6 +37,7 @@ import Container from '@/components/layout/Container'
 import ContentLayout from '@/components/layout/ContentLayout'
 import Head from '@/components/layout/Head'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
+import YouTubeEmbed from '@/components/townhall/YouTubeEmbed'
 import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
 
 type OverviewPathVoteProps = {
@@ -435,6 +436,9 @@ export default function OverviewPathVote({
           preFooter={<NoticeFooter />}
         >
           <div className="flex flex-col gap-6 md:gap-8 w-full max-w-[900px] mx-auto">
+            {/* Community update video */}
+            <YouTubeEmbed videoId="YzecKAp9V8U" />
+
             {/* Proposal */}
             <div className="p-4 sm:p-6 md:p-8 bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl">
               <h2 className="text-lg sm:text-xl font-GoodTimes text-white mb-2 sm:mb-3">

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -223,7 +223,7 @@ export default function OverviewPathVote({
 
   const handleSubmit = async () => {
     if (!account) return
-    if (votingClosed) {
+    if (deadline != null && Date.now() > deadline.getTime()) {
       toast.error('Voting has closed.', { style: toastStyle })
       return
     }

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -8,7 +8,6 @@ import {
   VOTES_TABLE_ADDRESSES,
   VOTES_TABLE_NAMES,
 } from 'const/config'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
@@ -426,12 +425,12 @@ export default function OverviewPathVote({
           popOverEffect={false}
           isProfile
           description={
-            <span style={{ fontSize: 'max(22px, min(3vw, 56px))' }}>
+            <p className="text-gray-300 text-base md:text-lg leading-relaxed max-w-3xl">
               A formal $OVERVIEW-weighted vote on the next step for the
               Overview Effect Flight (&quot;Send Frank to Space&quot;). ~$172k
               has been raised or pledged and none of it has been spent. Token
               holders now decide between three paths.
-            </span>
+            </p>
           }
           preFooter={<NoticeFooter />}
         >
@@ -617,27 +616,19 @@ export default function OverviewPathVote({
               )}
 
               {/* Balance */}
-              <div className="mb-4 sm:mb-6 bg-black/20 border border-white/10 rounded-lg p-3 sm:p-4 flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-gray-400 text-xs sm:text-sm">
-                    Your $OVERVIEW Balance
-                  </p>
-                  <p className="text-white text-xl sm:text-2xl font-semibold">
-                    {userAddress
-                      ? userBalance != null && Number.isFinite(userBalance)
-                        ? userBalance.toLocaleString(undefined, {
-                            maximumFractionDigits: 2,
-                          })
-                        : '...'
-                      : 'Connect wallet'}
-                  </p>
-                </div>
-                <Link
-                  href="/mission/4"
-                  className="flex-shrink-0 px-3 sm:px-4 py-2 bg-indigo-500/20 hover:bg-indigo-500/30 text-indigo-300 hover:text-indigo-200 text-xs sm:text-sm font-medium rounded-lg transition-colors"
-                >
-                  Get $OVERVIEW
-                </Link>
+              <div className="mb-4 sm:mb-6 bg-black/20 border border-white/10 rounded-lg p-3 sm:p-4">
+                <p className="text-gray-400 text-xs sm:text-sm">
+                  Your $OVERVIEW Balance
+                </p>
+                <p className="text-white text-xl sm:text-2xl font-semibold">
+                  {userAddress
+                    ? userBalance != null && Number.isFinite(userBalance)
+                      ? userBalance.toLocaleString(undefined, {
+                          maximumFractionDigits: 2,
+                        })
+                      : '...'
+                    : 'Connect wallet'}
+                </p>
               </div>
 
               {/* Current vote */}

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -167,6 +167,7 @@ export default function OverviewPathVote({ voteResults, tokenAddress }: Overview
     const liveAmount = Math.floor(userBalance)
     const entry = displayResults.results.find((r) => r.optionId === previousVote.optionId)
     if (!entry || previousVote.amount === liveAmount) return displayResults
+    if (entry.totalVoted >= liveAmount) return displayResults
 
     const userServerContribution = Math.min(entry.totalVoted, previousVote.amount)
     const adjustedResults = displayResults.results.map((r) =>
@@ -325,6 +326,14 @@ export default function OverviewPathVote({ voteResults, tokenAddress }: Overview
         for (let i = 0; i < retries; i++) {
           await new Promise((r) => setTimeout(r, 4000 + i * 2000))
           try {
+            await fetch('/api/revalidate', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                secret: process.env.NEXT_PUBLIC_REVALIDATE_SECRET,
+                path: '/overview-path-vote',
+              }),
+            })
             const res = await fetch('/overview-path-vote', {
               headers: { Accept: 'text/html' },
             })

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -15,14 +15,8 @@ import toast from 'react-hot-toast'
 import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
-import {
-  emptyPathVoteResults,
-  fetchPathVoteResults,
-} from '@/lib/overview-path-vote/fetchResults'
-import type {
-  PathVoteResults,
-  PathVoteVoter,
-} from '@/lib/overview-path-vote/fetchResults'
+import { emptyPathVoteResults, fetchPathVoteResults } from '@/lib/overview-path-vote/fetchResults'
+import type { PathVoteResults, PathVoteVoter } from '@/lib/overview-path-vote/fetchResults'
 import {
   getPathVoteOption,
   isPathVoteOptionId,
@@ -81,10 +75,7 @@ const OPTION_ACCENTS: Record<
   },
 }
 
-export default function OverviewPathVote({
-  voteResults,
-  tokenAddress,
-}: OverviewPathVoteProps) {
+export default function OverviewPathVote({ voteResults, tokenAddress }: OverviewPathVoteProps) {
   const router = useRouter()
   const overviewChain = arbitrum
   const overviewChainSlug = getChainSlug(overviewChain)
@@ -93,10 +84,8 @@ export default function OverviewPathVote({
 
   const userBalance = useWatchTokenBalance(overviewChain, tokenAddress)
 
-  const [selectedOption, setSelectedOption] =
-    useState<PathVoteOptionId | null>(null)
-  const [expandedOption, setExpandedOption] =
-    useState<PathVoteOptionId | null>(null)
+  const [selectedOption, setSelectedOption] = useState<PathVoteOptionId | null>(null)
+  const [expandedOption, setExpandedOption] = useState<PathVoteOptionId | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [hasExistingVote, setHasExistingVote] = useState(false)
   const [previousVote, setPreviousVote] = useState<{
@@ -110,9 +99,7 @@ export default function OverviewPathVote({
     setDisplayResults(voteResults)
   }, [voteResults])
 
-  const deadline = OVERVIEW_PATH_VOTE_DEADLINE
-    ? new Date(OVERVIEW_PATH_VOTE_DEADLINE)
-    : null
+  const deadline = OVERVIEW_PATH_VOTE_DEADLINE ? new Date(OVERVIEW_PATH_VOTE_DEADLINE) : null
   const votingClosed = deadline != null && Date.now() > deadline.getTime()
   // Per-option tallies stay sealed until voting closes, mirroring the
   // governance proposal pages. Until then we only show who has voted and with
@@ -138,18 +125,14 @@ export default function OverviewPathVote({
     const checkExisting = async () => {
       try {
         const stmt = `SELECT * FROM ${votesTableName} WHERE voteId = ${OVERVIEW_PATH_VOTE_ID} AND address = '${userAddress.toLowerCase()}'`
-        const res = await fetch(
-          `${TABLELAND_ENDPOINT}?statement=${encodeURIComponent(stmt)}`
-        )
+        const res = await fetch(`${TABLELAND_ENDPOINT}?statement=${encodeURIComponent(stmt)}`)
         if (res.ok) {
           const data = await res.json()
           if (Array.isArray(data) && data.length > 0) {
             setHasExistingVote(true)
             try {
               const vote =
-                typeof data[0].vote === 'string'
-                  ? JSON.parse(data[0].vote)
-                  : data[0].vote
+                typeof data[0].vote === 'string' ? JSON.parse(data[0].vote) : data[0].vote
               const entries = Object.entries(vote)
               if (entries.length > 0) {
                 const [optionId, amount] = entries[0]
@@ -178,44 +161,28 @@ export default function OverviewPathVote({
   // the totals don't look stale relative to the balance shown right above
   // them (ISR revalidates every 60s; the balance hook is live).
   const visibleResults = useMemo(() => {
-    if (
-      !previousVote ||
-      userBalance == null ||
-      !Number.isFinite(userBalance) ||
-      userBalance <= 0
-    ) {
+    if (!previousVote || userBalance == null || !Number.isFinite(userBalance) || userBalance <= 0) {
       return displayResults
     }
     const liveAmount = Math.floor(userBalance)
-    const entry = displayResults.results.find(
-      (r) => r.optionId === previousVote.optionId
-    )
-    if (!entry || entry.totalVoted >= liveAmount) return displayResults
+    const entry = displayResults.results.find((r) => r.optionId === previousVote.optionId)
+    if (!entry || previousVote.amount === liveAmount) return displayResults
 
-    const userServerContribution = Math.min(
-      entry.totalVoted,
-      previousVote.amount
-    )
+    const userServerContribution = Math.min(entry.totalVoted, previousVote.amount)
     const adjustedResults = displayResults.results.map((r) =>
       r.optionId === previousVote.optionId
         ? {
             ...r,
-            totalVoted: Math.max(
-              0,
-              r.totalVoted - userServerContribution + liveAmount
-            ),
+            totalVoted: Math.max(0, r.totalVoted - userServerContribution + liveAmount),
           }
-        : r
+        : r,
     )
     const totalVoted = adjustedResults.reduce((s, r) => s + r.totalVoted, 0)
     return {
       ...displayResults,
       results: adjustedResults.map((r) => ({
         ...r,
-        percentage:
-          totalVoted > 0
-            ? Math.round((r.totalVoted / totalVoted) * 1000) / 10
-            : 0,
+        percentage: totalVoted > 0 ? Math.round((r.totalVoted / totalVoted) * 1000) / 10 : 0,
       })),
       totalVoted: Math.round(totalVoted * 100) / 100,
     }
@@ -231,24 +198,19 @@ export default function OverviewPathVote({
       toast.error('Please select an option.', { style: toastStyle })
       return
     }
-    if (
-      userBalance == null ||
-      !Number.isFinite(userBalance) ||
-      userBalance <= 0
-    ) {
+    if (userBalance == null || !Number.isFinite(userBalance) || userBalance <= 0) {
       toast.error(
         userBalance == null || !Number.isFinite(userBalance)
           ? 'Your $OVERVIEW balance is still loading. Please wait a moment and try again.'
           : 'You need $OVERVIEW tokens to vote.',
-        { style: toastStyle }
+        { style: toastStyle },
       )
       return
     }
     if (!votesContract) {
-      toast.error(
-        'Voting contract is not ready yet. Please wait a moment and try again.',
-        { style: toastStyle }
-      )
+      toast.error('Voting contract is not ready yet. Please wait a moment and try again.', {
+        style: toastStyle,
+      })
       return
     }
 
@@ -271,9 +233,7 @@ export default function OverviewPathVote({
       let existsNow = hasExistingVote
       try {
         const stmt = `SELECT id FROM ${votesTableName} WHERE voteId = ${OVERVIEW_PATH_VOTE_ID} AND address = '${userAddress!.toLowerCase()}'`
-        const res = await fetch(
-          `${TABLELAND_ENDPOINT}?statement=${encodeURIComponent(stmt)}`
-        )
+        const res = await fetch(`${TABLELAND_ENDPOINT}?statement=${encodeURIComponent(stmt)}`)
         if (res.ok) {
           const data = await res.json()
           existsNow = Array.isArray(data) && data.length > 0
@@ -281,7 +241,7 @@ export default function OverviewPathVote({
       } catch (lookupErr) {
         console.warn(
           '[overview-path-vote] pre-submit existence check failed; falling back to cached value',
-          lookupErr
+          lookupErr,
         )
       }
 
@@ -304,7 +264,7 @@ export default function OverviewPathVote({
       const optionTitle = getPathVoteOption(selectedOption)?.title
       toast.success(
         `Vote submitted for Option ${getPathVoteOption(selectedOption)?.letter}${optionTitle ? ` — ${optionTitle}` : ''}.`,
-        { style: toastStyle }
+        { style: toastStyle },
       )
 
       // Optimistic tally update: move the user's weight from their previous
@@ -343,18 +303,13 @@ export default function OverviewPathVote({
                 citizenName: existing?.citizenName,
                 citizenId: existing?.citizenId,
               },
-              ...current.voters.filter(
-                (v) => v.address.toLowerCase() !== lowerAddr
-              ),
+              ...current.voters.filter((v) => v.address.toLowerCase() !== lowerAddr),
             ].sort((a, b) => b.votingPower - a.votingPower)
           : current.voters
         return {
           results: adjusted.map((r) => ({
             ...r,
-            percentage:
-              totalVoted > 0
-                ? Math.round((r.totalVoted / totalVoted) * 1000) / 10
-                : 0,
+            percentage: totalVoted > 0 ? Math.round((r.totalVoted / totalVoted) * 1000) / 10 : 0,
           })),
           totalVoted: Math.round(totalVoted * 100) / 100,
           totalVoters: lowerAddr && !existing ? nextVoters.length : totalVoters,
@@ -370,14 +325,6 @@ export default function OverviewPathVote({
         for (let i = 0; i < retries; i++) {
           await new Promise((r) => setTimeout(r, 4000 + i * 2000))
           try {
-            await fetch('/api/revalidate', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                secret: process.env.NEXT_PUBLIC_REVALIDATE_SECRET,
-                path: '/overview-path-vote',
-              }),
-            })
             const res = await fetch('/overview-path-vote', {
               headers: { Accept: 'text/html' },
             })
@@ -408,18 +355,14 @@ export default function OverviewPathVote({
         lower.includes('action_rejected')
       ) {
         toastMessage = 'Transaction cancelled in your wallet.'
-      } else if (
-        lower.includes('insufficient funds') ||
-        lower.includes('insufficient balance')
-      ) {
+      } else if (lower.includes('insufficient funds') || lower.includes('insufficient balance')) {
         toastMessage =
           'Not enough ETH on Arbitrum to cover gas. Add a small amount of ETH to your wallet on Arbitrum and try again.'
       } else if (
         lower.includes('chain') &&
         (lower.includes('mismatch') || lower.includes('switch'))
       ) {
-        toastMessage =
-          'Wallet is on the wrong network. Please switch to Arbitrum and try again.'
+        toastMessage = 'Wallet is on the wrong network. Please switch to Arbitrum and try again.'
       } else if (
         lower.includes('invalid bignumber') ||
         lower.includes('value="nan"') ||
@@ -437,9 +380,7 @@ export default function OverviewPathVote({
     }
   }
 
-  const previousOption = previousVote
-    ? getPathVoteOption(previousVote.optionId)
-    : null
+  const previousOption = previousVote ? getPathVoteOption(previousVote.optionId) : null
 
   return (
     <div className="animate-fadeIn flex flex-col items-center">
@@ -467,10 +408,9 @@ export default function OverviewPathVote({
           }
           description={
             <p className="text-gray-300 text-base md:text-lg leading-relaxed max-w-3xl">
-              A formal $OVERVIEW-weighted vote on the next step for the
-              Overview Effect Flight (&quot;Send Frank to Space&quot;). ~$172k
-              has been raised or pledged and none of it has been spent. Token
-              holders now decide between three paths.
+              A formal $OVERVIEW-weighted vote on the next step for the Overview Effect Flight
+              (&quot;Send Frank to Space&quot;). ~$172k has been raised or pledged and none of it
+              has been spent. Token holders now decide between three paths.
             </p>
           }
           preFooter={<NoticeFooter />}
@@ -486,24 +426,22 @@ export default function OverviewPathVote({
               </h2>
               <div className="text-gray-300 text-xs sm:text-sm leading-relaxed space-y-3">
                 <p>
-                  After 30 days of post-fundraising carrier negotiation, we
-                  engaged 12 companies across the commercial space tourism
-                  industry and collected real quotes, draft contracts, flight
-                  profiles, and timelines. The findings below frame the
-                  decision. The community now chooses one of three paths:
-                  commit to a stratospheric balloon seat for Frank today, keep
-                  options open and continue fundraising toward two seats, or
-                  activate refunds.
+                  After 30 days of post-fundraising carrier negotiation, we engaged 12 companies
+                  across the commercial space tourism industry and collected real quotes, draft
+                  contracts, flight profiles, and timelines. The findings below frame the decision.
+                  The community now chooses one of three paths: commit to a stratospheric balloon
+                  seat for Frank today, keep options open and continue fundraising toward two seats,
+                  or activate refunds.
                 </p>
                 <p>
-                  Voting weight is your live $OVERVIEW balance. Your tokens
-                  never leave your wallet — only your voting power is
-                  recorded. You can change your vote at any time
+                  Voting weight is your live $OVERVIEW balance. Your tokens never leave your wallet
+                  — only your voting power is recorded. You can change your vote at any time
                   {deadline
-                    ? ` until voting closes on ${deadline.toLocaleDateString(
-                        undefined,
-                        { year: 'numeric', month: 'long', day: 'numeric' }
-                      )}`
+                    ? ` until voting closes on ${deadline.toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                      })}`
                     : ' until the vote is closed'}
                   .
                 </p>
@@ -516,16 +454,11 @@ export default function OverviewPathVote({
                 </p>
                 <dl className="space-y-2">
                   {PATH_VOTE_AT_A_GLANCE.map((item) => (
-                    <div
-                      key={item.label}
-                      className="flex flex-col sm:flex-row sm:gap-4"
-                    >
+                    <div key={item.label} className="flex flex-col sm:flex-row sm:gap-4">
                       <dt className="text-gray-400 text-xs sm:text-sm sm:w-56 flex-shrink-0">
                         {item.label}
                       </dt>
-                      <dd className="text-white text-xs sm:text-sm">
-                        {item.value}
-                      </dd>
+                      <dd className="text-white text-xs sm:text-sm">{item.value}</dd>
                     </div>
                   ))}
                 </dl>
@@ -551,10 +484,9 @@ export default function OverviewPathVote({
                     </div>
                   ))}
                   <p className="text-gray-500 text-xs leading-relaxed pt-1">
-                    A portion of what we received is under NDA — specific
-                    quoted prices, draft contract language, and some technical
-                    details are not shared publicly. Provider-by-provider
-                    scoring (within NDA limits) will be published as NDAs
+                    A portion of what we received is under NDA — specific quoted prices, draft
+                    contract language, and some technical details are not shared publicly.
+                    Provider-by-provider scoring (within NDA limits) will be published as NDAs
                     allow.
                   </p>
                 </div>
@@ -571,23 +503,17 @@ export default function OverviewPathVote({
                 <div className="px-3 sm:px-4 pb-3 sm:pb-4">
                   <div className="space-y-2">
                     {PATH_VOTE_DILIGENCE_AXES.map((row) => (
-                      <div
-                        key={row.axis}
-                        className="flex flex-col sm:flex-row sm:gap-4"
-                      >
+                      <div key={row.axis} className="flex flex-col sm:flex-row sm:gap-4">
                         <p className="text-white text-xs sm:text-sm font-medium sm:w-56 flex-shrink-0">
                           {row.axis}
                         </p>
-                        <p className="text-gray-400 text-xs sm:text-sm">
-                          {row.criteria}
-                        </p>
+                        <p className="text-gray-400 text-xs sm:text-sm">{row.criteria}</p>
                       </div>
                     ))}
                   </div>
                   <p className="text-gray-500 text-xs leading-relaxed mt-3">
-                    No provider scores top-of-class on every axis today. The
-                    job of the diligence is to surface the trade-offs
-                    honestly, not to declare a winner.
+                    No provider scores top-of-class on every axis today. The job of the diligence is
+                    to surface the trade-offs honestly, not to declare a winner.
                   </p>
                 </div>
               </details>
@@ -602,25 +528,23 @@ export default function OverviewPathVote({
                 </summary>
                 <div className="px-3 sm:px-4 pb-3 sm:pb-4 space-y-2">
                   <p className="text-gray-400 text-xs sm:text-sm leading-relaxed">
-                    The original campaign promised a community-selected
-                    Candidate flying alongside Frank, chosen through a
-                    four-round merit-based process culminating in a $vMOONEY
-                    quadratic vote. That process is not cancelled — its status
-                    depends on the path chosen:
+                    The original campaign promised a community-selected Candidate flying alongside
+                    Frank, chosen through a four-round merit-based process culminating in a $vMOONEY
+                    quadratic vote. That process is not cancelled — its status depends on the path
+                    chosen:
                   </p>
                   <ul className="text-gray-400 text-xs sm:text-sm leading-relaxed list-disc pl-5 space-y-1">
                     <li>
-                      <span className="text-white">Option A:</span> the
-                      Candidate seat is deferred — either dropped or contingent
-                      on a second fundraise.
+                      <span className="text-white">Option A:</span> the Candidate seat is deferred —
+                      either dropped or contingent on a second fundraise.
                     </li>
                     <li>
-                      <span className="text-white">Option B:</span> the
-                      Candidate seat remains an active goal.
+                      <span className="text-white">Option B:</span> the Candidate seat remains an
+                      active goal.
                     </li>
                     <li>
-                      <span className="text-white">Option C:</span> the
-                      Candidate process is paused indefinitely.
+                      <span className="text-white">Option C:</span> the Candidate process is paused
+                      indefinitely.
                     </li>
                   </ul>
                 </div>
@@ -633,13 +557,9 @@ export default function OverviewPathVote({
                 Cast Your Vote
               </h2>
               <p className="text-gray-400 text-xs sm:text-sm mb-4 sm:mb-6 leading-relaxed">
-                Select one of the three paths below and submit. Your full
-                $OVERVIEW balance is pledged as voting weight — tokens stay in
-                your wallet. You can change your vote{' '}
-                {deadline
-                  ? 'until voting closes'
-                  : 'at any time while the vote is open'}
-                .
+                Select one of the three paths below and submit. Your full $OVERVIEW balance is
+                pledged as voting weight — tokens stay in your wallet. You can change your vote{' '}
+                {deadline ? 'until voting closes' : 'at any time while the vote is open'}.
               </p>
 
               {votingClosed && (
@@ -658,9 +578,7 @@ export default function OverviewPathVote({
 
               {/* Balance */}
               <div className="mb-4 sm:mb-6 bg-black/20 border border-white/10 rounded-lg p-3 sm:p-4">
-                <p className="text-gray-400 text-xs sm:text-sm">
-                  Your $OVERVIEW Balance
-                </p>
+                <p className="text-gray-400 text-xs sm:text-sm">Your $OVERVIEW Balance</p>
                 <p className="text-white text-xl sm:text-2xl font-semibold">
                   {userAddress
                     ? userBalance != null && Number.isFinite(userBalance)
@@ -701,9 +619,9 @@ export default function OverviewPathVote({
                   const isExpanded = expandedOption === option.id
                   const hasDetails = Boolean(
                     option.fundsImpact ||
-                      option.candidateImpact ||
-                      option.realRisk ||
-                      option.bestCase
+                    option.candidateImpact ||
+                    option.realRisk ||
+                    option.bestCase,
                   )
                   return (
                     <div
@@ -717,9 +635,7 @@ export default function OverviewPathVote({
                       {/* Selectable row */}
                       <button
                         type="button"
-                        onClick={() =>
-                          !votingClosed && setSelectedOption(option.id)
-                        }
+                        onClick={() => !votingClosed && setSelectedOption(option.id)}
                         disabled={votingClosed}
                         className="w-full text-left p-3 sm:p-5"
                       >
@@ -744,9 +660,7 @@ export default function OverviewPathVote({
                           </div>
                           <span
                             className={`flex-shrink-0 w-5 h-5 rounded-full border-2 mt-1 flex items-center justify-center ${
-                              isSelected
-                                ? 'border-white bg-white/90'
-                                : 'border-white/30'
+                              isSelected ? 'border-white bg-white/90' : 'border-white/30'
                             }`}
                           >
                             {isSelected && (
@@ -758,50 +672,40 @@ export default function OverviewPathVote({
 
                       {/* Details accordion */}
                       {hasDetails && (
-                      <div className="px-3 sm:px-5 pb-2">
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setExpandedOption(isExpanded ? null : option.id)
-                          }
-                          className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors pb-2"
-                        >
-                          <span
-                            className={`transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
+                        <div className="px-3 sm:px-5 pb-2">
+                          <button
+                            type="button"
+                            onClick={() => setExpandedOption(isExpanded ? null : option.id)}
+                            className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors pb-2"
                           >
-                            ▶
-                          </span>
-                          {isExpanded ? 'Hide details' : 'Show details'}
-                        </button>
-                        {isExpanded && (
-                          <div className="pb-3 sm:pb-4 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
-                            <p className="text-xs sm:text-sm text-gray-400">
-                              <span className="text-gray-300 font-medium">
-                                Funds:{' '}
-                              </span>
-                              {option.fundsImpact}
-                            </p>
-                            <p className="text-xs sm:text-sm text-gray-400">
-                              <span className="text-gray-300 font-medium">
-                                Candidate seat:{' '}
-                              </span>
-                              {option.candidateImpact}
-                            </p>
-                            <p className="text-xs sm:text-sm text-gray-400">
-                              <span className="text-red-300/80 font-medium">
-                                Real risk:{' '}
-                              </span>
-                              {option.realRisk}
-                            </p>
-                            <p className="text-xs sm:text-sm text-gray-400">
-                              <span className="text-emerald-300/80 font-medium">
-                                Best case:{' '}
-                              </span>
-                              {option.bestCase}
-                            </p>
-                          </div>
-                        )}
-                      </div>
+                            <span
+                              className={`transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
+                            >
+                              ▶
+                            </span>
+                            {isExpanded ? 'Hide details' : 'Show details'}
+                          </button>
+                          {isExpanded && (
+                            <div className="pb-3 sm:pb-4 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
+                              <p className="text-xs sm:text-sm text-gray-400">
+                                <span className="text-gray-300 font-medium">Funds: </span>
+                                {option.fundsImpact}
+                              </p>
+                              <p className="text-xs sm:text-sm text-gray-400">
+                                <span className="text-gray-300 font-medium">Candidate seat: </span>
+                                {option.candidateImpact}
+                              </p>
+                              <p className="text-xs sm:text-sm text-gray-400">
+                                <span className="text-red-300/80 font-medium">Real risk: </span>
+                                {option.realRisk}
+                              </p>
+                              <p className="text-xs sm:text-sm text-gray-400">
+                                <span className="text-emerald-300/80 font-medium">Best case: </span>
+                                {option.bestCase}
+                              </p>
+                            </div>
+                          )}
+                        </div>
                       )}
                     </div>
                   )
@@ -821,10 +725,7 @@ export default function OverviewPathVote({
                   action={handleSubmit}
                   requiredChain={overviewChain}
                   isDisabled={
-                    isSubmitting ||
-                    !selectedOption ||
-                    !userBalance ||
-                    userBalance <= 0
+                    isSubmitting || !selectedOption || !userBalance || Math.floor(userBalance) <= 0
                   }
                   className="w-full px-4 sm:px-6 py-2.5 sm:py-3 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white text-sm sm:text-base font-semibold rounded-xl transition-all duration-300 shadow-lg hover:shadow-xl border-0 disabled:opacity-50"
                 />
@@ -842,8 +743,8 @@ export default function OverviewPathVote({
                     maximumFractionDigits: 0,
                   })}{' '}
                   $OVERVIEW across {visibleResults.totalVoters} voter
-                  {visibleResults.totalVoters !== 1 ? 's' : ''}. Tallies
-                  re-weight to voters&apos; live balances.
+                  {visibleResults.totalVoters !== 1 ? 's' : ''}. Tallies re-weight to voters&apos;
+                  live balances.
                 </p>
 
                 <div className="space-y-4 sm:space-y-5">
@@ -886,9 +787,7 @@ export default function OverviewPathVote({
             {/* Voters (who voted + voting power; choices stay sealed) */}
             <div className="p-4 sm:p-6 md:p-8 bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl">
               <div className="flex items-center justify-between mb-2 sm:mb-3">
-                <h2 className="text-lg sm:text-xl font-GoodTimes text-white">
-                  Votes
-                </h2>
+                <h2 className="text-lg sm:text-xl font-GoodTimes text-white">Votes</h2>
                 {isRefreshing && (
                   <div className="flex items-center gap-2 text-indigo-400 text-xs sm:text-sm">
                     <div className="w-3 h-3 border-2 border-indigo-400/30 border-t-indigo-400 rounded-full animate-spin" />
@@ -899,17 +798,16 @@ export default function OverviewPathVote({
               <p className="text-gray-400 text-xs sm:text-sm mb-4 sm:mb-6 leading-relaxed">
                 {!resultsRevealed && (
                   <span className="inline-flex items-center gap-1.5 mr-1 text-indigo-300">
-                    <span aria-hidden>🔒</span> Individual choices and the tally
-                    stay hidden until voting closes.
+                    <span aria-hidden>🔒</span> Individual choices and the tally stay hidden until
+                    voting closes.
                   </span>
                 )}
                 {visibleResults.totalVoters > 0
                   ? `${visibleResults.totalVoters} voter${
                       visibleResults.totalVoters !== 1 ? 's' : ''
-                    } so far, ${visibleResults.totalVoted.toLocaleString(
-                      undefined,
-                      { maximumFractionDigits: 0 }
-                    )} $OVERVIEW of voting power committed.`
+                    } so far, ${visibleResults.totalVoted.toLocaleString(undefined, {
+                      maximumFractionDigits: 0,
+                    })} $OVERVIEW of voting power committed.`
                   : 'No votes yet. Be the first to choose a path.'}
               </p>
 
@@ -923,7 +821,7 @@ export default function OverviewPathVote({
                           <Link
                             href={`/citizen/${generatePrettyLinkWithId(
                               voter.citizenName,
-                              String(voter.citizenId)
+                              String(voter.citizenId),
                             )}`}
                             className="text-white hover:underline break-all"
                           >

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -417,8 +417,8 @@ export default function OverviewPathVote({
           mode="compact"
           popOverEffect={false}
           isProfile
-          branded={false}
           maxWidth="900px"
+          logo={<div aria-hidden />}
           description={
             <p className="text-gray-300 text-base md:text-lg leading-relaxed max-w-3xl">
               A formal $OVERVIEW-weighted vote on the next step for the

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -8,6 +8,7 @@ import {
   VOTES_TABLE_ADDRESSES,
   VOTES_TABLE_NAMES,
 } from 'const/config'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
@@ -18,7 +19,10 @@ import {
   emptyPathVoteResults,
   fetchPathVoteResults,
 } from '@/lib/overview-path-vote/fetchResults'
-import type { PathVoteResults } from '@/lib/overview-path-vote/fetchResults'
+import type {
+  PathVoteResults,
+  PathVoteVoter,
+} from '@/lib/overview-path-vote/fetchResults'
 import {
   getPathVoteOption,
   isPathVoteOptionId,
@@ -29,6 +33,7 @@ import {
 } from '@/lib/overview-path-vote/options'
 import type { PathVoteOptionId } from '@/lib/overview-path-vote/options'
 import { arbitrum } from '@/lib/rpc/chains'
+import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
 import useWatchTokenBalance from '@/lib/tokens/hooks/useWatchTokenBalance'
@@ -36,6 +41,8 @@ import Container from '@/components/layout/Container'
 import ContentLayout from '@/components/layout/ContentLayout'
 import Head from '@/components/layout/Head'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
+import Votes, { VoteItem, VoteItemHeader } from '@/components/layout/Votes'
+import { ShortAddressLink } from '@/components/nance/AddressLink'
 import YouTubeEmbed from '@/components/townhall/YouTubeEmbed'
 import { PrivyWeb3Button } from '@/components/privy/PrivyWeb3Button'
 
@@ -107,6 +114,10 @@ export default function OverviewPathVote({
     ? new Date(OVERVIEW_PATH_VOTE_DEADLINE)
     : null
   const votingClosed = deadline != null && Date.now() > deadline.getTime()
+  // Per-option tallies stay sealed until voting closes, mirroring the
+  // governance proposal pages. Until then we only show who has voted and with
+  // how much voting power.
+  const resultsRevealed = votingClosed
 
   const votesContract = useContract({
     address: VOTES_TABLE_ADDRESSES[overviewChainSlug],
@@ -318,6 +329,25 @@ export default function OverviewPathVote({
         })
         const totalVoted = adjusted.reduce((s, r) => s + r.totalVoted, 0)
         const totalVoters = adjusted.reduce((s, r) => s + r.voterCount, 0)
+        // Optimistically reflect the connected wallet in the voter list with
+        // its live weight (no choice attached, matching the sealed display).
+        const lowerAddr = userAddress?.toLowerCase()
+        const existing = lowerAddr
+          ? current.voters.find((v) => v.address.toLowerCase() === lowerAddr)
+          : undefined
+        const nextVoters: PathVoteVoter[] = lowerAddr
+          ? [
+              {
+                address: lowerAddr,
+                votingPower: voteAmount,
+                citizenName: existing?.citizenName,
+                citizenId: existing?.citizenId,
+              },
+              ...current.voters.filter(
+                (v) => v.address.toLowerCase() !== lowerAddr
+              ),
+            ].sort((a, b) => b.votingPower - a.votingPower)
+          : current.voters
         return {
           results: adjusted.map((r) => ({
             ...r,
@@ -327,7 +357,8 @@ export default function OverviewPathVote({
                 : 0,
           })),
           totalVoted: Math.round(totalVoted * 100) / 100,
-          totalVoters,
+          totalVoters: lowerAddr && !existing ? nextVoters.length : totalVoters,
+          voters: nextVoters,
         }
       })
 
@@ -791,11 +822,63 @@ export default function OverviewPathVote({
               )}
             </div>
 
-            {/* Live results */}
+            {/* Results (sealed until voting closes) */}
+            {resultsRevealed && (
+              <div className="p-4 sm:p-6 md:p-8 bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl">
+                <h2 className="text-lg sm:text-xl font-GoodTimes text-white mb-2 sm:mb-3">
+                  Final Results
+                </h2>
+                <p className="text-gray-400 text-xs sm:text-sm mb-4 sm:mb-6 leading-relaxed">
+                  {visibleResults.totalVoted.toLocaleString(undefined, {
+                    maximumFractionDigits: 0,
+                  })}{' '}
+                  $OVERVIEW across {visibleResults.totalVoters} voter
+                  {visibleResults.totalVoters !== 1 ? 's' : ''}. Tallies
+                  re-weight to voters&apos; live balances.
+                </p>
+
+                <div className="space-y-4 sm:space-y-5">
+                  {visibleResults.results.map((result) => {
+                    const option = getPathVoteOption(result.optionId)
+                    if (!option) return null
+                    const accents = OPTION_ACCENTS[result.optionId]
+                    return (
+                      <div key={result.optionId}>
+                        <div className="flex items-baseline justify-between gap-3 mb-1.5">
+                          <p className="text-white text-xs sm:text-sm font-medium truncate">
+                            Option {option.letter} — {option.title}
+                          </p>
+                          <p className="text-gray-400 text-xs sm:text-sm flex-shrink-0">
+                            {result.totalVoted.toLocaleString(undefined, {
+                              maximumFractionDigits: 0,
+                            })}{' '}
+                            $OVERVIEW ({result.percentage}%)
+                          </p>
+                        </div>
+                        <div className="h-2.5 sm:h-3 bg-white/5 rounded-full overflow-hidden">
+                          <div
+                            className={`h-full rounded-full transition-all duration-500 ${accents.bar}`}
+                            style={{
+                              width: `${Math.min(100, result.percentage)}%`,
+                            }}
+                          />
+                        </div>
+                        <p className="text-gray-500 text-xs mt-1">
+                          {result.voterCount} voter
+                          {result.voterCount !== 1 ? 's' : ''}
+                        </p>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Voters (who voted + voting power; choices stay sealed) */}
             <div className="p-4 sm:p-6 md:p-8 bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl">
               <div className="flex items-center justify-between mb-2 sm:mb-3">
                 <h2 className="text-lg sm:text-xl font-GoodTimes text-white">
-                  Live Results
+                  Votes
                 </h2>
                 {isRefreshing && (
                   <div className="flex items-center gap-2 text-indigo-400 text-xs sm:text-sm">
@@ -805,55 +888,56 @@ export default function OverviewPathVote({
                 )}
               </div>
               <p className="text-gray-400 text-xs sm:text-sm mb-4 sm:mb-6 leading-relaxed">
-                {visibleResults.totalVoters > 0 ? (
-                  <>
-                    {visibleResults.totalVoted.toLocaleString(undefined, {
-                      maximumFractionDigits: 0,
-                    })}{' '}
-                    $OVERVIEW pledged across {visibleResults.totalVoters}{' '}
-                    voter
-                    {visibleResults.totalVoters !== 1 ? 's' : ''}. Tallies
-                    re-weight to voters&apos; live balances.
-                  </>
-                ) : (
-                  'No votes yet. Be the first to choose a path.'
+                {!resultsRevealed && (
+                  <span className="inline-flex items-center gap-1.5 mr-1 text-indigo-300">
+                    <span aria-hidden>🔒</span> Individual choices and the tally
+                    stay hidden until voting closes.
+                  </span>
                 )}
+                {visibleResults.totalVoters > 0
+                  ? `${visibleResults.totalVoters} voter${
+                      visibleResults.totalVoters !== 1 ? 's' : ''
+                    } so far, ${visibleResults.totalVoted.toLocaleString(
+                      undefined,
+                      { maximumFractionDigits: 0 }
+                    )} $OVERVIEW of voting power committed.`
+                  : 'No votes yet. Be the first to choose a path.'}
               </p>
 
-              <div className="space-y-4 sm:space-y-5">
-                {visibleResults.results.map((result) => {
-                  const option = getPathVoteOption(result.optionId)
-                  if (!option) return null
-                  const accents = OPTION_ACCENTS[result.optionId]
-                  return (
-                    <div key={result.optionId}>
-                      <div className="flex items-baseline justify-between gap-3 mb-1.5">
-                        <p className="text-white text-xs sm:text-sm font-medium truncate">
-                          Option {option.letter} — {option.title}
-                        </p>
-                        <p className="text-gray-400 text-xs sm:text-sm flex-shrink-0">
-                          {result.totalVoted.toLocaleString(undefined, {
+              <Votes
+                emptyStateMessage="No votes yet. Be the first to choose a path."
+                voteItems={visibleResults.voters.map((voter) => (
+                  <VoteItem key={voter.address}>
+                    <VoteItemHeader
+                      leftContent={
+                        voter.citizenName && voter.citizenId != null ? (
+                          <Link
+                            href={`/citizen/${generatePrettyLinkWithId(
+                              voter.citizenName,
+                              String(voter.citizenId)
+                            )}`}
+                            className="text-white hover:underline break-all"
+                          >
+                            {voter.citizenName}
+                          </Link>
+                        ) : (
+                          <span className="text-gray-300">
+                            <ShortAddressLink address={voter.address} />
+                          </span>
+                        )
+                      }
+                      rightContent={
+                        <span className="text-gray-400">
+                          {voter.votingPower.toLocaleString(undefined, {
                             maximumFractionDigits: 0,
                           })}{' '}
-                          $OVERVIEW ({result.percentage}%)
-                        </p>
-                      </div>
-                      <div className="h-2.5 sm:h-3 bg-white/5 rounded-full overflow-hidden">
-                        <div
-                          className={`h-full rounded-full transition-all duration-500 ${accents.bar}`}
-                          style={{
-                            width: `${Math.min(100, result.percentage)}%`,
-                          }}
-                        />
-                      </div>
-                      <p className="text-gray-500 text-xs mt-1">
-                        {result.voterCount} voter
-                        {result.voterCount !== 1 ? 's' : ''}
-                      </p>
-                    </div>
-                  )
-                })}
-              </div>
+                          $OVERVIEW
+                        </span>
+                      }
+                    />
+                  </VoteItem>
+                ))}
+              />
             </div>
           </div>
         </ContentLayout>

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -82,6 +82,8 @@ export default function OverviewPathVote({
 
   const [selectedOption, setSelectedOption] =
     useState<PathVoteOptionId | null>(null)
+  const [expandedOption, setExpandedOption] =
+    useState<PathVoteOptionId | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [hasExistingVote, setHasExistingVote] = useState(false)
   const [previousVote, setPreviousVote] = useState<{
@@ -423,12 +425,12 @@ export default function OverviewPathVote({
           popOverEffect={false}
           isProfile
           description={
-            <>
+            <span style={{ fontSize: 'max(22px, min(3vw, 56px))' }}>
               A formal $OVERVIEW-weighted vote on the next step for the
               Overview Effect Flight (&quot;Send Frank to Space&quot;). ~$172k
               has been raised or pledged and none of it has been spent. Token
               holders now decide between three paths.
-            </>
+            </span>
           }
           preFooter={<NoticeFooter />}
         >
@@ -660,39 +662,76 @@ export default function OverviewPathVote({
                 {PATH_VOTE_OPTIONS.map((option) => {
                   const accents = OPTION_ACCENTS[option.id]
                   const isSelected = selectedOption === option.id
+                  const isExpanded = expandedOption === option.id
                   return (
-                    <button
+                    <div
                       key={option.id}
-                      type="button"
-                      onClick={() =>
-                        !votingClosed && setSelectedOption(option.id)
-                      }
-                      disabled={votingClosed}
-                      className={`w-full text-left p-3 sm:p-5 rounded-xl border transition-all duration-200 ${
+                      className={`rounded-xl border transition-all duration-200 ${
                         isSelected
                           ? `${accents.border} ${accents.bg} shadow-lg`
-                          : 'border-white/10 bg-black/20 hover:border-white/30'
-                      } ${votingClosed ? 'cursor-default opacity-80' : ''}`}
+                          : 'border-white/10 bg-black/20'
+                      } ${votingClosed ? 'opacity-80' : ''}`}
                     >
-                      <div className="flex items-start gap-3">
-                        <span
-                          className={`flex-shrink-0 w-8 h-8 sm:w-9 sm:h-9 rounded-full flex items-center justify-center font-bold text-sm sm:text-base ${accents.badge}`}
-                        >
-                          {option.letter}
-                        </span>
-                        <div className="flex-1 min-w-0">
-                          <div className="flex flex-wrap items-baseline gap-x-2">
-                            <h3 className="text-white text-sm sm:text-base font-semibold">
-                              {option.title}
-                            </h3>
-                            <span className="text-gray-400 text-xs sm:text-sm">
-                              {option.subtitle}
-                            </span>
+                      {/* Selectable row */}
+                      <button
+                        type="button"
+                        onClick={() =>
+                          !votingClosed && setSelectedOption(option.id)
+                        }
+                        disabled={votingClosed}
+                        className="w-full text-left p-3 sm:p-5"
+                      >
+                        <div className="flex items-start gap-3">
+                          <span
+                            className={`flex-shrink-0 w-8 h-8 sm:w-9 sm:h-9 rounded-full flex items-center justify-center font-bold text-sm sm:text-base ${accents.badge}`}
+                          >
+                            {option.letter}
+                          </span>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex flex-wrap items-baseline gap-x-2">
+                              <h3 className="text-white text-sm sm:text-base font-semibold">
+                                {option.title}
+                              </h3>
+                              <span className="text-gray-400 text-xs sm:text-sm">
+                                {option.subtitle}
+                              </span>
+                            </div>
+                            <p className="text-gray-400 text-xs sm:text-sm leading-relaxed mt-1.5">
+                              {option.summary}
+                            </p>
                           </div>
-                          <p className="text-gray-400 text-xs sm:text-sm leading-relaxed mt-1.5">
-                            {option.summary}
-                          </p>
-                          <div className="mt-2.5 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5">
+                          <span
+                            className={`flex-shrink-0 w-5 h-5 rounded-full border-2 mt-1 flex items-center justify-center ${
+                              isSelected
+                                ? 'border-white bg-white/90'
+                                : 'border-white/30'
+                            }`}
+                          >
+                            {isSelected && (
+                              <span className="w-2.5 h-2.5 rounded-full bg-gray-900" />
+                            )}
+                          </span>
+                        </div>
+                      </button>
+
+                      {/* Details accordion */}
+                      <div className="px-3 sm:px-5 pb-2">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExpandedOption(isExpanded ? null : option.id)
+                          }
+                          className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-200 transition-colors pb-2"
+                        >
+                          <span
+                            className={`transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
+                          >
+                            ▶
+                          </span>
+                          {isExpanded ? 'Hide details' : 'Show details'}
+                        </button>
+                        {isExpanded && (
+                          <div className="pb-3 sm:pb-4 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
                             <p className="text-xs sm:text-sm text-gray-400">
                               <span className="text-gray-300 font-medium">
                                 Funds:{' '}
@@ -718,20 +757,9 @@ export default function OverviewPathVote({
                               {option.bestCase}
                             </p>
                           </div>
-                        </div>
-                        <span
-                          className={`flex-shrink-0 w-5 h-5 rounded-full border-2 mt-1 flex items-center justify-center ${
-                            isSelected
-                              ? 'border-white bg-white/90'
-                              : 'border-white/30'
-                          }`}
-                        >
-                          {isSelected && (
-                            <span className="w-2.5 h-2.5 rounded-full bg-gray-900" />
-                          )}
-                        </span>
+                        )}
                       </div>
-                    </button>
+                    </div>
                   )
                 })}
               </div>

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -412,18 +412,13 @@ export default function OverviewPathVote({
       />
       <Container>
         <ContentLayout
-          header={
-            <span
-              style={{ fontSize: 'max(22px, min(3vw, 56px))' }}
-              className="sm:whitespace-nowrap"
-            >
-              Choose the Path Forward
-            </span>
-          }
+          header="Choose the Path Forward"
           mainPadding
           mode="compact"
           popOverEffect={false}
           isProfile
+          branded={false}
+          maxWidth="900px"
           description={
             <p className="text-gray-300 text-base md:text-lg leading-relaxed max-w-3xl">
               A formal $OVERVIEW-weighted vote on the next step for the

--- a/ui/pages/overview-path-vote.tsx
+++ b/ui/pages/overview-path-vote.tsx
@@ -66,6 +66,12 @@ const OPTION_ACCENTS: Record<
     badge: 'bg-amber-500/20 text-amber-300',
     bar: 'bg-gradient-to-r from-amber-500 to-amber-400',
   },
+  abstain: {
+    border: 'border-gray-400/60',
+    bg: 'bg-gray-500/10',
+    badge: 'bg-gray-500/20 text-gray-300',
+    bar: 'bg-gradient-to-r from-gray-500 to-gray-400',
+  },
 }
 
 export default function OverviewPathVote({
@@ -653,6 +659,12 @@ export default function OverviewPathVote({
                   const accents = OPTION_ACCENTS[option.id]
                   const isSelected = selectedOption === option.id
                   const isExpanded = expandedOption === option.id
+                  const hasDetails = Boolean(
+                    option.fundsImpact ||
+                      option.candidateImpact ||
+                      option.realRisk ||
+                      option.bestCase
+                  )
                   return (
                     <div
                       key={option.id}
@@ -705,6 +717,7 @@ export default function OverviewPathVote({
                       </button>
 
                       {/* Details accordion */}
+                      {hasDetails && (
                       <div className="px-3 sm:px-5 pb-2">
                         <button
                           type="button"
@@ -749,6 +762,7 @@ export default function OverviewPathVote({
                           </div>
                         )}
                       </div>
+                      )}
                     </div>
                   )
                 })}


### PR DESCRIPTION
## Summary

- Adds `/overview-path-vote` — a one-off $OVERVIEW-weighted vote page for the "Send Frank to Space" campaign path decision
- Three options (A: commit now to a stratospheric balloon, B: keep options open + continue fundraising, C: refunds) presented with full proposal copy from the 30-day carrier negotiation update, condensed into collapsible sections (at a glance, key findings, diligence framework, Candidate seat status)
- Reuses the existing Tableland Votes contract mechanism (voteId = 3); vote weight is the voter's live $OVERVIEW balance — tokens never leave the wallet; one choice per address, changeable any time while the vote is open
- Results tallied server-side via the same `engineBatchRead` pipeline as the delegation leaderboard, with ISR `revalidate: 60` and optimistic-update + revalidate-poll after each vote lands

## New files

- `ui/lib/overview-path-vote/options.ts` — static option definitions and all proposal copy (at-a-glance facts, key findings, diligence axes)
- `ui/lib/overview-path-vote/fetchResults.ts` — server-side tally: queries voteId-3 rows, re-weights by live balances, aggregates per option
- `ui/pages/overview-path-vote.tsx` — voting page with proposal sections, radio-style option cards, vote panel, and live results bar chart

## Changed files

- `ui/const/config.ts` — adds `OVERVIEW_PATH_VOTE_ID = 3` and `OVERVIEW_PATH_VOTE_DEADLINE` (currently `null`; set to an ISO date to show a deadline and disable voting after it passes)

## Test plan

- [ ] Visit `/overview-path-vote` while disconnected — page loads, results show "No votes yet"
- [ ] Connect a wallet with $OVERVIEW — balance displays correctly, all three option cards are selectable
- [ ] Select an option and submit — transaction fires on Arbitrum, confetti + success toast, results update optimistically
- [ ] Revisit the page — current vote banner shows the previously selected option, updating vote re-routes to `updateTableCol`
- [ ] Test error paths: reject in wallet, wrong network, zero balance — each should show the appropriate toast message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> On-chain votes affect a high-stakes campaign decision and fund paths (including refunds), but the implementation reuses the established Votes contract and delegation-leaderboard tally pattern rather than new auth or payment logic.
> 
> **Overview**
> Adds **`/overview-path-vote`**, a one-off **$OVERVIEW-weighted** community vote on the Overview Effect Flight path forward (commit now, keep fundraising, or refunds), wired into the existing Tableland **Votes** flow as **`voteId` 3**.
> 
> **Config & nav:** `OVERVIEW_PATH_VOTE_ID`, optional `OVERVIEW_PATH_VOTE_DEADLINE` (null = open-ended; when set, voting closes and per-option results unlock). **Send Frank to Space** nav gains **Path Forward Vote**. **`/api/revalidate`** allowlists the new path.
> 
> **New stack:** Static option/proposal copy in `options.ts`; server tally in `fetchResults.ts` (Tableland rows for vote 3, re-weight by live `$OVERVIEW` via `engineBatchRead`, citizen name lookup, RPC fallback to stored amounts). The page shows full proposal UI, wallet voting (`insertIntoTable` / `updateTableCol`), **sealed tallies** until the deadline (participation list without choices), ISR **60s**, optimistic updates, and post-vote revalidate polling—aligned with `overview-vote`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba5340b8ceb44465c126cc54b64abf7d62a6bf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->