### PR TITLE
fix(build): clean install on Vercel to prevent poisoned-cache build failures

### DIFF
--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,1 +1,3 @@
-{}
+{
+  "installCommand": "rm -rf node_modules && yarn install --frozen-lockfile"
+}


### PR DESCRIPTION
## Summary

Restores the Vercel install-command override (`ui/vercel.json`) that was added in `800a5bc5` and removed in `1f7a1998`.

Vercel restores a cached `node_modules` and runs `yarn install` on top of it, which does **not** prune stale nested transitive deps. This recently broke `next build` again on PR #1378 with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './legacy' is not defined by "exports" in /vercel/path0/ui/node_modules/@scure/bip32/node_modules/@noble/hashes/package.json
```

A stale nested `@scure/bip32/node_modules/@noble/hashes` (an old copy without `./legacy`) survives across deploys even though the lockfile already resolves **every** `@noble/hashes` range to a single `1.8.0` (which does export `./legacy`). The failure is at **Node's ESM resolver**, so the `next.config.js` webpack alias and the `package.json` `resolutions` pin from #1394 cannot reach it.

## Fix

```json
{ "installCommand": "rm -rf node_modules && yarn install --frozen-lockfile" }
```

Forces a clean dependency tree each deploy — mirroring GitHub CI, which already passes — so poisoned-cache mismatches can't persist. This is the same remedy used previously in this repo for the Privy v3 lockfile change.

## Test plan

- [ ] Vercel preview deploy of this PR builds successfully
- [ ] Confirm `next build` completes without `ERR_PACKAGE_PATH_NOT_EXPORTED`

Made with [Cursor](https://cursor.com)