### PR TITLE
fix(team): manage team UI and restore Safe signer data

### DIFF
--- a/ui/components/subscription/TeamManageMembers.tsx
+++ b/ui/components/subscription/TeamManageMembers.tsx
@@ -1,5 +1,4 @@
 import { hatIdDecimalToHex } from '@hatsprotocol/sdk-v1-core'
-import { XMarkIcon } from '@heroicons/react/24/outline'
 import { TrashIcon } from '@heroicons/react/24/outline'
 import { useWallets } from '@privy-io/react-auth'
 import { DEFAULT_CHAIN_V5, HATS_ADDRESS } from 'const/config'
@@ -216,14 +215,7 @@ function TeamManageMembersModal({
     <Modal id="team-manage-members-modal" setEnabled={setEnabled}>
       <div className="w-full rounded-[2vmax] flex flex-col gap-2 items-start justify-start w-auto md:w-[500px] p-5 py-0 bg-gradient-to-b from-dark-cool to-darkest-cool h-screen md:h-auto">
         <div className="w-full flex mt-5 mb-2 items-end justify-between">
-          <h2 className="font-GoodTimes">{`Manage Members`}</h2>
-          <button
-            type="button"
-            className="flex h-10 w-10 border-2 items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
-            onClick={() => setEnabled(false)}
-          >
-            <XMarkIcon className="h-6 w-6 text-white" aria-hidden="true" />
-          </button>
+          <h2 className="font-GoodTimes">{`Manage Team`}</h2>
         </div>
 
         <div className="border-b-[3px] border-dark-cool rounded-[2vmax] w-full">
@@ -534,7 +526,7 @@ export default function TeamManageMembers({
         className="min-w-[200px] gradient-2 rounded-[2vmax] rounded-bl-[10px] transition-all duration-200 hover:scale-105"
         onClick={() => setManagerModalEnabled(true)}
       >
-        {'Manage Members'}
+        {'Manage Team'}
       </StandardButton>
     </div>
   )

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -195,7 +195,16 @@ function TeamDetailPageContent({
 
   const safeData = useSafe(nft?.owner)
 
-  const isSigner = safeOwners.includes(address || '')
+  // The SSR-prerendered `safeOwners` is best-effort and comes back empty
+  // whenever the Safe/RPC lookup blips at build time. Fall back to the
+  // client-side owners from `useSafe` so the signer list and the
+  // signer-gated pending-transactions UI keep working.
+  const resolvedSafeOwners =
+    safeOwners && safeOwners.length > 0 ? safeOwners : safeData?.owners || []
+
+  const isSigner = resolvedSafeOwners.some(
+    (owner: string) => owner.toLowerCase() === (address || '').toLowerCase()
+  )
 
   // Only citizens (or team managers / owners / signers) can see team content
   const canViewContent = !!(citizen || isManager || isTableOperator || isSigner || address === nft.owner)
@@ -549,7 +558,7 @@ function TeamDetailPageContent({
                 isSigner={isSigner}
                 safeData={safeData}
                 multisigAddress={nft.owner}
-                safeOwners={safeOwners}
+                safeOwners={resolvedSafeOwners}
               />
             </div>
           )}
@@ -650,7 +659,7 @@ function TeamDetailPageContent({
                   isSigner={isSigner}
                   safeData={safeData}
                   multisigAddress={nft.owner}
-                  safeOwners={safeOwners}
+                  safeOwners={resolvedSafeOwners}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Rename "Manage Members" to "Manage Team" on the button and modal to avoid confusion when adding managers
- Remove duplicate close button from the manage team modal (shared `Modal` already provides one)
- Restore team Safe signer addresses and pending transactions by falling back to client-side `useSafe` owners when SSR `safeOwners` is empty

## Test plan
- [ ] Open a team page as a manager and confirm the button/modal say "Manage Team"
- [ ] Open the manage team modal and confirm only one close (X) button appears
- [ ] On a team with a Safe multisig, confirm signer addresses appear in the Treasury section
- [ ] Connect a Privy wallet that is a Safe signer and confirm pending transactions are visible and can be signed

Made with [Cursor](https://cursor.com)