### PR TITLE
fix(build): remove cache-busting commands to speed up Vercel deploys (~16 min → ~6-8 min)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev",
-    "build": "rm -rf .next/cache && NODE_OPTIONS='--max-old-space-size=8192' next build",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' next build",
     "analyze": "ANALYZE=true NODE_OPTIONS='--max-old-space-size=8192' next build",
     "postbuild": "next-sitemap",
     "start": "next start",

--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,3 +1,3 @@
 {
-  "installCommand": "rm -rf node_modules && yarn install --frozen-lockfile"
+  "installCommand": "yarn install --frozen-lockfile"
 }


### PR DESCRIPTION
## Summary

- **Remove `rm -rf node_modules`** from `ui/vercel.json` `installCommand`: Vercel restores `node_modules` from its 779 MB build cache, then this command immediately deleted it — forcing yarn to rebuild all native Node addons from source. That's the `[4/4] Building fresh packages... Done in 462.52s` seen in recent logs (~7.5 min wasted every deploy).
- **Remove `rm -rf .next/cache`** from the `build` script in `ui/package.json`: this disabled Next.js's webpack persistent cache, forcing a full recompilation on every build instead of incremental compilation.

## Expected improvement

| Phase | Before | After |
|---|---|---|
| `yarn install` | ~7.5 min (rebuilds native packages) | ~1 min (uses cached modules) |
| `next build` compilation | ~2 min (full recompile) | ~30–60 sec (incremental) |
| **Total** | **~16 min** | **~6–8 min** |

## Test plan

- [ ] Trigger a Vercel preview deployment and verify the build completes in under 8 minutes
- [ ] Verify the deployed app works correctly (no stale module issues)

Made with [Cursor](https://cursor.com)