### PR TITLE
fix: wait for Tableland indexing before sending Discord new-citizen notification

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -9,9 +9,7 @@ import {
   LAYERZERO_SOURCE_CHAIN_TO_DESTINATION_EID,
   CK_NETWORK_SIGNUP_FORM_ID,
   CK_NETWORK_SIGNUP_TAG_ID,
-  DEPLOYED_ORIGIN,
   DEFAULT_CHAIN_V5,
-  DISCORD_CITIZEN_ROLE_ID,
 } from 'const/config'
 import { ethers } from 'ethers'
 import Image from 'next/image'
@@ -41,7 +39,6 @@ import { useOnrampInitialStage } from '@/lib/coinbase/useOnrampInitialStage'
 import useOnrampJWT from '@/lib/coinbase/useOnrampJWT'
 import useSubscribe from '@/lib/convert-kit/useSubscribe'
 import useTag from '@/lib/convert-kit/useTag'
-import sendDiscordMessage from '@/lib/discord/sendDiscordMessage'
 import { pinBlobOrFile } from '@/lib/ipfs/pinBlobOrFile'
 import {
   estimateGasWithAPI,
@@ -880,11 +877,18 @@ export default function CreateCitizen({
       setMintComplete(true)
       fireCelebrationConfetti()
 
-      // Fire-and-forget side effects — don't block the celebration on them.
-      sendDiscordMessage(
-        'networkNotifications',
-        `## [**${citizenName}**](${DEPLOYED_ORIGIN}/citizen/${citizenPrettyLink}?_timestamp=123456789) has just become a <@&${DISCORD_CITIZEN_ROLE_ID}> of the Space Acceleration Network!`,
-      ).catch((err) => console.error('Failed to send Discord message:', err))
+      // Fire-and-forget: notify Discord once Tableland has indexed the new
+      // citizen so Discord's bot can scrape the OG image from the profile page.
+      // The server-side route polls Tableland before sending the message.
+      fetch('/api/discord/notify-new-citizen', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tokenId: mintedTokenId,
+          citizenName,
+          prettyLink: citizenPrettyLink,
+        }),
+      }).catch((err) => console.error('Failed to send Discord notification:', err))
 
       // Clear the onboarding form cache (the citizen cache was just seeded).
       clearCache()

--- a/ui/pages/api/discord/notify-new-citizen.ts
+++ b/ui/pages/api/discord/notify-new-citizen.ts
@@ -1,0 +1,90 @@
+import {
+  CITIZEN_TABLE_NAMES,
+  DEFAULT_CHAIN_V5,
+  DEPLOYED_ORIGIN,
+  DISCORD_CITIZEN_ROLE_ID,
+  GENERAL_CHANNEL_ID,
+  TEST_CHANNEL_ID,
+} from 'const/config'
+import { authMiddleware } from 'middleware/authMiddleware'
+import withMiddleware from 'middleware/withMiddleware'
+import { NextApiRequest, NextApiResponse } from 'next'
+import queryTable from '@/lib/tableland/queryTable'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+
+// Allow up to 75 seconds so Tableland has time to index the new citizen before
+// the Discord message is sent. Discord scrapes the profile URL immediately on
+// receiving the message, so if the citizen row isn't in Tableland yet the page
+// returns 404 and Discord shows no preview image.
+export const maxDuration = 75
+
+const CHANNEL_ID =
+  process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? GENERAL_CHANNEL_ID : TEST_CHANNEL_ID
+
+const MAX_POLL_ATTEMPTS = 12
+const POLL_INTERVAL_MS = 5000
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { tokenId, citizenName, prettyLink } = req.body
+
+  if (!tokenId || !citizenName || !prettyLink) {
+    return res.status(400).json({ error: 'tokenId, citizenName and prettyLink are required' })
+  }
+
+  const chain = DEFAULT_CHAIN_V5
+  const chainSlug = getChainSlug(chain)
+  const statement = `SELECT id FROM ${CITIZEN_TABLE_NAMES[chainSlug]} WHERE id = ${Number(tokenId)} LIMIT 1`
+
+  // Poll Tableland until the citizen row is indexed so that when Discord
+  // scrapes the profile URL the SSR page actually has data to render.
+  let indexed = false
+  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+    try {
+      const rows = await queryTable(chain, statement)
+      if (rows?.length > 0) {
+        indexed = true
+        break
+      }
+    } catch (err) {
+      console.error(`[notify-new-citizen] Tableland poll attempt ${attempt + 1} failed:`, err)
+    }
+
+    if (attempt < MAX_POLL_ATTEMPTS - 1) {
+      await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+    }
+  }
+
+  if (!indexed) {
+    console.warn(
+      `[notify-new-citizen] Citizen ${tokenId} still not in Tableland after ${MAX_POLL_ATTEMPTS} attempts — sending notification anyway`
+    )
+  }
+
+  const message = `## [**${citizenName}**](${DEPLOYED_ORIGIN}/citizen/${prettyLink}) has just become a <@&${DISCORD_CITIZEN_ROLE_ID}> of the Space Acceleration Network!`
+
+  const discordRes = await fetch(
+    `https://discord.com/api/v10/channels/${CHANNEL_ID}/messages`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN}`,
+      },
+      body: JSON.stringify({ content: message }),
+    }
+  )
+
+  if (!discordRes.ok) {
+    const body = await discordRes.text()
+    console.error('[notify-new-citizen] Discord API error:', body)
+    return res.status(500).json({ error: 'Failed to send Discord message' })
+  }
+
+  return res.status(200).json({ success: true, indexed })
+}
+
+export default withMiddleware(handler, authMiddleware)


### PR DESCRIPTION
## Summary

- Discord scrapes the citizen profile URL immediately on receiving the notification message — if the citizen row hasn't yet propagated to Tableland, the SSR page returns 404 and Discord shows the message with no preview image
- Replaced the immediate client-side `sendDiscordMessage` call with a new server-side route `/api/discord/notify-new-citizen` that polls Tableland every 5 s (up to 12 attempts / 60 s) until the citizen row is indexed, then sends the Discord message
- Falls back to sending the notification anyway if Tableland hasn't indexed within that window, so the announcement still goes out

## Test plan

- [ ] Mint a new citizen NFT on testnet and verify the Discord notification appears with the profile image in the embed
- [ ] Confirm the celebration screen / confetti is unaffected (the fetch is still fire-and-forget)
- [ ] Verify the server logs show `[notify-new-citizen]` polling and eventual success


Made with [Cursor](https://cursor.com)