### PR TITLE
fix(projects): resolve untitled project names server-side

### DIFF
--- a/ui/components/project/DashboardActiveProjects.tsx
+++ b/ui/components/project/DashboardActiveProjects.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { RocketLaunchIcon } from '@heroicons/react/24/outline'
+import { getProjectDisplayName } from '@/lib/project/getProjectDisplayName'
 import { Project } from '@/lib/project/useProjectData'
 import { getRelativeQuarter } from '@/lib/utils/dates'
 
@@ -76,7 +77,7 @@ export default function DashboardActiveProjects({
                 <div className="bg-black/20 rounded-xl p-5 border border-white/5 cursor-pointer hover:bg-white/[0.05] hover:border-white/15 transition-all duration-300 h-[260px] flex flex-col">
                   <div className="flex justify-between items-start mb-4">
                     <h4 className="font-bold text-white text-lg flex-1 mr-3 leading-tight line-clamp-2">
-                      {project.name}
+                      {getProjectDisplayName(project)}
                     </h4>
                     <span
                       className={`px-3 py-1.5 rounded-lg text-sm font-medium flex-shrink-0 ${

--- a/ui/lib/project/enrichProjectNames.ts
+++ b/ui/lib/project/enrichProjectNames.ts
@@ -1,0 +1,33 @@
+import {
+  getProjectDisplayName,
+  isUntitledLike,
+  UNTITLED_FALLBACK,
+} from '@/lib/project/getProjectDisplayName'
+
+/**
+ * Server-side utility: for any project whose stored `name` is empty or
+ * "Untitled", fetch its IPFS proposal JSON and resolve the real title via
+ * `getProjectDisplayName`. Mutates each project's `name` in-place.
+ *
+ * Failures are silently swallowed — the client-side `useProposalJSON` hook
+ * in `ProjectCard` remains as a fallback.
+ */
+export async function enrichProjectNames(projects: any[]): Promise<void> {
+  const untitled = projects.filter(
+    (p) => isUntitledLike(p.name) && !!p.proposalIPFS
+  )
+  if (untitled.length === 0) return
+
+  await Promise.allSettled(
+    untitled.map(async (project) => {
+      try {
+        const res = await fetch(project.proposalIPFS)
+        const json = await res.json()
+        const resolved = getProjectDisplayName(project, json)
+        if (resolved !== UNTITLED_FALLBACK) project.name = resolved
+      } catch {
+        // leave as-is
+      }
+    })
+  )
+}

--- a/ui/lib/project/getProjectDisplayName.ts
+++ b/ui/lib/project/getProjectDisplayName.ts
@@ -1,10 +1,10 @@
 import type { Project } from '@/lib/project/useProjectData'
 
-const UNTITLED_FALLBACK = 'Untitled Project'
+export const UNTITLED_FALLBACK = 'Untitled Project'
 
 const UNTITLED_PATTERN = /^\s*untitled\b/i
 
-function isUntitledLike(value: string | undefined | null): boolean {
+export function isUntitledLike(value: string | undefined | null): boolean {
   if (!value) return true
   const trimmed = value.trim()
   if (!trimmed) return true

--- a/ui/pages/dashboard.tsx
+++ b/ui/pages/dashboard.tsx
@@ -24,6 +24,7 @@ import { getAUMHistory, getMooneyPrice } from '@/lib/coinstats'
 import { getIPFSGateway } from '@/lib/ipfs/gateway'
 import { getCitizensLocationData } from '@/lib/map'
 import { getAllNetworkTransfers, getRecentCitizenTransfers, getRecentTeamTransfers } from '@/lib/network/networkSubgraph'
+import { enrichProjectNames } from '@/lib/project/enrichProjectNames'
 import { Project } from '@/lib/project/useProjectData'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -417,6 +418,7 @@ export async function getStaticProps() {
     newestJobs = jobs
     newestTeams = teams.map((t: any) => ({ ...t, mintTimestamp: teamMintTsMap[String(t.id)] ?? null }))
     allProjects = projects
+    await enrichProjectNames(allProjects)
 
     // Process missions data - simplified to just pass basic data to client.
     // Always populate `missions` + `featuredMissionData` from the table row so

--- a/ui/pages/projects-overview.tsx
+++ b/ui/pages/projects-overview.tsx
@@ -12,6 +12,7 @@ import { GetServerSideProps } from 'next'
 import Image from 'next/image'
 import React, { useMemo, useEffect, useState } from 'react'
 import { useAssets } from '@/lib/dashboard/hooks'
+import { enrichProjectNames } from '@/lib/project/enrichProjectNames'
 import { Project } from '@/lib/project/useProjectData'
 import { ethereum } from '@/lib/rpc/chains'
 import queryTable from '@/lib/tableland/queryTable'
@@ -672,6 +673,8 @@ export const getServerSideProps: GetServerSideProps = async () => {
         }
       }
     }
+
+    await enrichProjectNames([...currentProjects, ...pastProjects])
 
     currentProjects.sort((a, b) => {
       if (a.eligible === b.eligible) {

--- a/ui/pages/projects/index.tsx
+++ b/ui/pages/projects/index.tsx
@@ -12,6 +12,11 @@ import { useRouter } from 'next/router'
 import { getContract, readContract } from 'thirdweb'
 import { PROJECT_ACTIVE, PROJECT_ENDED, PROJECT_PENDING } from '@/lib/nance/types'
 import { getProposalStatus } from '@/lib/nance/useProposalStatus'
+import {
+  getProjectDisplayName,
+  isUntitledLike,
+  UNTITLED_FALLBACK,
+} from '@/lib/project/getProjectDisplayName'
 import { Project } from '@/lib/project/useProjectData'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -103,6 +108,11 @@ export async function getStaticProps() {
               const proposalResponse = await fetch(project.proposalIPFS)
               const proposalJSON = await proposalResponse.json()
               if (!proposalJSON?.nonProjectProposal) {
+                // Enrich name from IPFS while we have the JSON in hand
+                if (isUntitledLike(project.name)) {
+                  const resolved = getProjectDisplayName(project, proposalJSON)
+                  if (resolved !== UNTITLED_FALLBACK) project.name = resolved
+                }
                 project.tempCheckApproved = approveds[index]
                 project.tempCheckFailed = faileds[index]
                 if (!faileds[index]) {
@@ -118,6 +128,27 @@ export async function getStaticProps() {
         }
       })
     )
+    // For active/past projects whose stored name is empty or "Untitled",
+    // fetch the IPFS proposal JSON server-side so the pre-rendered HTML
+    // already carries the real title instead of "Untitled Project".
+    const untitledNonPending = [...currentProjects, ...pastProjects].filter(
+      (p) => isUntitledLike(p.name) && !!p.proposalIPFS
+    )
+    if (untitledNonPending.length > 0) {
+      await Promise.allSettled(
+        untitledNonPending.map(async (project) => {
+          try {
+            const res = await fetch(project.proposalIPFS)
+            const json = await res.json()
+            const resolved = getProjectDisplayName(project, json)
+            if (resolved !== UNTITLED_FALLBACK) project.name = resolved
+          } catch {
+            // Leave the name as-is; the client-side hook will still resolve it
+          }
+        })
+      )
+    }
+
     currentProjects.sort((a, b) => {
       if (a.eligible === b.eligible) {
         return 0


### PR DESCRIPTION
## Summary

- Projects whose Tableland `name` field is empty or `"Untitled"` were rendering as **"Untitled Project"** in the pre-rendered HTML until the client-side IPFS fetch resolved on hydration.
- The real title lives in the IPFS proposal JSON. `getStaticProps` was already fetching that JSON for pending proposals (to check `nonProjectProposal`) but wasn't using it to fix the name, and wasn't fetching at all for active/past projects.
- This fix enriches `project.name` server-side so the ISR-rendered HTML already carries the correct title.

## Changes

- **`lib/project/getProjectDisplayName.ts`** — export `isUntitledLike` and `UNTITLED_FALLBACK` so they can be reused in server-side `getStaticProps` code without duplicating logic.
- **`pages/projects/index.tsx` `getStaticProps`**:
  - For **pending proposals**: extract the real title from the IPFS JSON that's already fetched in the loop (was previously used only to check `nonProjectProposal`).
  - For **active/past projects**: after categorisation, batch-fetch IPFS JSON via `Promise.allSettled` for any project with an untitled-like name and write the resolved title back to `project.name` before serialising props. Failures are silently swallowed — the client-side `useProposalJSON` hook remains as a fallback.

## Test plan

- [ ] Visit `/projects` — projects previously showing "Untitled Project" should now show their real title on first paint (no flash).
- [ ] Confirm the budget badge and expanded proposal body still work (client-side `useProposalJSON` is unchanged).
- [ ] ISR revalidation (`revalidate: 60`) will pick up the enrichment on the next build/revalidation cycle.

Made with [Cursor](https://cursor.com)