### PR TITLE
fix(teams): fix Manage Team modal layering and lock page scroll

### DIFF
--- a/ui/components/subscription/TeamManageMembers.tsx
+++ b/ui/components/subscription/TeamManageMembers.tsx
@@ -257,21 +257,28 @@ function TeamManageMembersModal({
     adminHatId
   )
 
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [])
+
   return (
     <Modal
       id="team-manage-members-modal"
       setEnabled={setEnabled}
       showCloseButton={false}
-      className="fixed inset-0 w-screen h-screen bg-[#00000080] backdrop-blur-sm flex justify-center items-start overflow-y-auto px-4 animate-fadeIn"
+      className="fixed inset-0 z-[9999] w-screen h-screen bg-[#00000080] backdrop-blur-sm flex justify-center items-start overflow-y-auto px-4 animate-fadeIn"
     >
       <div
         style={{
           marginTop: 80,
           marginBottom: 40,
           maxHeight: 'calc(100vh - 120px)',
-          zIndex: 10000,
         }}
-        className="flex flex-col w-full md:w-[520px] overflow-y-auto bg-[#0a0f1e] rounded-2xl border border-[#1e2a45]"
+        className="relative z-[10000] flex flex-col w-full md:w-[520px] overflow-y-auto bg-[#0a0f1e] rounded-2xl border border-[#1e2a45] shadow-2xl"
       >
 
         {/* Header */}


### PR DESCRIPTION
## Summary
- Add `z-[9999]` to the Manage Team modal overlay so it paints above page content. The modal looked "see-through" because the custom overlay `className` had no z-index, letting page elements with positive z-indexes render on top of it.
- Make the inner panel `relative z-[10000]` (the previous inline `zIndex: 10000` did nothing since the element wasn't positioned) and add `shadow-2xl` for depth.
- Lock body scroll while the modal is open via a `useEffect` that sets `document.body.style.overflow = 'hidden'` and restores the previous value on close.

## Test plan
- [x] Open a team page and click **Manage Team**.
- [x] Confirm the modal is fully opaque and renders above all page content.
- [x] Confirm the page behind the modal cannot be scrolled while it's open.
- [x] Close the modal and confirm page scroll is restored.

Made with [Cursor](https://cursor.com)