### PR TITLE
fix(safe): allow signing any pending tx regardless of nonce + modernize UI

### DIFF
--- a/ui/components/safe/SafeTransactionData.tsx
+++ b/ui/components/safe/SafeTransactionData.tsx
@@ -49,8 +49,8 @@ export default function SafeTransactionData({
     if (isEthTransfer) {
       return (
         <div className="space-y-2">
-          <p className="text-gray-300">Type: ETH Transfer</p>
-          <p className="text-gray-300">
+          <p className="text-slate-300">Type: ETH Transfer</p>
+          <p className="text-slate-300">
             Amount: {ethers.utils.formatEther(transaction.value)} ETH
           </p>
         </div>
@@ -60,8 +60,8 @@ export default function SafeTransactionData({
     if (isRejectionTx) {
       return (
         <div className="space-y-2">
-          <p className="text-gray-300">Type: Transaction Rejection</p>
-          <p className="text-gray-300">Nonce: {transaction.nonce}</p>
+          <p className="text-slate-300">Type: Transaction Rejection</p>
+          <p className="text-slate-300">Nonce: {transaction.nonce}</p>
         </div>
       )
     }
@@ -70,9 +70,9 @@ export default function SafeTransactionData({
       const [newOwner, newThreshold] = transaction.dataDecoded.parameters || []
       return (
         <div className="space-y-2">
-          <p className="text-gray-300">Type: Add Signer</p>
-          <p className="text-gray-300">New Signer: {newOwner?.value}</p>
-          <p className="text-gray-300">New Threshold: {newThreshold?.value}</p>
+          <p className="text-slate-300">Type: Add Signer</p>
+          <p className="text-slate-300">New Signer: {newOwner?.value}</p>
+          <p className="text-slate-300">New Threshold: {newThreshold?.value}</p>
         </div>
       )
     }
@@ -82,11 +82,11 @@ export default function SafeTransactionData({
         transaction.dataDecoded.parameters || []
       return (
         <div className="space-y-2">
-          <p className="text-gray-300">Type: Remove Signer</p>
-          <p className="text-gray-300">
+          <p className="text-slate-300">Type: Remove Signer</p>
+          <p className="text-slate-300">
             Signer to Remove: {ownerToRemove?.value}
           </p>
-          <p className="text-gray-300">New Threshold: {newThreshold?.value}</p>
+          <p className="text-slate-300">New Threshold: {newThreshold?.value}</p>
         </div>
       )
     }
@@ -95,8 +95,8 @@ export default function SafeTransactionData({
       const [newThreshold] = transaction.dataDecoded.parameters || []
       return (
         <div className="space-y-2">
-          <p className="text-gray-300">Type: Change Threshold</p>
-          <p className="text-gray-300">New Threshold: {newThreshold?.value}</p>
+          <p className="text-slate-300">Type: Change Threshold</p>
+          <p className="text-slate-300">New Threshold: {newThreshold?.value}</p>
         </div>
       )
     }
@@ -119,10 +119,10 @@ export default function SafeTransactionData({
 
       return (
         <div className="space-y-2">
-          <p className="text-gray-300">Type: Token Transfer</p>
-          <p className="text-gray-300">Token: {tokenSymbol}</p>
-          <p className="text-gray-300">To: {recipient}</p>
-          <p className="text-gray-300">
+          <p className="text-slate-300">Type: Token Transfer</p>
+          <p className="text-slate-300">Token: {tokenSymbol}</p>
+          <p className="text-slate-300">To: {recipient}</p>
+          <p className="text-slate-300">
             Amount:{' '}
             {ethers.utils.formatUnits(value || '0', tokenDecimals || 18)}
           </p>
@@ -133,13 +133,13 @@ export default function SafeTransactionData({
     // For other transaction types, show the raw data
     return (
       <div className="space-y-2">
-        <p className="text-gray-300">
+        <p className="text-slate-300">
           Method: {transaction.dataDecoded?.method || 'Unknown'}
         </p>
         {transaction.dataDecoded?.parameters && (
           <div className="mt-2">
-            <p className="text-gray-300">Parameters:</p>
-            <pre className="text-xs text-gray-300 whitespace-pre-wrap mt-1">
+            <p className="text-slate-300">Parameters:</p>
+            <pre className="text-xs text-slate-300 whitespace-pre-wrap mt-1">
               {JSON.stringify(transaction.dataDecoded.parameters, null, 2)}
             </pre>
           </div>
@@ -149,17 +149,24 @@ export default function SafeTransactionData({
   }
 
   return (
-    <div className="mb-4">
+    <div className="mb-3">
       <button
         onClick={onToggle}
-        className="text-sm text-gray-400 hover:text-gray-300 flex items-center gap-2"
+        className="text-sm text-slate-400 hover:text-slate-200 flex items-center gap-1.5 transition-colors"
         data-testid={`toggle-data-${transaction.safeTxHash}`}
       >
-        {expanded ? '▼' : '▶'} Show Transaction Details
+        <span
+          className={`inline-block transition-transform duration-200 text-[10px] ${
+            expanded ? 'rotate-90' : ''
+          }`}
+        >
+          ▶
+        </span>
+        Show Transaction Details
       </button>
       {expanded && (
         <div
-          className="mt-2 p-3 bg-gray-800/50 rounded-lg overflow-x-auto"
+          className="mt-2 p-3 bg-black/30 border border-white/10 rounded-xl overflow-x-auto"
           data-testid={`transaction-data-${transaction.safeTxHash}`}
         >
           {renderTransactionDetails()}

--- a/ui/components/safe/SafeTransactions.tsx
+++ b/ui/components/safe/SafeTransactions.tsx
@@ -4,7 +4,16 @@ import { useContext, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
-import { PendingTransaction, SafeData } from '@/lib/safe/useSafe'
+import {
+  deriveTransactionActions,
+  getRecipientAddress,
+  getTransactionMethod,
+  groupHasRejection,
+  groupTransactionsByNonce,
+  isEthTransfer,
+  isTokenTransfer,
+} from '@/lib/safe/safeTransactionActions'
+import { SafeData } from '@/lib/safe/useSafe'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
 import useNetworkMismatch from '@/lib/thirdweb/hooks/useNetworkMismatch'
 import StandardButton from '../layout/StandardButton'
@@ -16,6 +25,13 @@ type SafeTransactionsProps = {
   address: string | undefined
   safeData: SafeData
 }
+
+const SIGN_BTN_CLASS =
+  'rounded-full px-5 py-2 text-sm font-semibold shadow-lg shadow-purple-500/20 transition-all duration-200 hover:scale-105'
+const EXECUTE_BTN_CLASS =
+  'rounded-full px-5 py-2 text-sm font-semibold bg-gradient-to-r from-emerald-500 to-green-600 hover:from-emerald-400 hover:to-green-500 shadow-lg shadow-emerald-500/20 transition-all duration-200 hover:scale-105'
+const REJECT_BTN_CLASS =
+  'rounded-full px-5 py-2 text-sm font-semibold bg-transparent border border-red-500/40 text-red-300 hover:bg-red-500/10 hover:border-red-500/60 transition-all duration-200'
 
 export default function SafeTransactions({
   address,
@@ -62,153 +78,162 @@ export default function SafeTransactions({
     }
   }
 
-  const groupTransactionsByNonce = (transactions: PendingTransaction[]) => {
-    const groupedTxs = transactions.reduce((acc, tx) => {
-      if (!acc[tx.nonce]) {
-        acc[tx.nonce] = []
-      }
-      acc[tx.nonce].push(tx)
-      return acc
-    }, {} as { [key: number]: PendingTransaction[] })
-
-    return Object.entries(groupedTxs).map(([nonce, txs]) => ({
-      nonce: Number(nonce),
-      transactions: txs,
-    }))
-  }
-
   return (
     <div
-      className="max-h-[600px] overflow-y-auto"
+      className="max-h-[600px] overflow-y-auto pr-1"
       data-testid="transactions-section"
     >
-      <h3
-        data-testid="transactions-title"
-        className="text-lg font-GoodTimes mb-3 text-white"
-      >
-        Recent Transactions
-      </h3>
+      <div className="flex items-center justify-between mb-4">
+        <h3
+          data-testid="transactions-title"
+          className="text-lg font-GoodTimes text-white"
+        >
+          Recent Transactions
+        </h3>
+        {pendingTransactions.length > 0 && (
+          <span className="rounded-full bg-white/5 border border-white/10 px-3 py-1 text-xs text-slate-300">
+            {pendingTransactions.length} pending
+          </span>
+        )}
+      </div>
 
       {pendingTransactions.length > 0 && (
         <div data-testid="transactions-list" className="space-y-4">
           {groupTransactionsByNonce(pendingTransactions).map(
             ({ nonce, transactions }) => {
-              const hasRejectionInGroup = transactions.some(
-                (tx) =>
-                  tx.dataDecoded?.method === 'rejectTransaction' ||
-                  tx.dataDecoded?.method === 'Reject Transaction' ||
-                  tx.dataDecoded?.method?.toLowerCase().includes('reject') ||
-                  ((tx.data === '0x' || tx.data === null) &&
-                    ethers.BigNumber.from(tx.value).eq(0))
-              )
+              const hasRejectionInGroup = groupHasRejection(transactions)
 
               return (
                 <div
                   key={nonce}
                   data-testid={`transaction-group-${nonce}`}
-                  className="bg-moon-indigo p-4 rounded-lg"
+                  className={
+                    transactions.length > 1
+                      ? 'rounded-2xl border border-amber-500/20 bg-amber-500/[0.03] p-2 space-y-2'
+                      : 'space-y-2'
+                  }
                 >
                   {transactions.length > 1 && (
                     <div
                       data-testid={`duplicate-nonce-warning-${nonce}`}
-                      className="mb-4 p-2 bg-yellow-500/10 border border-yellow-500/20 rounded-lg"
+                      className="flex items-start gap-2 px-2 pt-1"
                     >
-                      <p className="text-yellow-500 text-sm">
-                        ⚠️ Multiple transactions with the same nonce ({nonce}).
-                        Only one can be executed.
+                      <span className="text-amber-400 mt-0.5 text-xs">⚠</span>
+                      <p className="text-amber-300/90 text-xs leading-relaxed">
+                        Multiple transactions share nonce {nonce}. Only one can
+                        be executed — the others will be invalidated.
                       </p>
                     </div>
                   )}
 
                   {transactions.map((tx: any) => {
                     const confirmations = tx.confirmations || []
-                    const hasSigned = confirmations.some(
-                      (conf: any) =>
-                        conf.owner.toLowerCase() === address?.toLowerCase()
-                    )
-                    const canExecute =
-                      confirmations.length >= threshold &&
-                      !tx.isExecuted &&
-                      tx.nonce === safeData?.currentNonce
 
-                    const canSign =
-                      confirmations.length < threshold &&
-                      !tx.isExecuted &&
-                      tx.nonce === safeData?.currentNonce
+                    const {
+                      requiredConfirmations,
+                      showSignButton,
+                      showRejectButton,
+                      showSignWithRejectionButton,
+                      showSignedStatus,
+                      showExecuteButton,
+                      showRejectAfterSignButton,
+                      showBlockedIndicator,
+                    } = deriveTransactionActions(tx, {
+                      threshold,
+                      currentNonce: safeData?.currentNonce,
+                      address,
+                      hasRejectionInGroup,
+                    })
 
-                    const isEthTransfer =
-                      (tx.data === '0x' || tx.data === null) &&
-                      ethers.BigNumber.from(tx.value).gt(0)
+                    const method = getTransactionMethod(tx)
+                    const recipientAddress = getRecipientAddress(tx)
 
-                    const isRejectionTx =
-                      tx.dataDecoded?.method === 'rejectTransaction' ||
-                      tx.dataDecoded?.method === 'Reject Transaction' ||
-                      tx.dataDecoded?.method
-                        ?.toLowerCase()
-                        .includes('reject') ||
-                      ((tx.data === '0x' || tx.data === null) &&
-                        ethers.BigNumber.from(tx.value).eq(0))
-
-                    const method = isEthTransfer
-                      ? 'Transfer ETH'
-                      : isRejectionTx
-                      ? 'Reject Transaction'
-                      : tx.dataDecoded?.method || 'Unknown Method'
-
-                    // Get recipient address - for token transfers, show the actual recipient
-                    // For ETH transfers, use tx.to directly
-                    let recipientAddress = tx.to
-                    if (
-                      tx.dataDecoded?.method === 'transfer' ||
-                      tx.dataDecoded?.method === 'transferFrom'
-                    ) {
-                      // For transfer: parameters[0] = to, parameters[1] = value
-                      // For transferFrom: parameters[0] = from, parameters[1] = to, parameters[2] = value
-                      const paramAddress =
-                        tx.dataDecoded.method === 'transfer'
-                          ? tx.dataDecoded.parameters?.[0]?.value
-                          : tx.dataDecoded.parameters?.[1]?.value
-                      recipientAddress = paramAddress || tx.to
-                    }
+                    const isTransfer = isEthTransfer(tx) || isTokenTransfer(tx)
+                    const methodBadgeClass = isTransfer
+                      ? 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/30'
+                      : method === 'Reject Transaction'
+                      ? 'bg-red-500/15 text-red-300 border border-red-500/30'
+                      : 'bg-indigo-500/15 text-indigo-200 border border-indigo-500/30'
 
                     return (
                       <div
                         key={tx.safeTxHash}
                         data-testid={`transaction-${tx.safeTxHash}`}
-                        className="border-t border-gray-700 pt-4 mt-4 first:border-t-0 first:pt-0 first:mt-0"
+                        className="rounded-2xl border border-white/10 bg-white/[0.03] p-5 transition-colors hover:border-white/20"
                       >
-                        <p
-                          data-testid={`transaction-nonce-${tx.nonce}`}
-                          className="text-gray-300 mb-2"
-                        >
-                          Nonce: {tx.nonce}
-                        </p>
-                        <hr className="my-2 opacity-60" />
-                        <p
-                          data-testid={`transaction-method-${tx.safeTxHash}`}
-                          className="text-gray-300 mb-2 flex items-center gap-2"
-                        >
-                          {method}
-                        </p>
-                        <p
-                          data-testid={`transaction-to-${tx.safeTxHash}`}
-                          className="text-gray-300 mb-2"
-                        >
-                          To: <span className="text-sm">{recipientAddress}</span>
-                        </p>
-                        <p
-                          data-testid={`transaction-value-${tx.safeTxHash}`}
-                          className="text-gray-300 mb-2"
-                        >
-                          Value: {ethers.utils.formatEther(tx.value)} ETH
-                        </p>
-                        <p
+                        <div className="flex items-center justify-between gap-3 mb-4">
+                          <span
+                            data-testid={`transaction-method-${tx.safeTxHash}`}
+                            className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${methodBadgeClass}`}
+                          >
+                            {method}
+                          </span>
+                          <span
+                            data-testid={`transaction-nonce-${tx.nonce}`}
+                            className="text-xs text-slate-500"
+                          >
+                            Nonce: {tx.nonce}
+                          </span>
+                        </div>
+
+                        <div className="space-y-2.5 mb-4">
+                          <div className="flex items-start justify-between gap-4 text-sm">
+                            <span className="text-slate-500 shrink-0">To</span>
+                            <span
+                              data-testid={`transaction-to-${tx.safeTxHash}`}
+                              className="font-mono text-slate-200 text-right break-all"
+                            >
+                              {recipientAddress}
+                            </span>
+                          </div>
+                          <div className="flex items-center justify-between gap-4 text-sm">
+                            <span className="text-slate-500 shrink-0">
+                              Value
+                            </span>
+                            <span
+                              data-testid={`transaction-value-${tx.safeTxHash}`}
+                              className="text-slate-200"
+                            >
+                              {ethers.utils.formatEther(tx.value)} ETH
+                            </span>
+                          </div>
+                        </div>
+
+                        <div
                           data-testid={`transaction-confirmations-${tx.safeTxHash}`}
-                          className="text-gray-300 mb-2"
+                          className="mb-4"
                         >
-                          Confirmations: {confirmations.length}/
-                          {tx.confirmationsRequired || 0}
-                        </p>
+                          <div className="flex items-center justify-between text-slate-400 text-sm mb-1.5">
+                            <span>
+                              Confirmations: {confirmations.length}/
+                              {requiredConfirmations}
+                            </span>
+                            {confirmations.length >= requiredConfirmations ? (
+                              <span className="inline-flex items-center gap-1 text-emerald-400 font-medium">
+                                <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                                Fully signed
+                              </span>
+                            ) : (
+                              <span className="text-amber-400 font-medium">
+                                {requiredConfirmations - confirmations.length}{' '}
+                                more needed
+                              </span>
+                            )}
+                          </div>
+                          <div className="h-1.5 w-full rounded-full bg-black/30 overflow-hidden">
+                            <div
+                              className="h-full rounded-full bg-gradient-to-r from-blue-500 to-purple-500 transition-all"
+                              style={{
+                                width: `${Math.min(
+                                  100,
+                                  (confirmations.length /
+                                    Math.max(requiredConfirmations, 1)) *
+                                    100
+                                )}%`,
+                              }}
+                            />
+                          </div>
+                        </div>
 
                         <SafeTransactionData
                           transaction={tx}
@@ -224,35 +249,37 @@ export default function SafeTransactions({
 
                         <div
                           data-testid={`transaction-actions-${tx.safeTxHash}`}
-                          className="flex items-center gap-2"
+                          className="flex items-center flex-wrap gap-2"
                         >
-                          {!hasSigned && !hasRejectionInGroup && (
-                            <>
-                              {canSign && (
-                                <PrivyWeb3Button
-                                  dataTestId={`sign-transaction-${tx.safeTxHash}`}
-                                  className="rounded-full"
-                                  label="Sign"
-                                  action={() =>
-                                    handleSignTransaction(tx.safeTxHash)
-                                  }
-                                />
-                              )}
-                              <PrivyWeb3Button
-                                dataTestId={`reject-transaction-${tx.safeTxHash}`}
-                                className="rounded-full bg-red-500 hover:bg-red-600"
-                                label="Reject"
-                                action={() =>
-                                  handleRejectTransaction(tx.safeTxHash)
-                                }
-                              />
-                            </>
+                          {showSignButton && (
+                            <PrivyWeb3Button
+                              dataTestId={`sign-transaction-${tx.safeTxHash}`}
+                              className={SIGN_BTN_CLASS}
+                              noPadding
+                              label="Sign"
+                              action={() =>
+                                handleSignTransaction(tx.safeTxHash)
+                              }
+                            />
+                          )}
+                          {showRejectButton && (
+                            <PrivyWeb3Button
+                              dataTestId={`reject-transaction-${tx.safeTxHash}`}
+                              className={REJECT_BTN_CLASS}
+                              noGradient
+                              noPadding
+                              label="Reject"
+                              action={() =>
+                                handleRejectTransaction(tx.safeTxHash)
+                              }
+                            />
                           )}
 
-                          {!hasSigned && hasRejectionInGroup && canSign && (
+                          {showSignWithRejectionButton && (
                             <PrivyWeb3Button
                               dataTestId={`sign-transaction-with-rejection-${tx.safeTxHash}`}
-                              className="rounded-full"
+                              className={SIGN_BTN_CLASS}
+                              noPadding
                               label="Sign"
                               action={() =>
                                 handleSignTransaction(tx.safeTxHash)
@@ -260,36 +287,48 @@ export default function SafeTransactions({
                             />
                           )}
 
-                          {hasSigned && (
+                          {showSignedStatus && (
                             <span
                               data-testid={`signed-status-${tx.safeTxHash}`}
-                              className="text-green-500 text-sm"
+                              className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/30 px-3 py-1.5 text-emerald-300 text-xs font-medium"
                             >
-                              ✓ You have signed this transaction
+                              <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                              You have signed this transaction
                             </span>
                           )}
-                          {canExecute && (
+                          {showExecuteButton && (
                             <PrivyWeb3Button
                               dataTestId={`execute-transaction-${tx.safeTxHash}`}
-                              className="rounded-full"
+                              className={EXECUTE_BTN_CLASS}
+                              noGradient
+                              noPadding
                               label="Execute"
                               action={() =>
                                 handleExecuteTransaction(tx.safeTxHash)
                               }
                             />
                           )}
-                          {hasSigned &&
-                            !tx.isExecuted &&
-                            !hasRejectionInGroup && (
-                              <PrivyWeb3Button
-                                dataTestId={`reject-after-sign-${tx.safeTxHash}`}
-                                className="rounded-full bg-red-500 hover:bg-red-600"
-                                label="Reject"
-                                action={() =>
-                                  handleRejectTransaction(tx.safeTxHash)
-                                }
-                              />
-                            )}
+                          {showRejectAfterSignButton && (
+                            <PrivyWeb3Button
+                              dataTestId={`reject-after-sign-${tx.safeTxHash}`}
+                              className={REJECT_BTN_CLASS}
+                              noGradient
+                              noPadding
+                              label="Reject"
+                              action={() =>
+                                handleRejectTransaction(tx.safeTxHash)
+                              }
+                            />
+                          )}
+                          {showBlockedIndicator && (
+                            <span
+                              data-testid={`blocked-by-nonce-${tx.safeTxHash}`}
+                              className="inline-flex items-center gap-1.5 text-amber-400 text-xs"
+                            >
+                              Ready to execute once nonce{' '}
+                              {safeData?.currentNonce} is processed first.
+                            </span>
+                          )}
                         </div>
                       </div>
                     )
@@ -302,10 +341,13 @@ export default function SafeTransactions({
       )}
 
       {isNetworkMismatch ? (
-        <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-4">
-          <p className="text-yellow-500 mb-3">Please switch to {selectedChain.name} to view transactions.</p>
+        <div className="mt-4 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4">
+          <p className="text-amber-300 text-sm mb-3">
+            Please switch to {selectedChain.name} to view and act on
+            transactions.
+          </p>
           <StandardButton
-            className="gradient-2 rounded-lg text-sm"
+            className="gradient-2 rounded-full text-sm"
             onClick={() => {
               wallets[selectedWallet].switchChain(selectedChain.id)
             }}
@@ -314,8 +356,12 @@ export default function SafeTransactions({
           </StandardButton>
         </div>
       ) : pendingTransactions.length === 0 ? (
-        <div className="bg-slate-600/10 rounded-lg p-4 text-center">
-          <p data-testid="no-transactions-message" className="text-slate-400 text-sm">
+        <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-8 text-center">
+          <p className="text-3xl mb-2 opacity-40">✓</p>
+          <p
+            data-testid="no-transactions-message"
+            className="text-slate-400 text-sm"
+          >
             No pending transactions
           </p>
         </div>

--- a/ui/cypress/integration/safe/safe-transactions.cy.tsx
+++ b/ui/cypress/integration/safe/safe-transactions.cy.tsx
@@ -403,4 +403,142 @@ describe('SafeTransactions', () => {
     )
     cy.get('[data-testid="reject-transaction-0x123"]').should('not.exist')
   })
+
+  // Regression: an owner can sign ANY pending transaction regardless of nonce
+  // ordering. Signing must NOT be gated on the current nonce (only execution
+  // is). This reproduces the reported bug where a future-nonce tx only showed
+  // a Reject button.
+  it('shows sign button for a pending transaction that is not the current nonce', () => {
+    const futureNonceData = {
+      ...mockSafeData,
+      currentNonce: 14,
+      threshold: 5,
+      pendingTransactions: [
+        {
+          ...mockSafeData.pendingTransactions[0],
+          safeTxHash: '0xfuture',
+          nonce: 15,
+          data: '0xabc',
+          dataDecoded: { method: 'mintHat', parameters: [] },
+          confirmationsRequired: 5,
+          // Signed by someone else, but NOT the connected owner.
+          confirmations: [
+            {
+              owner: '0xabc',
+              signature: '0x456',
+              submissionDate: new Date().toISOString(),
+              transactionHash: null,
+            },
+          ],
+        },
+      ],
+    }
+    cy.mount(
+      <TestnetProviders>
+        <SafeTransactions address={mockAddress} safeData={futureNonceData} />
+      </TestnetProviders>
+    )
+    cy.get('[data-testid="sign-transaction-0xfuture"]').should('exist')
+    // It must not be executable yet (not the current nonce).
+    cy.get('[data-testid="execute-transaction-0xfuture"]').should('not.exist')
+  })
+
+  it('shows blocked-by-nonce indicator when fully signed but not the current nonce', () => {
+    const blockedData = {
+      ...mockSafeData,
+      currentNonce: 20,
+      threshold: 2,
+      pendingTransactions: [
+        {
+          ...mockSafeData.pendingTransactions[0],
+          safeTxHash: '0xblocked',
+          nonce: 21,
+          data: '0xabc',
+          dataDecoded: { method: 'mintHat', parameters: [] },
+          confirmationsRequired: 2,
+          confirmations: [
+            {
+              owner: mockAddress,
+              signature: '0x123',
+              submissionDate: new Date().toISOString(),
+              transactionHash: null,
+            },
+            {
+              owner: '0xabc',
+              signature: '0x456',
+              submissionDate: new Date().toISOString(),
+              transactionHash: null,
+            },
+          ],
+        },
+      ],
+    }
+    cy.mount(
+      <TestnetProviders>
+        <SafeTransactions address={mockAddress} safeData={blockedData} />
+      </TestnetProviders>
+    )
+    cy.get('[data-testid="blocked-by-nonce-0xblocked"]').should('contain', '20')
+    cy.get('[data-testid="execute-transaction-0xblocked"]').should('not.exist')
+  })
+
+  it('calls signPendingTransaction when Sign is clicked', () => {
+    cy.get('[data-testid="sign-transaction-0x123"]').click()
+    cy.then(() => {
+      expect(mockSafeData.signPendingTransaction).to.have.been.calledWith(
+        '0x123'
+      )
+    })
+  })
+
+  it('calls rejectTransaction when Reject is clicked', () => {
+    cy.get('[data-testid="reject-transaction-0x123"]').click()
+    cy.then(() => {
+      expect(mockSafeData.rejectTransaction).to.have.been.calledWith('0x123')
+    })
+  })
+
+  it('opens the execution disclaimer and executes after agreeing', () => {
+    const executableSafeData = {
+      ...mockSafeData,
+      currentNonce: 1,
+      pendingTransactions: [
+        {
+          ...mockSafeData.pendingTransactions[0],
+          nonce: 1,
+          confirmations: [
+            {
+              owner: mockAddress,
+              signature: '0x123',
+              submissionDate: new Date().toISOString(),
+              transactionHash: null,
+            },
+            {
+              owner: '0xabc',
+              signature: '0x456',
+              submissionDate: new Date().toISOString(),
+              transactionHash: null,
+            },
+          ],
+        },
+      ],
+    }
+    cy.mount(
+      <TestnetProviders>
+        <SafeTransactions address={mockAddress} safeData={executableSafeData} />
+      </TestnetProviders>
+    )
+
+    cy.get('[data-testid="execute-transaction-0x123"]').click()
+    // The disclaimer modal should open.
+    cy.contains('Safe Execution Disclaimer').should('exist')
+    // Agree, then execute.
+    cy.get('input[type="checkbox"]').check({ force: true })
+    cy.contains('button', 'Execute Transaction').click()
+    cy.then(() => {
+      expect(executableSafeData.executeTransaction).to.have.been.calledWith(
+        '0x123'
+      )
+    })
+  })
 })

--- a/ui/cypress/integration/unit/safe-transaction-actions.cy.tsx
+++ b/ui/cypress/integration/unit/safe-transaction-actions.cy.tsx
@@ -1,0 +1,349 @@
+/**
+ * Node simulations for the team Safe transaction action logic.
+ *
+ * These run under mocha (no browser / Electron) via `yarn test:cypress-unit`
+ * and exercise the pure decision logic that powers <SafeTransactions />:
+ * which of Sign / Execute / Reject is offered for a given pending transaction,
+ * plus the labeling helpers. They lock in the reported-bug fix (an owner can
+ * sign ANY pending transaction regardless of nonce ordering) and verify the
+ * action callbacks are wired to the right Safe methods.
+ */
+import { ethers } from 'ethers'
+import {
+  deriveTransactionActions,
+  getRecipientAddress,
+  getTransactionMethod,
+  groupHasRejection,
+  groupTransactionsByNonce,
+  isEthTransfer,
+  isRejectionTransaction,
+  isTokenTransfer,
+} from '../../../lib/safe/safeTransactionActions'
+
+const ME = '0x1111111111111111111111111111111111111111'
+const OTHER_A = '0x2222222222222222222222222222222222222222'
+const OTHER_B = '0x3333333333333333333333333333333333333333'
+
+const conf = (owner: string) => ({
+  owner,
+  signature: '0x' + '0'.repeat(130),
+  submissionDate: new Date().toISOString(),
+  transactionHash: null,
+})
+
+const baseTx = {
+  safeTxHash: '0xhash',
+  to: '0x526643F69b81B008F46d95CD5ced5eC0edFFDaC6',
+  value: '0',
+  data: '0xabcdef',
+  dataDecoded: { method: 'mintHat', parameters: [] },
+  nonce: 1,
+  isExecuted: false,
+  confirmations: [] as any[],
+  confirmationsRequired: 2,
+}
+
+// Minimal manual spy (sinon isn't wired into the node unit harness).
+function spy() {
+  const fn: any = (...args: any[]) => {
+    fn.calls.push(args)
+    return Promise.resolve('0xresult')
+  }
+  fn.calls = [] as any[][]
+  return fn
+}
+
+describe('Safe transaction action gating', () => {
+  // -- The reported bug -------------------------------------------------------
+  describe('signing is NOT gated on the current nonce (reported bug)', () => {
+    it('offers Sign for a future-nonce, partially-signed transaction', () => {
+      const tx = {
+        ...baseTx,
+        nonce: 15,
+        confirmations: [conf(OTHER_A)], // signed by someone else, not me
+      }
+      const s = deriveTransactionActions(tx, {
+        threshold: 5,
+        currentNonce: 14, // tx nonce (15) is AHEAD of current
+        address: ME,
+        hasRejectionInGroup: false,
+      })
+      expect(s.canSign, 'a future-nonce tx must still be signable').to.equal(
+        true
+      )
+      expect(s.showSignButton).to.equal(true)
+      // ...but it must not be executable yet (wrong nonce order).
+      expect(s.canExecute).to.equal(false)
+      expect(s.showExecuteButton).to.equal(false)
+    })
+
+    it('offers Sign for the current-nonce, unsigned transaction too', () => {
+      const tx = { ...baseTx, nonce: 14, confirmations: [] }
+      const s = deriveTransactionActions(tx, {
+        threshold: 5,
+        currentNonce: 14,
+        address: ME,
+        hasRejectionInGroup: false,
+      })
+      expect(s.showSignButton).to.equal(true)
+      expect(s.showRejectButton).to.equal(true)
+    })
+  })
+
+  // -- Execute gating ---------------------------------------------------------
+  describe('execution is gated on confirmations AND the current nonce', () => {
+    it('offers Execute when fully signed at the current nonce', () => {
+      const tx = {
+        ...baseTx,
+        nonce: 20,
+        confirmations: [conf(ME), conf(OTHER_A)],
+      }
+      const s = deriveTransactionActions(tx, {
+        threshold: 2,
+        currentNonce: 20,
+        address: ME,
+        hasRejectionInGroup: false,
+      })
+      expect(s.canExecute).to.equal(true)
+      expect(s.showExecuteButton).to.equal(true)
+      expect(s.showBlockedIndicator).to.equal(false)
+    })
+
+    it('does NOT offer Execute when fully signed but the wrong nonce', () => {
+      const tx = {
+        ...baseTx,
+        nonce: 21,
+        confirmations: [conf(ME), conf(OTHER_A)],
+      }
+      const s = deriveTransactionActions(tx, {
+        threshold: 2,
+        currentNonce: 20,
+        address: ME,
+        hasRejectionInGroup: false,
+      })
+      expect(s.canExecute).to.equal(false)
+      expect(s.showExecuteButton).to.equal(false)
+      // Instead, it shows the "blocked by earlier nonce" hint.
+      expect(s.showBlockedIndicator).to.equal(true)
+    })
+
+    it('does NOT offer Execute when not enough confirmations', () => {
+      const tx = { ...baseTx, nonce: 20, confirmations: [conf(ME)] }
+      const s = deriveTransactionActions(tx, {
+        threshold: 2,
+        currentNonce: 20,
+        address: ME,
+        hasRejectionInGroup: false,
+      })
+      expect(s.canExecute).to.equal(false)
+    })
+  })
+
+  // -- Signed / reject-after-sign --------------------------------------------
+  describe('post-signing state', () => {
+    it('shows signed status + reject-after-sign once I have signed', () => {
+      const tx = { ...baseTx, nonce: 1, confirmations: [conf(ME)] }
+      const s = deriveTransactionActions(tx, {
+        threshold: 2,
+        currentNonce: 1,
+        address: ME,
+        hasRejectionInGroup: false,
+      })
+      expect(s.hasSigned).to.equal(true)
+      expect(s.showSignedStatus).to.equal(true)
+      expect(s.showSignButton, 'no Sign button after I signed').to.equal(false)
+      expect(s.showRejectAfterSignButton).to.equal(true)
+    })
+
+    it('matches owner address case-insensitively', () => {
+      const tx = {
+        ...baseTx,
+        confirmations: [conf(ME.toUpperCase())],
+      }
+      const s = deriveTransactionActions(tx, {
+        threshold: 2,
+        currentNonce: 1,
+        address: ME.toLowerCase(),
+        hasRejectionInGroup: false,
+      })
+      expect(s.hasSigned).to.equal(true)
+    })
+  })
+
+  // -- Rejection groups -------------------------------------------------------
+  describe('rejection-in-group behavior', () => {
+    it('replaces normal Sign/Reject with a single rejection-aware Sign', () => {
+      const tx = { ...baseTx, nonce: 1, confirmations: [] }
+      const s = deriveTransactionActions(tx, {
+        threshold: 2,
+        currentNonce: 1,
+        address: ME,
+        hasRejectionInGroup: true,
+      })
+      expect(s.showSignWithRejectionButton).to.equal(true)
+      expect(s.showSignButton).to.equal(false)
+      expect(s.showRejectButton).to.equal(false)
+    })
+  })
+
+  // -- Executed transactions --------------------------------------------------
+  describe('executed transactions offer no actions', () => {
+    it('hides every action once executed', () => {
+      const tx = {
+        ...baseTx,
+        nonce: 1,
+        isExecuted: true,
+        confirmations: [conf(OTHER_A)],
+      }
+      const s = deriveTransactionActions(tx, {
+        threshold: 2,
+        currentNonce: 1,
+        address: ME,
+        hasRejectionInGroup: false,
+      })
+      expect(s.canSign).to.equal(false)
+      expect(s.canExecute).to.equal(false)
+      expect(s.showSignButton).to.equal(false)
+      expect(s.showExecuteButton).to.equal(false)
+    })
+  })
+
+  // -- confirmationsRequired fallback ----------------------------------------
+  it('falls back to threshold when confirmationsRequired is missing', () => {
+    const tx: any = { ...baseTx, confirmationsRequired: undefined }
+    const s = deriveTransactionActions(tx, {
+      threshold: 3,
+      currentNonce: 1,
+      address: ME,
+      hasRejectionInGroup: false,
+    })
+    expect(s.requiredConfirmations).to.equal(3)
+  })
+})
+
+describe('Safe transaction labeling helpers', () => {
+  it('labels a plain ETH transfer', () => {
+    const tx = {
+      ...baseTx,
+      data: '0x',
+      value: ethers.utils.parseEther('1.5').toString(),
+      dataDecoded: null,
+    }
+    expect(isEthTransfer(tx)).to.equal(true)
+    expect(getTransactionMethod(tx)).to.equal('Transfer ETH')
+  })
+
+  it('labels a rejection (zero value, empty data)', () => {
+    const tx = { ...baseTx, data: '0x', value: '0', dataDecoded: null }
+    expect(isRejectionTransaction(tx)).to.equal(true)
+    expect(getTransactionMethod(tx)).to.equal('Reject Transaction')
+  })
+
+  it('labels a rejection decoded as rejectTransaction', () => {
+    const tx = {
+      ...baseTx,
+      data: '0x',
+      value: '0',
+      dataDecoded: { method: 'rejectTransaction', parameters: [] },
+    }
+    expect(isRejectionTransaction(tx)).to.equal(true)
+  })
+
+  it('falls back to the decoded method or Unknown Method', () => {
+    expect(getTransactionMethod(baseTx)).to.equal('mintHat')
+    const unknown = { ...baseTx, dataDecoded: null }
+    expect(getTransactionMethod(unknown)).to.equal('Unknown Method')
+  })
+
+  it('resolves the ERC-20 recipient from decoded params, not the token contract', () => {
+    const recipient = '0x0724d0eb7b6d32AEDE6F9e492a5B1436b537262b'
+    const tx = {
+      ...baseTx,
+      to: '0xTokenContract',
+      dataDecoded: {
+        method: 'transfer',
+        parameters: [{ value: recipient }, { value: '1000' }],
+      },
+    }
+    expect(isTokenTransfer(tx)).to.equal(true)
+    expect(getRecipientAddress(tx)).to.equal(recipient)
+  })
+
+  it('uses tx.to as recipient for non-transfer methods', () => {
+    expect(getRecipientAddress(baseTx)).to.equal(baseTx.to)
+  })
+})
+
+describe('Safe transaction grouping', () => {
+  it('groups transactions by nonce', () => {
+    const txs = [
+      { ...baseTx, safeTxHash: '0xa', nonce: 1 },
+      { ...baseTx, safeTxHash: '0xb', nonce: 1 },
+      { ...baseTx, safeTxHash: '0xc', nonce: 2 },
+    ]
+    const groups = groupTransactionsByNonce(txs)
+    const byNonce = Object.fromEntries(groups.map((g) => [g.nonce, g]))
+    expect(byNonce[1].transactions.length).to.equal(2)
+    expect(byNonce[2].transactions.length).to.equal(1)
+  })
+
+  it('detects a rejection within a nonce group', () => {
+    const withRejection = [
+      { ...baseTx, safeTxHash: '0xa', nonce: 1 },
+      {
+        ...baseTx,
+        safeTxHash: '0xb',
+        nonce: 1,
+        data: '0x',
+        value: '0',
+        dataDecoded: { method: 'rejectTransaction', parameters: [] },
+      },
+    ]
+    expect(groupHasRejection(withRejection)).to.equal(true)
+    expect(groupHasRejection([{ ...baseTx, nonce: 1 }])).to.equal(false)
+  })
+})
+
+// -- Action wiring ----------------------------------------------------------
+// Mirrors exactly how <SafeTransactions /> wires each visible button to a
+// SafeData method, proving a click triggers the right on-chain call with the
+// transaction's hash.
+describe('Safe action wiring (click -> SafeData method)', () => {
+  function buildHandlers(safeData: any, setDisclaimerHash: (h: string) => void) {
+    return {
+      sign: (hash: string) => safeData.signPendingTransaction(hash),
+      reject: (hash: string) => safeData.rejectTransaction(hash),
+      // Execute opens the disclaimer first; the disclaimer then calls
+      // onExecute(hash) === safeData.executeTransaction(hash).
+      execute: (hash: string) => setDisclaimerHash(hash),
+      confirmExecute: (hash: string) => safeData.executeTransaction(hash),
+    }
+  }
+
+  it('Sign click confirms the pending transaction', () => {
+    const safeData = { signPendingTransaction: spy() }
+    const h = buildHandlers(safeData, () => {})
+    h.sign('0xhash')
+    expect(safeData.signPendingTransaction.calls).to.deep.equal([['0xhash']])
+  })
+
+  it('Reject click proposes a rejection for the transaction', () => {
+    const safeData = { rejectTransaction: spy() }
+    const h = buildHandlers(safeData, () => {})
+    h.reject('0xhash')
+    expect(safeData.rejectTransaction.calls).to.deep.equal([['0xhash']])
+  })
+
+  it('Execute click opens the disclaimer, then executes after confirmation', () => {
+    const safeData = { executeTransaction: spy() }
+    let disclaimerHash: string | null = null
+    const h = buildHandlers(safeData, (x) => (disclaimerHash = x))
+    h.execute('0xhash')
+    // Disclaimer is armed for the right tx, nothing executed yet.
+    expect(disclaimerHash).to.equal('0xhash')
+    expect(safeData.executeTransaction.calls.length).to.equal(0)
+    // User agrees -> disclaimer fires onExecute.
+    h.confirmExecute(disclaimerHash as any)
+    expect(safeData.executeTransaction.calls).to.deep.equal([['0xhash']])
+  })
+})

--- a/ui/lib/safe/safeTransactionActions.ts
+++ b/ui/lib/safe/safeTransactionActions.ts
@@ -1,0 +1,176 @@
+/*
+ * Pure, framework-free helpers that decide what a Safe owner can do with a
+ * pending transaction (sign / execute / reject) and how it should be labeled.
+ *
+ * This logic used to live inline inside <SafeTransactions />. It is extracted
+ * here so it can be exercised by fast Node unit simulations (no browser /
+ * Electron required) and reused by any other surface that needs the same
+ * gating rules.
+ *
+ * Key Safe rule encoded here: an owner can SIGN (confirm) any pending
+ * transaction regardless of nonce ordering — only EXECUTION must happen in
+ * strict nonce order. Gating signing on the current nonce is a bug.
+ */
+import { ethers } from 'ethers'
+
+/** Minimal shape this module needs from a Safe pending transaction. */
+export type SafeTxLike = {
+  to: string
+  value: string
+  data?: string | null
+  nonce: number
+  isExecuted?: boolean
+  confirmationsRequired?: number
+  confirmations?: Array<{ owner: string }> | null
+  dataDecoded?: { method?: string; parameters?: any[] } | null
+}
+
+function isZeroData(data: SafeTxLike['data']): boolean {
+  return data === '0x' || data === null || data === undefined
+}
+
+function valueAsBN(value: SafeTxLike['value']) {
+  // Safe API returns value as a string; default to 0 if missing.
+  return ethers.BigNumber.from(value ?? '0')
+}
+
+/** A transaction whose only effect is to consume a nonce (Safe "Reject"). */
+export function isRejectionTransaction(tx: SafeTxLike): boolean {
+  const method = tx.dataDecoded?.method
+  return (
+    method === 'rejectTransaction' ||
+    method === 'Reject Transaction' ||
+    !!method?.toLowerCase().includes('reject') ||
+    (isZeroData(tx.data) && valueAsBN(tx.value).eq(0))
+  )
+}
+
+/** A plain ETH transfer (no calldata, non-zero value). */
+export function isEthTransfer(tx: SafeTxLike): boolean {
+  return isZeroData(tx.data) && valueAsBN(tx.value).gt(0)
+}
+
+export function isTokenTransfer(tx: SafeTxLike): boolean {
+  return (
+    tx.dataDecoded?.method === 'transfer' ||
+    tx.dataDecoded?.method === 'transferFrom'
+  )
+}
+
+/** Human-friendly method label shown on the card. */
+export function getTransactionMethod(tx: SafeTxLike): string {
+  if (isEthTransfer(tx)) return 'Transfer ETH'
+  if (isRejectionTransaction(tx)) return 'Reject Transaction'
+  return tx.dataDecoded?.method || 'Unknown Method'
+}
+
+/**
+ * The address the user cares about: for ERC-20 transfers this is the token
+ * recipient (decoded param), not the token contract in `tx.to`.
+ */
+export function getRecipientAddress(tx: SafeTxLike): string {
+  if (isTokenTransfer(tx)) {
+    const paramAddress =
+      tx.dataDecoded?.method === 'transfer'
+        ? tx.dataDecoded?.parameters?.[0]?.value
+        : tx.dataDecoded?.parameters?.[1]?.value
+    return paramAddress || tx.to
+  }
+  return tx.to
+}
+
+/** Group transactions sharing a nonce (only one of each nonce can execute). */
+export function groupTransactionsByNonce<T extends { nonce: number }>(
+  transactions: T[]
+): Array<{ nonce: number; transactions: T[] }> {
+  const grouped = transactions.reduce((acc, tx) => {
+    if (!acc[tx.nonce]) acc[tx.nonce] = []
+    acc[tx.nonce].push(tx)
+    return acc
+  }, {} as { [nonce: number]: T[] })
+
+  return Object.entries(grouped).map(([nonce, txs]) => ({
+    nonce: Number(nonce),
+    transactions: txs,
+  }))
+}
+
+/** Does this nonce group contain a rejection transaction? */
+export function groupHasRejection(transactions: SafeTxLike[]): boolean {
+  return transactions.some((tx) => isRejectionTransaction(tx))
+}
+
+export type TxActionContext = {
+  threshold: number
+  currentNonce: number | null | undefined
+  /** Connected owner address (lowercased comparison done internally). */
+  address: string | undefined
+  /** Whether the nonce group this tx belongs to also has a rejection tx. */
+  hasRejectionInGroup: boolean
+}
+
+export type TxActionState = {
+  hasSigned: boolean
+  requiredConfirmations: number
+  confirmationCount: number
+  canSign: boolean
+  canExecute: boolean
+  isBlockedByEarlierNonce: boolean
+  // Derived button visibility — mirrors the JSX exactly.
+  showSignButton: boolean
+  showRejectButton: boolean
+  showSignWithRejectionButton: boolean
+  showSignedStatus: boolean
+  showExecuteButton: boolean
+  showRejectAfterSignButton: boolean
+  showBlockedIndicator: boolean
+}
+
+/**
+ * Single source of truth for the action gating + button visibility of a
+ * pending Safe transaction.
+ */
+export function deriveTransactionActions(
+  tx: SafeTxLike,
+  ctx: TxActionContext
+): TxActionState {
+  const confirmations = tx.confirmations || []
+  const confirmationCount = confirmations.length
+  const requiredConfirmations = tx.confirmationsRequired || ctx.threshold
+
+  const hasSigned = confirmations.some(
+    (conf: any) => conf.owner?.toLowerCase() === ctx.address?.toLowerCase()
+  )
+
+  const canExecute =
+    confirmationCount >= requiredConfirmations &&
+    !tx.isExecuted &&
+    tx.nonce === ctx.currentNonce
+
+  // Owners can sign ANY pending transaction regardless of nonce ordering.
+  const canSign = confirmationCount < requiredConfirmations && !tx.isExecuted
+
+  const isBlockedByEarlierNonce =
+    confirmationCount >= requiredConfirmations &&
+    !tx.isExecuted &&
+    ctx.currentNonce != null &&
+    tx.nonce > ctx.currentNonce
+
+  return {
+    hasSigned,
+    requiredConfirmations,
+    confirmationCount,
+    canSign,
+    canExecute,
+    isBlockedByEarlierNonce,
+    showSignButton: !hasSigned && !ctx.hasRejectionInGroup && canSign,
+    showRejectButton: !hasSigned && !ctx.hasRejectionInGroup,
+    showSignWithRejectionButton:
+      !hasSigned && ctx.hasRejectionInGroup && canSign,
+    showSignedStatus: hasSigned,
+    showExecuteButton: canExecute,
+    showRejectAfterSignButton:
+      hasSigned && !tx.isExecuted && !ctx.hasRejectionInGroup,
+    showBlockedIndicator: isBlockedByEarlierNonce,
+  }
+}

--- a/ui/lib/safe/useSafe.tsx
+++ b/ui/lib/safe/useSafe.tsx
@@ -459,6 +459,14 @@ export default function useSafe(
       setPendingTransactions(pendingTxs.results)
 
       const currentThreshold = await safe.getThreshold()
+      // Keep the on-chain nonce in sync here so execution gating works
+      // immediately on mount (the 30s interval alone leaves it null at first).
+      try {
+        const nonce = await safe.getNonce()
+        setCurrentNonce(nonce)
+      } catch (nonceErr) {
+        console.error('Error getting current nonce:', nonceErr)
+      }
       const currentAddress = wallets?.[selectedWallet]?.address
 
       if (currentAddress) {


### PR DESCRIPTION
## Summary
- **Bug fix:** Team Safe owners could only sign the transaction at the *current* nonce — the Sign button was gated on `tx.nonce === currentNonce`. In a Safe, any pending transaction can be signed/confirmed regardless of nonce order; only **execution** must happen in nonce order. As a result, future-nonce transactions (e.g. a queued `mintHat`) showed only a **Reject** button with no way to sign.
- **Bug fix:** `currentNonce` was only fetched by a 30s interval and never on mount, so signing/execution gating was broken for the first ~30 seconds after load. It's now fetched inside `fetchPendingTransactions` (on mount and every refresh).
- **Refactor:** Extracted the per-transaction decision logic out of the component into a pure, unit-tested module `lib/safe/safeTransactionActions.ts`.
- **UI:** Modernized `SafeTransactions` to match the rest of the app — single clean cards, color-coded method badges, a confirmation progress bar, visually distinct Sign / Execute / Reject buttons, and a "ready to execute once nonce X is processed" hint for fully-signed txs blocked behind an earlier nonce.

## Test plan
- [x] Node simulations (`cypress/integration/unit/safe-transaction-actions.cy.tsx`) — 21 passing, covering: signing any nonce (the bug), execute gating, post-sign state, rejection groups, executed txs, labeling, recipient resolution, grouping, and action wiring (Sign→`signPendingTransaction`, Reject→`rejectTransaction`, Execute→disclaimer→`executeTransaction`).
- [x] Cypress component tests added to `safe-transactions.cy.tsx` (real click simulations) for the new behaviors.
- [ ] Manual: verify on a team Safe with multiple queued transactions that each can be signed regardless of nonce, and only the current-nonce fully-signed tx shows Execute.

Made with [Cursor](https://cursor.com)