### PR TITLE
fix(citizen): profile update fails on apostrophes in Tableland SQL

### DIFF
--- a/ui/components/subscription/CitizenMetadataModal.tsx
+++ b/ui/components/subscription/CitizenMetadataModal.tsx
@@ -305,7 +305,13 @@ export default function CitizenMetadataModal({ nft, selectedChain, setEnabled }:
 
                 const { cid: newImageIpfsHash } = await pinBlobOrFile(renamedCitizenImage)
 
-                await unpinCitizenImage(nft.metadata.id)
+                // Unpin the old image best-effort — a failure here must not
+                // block the profile update. The type mismatch between the
+                // numeric token ID and the string the API checks caused every
+                // unpin to return 401 and abort the entire update.
+                unpinCitizenImage(nft.metadata.id).catch((err) =>
+                  console.warn('Failed to unpin old citizen image (non-blocking):', err)
+                )
 
                 imageIpfsLink = `ipfs://${newImageIpfsHash}`
               }

--- a/ui/components/subscription/CitizenMetadataModal.tsx
+++ b/ui/components/subscription/CitizenMetadataModal.tsx
@@ -10,7 +10,11 @@ import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import { pinBlobOrFile } from '@/lib/ipfs/pinBlobOrFile'
 import { unpinCitizenImage } from '@/lib/ipfs/unpin'
-import cleanData, { unescapeQuotes } from '@/lib/tableland/cleanData'
+import {
+  formatCitizenLocationForTable,
+  sanitizeTablelandField,
+  unescapeQuotes,
+} from '@/lib/tableland/cleanData'
 import { waitForRow } from '@/lib/tableland/waitForRow'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
@@ -130,7 +134,7 @@ export default function CitizenMetadataModal({ nft, selectedChain, setEnabled }:
   const [croppedInputImage, setCroppedInputImage] = useState<File>()
   const [citizenData, setCitizenData] = useState<any>()
   const [formResponseId, setFormResponseId] = useState<string>(
-    getAttribute(nft?.metadata?.attributes, 'formId').value,
+    getAttribute(nft?.metadata?.attributes, 'formId')?.value ?? '',
   )
   const [agreedToOnChainData, setAgreedToOnChainData] = useState(false)
   const [showEmailUpdate, setShowEmailUpdate] = useState(false)
@@ -315,54 +319,59 @@ export default function CitizenMetadataModal({ nft, selectedChain, setEnabled }:
                 )
               }
 
-              const cleanedCitizenData = cleanData(citizenData)
-
-              let cleanedLocationData: { lat: number; lng: number; name: string } | string = ''
-              if (cleanedCitizenData.location && cleanedCitizenData.location.trim() !== '') {
+              // Geocode from raw user input — cleanData must run only when
+              // building the on-chain payload. Escaping before geocoding can
+              // double-escape location names and produce malformed SQL.
+              let locationForTable = ''
+              const rawLocation = citizenData.location?.trim() ?? ''
+              if (rawLocation !== '') {
                 const locationDataRes = await fetch('/api/google/geocoder', {
                   method: 'POST',
                   headers: {
                     'Content-Type': 'application/json',
                   },
                   body: JSON.stringify({
-                    location: cleanedCitizenData.location,
+                    location: rawLocation,
                   }),
                 })
                 const { data: locationData } = await locationDataRes.json()
                 const geocodedResult = locationData?.results?.[0]
                 if (geocodedResult) {
-                  const citizenLocationData = {
-                    lat: geocodedResult.geometry.location.lat,
-                    lng: geocodedResult.geometry.location.lng,
-                    name: geocodedResult.formatted_address,
-                  }
-                  cleanedLocationData = cleanData(citizenLocationData)
+                  locationForTable = formatCitizenLocationForTable(
+                    geocodedResult.geometry.location.lat,
+                    geocodedResult.geometry.location.lng,
+                    geocodedResult.formatted_address,
+                  )
                 } else {
-                  cleanedLocationData = cleanData({
-                    lat: 0,
-                    lng: 0,
-                    name: cleanedCitizenData.location.trim(),
-                  })
+                  locationForTable = formatCitizenLocationForTable(0, 0, rawLocation)
                 }
               }
 
-              const formattedCitizenTwitter = cleanedCitizenData.twitter
-                ? addHttpsIfMissing(cleanedCitizenData.twitter)
+              const cleanedName = sanitizeTablelandField(citizenData.name)
+              const cleanedDescription = sanitizeTablelandField(citizenData.description ?? '')
+              const cleanedView = sanitizeTablelandField(citizenData.view ?? 'public')
+
+              const formattedCitizenTwitter = citizenData.twitter?.trim()
+                ? sanitizeTablelandField(addHttpsIfMissing(citizenData.twitter.trim()))
                 : ''
-              const formattedCitizenInstagram = cleanedCitizenData.instagram
-                ? addHttpsIfMissing(cleanedCitizenData.instagram)
+              const formattedCitizenInstagram = citizenData.instagram?.trim()
+                ? sanitizeTablelandField(addHttpsIfMissing(citizenData.instagram.trim()))
                 : ''
-              const formattedCitizenLinkedin = cleanedCitizenData.linkedin
-                ? addHttpsIfMissing(cleanedCitizenData.linkedin)
+              const formattedCitizenLinkedin = citizenData.linkedin?.trim()
+                ? sanitizeTablelandField(addHttpsIfMissing(citizenData.linkedin.trim()))
                 : ''
-              const formattedCitizenWebsite = cleanedCitizenData.website
-                ? addHttpsIfMissing(cleanedCitizenData.website)
+              const formattedCitizenWebsite = citizenData.website?.trim()
+                ? sanitizeTablelandField(addHttpsIfMissing(citizenData.website.trim()))
                 : ''
-              const formattedCitizenDiscord = cleanedCitizenData.discord
-                ? cleanedCitizenData.discord.startsWith('@')
-                  ? cleanedCitizenData.discord.replace('@', '')
-                  : cleanedCitizenData.discord
+              const rawDiscord = citizenData.discord?.trim()
+                ? citizenData.discord.startsWith('@')
+                  ? citizenData.discord.replace('@', '')
+                  : citizenData.discord
                 : ''
+              const formattedCitizenDiscord = rawDiscord
+                ? sanitizeTablelandField(rawDiscord)
+                : ''
+              const formIdForTable = sanitizeTablelandField(formResponseId)
 
               const transaction = prepareContractCall({
                 contract: citizenTableContract,
@@ -383,17 +392,17 @@ export default function CitizenMetadataModal({ nft, selectedChain, setEnabled }:
                     'formId',
                   ],
                   [
-                    cleanedCitizenData.name,
-                    cleanedCitizenData.description,
+                    cleanedName,
+                    cleanedDescription,
                     imageIpfsLink,
-                    cleanedLocationData ? JSON.stringify(cleanedLocationData) : '',
+                    locationForTable,
                     formattedCitizenDiscord,
                     formattedCitizenTwitter,
                     formattedCitizenWebsite,
                     formattedCitizenInstagram,
                     formattedCitizenLinkedin,
-                    cleanedCitizenData.view,
-                    formResponseId,
+                    cleanedView,
+                    formIdForTable,
                   ],
                 ],
               })
@@ -411,8 +420,8 @@ export default function CitizenMetadataModal({ nft, selectedChain, setEnabled }:
                 // rather than the stale version.
                 const tableName = CITIZEN_TABLE_NAMES[getChainSlug(selectedChain)]
                 const statement = `SELECT id, name, description, image FROM ${tableName} WHERE id = ${nft.metadata.id}`
-                const expectedName = unescapeQuotes(cleanedCitizenData.name ?? '')
-                const expectedDescription = unescapeQuotes(cleanedCitizenData.description ?? '')
+                const expectedName = unescapeQuotes(cleanedName)
+                const expectedDescription = unescapeQuotes(cleanedDescription)
                 await waitForRow({
                   statement,
                   checkCondition: (rows) => {
@@ -430,9 +439,20 @@ export default function CitizenMetadataModal({ nft, selectedChain, setEnabled }:
                 })
                 router.reload()
               }
-            } catch (err) {
-              console.log(err)
-              toast.error('Something went wrong updating your profile. Please try again.')
+            } catch (err: any) {
+              console.error('Profile update failed:', err)
+              const message = err?.message ?? ''
+              if (
+                message.includes('gas required exceeds allowance') ||
+                message.includes('execution reverted')
+              ) {
+                toast.error(
+                  'Profile update failed — this usually means a name, bio, or location value contains an apostrophe or special character that broke the on-chain update. Try removing quotes/apostrophes and submit again.',
+                  { duration: 12000 },
+                )
+              } else {
+                toast.error('Something went wrong updating your profile. Please try again.')
+              }
             }
           }}
         />

--- a/ui/lib/tableland/cleanData.ts
+++ b/ui/lib/tableland/cleanData.ts
@@ -2,6 +2,48 @@ export function unescapeQuotes(v: string) {
   return v.replace(/''/g, "'")
 }
 
+const EMOJI_REGEX =
+  /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g
+
+/** Strip emoji from a user-facing string before on-chain storage. */
+export function stripEmojis(v: string): string {
+  return v.replace(EMOJI_REGEX, '')
+}
+
+/**
+ * Escape single quotes for an on-chain Tableland mutation.
+ *
+ * Tableland UPDATE/INSERT SQL is assembled on-chain with `SQLHelpers.quote()`,
+ * which wraps a value in single quotes and does NOT escape embedded quotes.
+ * Double the quote (`'` -> `''`) so SQLite stores it back as a single `'`.
+ * Smart/curly apostrophes are normalized to ASCII first.
+ */
+export function escapeSingleQuotes(v: string): string {
+  if (typeof v !== 'string') return ''
+  const normalized = v.replace(/[\u2018\u2019\u0060]/g, "'")
+  return normalized.replace(/'/g, "''")
+}
+
+/** Prepare one free-text field for a Tableland mutation payload. */
+export function sanitizeTablelandField(v: unknown): string {
+  if (v === null || v === undefined) return ''
+  if (typeof v !== 'string') return escapeSingleQuotes(String(v))
+  return escapeSingleQuotes(stripEmojis(v))
+}
+
+/** JSON location blob written to the citizen table `location` column. */
+export function formatCitizenLocationForTable(
+  lat: number,
+  lng: number,
+  name: string,
+): string {
+  return JSON.stringify({
+    lat,
+    lng,
+    name: sanitizeTablelandField(name),
+  })
+}
+
 export default function cleanData(obj: any) {
   const formattedObj: any = {}
 
@@ -11,13 +53,7 @@ export default function cleanData(obj: any) {
 
       // Check if the value is a string before attempting to replace
       if (typeof formattedString === 'string') {
-        //Escape single quote with double single quotes
-        formattedString = formattedString.replace(/'/g, "''")
-        // Replace emojis with nothing
-        formattedString = formattedString.replace(
-          /([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g,
-          '',
-        )
+        formattedString = sanitizeTablelandField(formattedString)
       }
 
       // Add the key and the potentially modified value to the new object

--- a/ui/pages/api/ipfs/unpinCitizenImage.ts
+++ b/ui/pages/api/ipfs/unpinCitizenImage.ts
@@ -62,7 +62,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         }
       }
 
-      if (ownedTokens.length === 0 || !ownedTokens.includes(citizenId)) {
+      const citizenIdNum = +citizenId
+      if (ownedTokens.length === 0 || !ownedTokens.includes(citizenIdNum)) {
         return res.status(401).json({ error: 'Citizen not found' })
       }
 


### PR DESCRIPTION
## Summary
- Fixes citizen profile updates that revert on-chain with MetaMask "gas required exceeds allowance" when name, bio, location, or social fields contain apostrophes or smart quotes
- Geocodes location from raw user input before SQL escaping (avoids double-escaping location names)
- Adds shared Tableland sanitizers in `cleanData.ts` and a clearer error toast when the wallet simulation reverts

## Test plan
- [ ] Open Edit Profile on a Vercel preview, update Instagram and/or photo, confirm transaction succeeds
- [ ] Retry with a bio containing an apostrophe (e.g. `Brazil's`) and confirm update succeeds
- [ ] Confirm success toast + page reload shows updated fields
- [ ] Confirm generic error toast still appears for unrelated failures


Made with [Cursor](https://cursor.com)