### PR TITLE
fix(ui): replace stale Discord invite links

### DIFF
--- a/ui/components/layout/ExpandedFooter.tsx
+++ b/ui/components/layout/ExpandedFooter.tsx
@@ -29,7 +29,7 @@ const socialLinks: SocialLink[] = [
     icon: <TwitterIcon />,
   },
   {
-    href: 'https://discord.gg/moondao',
+    href: 'https://moondao.com/discord',
     label: 'Discord',
     icon: <DiscordIcon />,
   },
@@ -326,7 +326,7 @@ export function ExpandedFooter({
                     has no Support group. Surface it here as a utility link
                     so users still have a one-click path to help. */}
                 <Link
-                  href="https://discord.gg/moondao"
+                  href="https://moondao.com/discord"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="hover:text-white transition-colors"

--- a/ui/components/layout/Sidebar/ColorsAndSocials.tsx
+++ b/ui/components/layout/Sidebar/ColorsAndSocials.tsx
@@ -23,7 +23,7 @@ const ColorsAndSocials = ({
       <Link
         className="opacity-[50%] hover:opacity-[100%] hover:scale-105 duration-150 ease-in-out max-[265px]:hidden"
         aria-label="Link to Discord"
-        href="https://discord.gg/moondao"
+        href="https://moondao.com/discord"
         target="_blank"
         rel="noreferrer"
         passHref

--- a/ui/components/onboarding/RegionRestrictedNotice.tsx
+++ b/ui/components/onboarding/RegionRestrictedNotice.tsx
@@ -75,7 +75,7 @@ export default function RegionRestrictedNotice({
                 textColor="text-white"
                 borderRadius="rounded-xl"
                 hoverEffect={false}
-                link="https://discord.gg/moondao"
+                link="https://moondao.com/discord"
                 target="_blank"
               >
                 Get Updates on Discord

--- a/ui/pages/api/proposals/send-confirmation-email.ts
+++ b/ui/pages/api/proposals/send-confirmation-email.ts
@@ -144,7 +144,7 @@ const generateHTML = (proposalId: string, proposalTitle: string) => {
                 <p style="color: #666; font-size: 12px; margin: 0;">
                   This email was sent because you submitted a proposal on MoonDAO.<br />
                   <a href="https://moondao.com" style="color: #3b82f6; text-decoration: none;">moondao.com</a> · 
-                  <a href="https://discord.gg/moondao" style="color: #3b82f6; text-decoration: none;">Discord</a> · 
+                  <a href="https://moondao.com/discord" style="color: #3b82f6; text-decoration: none;">Discord</a> · 
                   <a href="https://twitter.com/OfficialMoonDAO" style="color: #3b82f6; text-decoration: none;">Twitter</a>
                 </p>
               </td>

--- a/ui/pages/projects-overview.tsx
+++ b/ui/pages/projects-overview.tsx
@@ -580,7 +580,7 @@ const ProjectsOverview: React.FC<{
                     textColor="text-white"
                     borderRadius="rounded-full"
                     hoverEffect={false}
-                    link="https://discord.gg/moondao"
+                    link="https://moondao.com/discord"
                   >
                     Join Discord
                   </StandardButton>
@@ -627,7 +627,7 @@ const ProjectsOverview: React.FC<{
                 defaultTitle="Questions About Projects?"
                 defaultDescription="Join our Discord community to discuss project ideas and get support from fellow space entrepreneurs!"
                 defaultButtonText="Join Discord"
-                defaultButtonLink="https://discord.gg/moondao"
+                defaultButtonLink="https://moondao.com/discord"
                 imageWidth={200}
                 imageHeight={200}
               />

--- a/ui/pages/proposals.tsx
+++ b/ui/pages/proposals.tsx
@@ -144,7 +144,7 @@ export default function ProposalsPage({ project }: { project: Project }) {
                     </div>
                   </div>
                   <Link
-                    href="https://discord.gg/moondao"
+                    href="https://moondao.com/discord"
                     target="_blank"
                     rel="noreferrer"
                     className="flex-shrink-0 inline-flex items-center justify-center gap-2 px-4 py-2 bg-white/10 hover:bg-white/20 text-white rounded-lg transition-all duration-200 text-sm border border-white/10 w-full sm:w-auto"

--- a/ui/pages/resources.tsx
+++ b/ui/pages/resources.tsx
@@ -392,7 +392,7 @@ export default function Resources() {
                     Know of valuable resources that would benefit the MoonDAO community? We're always looking to expand this collection with high-quality tools, databases, and platforms that support space exploration and research.
                   </p>
                   <a
-                    href="https://discord.com/invite/moondao"
+                    href="https://moondao.com/discord"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 rounded-lg text-white font-medium transition-all duration-200 hover:scale-105"


### PR DESCRIPTION
## Summary
- Replaces all `discord.gg/moondao` and `discord.com/invite/moondao` links with `https://moondao.com/discord`
- The old vanity invite now points to a different server; the canonical redirect already routes to the correct guild via `next.config.js`

## Test plan
- [ ] Click Discord links in footer, sidebar, proposals page, projects overview, and resources page — each should land on the MoonDAO Discord server
- [ ] Verify `https://moondao.com/discord` redirects to the expected invite


Made with [Cursor](https://cursor.com)