### PR TITLE
fix(marketplace): fix listings not rendering on team pages

### DIFF
--- a/ui/components/subscription/TeamMarketplace.tsx
+++ b/ui/components/subscription/TeamMarketplace.tsx
@@ -86,7 +86,7 @@ export default function TeamMarketplace({
 
       return () => clearTimeout(timeout)
     }
-  }, [router.query.listingId])
+  }, [router.query.listing])
 
   return (
     <div id="team-marketplace" className="w-full p-6">

--- a/ui/lib/team/useTeamData.tsx
+++ b/ui/lib/team/useTeamData.tsx
@@ -39,7 +39,7 @@ export function useTeamData(
 
   // Activity data state (optional)
   const [jobs, setJobs] = useState<Job[]>([])
-  const [listings, setListings] = useState<TeamListing[]>([])
+  const [listings, setListings] = useState<TeamListing[] | undefined>(undefined)
   const [missions, setMissions] = useState<Mission[]>([])
   const [isLoadingActivityData, setIsLoadingActivityData] = useState(false)
   const [activityError, setActivityError] = useState<Error | null>(null)
@@ -217,36 +217,44 @@ export function useTeamData(
     async function getTableNames() {
       if (!fetchActivityData) return
 
-      try {
-        if (fetchActivityData.jobTableContract) {
+      if (fetchActivityData.jobTableContract) {
+        try {
           const jobName: any = await readContract({
             contract: fetchActivityData.jobTableContract,
             method: 'getTableName' as string,
             params: [],
           })
           setJobTableName(jobName)
+        } catch (err) {
+          console.error('Error fetching job table name:', err)
         }
+      }
 
-        if (fetchActivityData.marketplaceTableContract) {
+      if (fetchActivityData.marketplaceTableContract) {
+        try {
           const marketplaceName: any = await readContract({
             contract: fetchActivityData.marketplaceTableContract,
             method: 'getTableName' as string,
             params: [],
           })
           setMarketplaceTableName(marketplaceName)
+        } catch (err) {
+          console.error('Error fetching marketplace table name:', err)
+          setActivityError(err as Error)
         }
+      }
 
-        if (fetchActivityData.missionTableContract) {
+      if (fetchActivityData.missionTableContract) {
+        try {
           const missionName: any = await readContract({
             contract: fetchActivityData.missionTableContract,
             method: 'getTableName' as string,
             params: [],
           })
           setMissionTableName(missionName)
+        } catch (err) {
+          console.error('Error fetching mission table name:', err)
         }
-      } catch (err) {
-        console.error('Error fetching table names:', err)
-        setActivityError(err as Error)
       }
     }
     getTableNames()


### PR DESCRIPTION
## Summary

- **Isolated table-name fetches** — All three `readContract` calls for job/marketplace/mission table names shared a single `try/catch`. A transient RPC error on any one of them (e.g. job table rate-limit) would abort the entire block, leaving `marketplaceTableName` null, `listingStatement` null, and SWR never firing — so listings stayed permanently empty. Each fetch now has its own `try/catch` so failures are independent.
- **Fixed stuck empty state** — `listings` in `useTeamData` was initialized as `[]`. `TeamMarketplace` checks `shouldFetch = !externalListings` — since `[]` is truthy, the component permanently disabled its own fallback fetch from the very first render, even before any data arrived. Changing the initial value to `undefined` means the component keeps its internal fetch active until `useTeamData` actually resolves, providing a recovery path if the upstream fetch fails.
- **Fixed deep-link modal** — `TeamMarketplace`'s `useEffect` for `?listing=<id>` URL params was watching `router.query.listingId` but reading `router.query.listing`, so the scroll-to and buy modal auto-open never triggered for shared listing links.

## Test plan
- [ ] Visit a team page that has active marketplace listings — confirm they render
- [ ] Visit a team page with no listings — confirm empty state still shows
- [ ] Simulate a job-table RPC failure (or use a team on a chain where job table is unavailable) — confirm marketplace listings still load
- [ ] Visit a team page with `?listing=<id>` in the URL — confirm the buy modal auto-opens

Made with [Cursor](https://cursor.com)