### PR TITLE
fix(onramp): enable email as a Privy login method

### DIFF
--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -57,7 +57,7 @@ function App({ Component, pageProps: { session, ...pageProps } }: any) {
           <PrivyProvider
             appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID as string}
             config={{
-              loginMethods: ['wallet', 'sms', 'google', 'twitter', 'discord', 'github'],
+              loginMethods: ['wallet', 'sms', 'email', 'google', 'twitter', 'discord', 'github'],
               // Auto-provision an embedded wallet for users who sign up without
               // one (e.g. via SMS/social on a magic-link invite) so they have an
               // address to receive their sponsored citizen mint.


### PR DESCRIPTION
## Summary
- The Coinbase headless onramp flow (`CBHeadlessOnramp.tsx` → `useOnrampVerification`) requires both a verified phone **and** an email, and its "Add email" button calls Privy's `linkEmail()`.
- Privy only permits linking methods that are enabled in `loginMethods`. Since `'email'` was absent, every `linkEmail()` attempt failed with **"Login with email not allowed"** — for any email, regardless of whether it was already in use.
- This adds `'email'` to `loginMethods` in `ui/pages/_app.tsx` so users can link an email and satisfy the onramp verification gate.

## Notes
- Side effect: email/OTP also becomes a sign-in option in the Privy login modal (Privy ties linkable methods to login methods).
- Requires Email to also be enabled in the Privy **dashboard** for the change to take full effect.
- Unrelated/expected: linking a phone or email already attached to another Privy user still returns "already linked to another user" — that's a Privy uniqueness constraint, not a bug.

## Test plan
- [ ] Log in via SMS/wallet, open the Coinbase / Apple Pay onramp, click "Add email", complete OTP, and confirm the email links without the "Login with email not allowed" error.
- [ ] Confirm the Continue button unlocks once both phone and email are verified.
- [ ] Verify existing login methods (wallet, sms, google, etc.) still work.

Made with [Cursor](https://cursor.com)