### PR TITLE
fix(marketplace): harden getStaticProps against transient failures

### DIFF
--- a/ui/pages/marketplace/index.tsx
+++ b/ui/pages/marketplace/index.tsx
@@ -4,6 +4,7 @@ import TeamABI from 'const/abis/Team.json'
 import {
   DEFAULT_CHAIN_V5,
   MARKETPLACE_TABLE_ADDRESSES,
+  MARKETPLACE_TABLE_NAMES,
   TEAM_ADDRESSES,
   TEAM_TABLE_NAMES,
 } from 'const/config'
@@ -250,10 +251,17 @@ export async function getStaticProps() {
       abi: TeamABI as any,
     })
 
-    const marketplaceTableName = await readContract({
-      contract: marketplaceTableContract,
-      method: 'getTableName',
-    })
+    // The table name is a known constant, so prefer it and avoid an RPC call on
+    // the critical path. Only fall back to the on-chain lookup if the constant
+    // is somehow missing. A rate-limited getTableName() previously took down the
+    // entire page (every render fell into the catch block below).
+    let marketplaceTableName: any = MARKETPLACE_TABLE_NAMES[chainSlug]
+    if (!marketplaceTableName) {
+      marketplaceTableName = await readContract({
+        contract: marketplaceTableContract,
+        method: 'getTableName',
+      })
+    }
 
     const statement = `SELECT * FROM ${marketplaceTableName} WHERE (startTime = 0 OR startTime <= ${now}) AND (endTime = 0 OR endTime >= ${now}) ORDER BY id DESC`
 
@@ -324,10 +332,17 @@ export async function getStaticProps() {
       return expiration === null || expiration === undefined || expiration > now
     })
 
-    const allTeamNames = await queryTable(
-      chain,
-      `SELECT id, name FROM ${TEAM_TABLE_NAMES[chainSlug]}`
-    )
+    // Team names are a nice-to-have label. A failure here must not discard the
+    // listings we already fetched, so resolve it best-effort.
+    let allTeamNames: any[] = []
+    try {
+      allTeamNames = await queryTable(
+        chain,
+        `SELECT id, name FROM ${TEAM_TABLE_NAMES[chainSlug]}`
+      )
+    } catch (error) {
+      console.error('Failed to fetch team names for marketplace listings:', error)
+    }
 
     const listingsWithTeamNames = validListings.map((listing: any) => {
       return {
@@ -344,9 +359,11 @@ export async function getStaticProps() {
     }
   } catch (error) {
     console.error(error)
+    // Don't let a transient failure cache an empty marketplace for a full
+    // minute. Revalidate quickly so the next request can repopulate listings.
     return {
       props: { listings: [] },
-      revalidate: 60,
+      revalidate: 10,
     }
   }
 }


### PR DESCRIPTION
## Summary
After #1400 merged, the marketplace **still** intermittently showed "No marketplace listings available at this time" in production while working fine in preview.

I queried the live Tableland gateway with the page's exact filter and confirmed **the data is healthy** — all active listings are present. So this is not a data problem and not the expiration filter (already hardened in #1400). The remaining cause is that `getStaticProps` had three single points of failure that each fall into the `catch` block and then **cache an empty list for 60s**. Under real production traffic (vs. a one-off preview build) these intermittently trip:

1. **`getTableName()` was a live RPC call** even though the table name is a known constant (`MARKETPLACE_42161_159`). One rate-limited read blanked the whole page.
2. **The team-names query ran after listings were fetched** — a failure there threw away listings we already had.
3. **The `catch` cached empty for a full 60s** (`revalidate: 60`), so one blip blanks the page for a minute, repeatedly under load.

### Changes
- Use the `MARKETPLACE_TABLE_NAMES` constant for the table name; only fall back to the on-chain `getTableName()` if the constant is missing.
- Make the team-names query best-effort (its own try/catch) so it can't discard valid listings.
- On the error path, drop `revalidate` to `10s` so a transient failure repopulates quickly instead of serving an empty page for a minute.

## Also worth verifying (outside this PR)
Since it "works in preview, not production", please confirm these are set in the **Production** env scope on Vercel (not just Preview):
- `TABLELAND_PRIVATE_KEY` (server secret used by `queryTable`'s authenticated signer)
- `NEXT_PUBLIC_THIRDWEB_CLIENT_SECRET` (higher server RPC limits; falls back to the weaker public clientId when missing)
- `NEXT_PUBLIC_INFURA_KEY` (Arbitrum RPC provider for `queryTable`)

## Test plan
- [ ] Load `/marketplace` in production and confirm listings render.
- [ ] Confirm a forced Tableland/RPC failure no longer blanks the whole page and recovers within ~10s.

Made with [Cursor](https://cursor.com)