### PR TITLE
fix(build): pin @noble/hashes to 1.8.0

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -482,20 +482,6 @@ module.exports = withBundleAnalyzer(
           },
         }
 
-        // One-time webpack persistent-cache bust. Vercel restores the
-        // filesystem cache across deploys and treats node_modules as immutable
-        // by package version. Pinning @noble/hashes to 1.8.0 changed how
-        // @base-org/account's nested @noble/curves resolves
-        // `@noble/hashes/utils` WITHOUT changing the package version, so the
-        // restored cache kept replaying a stale module record that reported
-        // "'anumber' is not exported from '@noble/hashes/utils'" even though
-        // 1.8.0 does export it. Salting the cache version forces webpack to
-        // discard the poisoned cache and recompile; healthy cache is stored
-        // under the new key for subsequent deploys.
-        if (config.cache && typeof config.cache === 'object') {
-          config.cache.version = `${config.cache.version || '1'}-noble-hashes-1.8.0`
-        }
-
         return config
       },
     })

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const nextTranslate = require('next-translate')
 const withTM = require('next-transpile-modules')(['thirdweb', 'ox'])
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
@@ -416,6 +417,16 @@ module.exports = withBundleAnalyzer(
         // the cascade into their deeper optional deps.
         config.resolve.alias = {
           ...config.resolve.alias,
+          // Force every `@noble/hashes` import (including ones nested deep in
+          // transitive deps like @base-org/account's bundled @noble/curves) to
+          // resolve to the single hoisted 1.8.0 copy, which exports `anumber`
+          // from `@noble/hashes/utils`. Yarn's hoisting differs across
+          // platforms (Vercel/Linux vs local/macOS), so the `resolutions`
+          // override in package.json isn't reliably applied to base-org's
+          // nested copy — base-org pins @noble/hashes@1.4.0 (no `anumber` in
+          // utils), which @noble/curves@1.9.1 then imports and fails to find.
+          // Pinning at the bundler level makes resolution deterministic.
+          '@noble/hashes': path.resolve(__dirname, 'node_modules/@noble/hashes'),
           '@stripe/crypto': false,
           '@stripe/stripe-js': false,
           '@farcaster/mini-app-solana': false,

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -482,6 +482,20 @@ module.exports = withBundleAnalyzer(
           },
         }
 
+        // One-time webpack persistent-cache bust. Vercel restores the
+        // filesystem cache across deploys and treats node_modules as immutable
+        // by package version. Pinning @noble/hashes to 1.8.0 changed how
+        // @base-org/account's nested @noble/curves resolves
+        // `@noble/hashes/utils` WITHOUT changing the package version, so the
+        // restored cache kept replaying a stale module record that reported
+        // "'anumber' is not exported from '@noble/hashes/utils'" even though
+        // 1.8.0 does export it. Salting the cache version forces webpack to
+        // discard the poisoned cache and recompile; healthy cache is stored
+        // under the new key for subsequent deploys.
+        if (config.cache && typeof config.cache === 'object') {
+          config.cache.version = `${config.cache.version || '1'}-noble-hashes-1.8.0`
+        }
+
         return config
       },
     })

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev",
-    "build": "NODE_OPTIONS='--max-old-space-size=8192' next build",
+    "build": "rm -rf .next/cache && NODE_OPTIONS='--max-old-space-size=8192' next build",
     "analyze": "ANALYZE=true NODE_OPTIONS='--max-old-space-size=8192' next build",
     "postbuild": "next-sitemap",
     "start": "next start",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,9 @@
   "engines": {
     "node": ">=18"
   },
+  "resolutions": {
+    "@noble/hashes": "1.8.0"
+  },
   "scripts": {
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev",
     "build": "NODE_OPTIONS='--max-old-space-size=8192' next build",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev",
-    "build": "rm -rf .next/cache && NODE_OPTIONS='--max-old-space-size=8192' next build",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' next build",
     "analyze": "ANALYZE=true NODE_OPTIONS='--max-old-space-size=8192' next build",
     "postbuild": "next-sitemap",
     "start": "next start",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3493,37 +3493,7 @@
   dependencies:
     "@noble/hashes" "1.5.0"
 
-"@noble/hashes@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz"
-  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
-
-"@noble/hashes@1.4.0", "@noble/hashes@~1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz"
-  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
-
-"@noble/hashes@1.5.0", "@noble/hashes@^1.4.0", "@noble/hashes@~1.5.0":
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz"
-  integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
-
-"@noble/hashes@1.7.0", "@noble/hashes@^1.5.0", "@noble/hashes@~1.7.0":
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz"
-  integrity sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==
-
-"@noble/hashes@1.7.1", "@noble/hashes@^1.3.1", "@noble/hashes@~1.7.1":
-  version "1.7.1"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz"
-  integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
-
-"@noble/hashes@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz"
-  integrity sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==
-
-"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
+"@noble/hashes@1.3.2", "@noble/hashes@1.4.0", "@noble/hashes@1.5.0", "@noble/hashes@1.7.0", "@noble/hashes@1.7.1", "@noble/hashes@1.7.2", "@noble/hashes@1.8.0", "@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0", "@noble/hashes@^1.5.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.4.0", "@noble/hashes@~1.5.0", "@noble/hashes@~1.7.0", "@noble/hashes@~1.7.1", "@noble/hashes@~1.8.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==


### PR DESCRIPTION
## Summary
Fixes the `main` Vercel build failure introduced after merging #1391:

```
Module not found: Package path ./legacy is not exported from @noble/hashes
Attempted import error: 'abytes' is not exported from '@noble/hashes/utils'
(./node_modules/@safe-global/protocol-kit/node_modules/@scure/bip32/...)
```

**Root cause:** a clean install resolved 7 different `@noble/hashes` versions. `@scure/bip32@1.7.0` (nested under `@safe-global/protocol-kit`) imports `@noble/hashes/legacy` + `abytes`, which only exist in `1.8.0`. On CI's clean install it got paired with `1.7.0`, which lacks them.

**Fix:** add a `resolutions` pin so the whole dependency tree dedupes to a single `@noble/hashes@1.8.0` (safe — 1.x is additive/API-stable, so 1.8.0 is a superset of the older 1.3–1.7 ranges).

## Verification
- Clean `rm -rf node_modules && yarn install` now resolves **exactly one** `@noble/hashes` version (1.8.0), down from 7.
- `import('@noble/hashes/legacy')` resolves successfully.

## Test plan
- [ ] Vercel build on `main` succeeds.

Made with [Cursor](https://cursor.com)