### PR TITLE
fix(marketplace): prevent empty listings under RPC rate limiting

### DIFF
--- a/ui/pages/marketplace/index.tsx
+++ b/ui/pages/marketplace/index.tsx
@@ -212,36 +212,70 @@ export async function getStaticProps() {
 
     const allListings = await queryTable(chain, statement)
 
-    // Process listings in batches to check expiration and avoid rate limiting
+    // Resolve each team's expiration only once. Multiple listings frequently
+    // share a teamId, so de-duping drastically cuts the number of RPC calls and
+    // therefore the chance of getting rate limited under heavy traffic.
+    const uniqueTeamIds = Array.from(
+      new Set(allListings.map((listing: any) => listing.teamId))
+    )
+
+    async function getTeamExpiration(
+      teamId: any,
+      retries = 3,
+      delay = 500
+    ): Promise<number | null> {
+      for (let attempt = 0; attempt < retries; attempt++) {
+        try {
+          const teamExpiration = await readContract({
+            contract: teamContract,
+            method: 'expiresAt',
+            params: [teamId],
+          })
+          return +teamExpiration.toString()
+        } catch (error) {
+          if (attempt < retries - 1) {
+            await new Promise((resolve) =>
+              setTimeout(resolve, delay * Math.pow(2, attempt))
+            )
+            continue
+          }
+          // Persistent failure (likely rate limiting). Return null so the
+          // caller can decide to "fail open" rather than dropping listings.
+          return null
+        }
+      }
+      return null
+    }
+
+    // Process unique teams in batches to check expiration and avoid rate limiting
     const BATCH_SIZE = 10
     const DELAY_BETWEEN_BATCHES = 100 // ms
-    const validListings: any[] = []
+    const teamExpirations = new Map<any, number | null>()
 
-    for (let i = 0; i < allListings.length; i += BATCH_SIZE) {
-      const batch = allListings.slice(i, i + BATCH_SIZE)
-      
-      const batchResults = await Promise.all(
-        batch.map(async (listing: any) => {
-          try {
-            const teamExpiration = await readContract({
-              contract: teamContract,
-              method: 'expiresAt',
-              params: [listing.teamId],
-            })
-            return +teamExpiration.toString() > now ? listing : null
-          } catch {
-            return null
-          }
+    for (let i = 0; i < uniqueTeamIds.length; i += BATCH_SIZE) {
+      const batch = uniqueTeamIds.slice(i, i + BATCH_SIZE)
+
+      await Promise.all(
+        batch.map(async (teamId: any) => {
+          teamExpirations.set(teamId, await getTeamExpiration(teamId))
         })
       )
 
-      validListings.push(...batchResults.filter((listing: any) => listing !== null))
-
       // Add delay between batches to avoid rate limiting
-      if (i + BATCH_SIZE < allListings.length) {
-        await new Promise(resolve => setTimeout(resolve, DELAY_BETWEEN_BATCHES))
+      if (i + BATCH_SIZE < uniqueTeamIds.length) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, DELAY_BETWEEN_BATCHES)
+        )
       }
     }
+
+    // Keep a listing when its team is unexpired. If the expiration could not be
+    // resolved (null, e.g. rate limited), fail open and keep the listing so a
+    // transient RPC issue never wipes out the entire marketplace.
+    const validListings = allListings.filter((listing: any) => {
+      const expiration = teamExpirations.get(listing.teamId)
+      return expiration === null || expiration === undefined || expiration > now
+    })
 
     const allTeamNames = await queryTable(
       chain,


### PR DESCRIPTION
## Summary
The marketplace page was intermittently showing **"No marketplace listings available at this time"** even though listings exist — most noticeably under high traffic.

Root cause: in `getStaticProps`, each listing is validated by reading its team's on-chain expiration (`expiresAt`). That RPC call was wrapped in `catch { return null }`, so **any** failure silently dropped the listing. When the RPC provider rate-limits these calls (traffic spike), every check fails and the entire marketplace renders empty.

### Changes
- **De-dupe RPC calls**: resolve `expiresAt` once per unique `teamId` instead of once per listing (many listings share a team), sharply reducing RPC volume.
- **Retry with backoff**: each expiration read retries up to 3x with exponential backoff (500ms → 1s → 2s), matching the existing `queryTable` pattern.
- **Fail open**: if an expiration can't be resolved after retries (persistent rate limiting), the listing is kept rather than dropped. A transient RPC hiccup can no longer wipe out the whole marketplace; ISR (`revalidate: 60`) self-corrects on the next pass.

Genuine expiration filtering still applies whenever the RPC responds normally.

## Test plan
- [ ] Load `/marketplace` and confirm active listings render.
- [ ] Confirm listings belonging to expired teams are still filtered out when the RPC is healthy.
- [ ] Simulate RPC rate limiting and confirm listings are retained (fail-open) instead of the page going empty.

## Notes
The same fragile `catch { return null }` pattern still exists in `ui/pages/citizen/[tokenIdOrName].tsx` (client-side) and `ui/lib/subscription/getMarketplaceListings.ts` (Cypress helper). Left untouched to keep this change surgical — happy to follow up.

Made with [Cursor](https://cursor.com)