### PR TITLE
feat(marketplace): restore share/copy-link button on listings

### DIFF
--- a/ui/components/subscription/TeamListing.tsx
+++ b/ui/components/subscription/TeamListing.tsx
@@ -223,14 +223,22 @@ export default function TeamListing({
             <div className="flex items-center gap-2">
               <button
                 id="share-listing-button"
-                onClick={(e) => {
+                onClick={async (e) => {
                   e.stopPropagation()
                   const origin = typeof window !== 'undefined' ? window.location.origin : 'https://www.moondao.com'
                   const teamSlug = teamNFT?.metadata?.name
                     ? generatePrettyLink(teamNFT.metadata.name)
                     : String(listing.teamId)
-                  navigator.clipboard.writeText(`${origin}/team/${teamSlug}?listing=${listing.id}`)
-                  toast.success('Link copied to clipboard.')
+                  const shareLink = `${origin}/team/${teamSlug}?listing=${listing.id}`
+                  try {
+                    if (!navigator.clipboard?.writeText) {
+                      throw new Error('Clipboard API unavailable')
+                    }
+                    await navigator.clipboard.writeText(shareLink)
+                    toast.success('Link copied to clipboard.')
+                  } catch (err) {
+                    toast.error('Could not copy link. Please copy it manually.')
+                  }
                 }}
                 className="text-white/40 hover:text-white/80 transition-colors"
                 title="Copy link"

--- a/ui/components/subscription/TeamListing.tsx
+++ b/ui/components/subscription/TeamListing.tsx
@@ -1,4 +1,4 @@
-import { PencilIcon, ShoppingBagIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { LinkIcon, PencilIcon, ShoppingBagIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { useWallets } from '@privy-io/react-auth'
 import { useRouter } from 'next/router'
 import { useContext, useEffect, useState, useRef } from 'react'
@@ -220,8 +220,26 @@ export default function TeamListing({
               <span className="text-white/30 text-xs">—</span>
             )}
 
+            <div className="flex items-center gap-2">
+              <button
+                id="share-listing-button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  const origin = typeof window !== 'undefined' ? window.location.origin : 'https://www.moondao.com'
+                  const teamSlug = teamNFT?.metadata?.name
+                    ? generatePrettyLink(teamNFT.metadata.name)
+                    : String(listing.teamId)
+                  navigator.clipboard.writeText(`${origin}/team/${teamSlug}?listing=${listing.id}`)
+                  toast.success('Link copied to clipboard.')
+                }}
+                className="text-white/40 hover:text-white/80 transition-colors"
+                title="Copy link"
+              >
+                <LinkIcon className="w-4 h-4" />
+              </button>
+
             {editable && (
-              <div className="flex items-center gap-2">
+              <>
                 <button
                   id="edit-listing-button"
                   onClick={(e) => { e.stopPropagation(); setEnabledMarketplaceListingModal(true) }}
@@ -297,8 +315,9 @@ export default function TeamListing({
                     <TrashIcon className="w-4 h-4" />
                   </button>
                 )}
-              </div>
+              </>
             )}
+            </div>
           </div>
 
           {isUpcoming && editable && (


### PR DESCRIPTION
## Summary

Restores the share button that was previously removed from marketplace listing cards.

- Each listing card now has a `🔗` (link) icon button in the footer, visible to all users
- Clicking it copies a deep-link URL to the clipboard: `/team/<slug>?listing=<id>` (e.g. `/team/moondao?listing=31`)
- The team slug is derived from the team name if available, falling back to the numeric team ID
- The existing `?listing=` query param handling already auto-opens the purchase modal and scrolls to the correct card on page load — no server-side changes needed
- The visibility bug that would have blocked these links for non-citizens is fixed in PR #1386

## Test plan

- [ ] Visit a team page as any user — each listing card should show a link icon in the bottom-right
- [ ] Click the icon — toast should confirm "Link copied to clipboard"
- [ ] Paste and navigate to the copied URL — the listing's buy modal should open automatically
- [ ] Confirm managers still see pencil + trash icons alongside the share icon

Made with [Cursor](https://cursor.com)