### PR TITLE
feat(swaps): add Privy token swaps to the wallet experience

### DIFF
--- a/ui/components/home/WalletInfoCard.tsx
+++ b/ui/components/home/WalletInfoCard.tsx
@@ -2,12 +2,14 @@ import {
   WalletIcon,
   ArrowUpIcon,
   ArrowDownIcon,
+  ArrowsRightLeftIcon,
   ClipboardDocumentIcon,
   ChevronDownIcon,
 } from '@heroicons/react/24/outline'
 import Image from 'next/image'
 import { NavLink } from '@/components/layout/NavLink'
 import { FundOnrampModal } from '@/components/onramp/FundOnrampModal'
+import SwapModal from '@/components/swap/SwapModal'
 import { useState, useContext } from 'react'
 import { toast } from 'react-hot-toast'
 import { useActiveAccount, useWalletBalance } from 'thirdweb/react'
@@ -88,12 +90,13 @@ export default function WalletInfoCard({
   const ens = ensData?.name
   const [copied, setCopied] = useState(false)
   const [fundModalOpen, setFundModalOpen] = useState(false)
+  const [swapModalOpen, setSwapModalOpen] = useState(false)
   const { selectedChain, setSelectedChain }: any = useContext(ChainContextV5)
   const chainSlug = getChainSlug(selectedChain)
   const [networkDropdownOpen, setNetworkDropdownOpen] = useState(false)
 
   // ETH (native) balance
-  const { data: ethBalanceData } = useWalletBalance({
+  const { data: ethBalanceData, refetch: refetchEthBalance } = useWalletBalance({
     client,
     address,
     chain: selectedChain,
@@ -102,13 +105,21 @@ export default function WalletInfoCard({
 
   // USDC balance
   const usdcAddress = USDC_ADDRESSES[chainSlug] as `0x${string}` | undefined
-  const { data: usdcBalanceData } = useWalletBalance({
+  const { data: usdcBalanceData, refetch: refetchUsdcBalance } = useWalletBalance({
     client,
     address,
     chain: selectedChain,
     tokenAddress: usdcAddress,
   })
   const usdcBalance = usdcBalanceData ? Number(usdcBalanceData.displayValue) : null
+
+  // After a swap settles, nudge the thirdweb balance hooks to refetch. On-chain
+  // state may lag a few seconds, so the modal also tells the user balances may
+  // take a moment to update.
+  const handleSwapSuccess = () => {
+    refetchEthBalance?.()
+    refetchUsdcBalance?.()
+  }
 
   const availableChains = [
     arbitrum,
@@ -343,17 +354,24 @@ export default function WalletInfoCard({
       </div>
 
       {/* Action Buttons */}
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-3 gap-2">
         <button
           onClick={() => setFundModalOpen(true)}
-          className="flex items-center justify-center gap-1.5 bg-green-600/20 hover:bg-green-600/30 text-green-300 py-2 px-3 rounded-lg text-xs font-medium transition-all"
+          className="flex items-center justify-center gap-1.5 bg-green-600/20 hover:bg-green-600/30 text-green-300 py-2 px-2 rounded-lg text-xs font-medium transition-all"
         >
           <ArrowDownIcon className="w-3.5 h-3.5" />
           Fund
         </button>
         <button
+          onClick={() => setSwapModalOpen(true)}
+          className="flex items-center justify-center gap-1.5 bg-purple-600/20 hover:bg-purple-600/30 text-purple-300 py-2 px-2 rounded-lg text-xs font-medium transition-all"
+        >
+          <ArrowsRightLeftIcon className="w-3.5 h-3.5" />
+          Swap
+        </button>
+        <button
           onClick={() => setSendModalEnabled ? setSendModalEnabled(true) : onSendClick?.()}
-          className="flex items-center justify-center gap-1.5 bg-blue-600/20 hover:bg-blue-600/30 text-blue-300 py-2 px-3 rounded-lg text-xs font-medium transition-all"
+          className="flex items-center justify-center gap-1.5 bg-blue-600/20 hover:bg-blue-600/30 text-blue-300 py-2 px-2 rounded-lg text-xs font-medium transition-all"
         >
           <ArrowUpIcon className="w-3.5 h-3.5" />
           Send
@@ -369,6 +387,14 @@ export default function WalletInfoCard({
           ethAmount={0}
           context="wallet-fund"
           allowAmountInput
+        />
+      )}
+
+      {address && (
+        <SwapModal
+          enabled={swapModalOpen}
+          setEnabled={setSwapModalOpen}
+          onSuccess={handleSwapSuccess}
         />
       )}
     </div>

--- a/ui/components/swap/SwapModal.tsx
+++ b/ui/components/swap/SwapModal.tsx
@@ -1,0 +1,409 @@
+import { ArrowsUpDownIcon, ChevronDownIcon } from '@heroicons/react/24/outline'
+import Image from 'next/image'
+import { useContext, useEffect, useMemo, useState } from 'react'
+import toast from 'react-hot-toast'
+import { useActiveAccount } from 'thirdweb/react'
+import { LoadingSpinner } from '@/components/layout/LoadingSpinner'
+import Modal from '@/components/layout/Modal'
+import { usePrivySwap } from '@/lib/privy/hooks/usePrivySwap'
+import {
+  ARBITRUM_CHAIN_ID,
+  baseUnitsToHumanAmount,
+  DEFAULT_SLIPPAGE_BPS,
+  getDefaultSwapTokens,
+  getSwapToken,
+  SwapTokenConfig,
+  SwapTokenKey,
+} from '@/lib/privy/swapTokens'
+import { arbitrum } from '@/lib/rpc/chains'
+import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
+
+type SwapModalProps = {
+  enabled: boolean
+  setEnabled: (enabled: boolean) => void
+  onSuccess?: () => void
+}
+
+function TokenButton({
+  token,
+  onClick,
+}: {
+  token: SwapTokenConfig
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-2 rounded-lg bg-white/10 hover:bg-white/20 px-3 py-2 transition-colors"
+    >
+      <Image
+        src={token.icon}
+        width={20}
+        height={20}
+        alt={token.symbol}
+        className="rounded-full object-contain"
+      />
+      <span className="text-white text-sm font-semibold">{token.symbol}</span>
+      <ChevronDownIcon className="w-4 h-4 text-gray-400" />
+    </button>
+  )
+}
+
+export default function SwapModal({ enabled, setEnabled, onSuccess }: SwapModalProps) {
+  const account = useActiveAccount()
+  const address = account?.address
+  const { selectedChain, setSelectedChain }: any = useContext(ChainContextV5)
+  const isArbitrum = selectedChain?.id === ARBITRUM_CHAIN_ID
+
+  const tokens = useMemo(() => getDefaultSwapTokens(), [])
+
+  const [fromKey, setFromKey] = useState<SwapTokenKey>('ETH')
+  const [toKey, setToKey] = useState<SwapTokenKey>('USDC')
+  const [amount, setAmount] = useState('')
+  const [slippageBps, setSlippageBps] = useState(DEFAULT_SLIPPAGE_BPS)
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [pickerOpen, setPickerOpen] = useState<null | 'from' | 'to'>(null)
+
+  const { phase, quote, error, failureReason, fetchQuote, executeSwap, reset } =
+    usePrivySwap()
+
+  const fromToken = getSwapToken(fromKey)
+  const toToken = getSwapToken(toKey)
+
+  // Surface server/Privy errors as toasts (matching app conventions) without
+  // losing the inline state shown in the modal.
+  useEffect(() => {
+    if ((phase === 'error' || phase === 'rejected' || phase === 'failed') && error) {
+      toast.error(error)
+    }
+  }, [phase, error])
+
+  useEffect(() => {
+    if (phase === 'succeeded') {
+      toast.success('Swap complete!')
+      onSuccess?.()
+    }
+  }, [phase, onSuccess])
+
+  const handleClose = () => {
+    reset()
+    setAmount('')
+    setEnabled(false)
+  }
+
+  const swapDirection = () => {
+    setFromKey(toKey)
+    setToKey(fromKey)
+    if (phase !== 'idle') reset()
+  }
+
+  const selectToken = (side: 'from' | 'to', key: SwapTokenKey) => {
+    if (side === 'from') {
+      if (key === toKey) setToKey(fromKey)
+      setFromKey(key)
+    } else {
+      if (key === fromKey) setFromKey(toKey)
+      setToKey(key)
+    }
+    setPickerOpen(null)
+    if (phase !== 'idle') reset()
+  }
+
+  const handleReview = async () => {
+    if (!address) {
+      toast.error('No wallet selected.')
+      return
+    }
+    if (!amount || Number(amount) <= 0) {
+      toast.error('Enter an amount to swap.')
+      return
+    }
+    await fetchQuote({
+      address,
+      fromToken: fromKey,
+      toToken: toKey,
+      amount,
+      chainId: ARBITRUM_CHAIN_ID,
+    })
+  }
+
+  const handleConfirm = async () => {
+    if (!address) return
+    await executeSwap({
+      address,
+      fromToken: fromKey,
+      toToken: toKey,
+      amount,
+      chainId: ARBITRUM_CHAIN_ID,
+      slippageBps,
+    })
+  }
+
+  const estOutputDisplay =
+    quote?.estOutputAmount != null
+      ? baseUnitsToHumanAmount(quote.estOutputAmount, toToken.decimals, 6)
+      : null
+  const minOutputDisplay =
+    quote?.minimumOutputAmount != null
+      ? baseUnitsToHumanAmount(quote.minimumOutputAmount, toToken.decimals, 6)
+      : null
+
+  const isBusy = phase === 'quoting' || phase === 'executing' || phase === 'pending'
+
+  if (!enabled) return null
+
+  return (
+    <Modal
+      id="swap-modal"
+      setEnabled={handleClose}
+      className="fixed top-0 left-0 w-screen h-screen bg-[#00000080] backdrop-blur-sm flex flex-col justify-start items-center z-[9999] overflow-y-auto bg-gradient-to-t from-[#3F3FA690] via-[#00000080] to-transparent animate-fadeIn py-6 px-4"
+      showCloseButton={false}
+    >
+      <div className="my-auto w-full max-w-md">
+        <div className="bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl text-white overflow-hidden">
+          {/* Header */}
+          <div className="flex items-center justify-between p-5 border-b border-white/10">
+            <h2 className="text-lg font-semibold">Swap tokens</h2>
+            <button
+              onClick={handleClose}
+              className="text-gray-400 hover:text-white transition-colors text-sm"
+            >
+              Close
+            </button>
+          </div>
+
+          {/* Arbitrum guard */}
+          {!isArbitrum ? (
+            <div className="p-6 space-y-4">
+              <p className="text-gray-300 text-sm">
+                Swaps are currently supported on Arbitrum only.
+              </p>
+              <button
+                onClick={() => setSelectedChain(arbitrum)}
+                className="w-full py-2.5 rounded-lg bg-blue-600/30 hover:bg-blue-600/50 text-blue-200 text-sm font-medium transition-all"
+              >
+                Switch to Arbitrum
+              </button>
+            </div>
+          ) : phase === 'succeeded' ? (
+            <div className="p-6 text-center space-y-3">
+              <div className="mx-auto w-12 h-12 rounded-full bg-green-500/20 flex items-center justify-center">
+                <svg className="w-6 h-6 text-green-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
+              </div>
+              <p className="text-white font-semibold">Swap complete</p>
+              <p className="text-gray-400 text-xs">
+                Balances may take a moment to update.
+              </p>
+              <button
+                onClick={handleClose}
+                className="w-full py-2.5 rounded-lg bg-white/10 hover:bg-white/20 text-white text-sm font-medium transition-all"
+              >
+                Done
+              </button>
+            </div>
+          ) : phase === 'failed' || phase === 'rejected' ? (
+            <div className="p-6 text-center space-y-3">
+              <div className="mx-auto w-12 h-12 rounded-full bg-red-500/20 flex items-center justify-center">
+                <svg className="w-6 h-6 text-red-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+              </div>
+              <p className="text-white font-semibold">
+                {phase === 'rejected' ? 'Swap rejected' : 'Swap failed'}
+              </p>
+              <p className="text-gray-400 text-xs break-words">
+                {failureReason || error || 'Please try again.'}
+              </p>
+              <button
+                onClick={reset}
+                className="w-full py-2.5 rounded-lg bg-white/10 hover:bg-white/20 text-white text-sm font-medium transition-all"
+              >
+                Try again
+              </button>
+            </div>
+          ) : (
+            <div className="p-5 space-y-3">
+              {/* From */}
+              <div className="bg-black/30 rounded-xl p-4 border border-white/5">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-xs text-gray-400">From</span>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="0.0"
+                    value={amount}
+                    disabled={isBusy}
+                    onChange={(e) => {
+                      const v = e.target.value
+                      if (v === '' || /^\d*\.?\d*$/.test(v)) {
+                        setAmount(v)
+                        if (phase === 'quoted' || phase === 'error') reset()
+                      }
+                    }}
+                    className="bg-transparent text-2xl font-semibold text-white outline-none w-full min-w-0"
+                  />
+                  <div className="relative flex-shrink-0">
+                    <TokenButton
+                      token={fromToken}
+                      onClick={() => setPickerOpen(pickerOpen === 'from' ? null : 'from')}
+                    />
+                    {pickerOpen === 'from' && (
+                      <div className="absolute right-0 top-full mt-2 w-40 bg-gray-900 border border-white/20 rounded-lg shadow-2xl z-50 overflow-hidden">
+                        {tokens.map((t) => (
+                          <button
+                            key={t.key}
+                            type="button"
+                            onClick={() => selectToken('from', t.key)}
+                            className="w-full flex items-center gap-2 px-3 py-2 hover:bg-white/10 text-left text-sm text-white"
+                          >
+                            <Image src={t.icon} width={18} height={18} alt={t.symbol} className="rounded-full object-contain" />
+                            {t.symbol}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Direction toggle */}
+              <div className="flex justify-center -my-1">
+                <button
+                  type="button"
+                  onClick={swapDirection}
+                  disabled={isBusy}
+                  className="w-9 h-9 rounded-full bg-white/10 hover:bg-white/20 border border-white/10 flex items-center justify-center transition-colors disabled:opacity-50"
+                  aria-label="Swap direction"
+                >
+                  <ArrowsUpDownIcon className="w-4 h-4 text-blue-300" />
+                </button>
+              </div>
+
+              {/* To */}
+              <div className="bg-black/30 rounded-xl p-4 border border-white/5">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-xs text-gray-400">To (estimated)</span>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-2xl font-semibold text-white truncate">
+                    {estOutputDisplay ?? '0.0'}
+                  </span>
+                  <div className="relative flex-shrink-0">
+                    <TokenButton
+                      token={toToken}
+                      onClick={() => setPickerOpen(pickerOpen === 'to' ? null : 'to')}
+                    />
+                    {pickerOpen === 'to' && (
+                      <div className="absolute right-0 top-full mt-2 w-40 bg-gray-900 border border-white/20 rounded-lg shadow-2xl z-50 overflow-hidden">
+                        {tokens.map((t) => (
+                          <button
+                            key={t.key}
+                            type="button"
+                            onClick={() => selectToken('to', t.key)}
+                            className="w-full flex items-center gap-2 px-3 py-2 hover:bg-white/10 text-left text-sm text-white"
+                          >
+                            <Image src={t.icon} width={18} height={18} alt={t.symbol} className="rounded-full object-contain" />
+                            {t.symbol}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Quote details */}
+              {phase === 'quoted' && quote && (
+                <div className="bg-black/20 rounded-lg p-3 border border-white/5 space-y-1.5 text-xs">
+                  <div className="flex justify-between text-gray-400">
+                    <span>Minimum received</span>
+                    <span className="text-white">
+                      {minOutputDisplay ?? '—'} {toToken.symbol}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-gray-400">
+                    <span>Slippage</span>
+                    <span className="text-white">{(slippageBps / 100).toFixed(2)}%</span>
+                  </div>
+                  {quote.gasEstimate && (
+                    <div className="flex justify-between text-gray-400">
+                      <span>Gas</span>
+                      <span className="text-white">Sponsored by MoonDAO</span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Advanced slippage */}
+              <button
+                type="button"
+                onClick={() => setShowAdvanced((s) => !s)}
+                className="text-xs text-gray-400 hover:text-white transition-colors"
+              >
+                {showAdvanced ? 'Hide' : 'Advanced'} settings
+              </button>
+              {showAdvanced && (
+                <div className="bg-black/20 rounded-lg p-3 border border-white/5">
+                  <label className="block text-xs text-gray-400 mb-1">
+                    Slippage tolerance (bps)
+                  </label>
+                  <input
+                    type="number"
+                    min={0}
+                    max={10000}
+                    value={slippageBps}
+                    disabled={isBusy}
+                    onChange={(e) => {
+                      const v = Math.round(Number(e.target.value))
+                      if (!Number.isNaN(v)) setSlippageBps(Math.min(10000, Math.max(0, v)))
+                    }}
+                    className="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none"
+                  />
+                </div>
+              )}
+
+              {/* Inline error */}
+              {phase === 'error' && error && (
+                <p className="text-red-400 text-xs">{error}</p>
+              )}
+
+              {/* Primary action */}
+              {phase === 'quoted' ? (
+                <button
+                  onClick={handleConfirm}
+                  disabled={isBusy}
+                  className="w-full py-3 rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-semibold text-sm transition-all flex items-center justify-center gap-2"
+                >
+                  Confirm swap
+                </button>
+              ) : (
+                <button
+                  onClick={handleReview}
+                  disabled={isBusy || !amount}
+                  className="w-full py-3 rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-semibold text-sm transition-all flex items-center justify-center gap-2"
+                >
+                  {phase === 'quoting' ? (
+                    <>
+                      <LoadingSpinner width="w-4" height="h-4" />
+                      Getting quote…
+                    </>
+                  ) : (
+                    'Review swap'
+                  )}
+                </button>
+              )}
+
+              {phase === 'executing' || phase === 'pending' ? (
+                <div className="flex items-center justify-center gap-2 text-xs text-gray-400">
+                  <LoadingSpinner width="w-4" height="h-4" />
+                  {phase === 'executing' ? 'Submitting swap…' : 'Waiting for confirmation…'}
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/ui/cypress/integration/lib/privy/swap-tokens.cy.ts
+++ b/ui/cypress/integration/lib/privy/swap-tokens.cy.ts
@@ -1,0 +1,143 @@
+import {
+  ARBITRUM_CAIP2,
+  ARBITRUM_CHAIN_ID,
+  baseUnitsToHumanAmount,
+  DEFAULT_SLIPPAGE_BPS,
+  getDefaultSwapTokens,
+  getSwapToken,
+  humanAmountToBaseUnits,
+  isSupportedSwapChainId,
+  isSwapTokenKey,
+  isValidSlippageBps,
+  validateSwapPair,
+} from '@/lib/privy/swapTokens'
+
+describe('swapTokens allowlist', () => {
+  it('exposes Arbitrum constants', () => {
+    expect(ARBITRUM_CHAIN_ID).to.equal(42161)
+    expect(ARBITRUM_CAIP2).to.equal('eip155:42161')
+  })
+
+  it('recognizes only allowlisted token keys', () => {
+    expect(isSwapTokenKey('ETH')).to.equal(true)
+    expect(isSwapTokenKey('USDC')).to.equal(true)
+    expect(isSwapTokenKey('MOONEY')).to.equal(true)
+    expect(isSwapTokenKey('DAI')).to.equal(false)
+    expect(isSwapTokenKey('0xdeadbeef')).to.equal(false)
+    expect(isSwapTokenKey('')).to.equal(false)
+    expect(isSwapTokenKey(undefined)).to.equal(false)
+  })
+
+  it('getSwapToken returns config for allowed keys', () => {
+    const usdc = getSwapToken('USDC')
+    expect(usdc.symbol).to.equal('USDC')
+    expect(usdc.decimals).to.equal(6)
+    expect(usdc.assetAddress).to.match(/^0x[a-fA-F0-9]{40}$/)
+
+    const eth = getSwapToken('ETH')
+    expect(eth.assetAddress).to.equal('native')
+    expect(eth.decimals).to.equal(18)
+  })
+
+  it('getSwapToken rejects arbitrary / forged token addresses', () => {
+    expect(() => getSwapToken('0x1234567890123456789012345678901234567890')).to.throw()
+    expect(() => getSwapToken('NOTATOKEN')).to.throw()
+    expect(() => getSwapToken(undefined)).to.throw()
+  })
+
+  it('default token picker excludes hidden/experimental tokens (MOONEY)', () => {
+    const keys = getDefaultSwapTokens().map((t) => t.key)
+    expect(keys).to.include('ETH')
+    expect(keys).to.include('USDC')
+    expect(keys).to.not.include('MOONEY')
+  })
+})
+
+describe('isSupportedSwapChainId', () => {
+  it('accepts only Arbitrum', () => {
+    expect(isSupportedSwapChainId(42161)).to.equal(true)
+    expect(isSupportedSwapChainId('42161')).to.equal(true)
+    expect(isSupportedSwapChainId(1)).to.equal(false)
+    expect(isSupportedSwapChainId(8453)).to.equal(false)
+    expect(isSupportedSwapChainId(137)).to.equal(false)
+    expect(isSupportedSwapChainId(undefined)).to.equal(false)
+    expect(isSupportedSwapChainId(null)).to.equal(false)
+  })
+})
+
+describe('validateSwapPair', () => {
+  it('accepts two different allowlisted tokens', () => {
+    const { from, to } = validateSwapPair('ETH', 'USDC')
+    expect(from.key).to.equal('ETH')
+    expect(to.key).to.equal('USDC')
+  })
+
+  it('rejects identical input/output tokens', () => {
+    expect(() => validateSwapPair('ETH', 'ETH')).to.throw('different')
+  })
+
+  it('rejects unsupported tokens in a pair', () => {
+    expect(() => validateSwapPair('ETH', 'DAI')).to.throw()
+    expect(() => validateSwapPair('FOO', 'USDC')).to.throw()
+  })
+})
+
+describe('isValidSlippageBps', () => {
+  it('accepts integers within 0..10000', () => {
+    expect(isValidSlippageBps(0)).to.equal(true)
+    expect(isValidSlippageBps(DEFAULT_SLIPPAGE_BPS)).to.equal(true)
+    expect(isValidSlippageBps(10000)).to.equal(true)
+  })
+
+  it('rejects out-of-range or non-integer values', () => {
+    expect(isValidSlippageBps(-1)).to.equal(false)
+    expect(isValidSlippageBps(10001)).to.equal(false)
+    expect(isValidSlippageBps(12.5)).to.equal(false)
+    expect(isValidSlippageBps('50' as unknown)).to.equal(false)
+  })
+})
+
+describe('humanAmountToBaseUnits', () => {
+  it('converts whole and fractional ETH (18 decimals)', () => {
+    expect(humanAmountToBaseUnits('1', 18).toString()).to.equal('1000000000000000000')
+    expect(humanAmountToBaseUnits('0.5', 18).toString()).to.equal('500000000000000000')
+    expect(humanAmountToBaseUnits('0.0125', 18).toString()).to.equal('12500000000000000')
+  })
+
+  it('converts USDC (6 decimals)', () => {
+    expect(humanAmountToBaseUnits('1', 6).toString()).to.equal('1000000')
+    expect(humanAmountToBaseUnits('2.5', 6).toString()).to.equal('2500000')
+    expect(humanAmountToBaseUnits('0.000001', 6).toString()).to.equal('1')
+  })
+
+  it('rejects zero, negative, empty, and malformed amounts', () => {
+    expect(() => humanAmountToBaseUnits('0', 18)).to.throw()
+    expect(() => humanAmountToBaseUnits('', 18)).to.throw()
+    expect(() => humanAmountToBaseUnits('.', 18)).to.throw()
+    expect(() => humanAmountToBaseUnits('-1', 18)).to.throw()
+    expect(() => humanAmountToBaseUnits('abc', 18)).to.throw()
+    expect(() => humanAmountToBaseUnits('1e18', 18)).to.throw()
+  })
+
+  it('rejects more decimal places than the token supports', () => {
+    expect(() => humanAmountToBaseUnits('1.1234567', 6)).to.throw('decimal')
+  })
+})
+
+describe('baseUnitsToHumanAmount', () => {
+  it('formats base units back to a human amount', () => {
+    expect(baseUnitsToHumanAmount('1000000000000000000', 18)).to.equal('1')
+    expect(baseUnitsToHumanAmount('500000000000000000', 18)).to.equal('0.5')
+    expect(baseUnitsToHumanAmount('2500000', 6)).to.equal('2.5')
+    expect(baseUnitsToHumanAmount('0', 18)).to.equal('0')
+  })
+
+  it('respects max display decimals', () => {
+    expect(baseUnitsToHumanAmount('1234567890123456789', 18, 4)).to.equal('1.2345')
+  })
+
+  it('round-trips with humanAmountToBaseUnits', () => {
+    const base = humanAmountToBaseUnits('3.14159', 18)
+    expect(baseUnitsToHumanAmount(base, 18)).to.equal('3.14159')
+  })
+})

--- a/ui/lib/privy/hooks/usePrivySwap.ts
+++ b/ui/lib/privy/hooks/usePrivySwap.ts
@@ -1,0 +1,227 @@
+import { getAccessToken } from '@privy-io/react-auth'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { SwapTokenKey } from '@/lib/privy/swapTokens'
+
+// Client-side lifecycle for a single Privy swap: fetch a quote, execute after
+// the user confirms, then poll the wallet action until it reaches a terminal
+// state. All Privy API access happens server-side behind /api/privy/swap/*.
+
+export type SwapPhase =
+  | 'idle'
+  | 'quoting'
+  | 'quoted'
+  | 'executing'
+  | 'pending'
+  | 'succeeded'
+  | 'failed'
+  | 'rejected'
+  | 'error'
+
+export interface SwapQuote {
+  fromToken: SwapTokenKey
+  toToken: SwapTokenKey
+  inputDecimals: number
+  outputDecimals: number
+  inputAmount: string | null
+  estOutputAmount: string | null
+  minimumOutputAmount: string | null
+  gasEstimate: string | null
+  caip2: string | null
+  expiresAt: number | null
+  chainId: number
+}
+
+export interface QuoteParams {
+  address: string
+  fromToken: SwapTokenKey
+  toToken: SwapTokenKey
+  amount: string
+  chainId: number
+}
+
+export interface ExecuteParams extends QuoteParams {
+  slippageBps: number
+}
+
+const TERMINAL_PHASES: SwapPhase[] = ['succeeded', 'failed', 'rejected']
+const POLL_INTERVAL_MS = 3000
+const POLL_TIMEOUT_MS = 3 * 60 * 1000
+
+async function authedFetch(url: string, init?: RequestInit) {
+  const accessToken = await getAccessToken()
+  if (!accessToken) {
+    throw new Error('You must be signed in to swap.')
+  }
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+      ...(init?.headers || {}),
+    },
+  })
+  let data: any = null
+  try {
+    data = await res.json()
+  } catch {
+    data = null
+  }
+  if (!res.ok) {
+    throw new Error(data?.error || 'Request failed. Please try again.')
+  }
+  return data
+}
+
+export function usePrivySwap() {
+  const [phase, setPhase] = useState<SwapPhase>('idle')
+  const [quote, setQuote] = useState<SwapQuote | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [failureReason, setFailureReason] = useState<string | null>(null)
+  const [actionId, setActionId] = useState<string | null>(null)
+
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const pollDeadlineRef = useRef<number>(0)
+  const idempotencyKeyRef = useRef<string | null>(null)
+  const mountedRef = useRef(true)
+
+  const clearPoll = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      clearPoll()
+    }
+  }, [clearPoll])
+
+  const reset = useCallback(() => {
+    clearPoll()
+    idempotencyKeyRef.current = null
+    setPhase('idle')
+    setQuote(null)
+    setError(null)
+    setFailureReason(null)
+    setActionId(null)
+  }, [clearPoll])
+
+  const fetchQuote = useCallback(async (params: QuoteParams) => {
+    setError(null)
+    setFailureReason(null)
+    setPhase('quoting')
+    try {
+      const data = await authedFetch('/api/privy/swap/quote', {
+        method: 'POST',
+        body: JSON.stringify(params),
+      })
+      if (!mountedRef.current) return null
+      setQuote(data.quote as SwapQuote)
+      setPhase('quoted')
+      return data.quote as SwapQuote
+    } catch (err: any) {
+      if (!mountedRef.current) return null
+      setError(err?.message || 'Could not fetch a quote.')
+      setPhase('error')
+      return null
+    }
+  }, [])
+
+  const startPolling = useCallback(
+    (address: string, id: string) => {
+      clearPoll()
+      pollDeadlineRef.current = Date.now() + POLL_TIMEOUT_MS
+
+      const poll = async () => {
+        try {
+          const data = await authedFetch(
+            `/api/privy/swap/action/${encodeURIComponent(id)}?address=${encodeURIComponent(
+              address
+            )}`
+          )
+          if (!mountedRef.current) return
+          const status = data.status as SwapPhase
+          if (status === 'succeeded' || status === 'failed' || status === 'rejected') {
+            clearPoll()
+            if (data.failureReason) setFailureReason(data.failureReason)
+            setPhase(status)
+            return
+          }
+          // 'created' / 'pending' → keep waiting.
+          if (Date.now() > pollDeadlineRef.current) {
+            clearPoll()
+            setPhase('pending')
+            setError(
+              'This swap is taking longer than expected. Your balances may update in a few minutes.'
+            )
+          }
+        } catch (err: any) {
+          // Transient polling errors shouldn't kill the flow; stop only on timeout.
+          if (Date.now() > pollDeadlineRef.current) {
+            clearPoll()
+            setPhase('pending')
+            setError(err?.message || 'Lost track of the swap status.')
+          }
+        }
+      }
+
+      pollRef.current = setInterval(poll, POLL_INTERVAL_MS)
+      // Kick off an immediate poll so the user isn't waiting a full interval.
+      poll()
+    },
+    [clearPoll]
+  )
+
+  const executeSwap = useCallback(
+    async (params: ExecuteParams) => {
+      setError(null)
+      setFailureReason(null)
+      setPhase('executing')
+
+      // Stable idempotency key per confirmed swap so accidental double-submits
+      // (or retries) don't create two swaps.
+      if (!idempotencyKeyRef.current) {
+        idempotencyKeyRef.current =
+          typeof crypto !== 'undefined' && 'randomUUID' in crypto
+            ? crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+      }
+
+      try {
+        const data = await authedFetch('/api/privy/swap/execute', {
+          method: 'POST',
+          body: JSON.stringify({
+            ...params,
+            idempotencyKey: idempotencyKeyRef.current,
+          }),
+        })
+        if (!mountedRef.current) return null
+        setActionId(data.actionId)
+        setPhase('pending')
+        startPolling(params.address, data.actionId)
+        return data.actionId as string
+      } catch (err: any) {
+        if (!mountedRef.current) return null
+        setError(err?.message || 'Could not start the swap.')
+        setPhase('error')
+        return null
+      }
+    },
+    [startPolling]
+  )
+
+  return {
+    phase,
+    quote,
+    error,
+    failureReason,
+    actionId,
+    isTerminal: TERMINAL_PHASES.includes(phase),
+    fetchQuote,
+    executeSwap,
+    reset,
+  }
+}

--- a/ui/lib/privy/swapTokens.ts
+++ b/ui/lib/privy/swapTokens.ts
@@ -1,0 +1,182 @@
+import { MOONEY_ADDRESSES, USDC_ADDRESSES } from 'const/config'
+
+// v1 swaps are Arbitrum-only. These constants are the single source of truth so
+// the server can reject anything off Arbitrum and the client can guard the UI.
+export const ARBITRUM_CHAIN_ID = 42161
+export const ARBITRUM_CAIP2 = 'eip155:42161'
+
+// Privy represents the chain's native asset (ETH on Arbitrum) with the literal
+// string "native" rather than an address.
+export const NATIVE_ASSET = 'native'
+
+export type SwapTokenKey = 'ETH' | 'USDC' | 'MOONEY'
+
+export interface SwapTokenConfig {
+  key: SwapTokenKey
+  symbol: string
+  name: string
+  /** ERC-20 decimals, or 18 for native ETH. Used to convert human amounts. */
+  decimals: number
+  /** Either NATIVE_ASSET ("native") or a checksummed ERC-20 address. */
+  assetAddress: string
+  /** Small icon path used by the modal. */
+  icon: string
+  /**
+   * When false, the token is allowlisted server-side but hidden from the
+   * default token pickers. Used to keep an unproven pair (MOONEY) out of the
+   * happy path until its routing/liquidity is confirmed via real quotes.
+   */
+  showByDefault: boolean
+  /**
+   * Marks a token whose swap routing has not been verified end-to-end. The UI
+   * can surface a warning; quotes that fail for these still degrade gracefully.
+   */
+  experimental?: boolean
+}
+
+// Token addresses come exclusively from const/config.ts — never invented here,
+// never accepted from the client. The client only ever sends a token KEY.
+export const ARBITRUM_SWAP_TOKENS: Record<SwapTokenKey, SwapTokenConfig> = {
+  ETH: {
+    key: 'ETH',
+    symbol: 'ETH',
+    name: 'Ethereum',
+    decimals: 18,
+    assetAddress: NATIVE_ASSET,
+    icon: '/icons/networks/arbitrum.svg',
+    showByDefault: true,
+  },
+  USDC: {
+    key: 'USDC',
+    symbol: 'USDC',
+    name: 'USD Coin',
+    decimals: 6,
+    assetAddress: USDC_ADDRESSES.arbitrum,
+    icon: '/coins/USDC.svg',
+    showByDefault: true,
+  },
+  // MOONEY is allowlisted but kept out of the default UI until quote/execute is
+  // confirmed to route reliably on Arbitrum. See TODO in lib/privy/swaps.ts.
+  MOONEY: {
+    key: 'MOONEY',
+    symbol: 'MOONEY',
+    name: 'MOONEY',
+    decimals: 18,
+    assetAddress: MOONEY_ADDRESSES.arbitrum,
+    icon: '/coins/MOONEY.png',
+    showByDefault: false,
+    experimental: true,
+  },
+}
+
+export const SWAP_TOKEN_KEYS = Object.keys(ARBITRUM_SWAP_TOKENS) as SwapTokenKey[]
+
+export function isSupportedSwapChainId(chainId: number | string | undefined | null): boolean {
+  if (chainId === undefined || chainId === null) return false
+  return Number(chainId) === ARBITRUM_CHAIN_ID
+}
+
+export function isSwapTokenKey(value: unknown): value is SwapTokenKey {
+  return typeof value === 'string' && Object.prototype.hasOwnProperty.call(ARBITRUM_SWAP_TOKENS, value)
+}
+
+/**
+ * Resolve a client-supplied token key to its allowlisted config. Throws on any
+ * unknown key so callers never operate on an arbitrary/forged token.
+ */
+export function getSwapToken(key: unknown): SwapTokenConfig {
+  if (!isSwapTokenKey(key)) {
+    throw new Error(`Unsupported token: ${typeof key === 'string' ? key : 'unknown'}`)
+  }
+  const token = ARBITRUM_SWAP_TOKENS[key]
+  if (!token.assetAddress) {
+    // Defensive: a missing address in config would otherwise produce a bad quote.
+    throw new Error(`Token ${key} is not configured for Arbitrum`)
+  }
+  return token
+}
+
+/** Tokens shown in the picker by default (excludes experimental/hidden ones). */
+export function getDefaultSwapTokens(): SwapTokenConfig[] {
+  return SWAP_TOKEN_KEYS.map((k) => ARBITRUM_SWAP_TOKENS[k]).filter((t) => t.showByDefault)
+}
+
+/**
+ * Validate that a from/to pair is allowed: both keys must be on the allowlist
+ * and they must be different. Returns the resolved configs.
+ */
+export function validateSwapPair(
+  fromKey: unknown,
+  toKey: unknown
+): { from: SwapTokenConfig; to: SwapTokenConfig } {
+  const from = getSwapToken(fromKey)
+  const to = getSwapToken(toKey)
+  if (from.key === to.key) {
+    throw new Error('Input and output tokens must be different')
+  }
+  return { from, to }
+}
+
+/** Slippage must be an integer in [0, 10000] basis points (0%–100%). */
+export function isValidSlippageBps(bps: unknown): boolean {
+  return typeof bps === 'number' && Number.isInteger(bps) && bps >= 0 && bps <= 10000
+}
+
+export const DEFAULT_SLIPPAGE_BPS = 50
+
+/**
+ * Convert a human-readable decimal amount (e.g. "0.0125") to base units as a
+ * bigint, using the token's decimals. Pure string math — no floating point — so
+ * it is safe for on-chain values. Throws a clear error on any malformed input.
+ */
+export function humanAmountToBaseUnits(amount: string | number, decimals: number): bigint {
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 36) {
+    throw new Error('Invalid token decimals')
+  }
+  const raw = typeof amount === 'number' ? String(amount) : amount
+  const trimmed = (raw ?? '').trim()
+
+  // Reject scientific notation, signs, and anything that isn't digits + one dot.
+  if (trimmed === '' || trimmed === '.' || !/^\d*\.?\d*$/.test(trimmed)) {
+    throw new Error('Enter a valid amount')
+  }
+
+  const [wholePart, fracPart = ''] = trimmed.split('.')
+  if (fracPart.length > decimals) {
+    throw new Error(`This token supports at most ${decimals} decimal places`)
+  }
+
+  const paddedFrac = fracPart.padEnd(decimals, '0')
+  const combined = `${wholePart}${paddedFrac}`.replace(/^0+(?=\d)/, '') || '0'
+  const result = BigInt(combined)
+
+  if (result <= BigInt(0)) {
+    throw new Error('Amount must be greater than zero')
+  }
+  return result
+}
+
+/**
+ * Convert base units back to a human-readable decimal string for display.
+ * Trims trailing zeros. Pure string math.
+ */
+export function baseUnitsToHumanAmount(
+  baseUnits: string | bigint,
+  decimals: number,
+  maxDisplayDecimals?: number
+): string {
+  const value = typeof baseUnits === 'bigint' ? baseUnits : BigInt(baseUnits || '0')
+  const negative = value < BigInt(0)
+  const abs = negative ? value * BigInt(-1) : value
+  const digits = abs.toString().padStart(decimals + 1, '0')
+  const whole = digits.slice(0, digits.length - decimals)
+  let frac = decimals > 0 ? digits.slice(digits.length - decimals) : ''
+
+  if (maxDisplayDecimals !== undefined && frac.length > maxDisplayDecimals) {
+    frac = frac.slice(0, maxDisplayDecimals)
+  }
+  frac = frac.replace(/0+$/, '')
+
+  const result = frac ? `${whole}.${frac}` : whole
+  return negative ? `-${result}` : result
+}

--- a/ui/lib/privy/swaps.ts
+++ b/ui/lib/privy/swaps.ts
@@ -1,0 +1,447 @@
+import crypto from 'crypto'
+import { ARBITRUM_CAIP2 } from './swapTokens'
+
+// SERVER-ONLY. This module talks to the Privy REST API using the app secret.
+// It must never be imported into client bundles. All exported functions assume
+// they run inside an API route.
+
+const PRIVY_API_BASE = 'https://api.privy.io'
+const PRIVY_APP_ID = process.env.NEXT_PUBLIC_PRIVY_APP_ID as string
+const PRIVY_APP_SECRET = process.env.PRIVY_APP_SECRET as string
+// Optional. Required only when the app's embedded wallets have explicit owners
+// or signers (Privy then mandates a request authorization signature). Stored as
+// the raw "wallet-auth:<base64-pkcs8>" string from the Privy dashboard.
+const PRIVY_AUTHORIZATION_KEY = process.env.PRIVY_AUTHORIZATION_KEY
+
+const REQUEST_TIMEOUT_MS = 12000
+
+export type WalletActionStatus =
+  | 'created'
+  | 'pending'
+  | 'succeeded'
+  | 'failed'
+  | 'rejected'
+
+export const TERMINAL_STATUSES: WalletActionStatus[] = ['succeeded', 'failed', 'rejected']
+
+export interface SwapAsset {
+  caip2: string
+  // 'native' or a 0x ERC-20 address
+  asset_address: string
+}
+
+export interface SwapQuoteResult {
+  estOutputAmount: string | null
+  minimumOutputAmount: string | null
+  gasEstimate: string | null
+  inputAmount: string | null
+  inputToken: string | null
+  outputToken: string | null
+  caip2: string | null
+  expiresAt: number | null
+  // Pass-through of any sponsorship/fee metadata Privy returns, untrusted shape.
+  raw: Record<string, any>
+}
+
+export interface SwapExecuteResult {
+  actionId: string
+  status: WalletActionStatus
+  walletId: string
+  inputToken: string | null
+  outputToken: string | null
+  caip2: string | null
+}
+
+export interface WalletActionResult {
+  actionId: string
+  status: WalletActionStatus
+  walletId: string | null
+  type: string | null
+  failureReason: string | null
+  raw: Record<string, any>
+}
+
+/**
+ * A swap error that carries a user-safe message and an HTTP-ish status the API
+ * route can forward. `userMessage` is always safe to show in the browser.
+ */
+export class PrivySwapError extends Error {
+  status: number
+  userMessage: string
+  constructor(userMessage: string, status = 400) {
+    super(userMessage)
+    this.name = 'PrivySwapError'
+    this.status = status
+    this.userMessage = userMessage
+  }
+}
+
+function assertServerConfig() {
+  if (!PRIVY_APP_ID || !PRIVY_APP_SECRET) {
+    // Never echo the values — just fail closed with a generic message.
+    throw new PrivySwapError('Swaps are temporarily unavailable. Please try again later.', 503)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Authorization signature (RFC 8785 canonicalize + ECDSA P-256, DER, base64)
+// ---------------------------------------------------------------------------
+
+// Minimal RFC 8785 (JCS) canonicalizer for the plain JSON payloads Privy signs.
+// Handles objects (sorted keys), arrays, strings, finite numbers, booleans and
+// null — which is all the authorization payload ever contains.
+function canonicalize(value: any): string {
+  if (value === null) return 'null'
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('Cannot canonicalize non-finite number')
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalize(v)).join(',')}]`
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value).sort()
+    const entries = keys.map((k) => `${JSON.stringify(k)}:${canonicalize(value[k])}`)
+    return `{${entries.join(',')}}`
+  }
+  throw new Error(`Cannot canonicalize value of type ${typeof value}`)
+}
+
+/**
+ * Build the `privy-authorization-signature` header for a POST request, if an
+ * authorization key is configured. Returns undefined when no key is set so the
+ * caller can attempt the request without it (Privy only requires it for wallets
+ * with explicit owners/signers). Never throws on a missing key.
+ */
+function buildAuthorizationSignature(
+  url: string,
+  body: Record<string, any>,
+  extraHeaders: Record<string, string> = {}
+): string | undefined {
+  if (!PRIVY_AUTHORIZATION_KEY) return undefined
+  try {
+    const headers: Record<string, string> = { 'privy-app-id': PRIVY_APP_ID, ...extraHeaders }
+    const payload = { version: 1, method: 'POST', url, body, headers }
+    const serialized = canonicalize(payload)
+
+    const keyString = PRIVY_AUTHORIZATION_KEY.replace('wallet-auth:', '')
+    const pem = `-----BEGIN PRIVATE KEY-----\n${keyString}\n-----END PRIVATE KEY-----`
+    const privateKey = crypto.createPrivateKey({ key: pem, format: 'pem' })
+    // crypto.sign with a P-256 key produces a DER-encoded ECDSA signature.
+    const signature = crypto.sign('sha256', Buffer.from(serialized), privateKey)
+    return signature.toString('base64')
+  } catch (err) {
+    // Signing is best-effort; log the failure without leaking the key material.
+    console.error('[privy/swaps] failed to build authorization signature')
+    return undefined
+  }
+}
+
+function basicAuthHeader(): string {
+  return `Basic ${Buffer.from(`${PRIVY_APP_ID}:${PRIVY_APP_SECRET}`).toString('base64')}`
+}
+
+function baseHeaders(): Record<string, string> {
+  return {
+    Authorization: basicAuthHeader(),
+    'privy-app-id': PRIVY_APP_ID,
+    'Content-Type': 'application/json',
+  }
+}
+
+async function privyFetch(
+  path: string,
+  init: { method: 'GET' | 'POST'; headers?: Record<string, string>; body?: string }
+): Promise<{ ok: boolean; status: number; data: any }> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    const res = await fetch(`${PRIVY_API_BASE}${path}`, {
+      method: init.method,
+      headers: init.headers,
+      body: init.body,
+      signal: controller.signal,
+    })
+    let data: any = null
+    try {
+      data = await res.json()
+    } catch {
+      data = null
+    }
+    return { ok: res.ok, status: res.status, data }
+  } catch (err: any) {
+    if (err?.name === 'AbortError') {
+      throw new PrivySwapError('Privy did not respond in time. Please try again.', 504)
+    }
+    throw new PrivySwapError('Could not reach the swap service. Please try again.', 502)
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+// Translate a Privy error response into a user-safe message. We intentionally
+// avoid forwarding raw Privy text in most cases, but surface a few well-known
+// conditions (gas sponsorship, slippage, liquidity, insufficient balance).
+function toUserSafeError(status: number, data: any): PrivySwapError {
+  const rawMessage: string =
+    (typeof data?.error === 'string' && data.error) ||
+    (typeof data?.message === 'string' && data.message) ||
+    ''
+  const lower = rawMessage.toLowerCase()
+
+  if (
+    lower.includes('sponsor') ||
+    lower.includes('gas credit') ||
+    lower.includes('credit limit') ||
+    lower.includes('paymaster')
+  ) {
+    return new PrivySwapError(
+      'Gas sponsorship is temporarily unavailable. Please try again later or fund your wallet with a little ETH for gas.',
+      503
+    )
+  }
+  if (lower.includes('insufficient') && lower.includes('balance')) {
+    return new PrivySwapError('Insufficient balance for this swap.', 400)
+  }
+  if (lower.includes('slippage')) {
+    return new PrivySwapError('Price moved beyond your slippage tolerance. Try again or raise slippage slightly.', 400)
+  }
+  if (lower.includes('liquidity') || lower.includes('no route') || lower.includes('route not found')) {
+    return new PrivySwapError('No swap route is available for this token pair right now.', 400)
+  }
+  if (status === 401 || status === 403) {
+    // Most likely the wallet needs an authorization signature this app can't
+    // currently produce, or the app secret is wrong. Keep it generic.
+    return new PrivySwapError('This wallet is not authorized for swaps. Please contact support.', 403)
+  }
+  if (status === 404) {
+    return new PrivySwapError('Swap could not be found.', 404)
+  }
+  if (status === 429) {
+    return new PrivySwapError('Too many requests. Please wait a moment and try again.', 429)
+  }
+  if (status >= 500) {
+    return new PrivySwapError('The swap service is having trouble. Please try again later.', 502)
+  }
+  return new PrivySwapError('We could not get a swap quote for this pair. Please try a different amount or pair.', 400)
+}
+
+function coerceStatus(value: unknown): WalletActionStatus {
+  if (
+    value === 'created' ||
+    value === 'pending' ||
+    value === 'succeeded' ||
+    value === 'failed' ||
+    value === 'rejected'
+  ) {
+    return value
+  }
+  // Unknown/missing status → treat as still pending so the client keeps polling
+  // rather than wrongly reporting success/failure.
+  return 'pending'
+}
+
+// ---------------------------------------------------------------------------
+// Wallet ID resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull a Privy wallet ID for `address` out of a raw user object's linked
+ * accounts. NOTE: Privy only populates `id` on embedded-wallet linked accounts
+ * when the wallet is delegated, so this can legitimately return null even for a
+ * wallet the user owns. Callers should fall back to getWalletIdByAddress.
+ */
+export function extractWalletIdFromUser(rawUser: any, address: string): string | null {
+  const lower = address.toLowerCase()
+  const accounts: any[] = Array.isArray(rawUser?.linked_accounts) ? rawUser.linked_accounts : []
+  for (const account of accounts) {
+    if (
+      account?.type === 'wallet' &&
+      typeof account?.address === 'string' &&
+      account.address.toLowerCase() === lower &&
+      typeof account?.id === 'string' &&
+      account.id.length > 0
+    ) {
+      return account.id
+    }
+  }
+  return null
+}
+
+/** Look up a wallet ID by address via the Privy wallets API. */
+export async function getWalletIdByAddress(address: string): Promise<string | null> {
+  assertServerConfig()
+  const { ok, data } = await privyFetch('/v1/wallets/address', {
+    method: 'POST',
+    headers: baseHeaders(),
+    body: JSON.stringify({ address }),
+  })
+  if (!ok) return null
+  return typeof data?.id === 'string' && data.id.length > 0 ? data.id : null
+}
+
+/**
+ * Resolve the Privy wallet ID for an address that has already been confirmed to
+ * belong to the authenticated user. Tries the user object first, then the
+ * address lookup. Throws a clear PrivySwapError if neither yields an ID.
+ */
+export async function resolveWalletId(rawUser: any, address: string): Promise<string> {
+  const fromUser = extractWalletIdFromUser(rawUser, address)
+  if (fromUser) return fromUser
+
+  const fromLookup = await getWalletIdByAddress(address)
+  if (fromLookup) return fromLookup
+
+  throw new PrivySwapError(
+    'We could not find a Privy-managed wallet for this address. Swaps are only available for embedded Privy wallets.',
+    400
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Quote / Execute / Status
+// ---------------------------------------------------------------------------
+
+export async function getSwapQuote(params: {
+  walletId: string
+  source: SwapAsset
+  destination: SwapAsset
+  baseAmount: string
+}): Promise<SwapQuoteResult> {
+  assertServerConfig()
+  const { walletId, source, destination, baseAmount } = params
+
+  const body = {
+    source,
+    destination,
+    base_amount: baseAmount,
+    amount_type: 'exact_input' as const,
+  }
+
+  const { ok, status, data } = await privyFetch(
+    `/v1/wallets/${encodeURIComponent(walletId)}/swap/quote`,
+    { method: 'POST', headers: baseHeaders(), body: JSON.stringify(body) }
+  )
+
+  if (!ok) {
+    // Log status only — never the request headers or body (which carry secrets).
+    console.error(`[privy/swaps] quote failed with status ${status}`)
+    throw toUserSafeError(status, data)
+  }
+
+  return {
+    estOutputAmount: data?.est_output_amount ?? null,
+    minimumOutputAmount: data?.minimum_output_amount ?? null,
+    gasEstimate: data?.gas_estimate ?? null,
+    inputAmount: data?.input_amount ?? baseAmount,
+    inputToken: data?.input_token ?? source.asset_address,
+    outputToken: data?.output_token ?? destination.asset_address,
+    caip2: data?.caip2 ?? source.caip2,
+    expiresAt: typeof data?.expires_at === 'number' ? data.expires_at : null,
+    raw: data && typeof data === 'object' ? data : {},
+  }
+}
+
+export async function executeSwap(params: {
+  walletId: string
+  source: SwapAsset
+  destination: SwapAsset
+  baseAmount: string
+  slippageBps: number
+  idempotencyKey: string
+}): Promise<SwapExecuteResult> {
+  assertServerConfig()
+  const { walletId, source, destination, baseAmount, slippageBps, idempotencyKey } = params
+
+  const body = {
+    source,
+    destination,
+    base_amount: baseAmount,
+    amount_type: 'exact_input' as const,
+    slippage_bps: slippageBps,
+  }
+
+  const url = `/v1/wallets/${encodeURIComponent(walletId)}/swap`
+  const headers = baseHeaders()
+  headers['privy-idempotency-key'] = idempotencyKey
+
+  // The idempotency key participates in the authorization signature payload.
+  const signature = buildAuthorizationSignature(`${PRIVY_API_BASE}${url}`, body, {
+    'privy-app-id': PRIVY_APP_ID,
+    'privy-idempotency-key': idempotencyKey,
+  })
+  if (signature) headers['privy-authorization-signature'] = signature
+
+  const { ok, status, data } = await privyFetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+
+  if (!ok) {
+    console.error(`[privy/swaps] execute failed with status ${status}`)
+    throw toUserSafeError(status, data)
+  }
+
+  if (!data?.id) {
+    throw new PrivySwapError('Swap was submitted but no action ID was returned. Check your balances in a moment.', 502)
+  }
+
+  return {
+    actionId: data.id,
+    status: coerceStatus(data.status),
+    walletId: data.wallet_id ?? walletId,
+    inputToken: data?.input_token ?? source.asset_address,
+    outputToken: data?.output_token ?? destination.asset_address,
+    caip2: data?.caip2 ?? source.caip2,
+  }
+}
+
+export async function getWalletActionStatus(params: {
+  walletId: string
+  actionId: string
+}): Promise<WalletActionResult> {
+  assertServerConfig()
+  const { walletId, actionId } = params
+
+  const { ok, status, data } = await privyFetch(
+    `/v1/wallets/${encodeURIComponent(walletId)}/actions/${encodeURIComponent(actionId)}?include=steps`,
+    { method: 'GET', headers: baseHeaders() }
+  )
+
+  if (!ok) {
+    console.error(`[privy/swaps] action status failed with status ${status}`)
+    throw toUserSafeError(status, data)
+  }
+
+  // Try to surface a readable failure reason from the steps, if present.
+  let failureReason: string | null = null
+  const steps: any[] = Array.isArray(data?.steps) ? data.steps : []
+  for (const step of steps) {
+    if (step?.status === 'failed' && typeof step?.error === 'string') {
+      failureReason = step.error
+      break
+    }
+    if (typeof step?.failure_reason === 'string') {
+      failureReason = step.failure_reason
+      break
+    }
+  }
+  if (!failureReason && typeof data?.error === 'string') failureReason = data.error
+
+  return {
+    actionId: data?.id ?? actionId,
+    status: coerceStatus(data?.status),
+    walletId: data?.wallet_id ?? walletId,
+    type: typeof data?.type === 'string' ? data.type : null,
+    failureReason,
+    raw: data && typeof data === 'object' ? data : {},
+  }
+}
+
+/** Convenience: build an Arbitrum swap asset from an allowlisted asset address. */
+export function arbitrumAsset(assetAddress: string): SwapAsset {
+  return { caip2: ARBITRUM_CAIP2, asset_address: assetAddress }
+}

--- a/ui/pages/api/privy/swap/action/[actionId].ts
+++ b/ui/pages/api/privy/swap/action/[actionId].ts
@@ -1,0 +1,75 @@
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getPrivyUserData } from '@/lib/privy'
+import {
+  getWalletActionStatus,
+  PrivySwapError,
+  resolveWalletId,
+} from '@/lib/privy/swaps'
+
+function getAccessTokenFromReq(req: NextApiRequest): string | null {
+  const authHeader = req.headers.authorization
+  if (authHeader?.startsWith('Bearer ')) {
+    return authHeader.slice('Bearer '.length).trim()
+  }
+  return null
+}
+
+function isValidEvmAddress(addr: unknown): addr is string {
+  return typeof addr === 'string' && /^0x[0-9a-fA-F]{40}$/.test(addr)
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    const { actionId, address } = req.query
+
+    if (typeof actionId !== 'string' || actionId.length === 0) {
+      return res.status(400).json({ error: 'A swap action ID is required.' })
+    }
+    if (!isValidEvmAddress(address)) {
+      return res.status(400).json({ error: 'A valid wallet address is required.' })
+    }
+
+    // --- Auth + wallet ownership ---
+    const accessToken = getAccessTokenFromReq(req)
+    if (!accessToken) {
+      return res.status(401).json({ error: 'You must be signed in to check a swap.' })
+    }
+    const userData = await getPrivyUserData(accessToken)
+    if (!userData) {
+      return res.status(401).json({ error: 'Your session has expired. Please sign in again.' })
+    }
+    const ownsWallet = userData.walletAddresses
+      .map((a) => a.toLowerCase())
+      .includes((address as string).toLowerCase())
+    if (!ownsWallet) {
+      return res.status(403).json({ error: 'This wallet does not belong to your account.' })
+    }
+
+    // Resolve the wallet ID server-side from the verified address rather than
+    // trusting a client-supplied wallet ID.
+    const walletId = await resolveWalletId(userData.userData, address as string)
+
+    const action = await getWalletActionStatus({ walletId, actionId })
+
+    return res.status(200).json({
+      success: true,
+      actionId: action.actionId,
+      status: action.status,
+      failureReason: action.failureReason,
+    })
+  } catch (err: any) {
+    if (err instanceof PrivySwapError) {
+      return res.status(err.status).json({ error: err.userMessage })
+    }
+    console.error('[api/privy/swap/action] unexpected error')
+    return res.status(500).json({ error: 'Could not fetch swap status. Please try again.' })
+  }
+}
+
+export default withMiddleware(handler, rateLimit)

--- a/ui/pages/api/privy/swap/execute.ts
+++ b/ui/pages/api/privy/swap/execute.ts
@@ -1,0 +1,130 @@
+import crypto from 'crypto'
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getPrivyUserData } from '@/lib/privy'
+import {
+  arbitrumAsset,
+  executeSwap,
+  PrivySwapError,
+  resolveWalletId,
+} from '@/lib/privy/swaps'
+import {
+  DEFAULT_SLIPPAGE_BPS,
+  humanAmountToBaseUnits,
+  isSupportedSwapChainId,
+  isValidSlippageBps,
+  validateSwapPair,
+} from '@/lib/privy/swapTokens'
+
+function getAccessTokenFromReq(req: NextApiRequest): string | null {
+  const authHeader = req.headers.authorization
+  if (authHeader?.startsWith('Bearer ')) {
+    return authHeader.slice('Bearer '.length).trim()
+  }
+  const bodyToken = (req.body as any)?.accessToken
+  return typeof bodyToken === 'string' && bodyToken.length > 0 ? bodyToken : null
+}
+
+function isValidEvmAddress(addr: unknown): addr is string {
+  return typeof addr === 'string' && /^0x[0-9a-fA-F]{40}$/.test(addr)
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    const {
+      address,
+      fromToken,
+      toToken,
+      amount,
+      slippageBps,
+      chainId,
+      idempotencyKey,
+    } = (req.body || {}) as Record<string, unknown>
+
+    // --- Input validation (re-validated independently from the quote step) ---
+    if (!isValidEvmAddress(address)) {
+      return res.status(400).json({ error: 'A valid wallet address is required.' })
+    }
+    if (chainId !== undefined && !isSupportedSwapChainId(chainId as any)) {
+      return res.status(400).json({ error: 'Swaps are currently supported on Arbitrum only.' })
+    }
+    if (typeof amount !== 'string' && typeof amount !== 'number') {
+      return res.status(400).json({ error: 'Enter a valid amount.' })
+    }
+
+    const resolvedSlippage =
+      slippageBps === undefined ? DEFAULT_SLIPPAGE_BPS : (slippageBps as number)
+    if (!isValidSlippageBps(resolvedSlippage)) {
+      return res.status(400).json({ error: 'Slippage must be between 0 and 10000 bps.' })
+    }
+
+    let pair
+    try {
+      pair = validateSwapPair(fromToken, toToken)
+    } catch (err: any) {
+      return res.status(400).json({ error: err?.message || 'Unsupported token pair.' })
+    }
+
+    let baseAmount: string
+    try {
+      baseAmount = humanAmountToBaseUnits(amount as string, pair.from.decimals).toString()
+    } catch (err: any) {
+      return res.status(400).json({ error: err?.message || 'Enter a valid amount.' })
+    }
+
+    // --- Auth + wallet ownership ---
+    const accessToken = getAccessTokenFromReq(req)
+    if (!accessToken) {
+      return res.status(401).json({ error: 'You must be signed in to swap.' })
+    }
+    const userData = await getPrivyUserData(accessToken)
+    if (!userData) {
+      return res.status(401).json({ error: 'Your session has expired. Please sign in again.' })
+    }
+    const ownsWallet = userData.walletAddresses
+      .map((a) => a.toLowerCase())
+      .includes((address as string).toLowerCase())
+    if (!ownsWallet) {
+      return res.status(403).json({ error: 'This wallet does not belong to your account.' })
+    }
+
+    const walletId = await resolveWalletId(userData.userData, address as string)
+
+    // Use the client key when provided (lets retries dedupe), else generate one.
+    const idemKey =
+      typeof idempotencyKey === 'string' && idempotencyKey.length > 0
+        ? idempotencyKey
+        : crypto.randomUUID()
+
+    const result = await executeSwap({
+      walletId,
+      source: arbitrumAsset(pair.from.assetAddress),
+      destination: arbitrumAsset(pair.to.assetAddress),
+      baseAmount,
+      slippageBps: resolvedSlippage,
+      idempotencyKey: idemKey,
+    })
+
+    return res.status(200).json({
+      success: true,
+      actionId: result.actionId,
+      walletId: result.walletId,
+      status: result.status,
+      fromToken: pair.from.key,
+      toToken: pair.to.key,
+    })
+  } catch (err: any) {
+    if (err instanceof PrivySwapError) {
+      return res.status(err.status).json({ error: err.userMessage })
+    }
+    console.error('[api/privy/swap/execute] unexpected error')
+    return res.status(500).json({ error: 'Something went wrong starting the swap. Please try again.' })
+  }
+}
+
+export default withMiddleware(handler, rateLimit)

--- a/ui/pages/api/privy/swap/quote.ts
+++ b/ui/pages/api/privy/swap/quote.ts
@@ -1,0 +1,120 @@
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getPrivyUserData } from '@/lib/privy'
+import {
+  arbitrumAsset,
+  getSwapQuote,
+  PrivySwapError,
+  resolveWalletId,
+} from '@/lib/privy/swaps'
+import {
+  humanAmountToBaseUnits,
+  isSupportedSwapChainId,
+  validateSwapPair,
+  ARBITRUM_CHAIN_ID,
+} from '@/lib/privy/swapTokens'
+
+function getAccessTokenFromReq(req: NextApiRequest): string | null {
+  const authHeader = req.headers.authorization
+  if (authHeader?.startsWith('Bearer ')) {
+    return authHeader.slice('Bearer '.length).trim()
+  }
+  const bodyToken = (req.body as any)?.accessToken
+  return typeof bodyToken === 'string' && bodyToken.length > 0 ? bodyToken : null
+}
+
+function isValidEvmAddress(addr: unknown): addr is string {
+  return typeof addr === 'string' && /^0x[0-9a-fA-F]{40}$/.test(addr)
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    const { address, fromToken, toToken, amount, chainId } = (req.body || {}) as Record<
+      string,
+      unknown
+    >
+
+    // --- Input validation (all server-side) ---
+    if (!isValidEvmAddress(address)) {
+      return res.status(400).json({ error: 'A valid wallet address is required.' })
+    }
+    // v1 is Arbitrum-only. If the client sends a chain, it must be Arbitrum.
+    if (chainId !== undefined && !isSupportedSwapChainId(chainId as any)) {
+      return res
+        .status(400)
+        .json({ error: 'Swaps are currently supported on Arbitrum only.' })
+    }
+    if (typeof amount !== 'string' && typeof amount !== 'number') {
+      return res.status(400).json({ error: 'Enter a valid amount.' })
+    }
+
+    let pair
+    try {
+      pair = validateSwapPair(fromToken, toToken)
+    } catch (err: any) {
+      return res.status(400).json({ error: err?.message || 'Unsupported token pair.' })
+    }
+
+    let baseAmount: string
+    try {
+      baseAmount = humanAmountToBaseUnits(amount as string, pair.from.decimals).toString()
+    } catch (err: any) {
+      return res.status(400).json({ error: err?.message || 'Enter a valid amount.' })
+    }
+
+    // --- Auth + wallet ownership ---
+    const accessToken = getAccessTokenFromReq(req)
+    if (!accessToken) {
+      return res.status(401).json({ error: 'You must be signed in to swap.' })
+    }
+    const userData = await getPrivyUserData(accessToken)
+    if (!userData) {
+      return res.status(401).json({ error: 'Your session has expired. Please sign in again.' })
+    }
+    const ownsWallet = userData.walletAddresses
+      .map((a) => a.toLowerCase())
+      .includes((address as string).toLowerCase())
+    if (!ownsWallet) {
+      return res.status(403).json({ error: 'This wallet does not belong to your account.' })
+    }
+
+    const walletId = await resolveWalletId(userData.userData, address as string)
+
+    const quote = await getSwapQuote({
+      walletId,
+      source: arbitrumAsset(pair.from.assetAddress),
+      destination: arbitrumAsset(pair.to.assetAddress),
+      baseAmount,
+    })
+
+    return res.status(200).json({
+      success: true,
+      quote: {
+        fromToken: pair.from.key,
+        toToken: pair.to.key,
+        inputDecimals: pair.from.decimals,
+        outputDecimals: pair.to.decimals,
+        inputAmount: quote.inputAmount,
+        estOutputAmount: quote.estOutputAmount,
+        minimumOutputAmount: quote.minimumOutputAmount,
+        gasEstimate: quote.gasEstimate,
+        caip2: quote.caip2,
+        expiresAt: quote.expiresAt,
+        chainId: ARBITRUM_CHAIN_ID,
+      },
+    })
+  } catch (err: any) {
+    if (err instanceof PrivySwapError) {
+      return res.status(err.status).json({ error: err.userMessage })
+    }
+    console.error('[api/privy/swap/quote] unexpected error')
+    return res.status(500).json({ error: 'Something went wrong fetching a quote. Please try again.' })
+  }
+}
+
+export default withMiddleware(handler, rateLimit)


### PR DESCRIPTION
## Summary
Adds a simple, utility-style **Swap** action to the Privy wallet experience so users can swap tokens directly from their embedded wallet. Arbitrum-only for v1, built on **Privy Wallet Actions** (no custom Uniswap integration). All Privy API access is server-side; secrets and auth headers are never exposed or logged.

- **Server-side helper** (`ui/lib/privy/swaps.ts`): Basic-auth quote/execute/status calls with timeouts, wallet-ID resolution (`linked_accounts` first, then `POST /v1/wallets/address` fallback), optional `privy-authorization-signature` (RFC-8785 + ECDSA P-256, env-gated), user-safe error mapping, and graceful gas-sponsorship/credit-exhaustion handling.
- **Token allowlist** (`ui/lib/privy/swapTokens.ts`): Arbitrum-only, keyed by token symbol (`ETH`, `USDC`, `MOONEY`); addresses come from `const/config.ts`. The client only ever sends token **keys** — never addresses. Input/output must differ; no cross-chain.
- **API routes**: `POST /api/privy/swap/quote`, `POST /api/privy/swap/execute`, `GET /api/privy/swap/action/[actionId]`. Each verifies the Privy access token, wallet ownership, chain, token pair, positive amount, and slippage (0–10000 bps); execute uses an idempotency key. Behind `rateLimit`.
- **`usePrivySwap` hook**: quote → execute → poll lifecycle (stops on `succeeded`/`failed`/`rejected`), stable idempotency key per confirmed swap.
- **`SwapModal`** + **Fund/Swap/Send** layout in `WalletInfoCard`, with ETH/USDC balance refetch on success and a non-Arbitrum guard ("Swaps are currently supported on Arbitrum only" + Switch to Arbitrum).
- **Unit tests** for the allowlist, unsupported chain/token/pair rejection, slippage bounds, and amount↔base-unit conversion.

## TODOs / blockers (need real-env validation)
- **Execute authorization signature**: Privy requires `privy-authorization-signature` for wallets with explicit owners/signers. Implemented as optional (env-gated `PRIVY_AUTHORIZATION_KEY`) with graceful 403 fallback. Confirm whether MoonDAO's embedded wallets need this and set the key if so.
- **MOONEY routing**: allowlisted server-side but hidden from the default UI (`showByDefault: false`) until quote/execute is confirmed to route reliably on Arbitrum.
- **Wallet delegation**: server-side execution may 401/403 if wallets aren't delegated/app-controllable; surfaced as a clean message — confirm during QA.

## Test plan
- [ ] `ui` typechecks (verified locally; only a pre-existing `NativeToMooney.tsx` error remains, unrelated to this PR).
- [ ] Run `cypress/integration/lib/privy/swap-tokens.cy.ts`.
- [ ] Log in with Privy; confirm wallet appears and network is Arbitrum.
- [ ] Quote + execute a tiny ETH → USDC swap; confirm pending → success.
- [ ] Confirm network responses contain no Privy secrets/auth headers.
- [ ] Confirm unsupported chains/tokens are rejected and gas-sponsorship errors are understandable.

Made with [Cursor](https://cursor.com)