### PR TITLE
fix(ui): point EU-restricted "Explore the Network" link to /network

### DIFF
--- a/ui/components/onboarding/RegionRestrictedNotice.tsx
+++ b/ui/components/onboarding/RegionRestrictedNotice.tsx
@@ -65,7 +65,7 @@ export default function RegionRestrictedNotice({
                 textColor="text-white"
                 borderRadius="rounded-xl"
                 hoverEffect={false}
-                link="/join"
+                link="/network"
               >
                 Explore the Network
               </StandardButton>


### PR DESCRIPTION
## Summary

- The `RegionRestrictedNotice` component (shown to EU users blocked from joining) had an **"Explore the Network"** CTA that linked to `/join` — the very page they're blocked from.
- Changed the link to `/network` so EU visitors can actually explore the network.

## Change

`ui/components/onboarding/RegionRestrictedNotice.tsx`: `/join` → `/network`

Made with [Cursor](https://cursor.com)