### PR TITLE
fix(teams): clarify Manage Team modal labels

### DIFF
--- a/ui/components/subscription/TeamManageMembers.tsx
+++ b/ui/components/subscription/TeamManageMembers.tsx
@@ -300,7 +300,7 @@ function TeamManageMembersModal({
         {/* Members list */}
         <div className="px-6 py-4">
           <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
-            Current Members
+            Current Team
           </p>
           <div className="flex flex-col gap-2 pr-1">
             {uniqueWearers?.[0] ? (
@@ -379,7 +379,7 @@ function TeamManageMembersModal({
         >
           <div className="flex items-center gap-2">
             <UserPlusIcon className="w-4 h-4 text-slate-400" />
-            <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Add a Member</p>
+            <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Add a Teammate</p>
           </div>
 
           {/* Role selector */}


### PR DESCRIPTION
## Summary
Addresses post-merge feedback on #1416. The role-management terms were confusing — users focused on "add member" and couldn't find how to add a manager. This relabels the section to read less restrictively:

- "Current Members" → "Current Team"
- "Add a Member" → "Add a Teammate"

## Test plan
- [ ] Open a team page and click **Manage Team**.
- [ ] Confirm the section header reads **Current Team**.
- [ ] Confirm the add form header reads **Add a Teammate**.

Made with [Cursor](https://cursor.com)