### PR TITLE
Fix citizen profile listings spacing and governance stats

### DIFF
--- a/ui/lib/xp/votes.ts
+++ b/ui/lib/xp/votes.ts
@@ -1,0 +1,83 @@
+import { gql, request as gqlRequest } from 'graphql-request'
+import { Address } from 'thirdweb'
+import {
+  DEFAULT_CHAIN_V5,
+  NON_PROJECT_PROPOSAL_TABLE_NAMES,
+  PROPOSALS_TABLE_NAMES,
+} from 'const/config'
+import queryTable from '@/lib/tableland/queryTable'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+
+// Server-side only. Centralizes the canonical vote count used for both the
+// "Votes" XP quest and the Citizen profile so the two never drift apart.
+
+const chain = DEFAULT_CHAIN_V5
+const chainSlug = getChainSlug(chain)
+
+const SNAPSHOT_SPACE = process.env.SNAPSHOT_SPACE || 'tomoondao.eth'
+
+// Count votes a user has cast through the current on-chain governance system:
+// project/member votes live in the Proposals table and non-project governance
+// votes live in the NonProjectProposal table. Each row is one cast vote.
+export async function fetchOnchainVotesCount(user: Address): Promise<number> {
+  const address = user.toLowerCase()
+  const tables = [
+    PROPOSALS_TABLE_NAMES[chainSlug],
+    NON_PROJECT_PROPOSAL_TABLE_NAMES[chainSlug],
+  ].filter(Boolean)
+
+  let total = 0
+  for (const table of tables) {
+    try {
+      const statement = `SELECT COUNT(*) AS c FROM ${table} WHERE LOWER(address) = '${address}'`
+      const rows = (await queryTable(chain, statement)) as Array<{
+        c: number | string
+      }>
+      total += Number(rows?.[0]?.c ?? 0)
+    } catch (err) {
+      console.error(`On-chain votes fetch failed for ${table}:`, err)
+    }
+  }
+  return total
+}
+
+// Legacy: votes cast in MoonDAO's historical Snapshot space. Retained so
+// Citizens who voted before the migration to on-chain governance still qualify.
+export async function fetchSnapshotVotesCount(user: Address): Promise<number> {
+  const endpoint = 'https://hub.snapshot.org/graphql'
+  const query = gql`
+    query Votes($address: String!) {
+      votes(
+        first: 1000
+        skip: 0
+        where: { voter: $address, space: "${SNAPSHOT_SPACE}" }
+      ) {
+        id
+        voter
+        choice
+        created
+        space {
+          id
+        }
+      }
+    }
+  `
+  try {
+    const data = (await gqlRequest(endpoint, query, {
+      address: user,
+    })) as any
+    const count = Array.isArray(data?.votes) ? data.votes.length : 0
+    return count
+  } catch (err) {
+    console.error('Snapshot votes fetch failed:', err)
+    return 0
+  }
+}
+
+export async function fetchVotesCount(user: Address): Promise<number> {
+  const [onchain, snapshot] = await Promise.all([
+    fetchOnchainVotesCount(user),
+    fetchSnapshotVotesCount(user),
+  ])
+  return onchain + snapshot
+}

--- a/ui/pages/api/xp/has-voted-proof.ts
+++ b/ui/pages/api/xp/has-voted-proof.ts
@@ -1,95 +1,17 @@
 import { utils as ethersUtils } from 'ethers'
-import { gql, request as gqlRequest } from 'graphql-request'
 import { authMiddleware } from 'middleware/authMiddleware'
 import withMiddleware from 'middleware/withMiddleware'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { Address } from 'thirdweb'
-import {
-  DEFAULT_CHAIN_V5,
-  NON_PROJECT_PROPOSAL_TABLE_NAMES,
-  PROPOSALS_TABLE_NAMES,
-} from 'const/config'
 import { addressBelongsToPrivyUser } from '@/lib/privy'
-import queryTable from '@/lib/tableland/queryTable'
-import { getChainSlug } from '@/lib/thirdweb/chain'
 import {
   getUserAndAccessToken,
   signHasVotedProof,
   submitHasVotedBulkClaimFor,
 } from '@/lib/xp'
+import { fetchVotesCount } from '@/lib/xp/votes'
 
 const VOTES_THRESHOLD = 1 //changing this while using the same verifier will allow users to claim xp again
-
-const chain = DEFAULT_CHAIN_V5
-const chainSlug = getChainSlug(chain)
-
-// Count votes a user has cast through the current on-chain governance system:
-// project/member votes live in the Proposals table and non-project governance
-// votes live in the NonProjectProposal table. Each row is one cast vote.
-async function fetchOnchainVotesCount(user: Address): Promise<number> {
-  const address = user.toLowerCase()
-  const tables = [
-    PROPOSALS_TABLE_NAMES[chainSlug],
-    NON_PROJECT_PROPOSAL_TABLE_NAMES[chainSlug],
-  ].filter(Boolean)
-
-  let total = 0
-  for (const table of tables) {
-    try {
-      const statement = `SELECT COUNT(*) AS c FROM ${table} WHERE LOWER(address) = '${address}'`
-      const rows = (await queryTable(chain, statement)) as Array<{
-        c: number | string
-      }>
-      total += Number(rows?.[0]?.c ?? 0)
-    } catch (err) {
-      console.error(`On-chain votes fetch failed for ${table}:`, err)
-    }
-  }
-  return total
-}
-
-const SNAPSHOT_SPACE = process.env.SNAPSHOT_SPACE || 'tomoondao.eth'
-
-// Legacy: votes cast in MoonDAO's historical Snapshot space. Retained so
-// Citizens who voted before the migration to on-chain governance still qualify.
-async function fetchSnapshotVotesCount(user: Address): Promise<number> {
-  const endpoint = 'https://hub.snapshot.org/graphql'
-  const query = gql`
-    query Votes($address: String!) {
-      votes(
-        first: 1000
-        skip: 0
-        where: { voter: $address, space: "${SNAPSHOT_SPACE}" }
-      ) {
-        id
-        voter
-        choice
-        created
-        space {
-          id
-        }
-      }
-    }
-  `
-  try {
-    const data = (await gqlRequest(endpoint, query, {
-      address: user,
-    })) as any
-    const count = Array.isArray(data?.votes) ? data.votes.length : 0
-    return count
-  } catch (err) {
-    console.error('Snapshot votes fetch failed:', err)
-    return 0
-  }
-}
-
-async function fetchVotesCount(user: Address): Promise<number> {
-  const [onchain, snapshot] = await Promise.all([
-    fetchOnchainVotesCount(user),
-    fetchSnapshotVotesCount(user),
-  ])
-  return onchain + snapshot
-}
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {

--- a/ui/pages/api/xp/votes-count.ts
+++ b/ui/pages/api/xp/votes-count.ts
@@ -1,0 +1,31 @@
+import { utils as ethersUtils } from 'ethers'
+import withMiddleware from 'middleware/withMiddleware'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { Address } from 'thirdweb'
+import { fetchVotesCount } from '@/lib/xp/votes'
+
+// Public, read-only endpoint that returns the canonical vote count for an
+// address (on-chain governance + legacy Snapshot). Used by the Citizen profile
+// so its "Votes" stat matches the "Votes" XP quest exactly. No auth required
+// because it only exposes already-public governance participation data.
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method !== 'GET')
+      return res.status(405).json({ error: 'Method not allowed' })
+
+    const address = req.query.address as string
+
+    if (!address || !ethersUtils.isAddress(address))
+      return res.status(400).json({ error: 'Invalid address' })
+
+    const votesCount = await fetchVotesCount(address as Address)
+
+    res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300')
+    return res.status(200).json({ votesCount })
+  } catch (err: any) {
+    console.error('votes-count error:', err)
+    return res.status(500).json({ error: err?.message || 'Internal error' })
+  }
+}
+
+export default withMiddleware(handler)

--- a/ui/pages/citizen/[tokenIdOrName].tsx
+++ b/ui/pages/citizen/[tokenIdOrName].tsx
@@ -547,7 +547,11 @@ function CitizenDetailPageContent({ nft, tokenId, hats, proposals }: any) {
                       </Tooltip>
                     </div>
                     <p className="text-3xl font-bold text-white">
-                      {votesCount ?? 0}
+                      {votesCount === undefined ? (
+                        <span className="text-white/40">—</span>
+                      ) : (
+                        votesCount
+                      )}
                     </p>
                   </div>
                 </div>

--- a/ui/pages/citizen/[tokenIdOrName].tsx
+++ b/ui/pages/citizen/[tokenIdOrName].tsx
@@ -36,7 +36,6 @@ import CitizenContext from '@/lib/citizen/citizen-context'
 import { useCitizenData } from '@/lib/citizen/useCitizenData'
 import hatsSubgraphClient from '@/lib/hats/hatsSubgraphClient'
 import { useTeamWearer } from '@/lib/hats/useTeamWearer'
-import { useVotesOfAddress } from '@/lib/snapshot'
 import { generatePrettyLinks } from '@/lib/subscription/pretty-links'
 import { useTablelandQuery } from '@/lib/swr/useTablelandQuery'
 import { citizenRowToNFT } from '@/lib/tableland/convertRow'
@@ -61,6 +60,7 @@ import IPFSRenderer from '@/components/layout/IPFSRenderer'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import SlidingCardMenu from '@/components/layout/SlidingCardMenu'
 import StandardButton from '@/components/layout/StandardButton'
+import Tooltip from '@/components/layout/Tooltip'
 import Action from '@/components/subscription/Action'
 import Card from '@/components/subscription/Card'
 import CitizenActions from '@/components/subscription/CitizenActions'
@@ -132,7 +132,32 @@ function CitizenDetailPageContent({ nft, tokenId, hats, proposals }: any) {
     }
   }, [router.query.edit, isOwner])
 
-  const { data: votes } = useVotesOfAddress(nft?.owner)
+  // Canonical vote count (on-chain governance + legacy Snapshot), matching the
+  // "Votes" XP quest. Fetched via a public endpoint so it stays in sync with
+  // the quest's count instead of only reflecting legacy Snapshot votes.
+  const [votesCount, setVotesCount] = useState<number | undefined>(undefined)
+  useEffect(() => {
+    const owner = nft?.owner
+    if (!owner) {
+      setVotesCount(undefined)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch(`/api/xp/votes-count?address=${owner}`)
+        const data = await res.json()
+        if (!cancelled && typeof data?.votesCount === 'number') {
+          setVotesCount(data.votesCount)
+        }
+      } catch (err) {
+        console.error('Failed to fetch votes count:', err)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [nft?.owner])
 
   // Balances
   const { nativeBalance } = useNativeBalance()
@@ -481,20 +506,49 @@ function CitizenDetailPageContent({ nft, tokenId, hats, proposals }: any) {
                 <h2 className="font-GoodTimes text-2xl text-white mb-6">Governance</h2>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                   <div className="bg-slate-600/20 rounded-xl p-4">
-                    <p className="text-lg text-slate-300 mb-2">$MOONEY</p>
+                    <div className="flex items-center gap-2 mb-2">
+                      <p className="text-lg text-slate-300">$MOONEY</p>
+                      <Tooltip
+                        buttonClassName="scale-75 flex-shrink-0"
+                        text="$MOONEY is MoonDAO's governance token. Stake it to receive vMOONEY and gain voting power over the network's decisions."
+                        compact
+                      >
+                        ?
+                      </Tooltip>
+                    </div>
                     <p className="text-3xl font-bold text-white">
                       {MOONEYBalance ? Math.round(MOONEYBalance).toLocaleString() : 0}
                     </p>
                   </div>
                   <div className="bg-slate-600/20 rounded-xl p-4">
-                    <p className="text-lg text-slate-300 mb-2">Voting Power</p>
+                    <div className="flex items-center gap-2 mb-2">
+                      <p className="text-lg text-slate-300">Voting Power</p>
+                      <Tooltip
+                        buttonClassName="scale-75 flex-shrink-0"
+                        text="Voting power determines how much weight your vote carries in governance. It comes from staking $MOONEY into vMOONEY, where longer lock times grant more voting power."
+                        compact
+                      >
+                        ?
+                      </Tooltip>
+                    </div>
                     <p className="text-3xl font-bold text-white">
                       {VMOONEYBalance ? Math.round(VMOONEYBalance).toLocaleString() : 0}
                     </p>
                   </div>
                   <div className="bg-slate-600/20 rounded-xl p-4">
-                    <p className="text-lg text-slate-300 mb-2">Votes</p>
-                    <p className="text-3xl font-bold text-white">{votes?.length}</p>
+                    <div className="flex items-center gap-2 mb-2">
+                      <p className="text-lg text-slate-300">Votes</p>
+                      <Tooltip
+                        buttonClassName="scale-75 flex-shrink-0"
+                        text="The total number of governance proposals you've voted on, including both on-chain proposals and legacy Snapshot votes."
+                        compact
+                      >
+                        ?
+                      </Tooltip>
+                    </div>
+                    <p className="text-3xl font-bold text-white">
+                      {votesCount ?? 0}
+                    </p>
                   </div>
                 </div>
                 {isOwner && (
@@ -564,14 +618,14 @@ function CitizenDetailPageContent({ nft, tokenId, hats, proposals }: any) {
                         Array.from({ length: 4 }).map((_, i) => (
                           <div
                             key={`skeleton-${i}`}
-                            className="w-[300px] flex-shrink-0 h-[420px] rounded-xl bg-slate-700/40 animate-pulse"
+                            className="w-56 flex-shrink-0 h-[420px] rounded-xl bg-slate-700/40 animate-pulse"
                           />
                         ))
                       ) : newListings.length === 0 ? (
                         <p className="text-slate-400 text-sm py-4">No active listings at the moment.</p>
                       ) : (
                         newListings.map((listing, i) => (
-                          <div key={`team-listing-${i}`} className="w-[300px] flex-shrink-0">
+                          <div key={`team-listing-${i}`} className="flex-shrink-0">
                             <TeamListing
                               listing={listing}
                               selectedChain={selectedChain}


### PR DESCRIPTION
## Summary
- Fix Newest Listings card spacing on the citizen profile by removing the oversized wrapper width so cards sit next to each other with consistent gaps.
- Add tooltips to the Governance section explaining $MOONEY, Voting Power, and Votes.
- Fix the Votes count mismatch by using the same on-chain + Snapshot vote logic as the Votes XP quest via a shared helper and public `/api/xp/votes-count` endpoint.

## Test plan
- [ ] Open a citizen profile and confirm Newest Listings cards are adjacent without large gaps between them.
- [ ] Hover/click the `?` tooltips in the Governance section and verify copy for $MOONEY, Voting Power, and Votes.
- [ ] Compare the profile Votes number with the Votes quest metric for the same wallet and confirm they match.
- [ ] Verify `/api/xp/votes-count?address=<wallet>` returns the expected count for wallets with on-chain and/or Snapshot votes.


Made with [Cursor](https://cursor.com)