### PR TITLE
Fix citizen mint failures when profile text contains apostrophes

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -53,13 +53,12 @@ import { arbitrum, base, ethereum, sepolia, arbitrumSepolia } from '@/lib/rpc/ch
 import { useGasPrice } from '@/lib/rpc/useGasPrice'
 import useETHPrice from '@/lib/etherscan/useETHPrice'
 import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
-import cleanData from '@/lib/tableland/cleanData'
+import cleanData, { escapeSingleQuotes } from '@/lib/tableland/cleanData'
 import { getChainSlug, v4SlugToV5Chain } from '@/lib/thirdweb/chain'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
 import client from '@/lib/thirdweb/client'
 import useContract from '@/lib/thirdweb/hooks/useContract'
 import { useNativeBalance } from '@/lib/thirdweb/hooks/useNativeBalance'
-import waitForERC721 from '@/lib/thirdweb/waitForERC721'
 import { CitizenData, formatCitizenShortFormData } from '@/lib/typeform/citizenFormData'
 import {
   renameFile,
@@ -727,15 +726,19 @@ export default function CreateCitizen({
           LAYERZERO_SOURCE_CHAIN_TO_DESTINATION_EID[selectedChainSlug].toString(),
           _options.toHex(),
           address,
-          citizenData.name,
-          profile.bio,
+          // Escape single quotes so an apostrophe (e.g. "Brazil's") can't produce
+          // malformed SQL the Tableland validator silently rejects. `location` is
+          // already escaped upstream (resolveLocationField -> cleanData) and
+          // `view` is a fixed enum, so neither needs re-escaping here.
+          escapeSingleQuotes(citizenData.name),
+          escapeSingleQuotes(profile.bio),
           `ipfs://${imageIpfsHash}`,
           profile.location,
-          profile.discord,
-          profile.twitter,
-          profile.website,
+          escapeSingleQuotes(profile.discord),
+          escapeSingleQuotes(profile.twitter),
+          escapeSingleQuotes(profile.website),
           profile.view,
-          citizenData.formResponseId,
+          escapeSingleQuotes(citizenData.formResponseId),
         ],
         value: MSG_VALUE + LAYER_ZERO_TRANSFER_COST,
       })
@@ -777,15 +780,19 @@ export default function CreateCitizen({
         method: 'mintTo' as string,
         params: [
           address,
-          citizenData.name,
-          profile.bio,
+          // Escape single quotes so an apostrophe (e.g. "Brazil's") can't produce
+          // malformed SQL the Tableland validator silently rejects. `location` is
+          // already escaped upstream (resolveLocationField -> cleanData) and
+          // `view` is a fixed enum, so neither needs re-escaping here.
+          escapeSingleQuotes(citizenData.name),
+          escapeSingleQuotes(profile.bio),
           `ipfs://${imageIpfsHash}`,
           profile.location,
-          profile.discord,
-          profile.twitter,
-          profile.website,
+          escapeSingleQuotes(profile.discord),
+          escapeSingleQuotes(profile.twitter),
+          escapeSingleQuotes(profile.website),
           profile.view,
-          citizenData.formResponseId,
+          escapeSingleQuotes(citizenData.formResponseId),
         ],
         value: cost,
       })
@@ -799,12 +806,28 @@ export default function CreateCitizen({
   )
 
   const handlePostMint = useCallback(
-    async (mintedTokenId: string, profile: CitizenProfileMintFields) => {
+    async (
+      mintedTokenId: string,
+      profile: CitizenProfileMintFields,
+      imageURI: string
+    ) => {
       await tagToNetworkSignup(citizenData.email)
 
-      const citizenNFT = await waitForERC721(citizenContract, +mintedTokenId)
       const citizenName = citizenData.name
       const citizenPrettyLink = generatePrettyLinkWithId(citizenName, mintedTokenId)
+
+      // The citizen's on-chain tokenURI is a Tableland gateway query, so its
+      // metadata (name/image/attributes) only resolves once Tableland has
+      // indexed the row inserted during mint — which routinely takes longer
+      // than a minute under load. Onboarding success must NOT block on that:
+      // the mint receipt already proves the NFT exists, and every field needed
+      // to seed the citizen is known locally (token id, name, profile, image).
+      // CitizenProvider's optimistic seed + Tableland polling reconciles the
+      // record (including the real tokenURI) as soon as it's indexed, so we
+      // seed immediately and never wait on the gateway here. Previously this
+      // awaited waitForERC721, which threw "Failed to fetch NFT after 60
+      // seconds" whenever indexing was slow — failing onboarding for a citizen
+      // whose NFT had already minted successfully on-chain.
 
       // Record referral
       try {
@@ -836,20 +859,23 @@ export default function CreateCitizen({
         console.error('Error recording referral:', error)
       }
 
-      // Normalize the thirdweb NFT to match the Tableland format before seeding.
-      // Reuse the exact profile fields that were written on-chain so the locally
-      // seeded citizen matches the mint — otherwise the seed could show
-      // un-normalized socials, an un-geocoded location, or worse, view='' (which
-      // the directory treats as hidden/deleted) for a citizen minted as 'public'.
-      // `profile.location` is already the geocoded `{lat,lng,name}` JSON string.
+      // Build the seed entirely from local data (matching the Tableland row
+      // shape produced by citizenRowToNFT). Reusing the exact profile fields
+      // written on-chain guarantees the seed matches the mint — otherwise it
+      // could show un-normalized socials, an un-geocoded location, or worse,
+      // view='' (which the directory treats as hidden/deleted) for a citizen
+      // minted as 'public'. `profile.location` is already the geocoded
+      // `{lat,lng,name}` JSON string and `imageURI` is the `ipfs://` URI that
+      // was written on-chain. None of this depends on Tableland indexing.
+      const numericTokenId = Number(mintedTokenId)
       const normalizedCitizen = {
-        id: typeof citizenNFT.id === 'bigint' ? Number(citizenNFT.id) : citizenNFT.id,
+        id: numericTokenId,
         metadata: {
-          id: typeof citizenNFT.id === 'bigint' ? Number(citizenNFT.id) : citizenNFT.id,
-          uri: citizenNFT.tokenURI || '',
-          name: citizenNFT.metadata?.name || '',
-          description: citizenNFT.metadata?.description || '',
-          image: citizenNFT.metadata?.image || '',
+          id: numericTokenId,
+          uri: '',
+          name: citizenName,
+          description: profile.bio,
+          image: imageURI,
           animation_url: '',
           external_url: '',
           attributes: [
@@ -863,8 +889,8 @@ export default function CreateCitizen({
             { trait_type: 'formId', value: citizenData.formResponseId || '' },
           ],
         },
-        owner: citizenNFT.owner || address || '',
-        tokenURI: citizenNFT.tokenURI || '',
+        owner: address || '',
+        tokenURI: '',
         type: 'ERC721',
       }
 
@@ -902,7 +928,6 @@ export default function CreateCitizen({
       citizenData.email,
       citizenData.name,
       citizenData.formResponseId,
-      citizenContract,
       address,
       clearCache,
       seedCitizen,
@@ -1375,7 +1400,7 @@ export default function CreateCitizen({
       }
 
       if (mintedTokenId) {
-        await handlePostMint(mintedTokenId, profile)
+        await handlePostMint(mintedTokenId, profile, `ipfs://${newImageIpfsHash}`)
         setIsLoadingMint(false)
       }
     } catch (err: any) {

--- a/ui/components/onboarding/CreateTeam.tsx
+++ b/ui/components/onboarding/CreateTeam.tsx
@@ -28,6 +28,7 @@ import {
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
 import { useGasPrice } from '@/lib/rpc/useGasPrice'
 import { generatePrettyLink } from '@/lib/subscription/pretty-links'
+import { escapeSingleQuotes } from '@/lib/tableland/cleanData'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
 import { useNativeBalance } from '@/lib/thirdweb/hooks/useNativeBalance'
@@ -321,14 +322,18 @@ export default function CreateTeam({ selectedChain, setSelectedTier }: any) {
             memberHatURI: 'ipfs://' + memberHatCid,
           },
           {
-            name: teamData.name,
-            bio: teamData.description,
+            // Escape single quotes so an apostrophe in any field can't produce
+            // malformed SQL that the Tableland validator silently rejects (the
+            // team contract builds its INSERT with the same unescaped
+            // SQLHelpers.quote()). `_view` is a fixed enum, so it's left as-is.
+            name: escapeSingleQuotes(teamData.name),
+            bio: escapeSingleQuotes(teamData.description),
             image: 'ipfs://' + newImageIpfsHash,
-            twitter: teamData.twitter,
-            communications: teamData.communications,
-            website: teamData.website,
+            twitter: escapeSingleQuotes(teamData.twitter),
+            communications: escapeSingleQuotes(teamData.communications),
+            website: escapeSingleQuotes(teamData.website),
             _view: teamData.view,
-            formId: teamData.formResponseId,
+            formId: escapeSingleQuotes(teamData.formResponseId),
           },
           [],
         ],
@@ -390,14 +395,15 @@ export default function CreateTeam({ selectedChain, setSelectedTier }: any) {
             memberHatURI: 'ipfs://placeholder',
           },
           {
-            name: teamData.name,
-            bio: teamData.description,
+            // Match the real mint's escaping so the gas estimate is accurate.
+            name: escapeSingleQuotes(teamData.name),
+            bio: escapeSingleQuotes(teamData.description),
             image: 'ipfs://placeholder',
-            twitter: teamData.twitter,
-            communications: teamData.communications,
-            website: teamData.website,
+            twitter: escapeSingleQuotes(teamData.twitter),
+            communications: escapeSingleQuotes(teamData.communications),
+            website: escapeSingleQuotes(teamData.website),
             _view: teamData.view,
-            formId: teamData.formResponseId || '0000',
+            formId: escapeSingleQuotes(teamData.formResponseId || '0000'),
           },
           [],
         ],

--- a/ui/lib/tableland/cleanData.ts
+++ b/ui/lib/tableland/cleanData.ts
@@ -2,6 +2,23 @@ export function unescapeQuotes(v: string) {
   return v.replace(/''/g, "'")
 }
 
+/**
+ * Escape single quotes for an on-chain Tableland mutation.
+ *
+ * Tableland INSERTs are assembled on-chain with `SQLHelpers.quote()`, which only
+ * wraps a value in single quotes and does NOT escape embedded quotes. An
+ * unescaped `'` in any user field (e.g. a bio containing "Brazil's") produces
+ * malformed SQL that the Tableland validator rejects — the NFT still mints, but
+ * the metadata row is never created, permanently. Doubling the quote (`'` ->
+ * `''`) is the SQLite-correct escape; SQLite stores it back as a single `'`.
+ *
+ * This is the same escape `cleanData()` applies on the profile-edit path; use it
+ * for every free-text field passed to `mintTo`/`crossChainMint`/`freeMint`.
+ */
+export function escapeSingleQuotes(v: string): string {
+  return typeof v === 'string' ? v.replace(/'/g, "''") : v
+}
+
 export default function cleanData(obj: any) {
   const formattedObj: any = {}
 

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -19,6 +19,7 @@ import { CitizenInvite, consumeInvite, peekInvite, restoreInvite } from '@/lib/c
 import { enforceRegionNotRestricted } from '@/lib/geo'
 import { createHSMWallet, sendEthFromHSM } from '@/lib/google/hsm-signer'
 import { addressBelongsToPrivyUser } from '@/lib/privy'
+import { escapeSingleQuotes } from '@/lib/tableland/cleanData'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import { serverClient } from '@/lib/thirdweb/serverClient'
@@ -295,17 +296,24 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       const transaction = prepareContractCall({
         contract: citizenContract,
         method: 'mintTo' as string,
+        // Escape single quotes on every free-text field. The Citizen contract
+        // builds the Tableland INSERT with SQLHelpers.quote(), which does NOT
+        // escape embedded quotes, so an apostrophe (e.g. a bio with "Brazil's")
+        // yields malformed SQL the validator rejects — the NFT mints but the
+        // metadata row is never created. `location` already arrives escaped from
+        // the client (buildCitizenProfileMintFields) and `privacy` is a fixed
+        // enum, so neither is re-escaped here.
         params: [
           address,
-          name,
-          bio,
+          escapeSingleQuotes(name),
+          escapeSingleQuotes(bio),
           image,
           location,
-          discord,
-          twitter,
-          website,
+          escapeSingleQuotes(discord),
+          escapeSingleQuotes(twitter),
+          escapeSingleQuotes(website),
           privacy,
-          formId,
+          escapeSingleQuotes(formId),
         ],
         value: cost,
       })

--- a/ui/scripts/propose-orphaned-citizens-safe.mjs
+++ b/ui/scripts/propose-orphaned-citizens-safe.mjs
@@ -1,0 +1,202 @@
+// Proposes the one-time Tableland backfill for citizen NFTs that minted on-chain
+// but whose metadata row was never created (unescaped `'` in the mint data, see
+// repair-orphaned-citizens.mjs for the full root cause).
+//
+// The CitizenTable owner is a 2-of-4 Safe
+// (0x29B0D7d7f0C88Ce0DF1De5888b37B90A6faF75cB), and insertIntoTable is
+// onlyOperators, so the fix must be executed by that Safe. This script batches
+// the inserts into ONE Safe transaction (MultiSend) and proposes it to the Safe
+// Transaction Service so the other owners can confirm it in the Safe UI.
+//
+// The signer MUST be one of the Safe owners (or a registered delegate):
+//   0xAF6f2A7643A97b849bD9cf6d3f57e142c5BbB0DA
+//   0xB2d3900807094D4Fe47405871B0C8AdB58E10D42
+//   0x679d87D8640e66778c3419D164998E720D7495f6
+//   0xb00E7F2C408D23337dFEe6be44EA2D7AAd4B0FE7
+//
+// Usage (from ui/):
+//   SAFE_PROPOSER_PK=0x<owner-or-delegate-key> node scripts/propose-orphaned-citizens-safe.mjs
+// Optional: ARBITRUM_RPC_URL=<rpc> (defaults to the public Arbitrum One RPC).
+// With no key set, it prints the batched calldata and exits without proposing.
+
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import SafeApiKit from '@safe-global/api-kit'
+import Safe from '@safe-global/protocol-kit'
+import { ethers } from 'ethers'
+
+const CHAIN_ID = 42161n
+const SAFE_ADDRESS = '0x29B0D7d7f0C88Ce0DF1De5888b37B90A6faF75cB'
+const CITIZEN_TABLE_ADDRESS = '0x0Eb1dF01b34cEDAFB3148f07D013793b557470d1'
+const DEFAULT_RPC = 'https://arb1.arbitrum.io/rpc'
+
+const INSERT_ABI = [
+  'function insertIntoTable(uint256 id, string name, string description, string image, string location, string discord, string twitter, string website, string _view, string formId, address owner)',
+]
+
+// Double single quotes so the on-chain (non-escaping) SQLHelpers.quote() yields
+// valid SQL; SQLite stores it back as a single `'`.
+const esc = (v) => (typeof v === 'string' ? v.replace(/'/g, "''") : v)
+
+// Per product: Lucas Fonseca keeps token 221 (wallet 0xe375…7693). His earlier
+// duplicate token 219 (wallet 0xa8c2f0…828A) is intentionally NOT backfilled.
+const RECORDS = [
+  {
+    id: 72,
+    owner: '0x063AF2EB31Dc1072eddcC871dbb2CCf1c1DF0548',
+    name: 'Noctis Phantomhive',
+    description:
+      'I am a Correctional Officer fulltime. I have a deep love for space and hope to one day start my own space company!',
+    image: 'ipfs://QmSLPAQKM4grv1aSw2BBSnjf3EjPRH6MYxrMSGgUc6LwUw',
+    location: '{"lat":39.4647665,"lng":-76.7336521,"name":"Baltimore County, MD, USA"}',
+    discord: 'nphantomhive',
+    twitter: 'https://x.com/Nphantomhivee',
+    website: '',
+    view: 'public',
+    formId: 'lqqvb3ybad2l9qiibe4ilqqvb3yb80d7',
+  },
+  {
+    id: 221,
+    owner: '0xe375bdc3ae9f6e48491415eABA0E16c569d57693',
+    name: 'Lucas Fonseca',
+    description:
+      "Brazilian space engineer, founder of Airvantis & Stratolit, Mission Director of Brazil's first lunar mission (Garatéa), and the only Brazilian on the historic Rosetta comet landing. Karman Fellow.",
+    image: 'ipfs://Qma8LCT7SRCNfwXpnLuzyMrqCJBmFB6W7WJtVbxobDX2vd',
+    location:
+      '{"lat":-23.5557714,"lng":-46.6395571,"name":"São Paulo, State of São Paulo, Brazil"}',
+    discord: 'lucas.fonseca',
+    twitter: 'https://@astrolucasf',
+    website: 'https://www.astrolucas.com',
+    view: 'public',
+    formId: '5o0u6iv4vi2vft6qe5x67rh5o0u9it9t',
+  },
+  {
+    id: 222,
+    owner: '0x6bf9d2B1Cc5dc3dB44966caC47d21f7c4B138635',
+    name: 'Nadine Nicole',
+    description:
+      "Filipina-German Actress & Founder (True-Connection.org, YariDesigns.com). Space for Humanity Advisor. \n\nJoining MoonDAO to help build humanity's multiplanetary future.",
+    image: 'ipfs://QmUUJXq7WoJibiKkkeSKRdVDugWk5MPKqYbA1XMbuo8oP1',
+    location: '{"lat":34.0549076,"lng":-118.242643,"name":"Los Angeles, CA, USA"}',
+    discord: '',
+    twitter: 'https://_nadinenicole_',
+    website: 'https://nadinenicole.com',
+    view: 'public',
+    formId: 'dxzpo2fxhonzc044nsrrdxzpo2bztlrb',
+  },
+]
+
+function loadEnvLocal() {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const envPath = join(here, '..', '.env.local')
+  try {
+    const raw = readFileSync(envPath, 'utf8')
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq === -1) continue
+      const key = trimmed.slice(0, eq).trim()
+      let value = trimmed.slice(eq + 1).trim()
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      if (!(key in process.env)) process.env[key] = value
+    }
+  } catch {
+    // .env.local is optional; rely on the process environment.
+  }
+}
+
+function buildMetaTransactions() {
+  const iface = new ethers.utils.Interface(INSERT_ABI)
+  return RECORDS.map((r) => ({
+    to: CITIZEN_TABLE_ADDRESS,
+    value: '0',
+    data: iface.encodeFunctionData('insertIntoTable', [
+      r.id,
+      esc(r.name),
+      esc(r.description),
+      esc(r.image),
+      r.location,
+      esc(r.discord),
+      esc(r.twitter),
+      esc(r.website),
+      r.view,
+      esc(r.formId),
+      r.owner,
+    ]),
+  }))
+}
+
+async function main() {
+  loadEnvLocal()
+  const transactions = buildMetaTransactions()
+
+  console.log(`Backfilling ${transactions.length} citizen rows (tokens ${RECORDS.map((r) => r.id).join(', ')})`)
+  console.log('Safe:           ', SAFE_ADDRESS)
+  console.log('Target contract:', CITIZEN_TABLE_ADDRESS, '\n')
+  transactions.forEach((t, i) => {
+    console.log(`  [${i}] token ${RECORDS[i].id} -> data ${t.data.slice(0, 26)}…`)
+  })
+  console.log('')
+
+  const pk = process.env.SAFE_PROPOSER_PK
+  if (!pk) {
+    console.log(
+      'No SAFE_PROPOSER_PK set — printed the batch above but did not propose.\n' +
+        'Re-run with an owner/delegate key to open the transaction on the Safe:\n' +
+        '  SAFE_PROPOSER_PK=0x<owner-key> node scripts/propose-orphaned-citizens-safe.mjs'
+    )
+    return
+  }
+
+  const rpcUrl = process.env.ARBITRUM_RPC_URL || process.env.RPC_URL || DEFAULT_RPC
+  const senderAddress = new ethers.Wallet(pk).address
+
+  const protocolKit = await Safe.init({
+    provider: rpcUrl,
+    signer: pk,
+    safeAddress: SAFE_ADDRESS,
+  })
+
+  const owners = (await protocolKit.getOwners()).map((o) => o.toLowerCase())
+  if (!owners.includes(senderAddress.toLowerCase())) {
+    console.warn(
+      `WARNING: proposer ${senderAddress} is not a Safe owner. ` +
+        'The Transaction Service will reject the proposal unless it is a registered delegate.'
+    )
+  }
+
+  // Multiple transactions are automatically wrapped in a MultiSend (one nonce).
+  const safeTransaction = await protocolKit.createTransaction({ transactions })
+  const safeTxHash = await protocolKit.getTransactionHash(safeTransaction)
+  const signature = await protocolKit.signHash(safeTxHash)
+
+  const apiKit = new SafeApiKit({ chainId: CHAIN_ID })
+  await apiKit.proposeTransaction({
+    safeAddress: SAFE_ADDRESS,
+    safeTransactionData: safeTransaction.data,
+    safeTxHash,
+    senderAddress,
+    senderSignature: signature.data,
+    origin: 'repair-orphaned-citizens',
+  })
+
+  console.log('\nProposed to the Safe ✅')
+  console.log('safeTxHash:', safeTxHash)
+  console.log(`Confirm at: https://app.safe.global/transactions/queue?safe=arb1:${SAFE_ADDRESS}`)
+  console.log('\nAfter execution, verify the rows materialized:')
+  console.log(
+    "  curl -s 'https://tableland.network/api/v1/query?statement=SELECT%20id,name%20FROM%20CITIZENTABLE_42161_126%20WHERE%20id%20IN%20(72,221,222)'"
+  )
+}
+
+main().catch((err) => {
+  console.error('Failed to propose Safe transaction:', err)
+  process.exit(1)
+})

--- a/ui/scripts/repair-orphaned-citizens.mjs
+++ b/ui/scripts/repair-orphaned-citizens.mjs
@@ -1,0 +1,124 @@
+// Repair script for citizen NFTs that minted on-chain but whose Tableland
+// metadata row was never created.
+//
+// ROOT CAUSE: the Citizen contract builds its Tableland INSERT with
+// SQLHelpers.quote(), which wraps a value in single quotes WITHOUT escaping
+// embedded quotes. Any mint whose name/bio/location/etc. contained a raw `'`
+// (e.g. a bio with "Brazil's") produced malformed SQL that the Tableland
+// validator rejected — so the NFT exists but has no metadata row. The mint
+// paths now escape `'` -> `''` (see lib/tableland/cleanData.ts), but these
+// already-minted tokens need a one-time backfill.
+//
+// The CitizenTable owner is a multisig Safe (0x29B0D7d7f0C88Ce0DF1De5888b37B90A6faF75cB),
+// and insertIntoTable is onlyOperators (owner or the Citizen NFT contract), so
+// this script does NOT send anything. It prints, for each orphaned token, the
+// target contract and the ABI-encoded calldata to execute from the owner Safe
+// (e.g. via the Safe Transaction Builder).
+//
+// NOTE: insertIntoTable ALSO uses the non-escaping SQLHelpers.quote(), so every
+// value below is pre-escaped (`'` -> `''`) here; SQLite stores it back as a
+// single `'`.
+//
+// Usage:  node ui/scripts/repair-orphaned-citizens.mjs
+
+import { ethers } from 'ethers'
+
+const CITIZEN_TABLE_ADDRESS = '0x0Eb1dF01b34cEDAFB3148f07D013793b557470d1'
+const OWNER_SAFE = '0x29B0D7d7f0C88Ce0DF1De5888b37B90A6faF75cB'
+
+const INSERT_ABI = [
+  'function insertIntoTable(uint256 id, string name, string description, string image, string location, string discord, string twitter, string website, string _view, string formId, address owner)',
+]
+
+// Double single quotes so the on-chain SQLHelpers.quote() produces valid SQL.
+const esc = (v) => (typeof v === 'string' ? v.replace(/'/g, "''") : v)
+
+// Source values were read from each token's original mintTo calldata on
+// Arbitrum. `description`/socials are passed through esc(); `location` is set to
+// clean JSON (token 72's original was malformed non-JSON with single quotes).
+const RECORDS = [
+  {
+    id: 72,
+    owner: '0x063AF2EB31Dc1072eddcC871dbb2CCf1c1DF0548',
+    name: 'Noctis Phantomhive',
+    description:
+      'I am a Correctional Officer fulltime. I have a deep love for space and hope to one day start my own space company!',
+    image: 'ipfs://QmSLPAQKM4grv1aSw2BBSnjf3EjPRH6MYxrMSGgUc6LwUw',
+    location: '{"lat":39.4647665,"lng":-76.7336521,"name":"Baltimore County, MD, USA"}',
+    discord: 'nphantomhive',
+    twitter: 'https://x.com/Nphantomhivee',
+    website: '',
+    view: 'public',
+    formId: 'lqqvb3ybad2l9qiibe4ilqqvb3yb80d7',
+  },
+  {
+    // Lucas Fonseca — KEEP this token (his latest attempt, current wallet).
+    // Token 219 (wallet 0xa8c2f00143727F9d98f17264975c122D5de4828A) is the same
+    // person's earlier attempt and is intentionally NOT backfilled to avoid a
+    // duplicate citizen. Backfill 219 instead/as well only if product decides.
+    id: 221,
+    owner: '0xe375bdc3ae9f6e48491415eABA0E16c569d57693',
+    name: 'Lucas Fonseca',
+    description:
+      "Brazilian space engineer, founder of Airvantis & Stratolit, Mission Director of Brazil's first lunar mission (Garatéa), and the only Brazilian on the historic Rosetta comet landing. Karman Fellow.",
+    image: 'ipfs://Qma8LCT7SRCNfwXpnLuzyMrqCJBmFB6W7WJtVbxobDX2vd',
+    location:
+      '{"lat":-23.5557714,"lng":-46.6395571,"name":"São Paulo, State of São Paulo, Brazil"}',
+    discord: 'lucas.fonseca',
+    twitter: 'https://@astrolucasf',
+    website: 'https://www.astrolucas.com',
+    view: 'public',
+    formId: '5o0u6iv4vi2vft6qe5x67rh5o0u9it9t',
+  },
+  {
+    id: 222,
+    owner: '0x6bf9d2B1Cc5dc3dB44966caC47d21f7c4B138635',
+    name: 'Nadine Nicole',
+    description:
+      "Filipina-German Actress & Founder (True-Connection.org, YariDesigns.com). Space for Humanity Advisor. \n\nJoining MoonDAO to help build humanity's multiplanetary future.",
+    image: 'ipfs://QmUUJXq7WoJibiKkkeSKRdVDugWk5MPKqYbA1XMbuo8oP1',
+    location: '{"lat":34.0549076,"lng":-118.242643,"name":"Los Angeles, CA, USA"}',
+    discord: '',
+    twitter: 'https://_nadinenicole_',
+    website: 'https://nadinenicole.com',
+    view: 'public',
+    formId: 'dxzpo2fxhonzc044nsrrdxzpo2bztlrb',
+  },
+]
+
+function main() {
+  const iface = new ethers.utils.Interface(INSERT_ABI)
+
+  console.log('Owner Safe (must execute these):', OWNER_SAFE)
+  console.log('Target contract (CitizenTable):', CITIZEN_TABLE_ADDRESS)
+  console.log('Chain: Arbitrum One (42161)\n')
+
+  for (const r of RECORDS) {
+    const data = iface.encodeFunctionData('insertIntoTable', [
+      r.id,
+      esc(r.name),
+      esc(r.description),
+      esc(r.image),
+      r.location, // JSON; double quotes are SQL-safe, contains no single quote
+      esc(r.discord),
+      esc(r.twitter),
+      esc(r.website),
+      r.view,
+      esc(r.formId),
+      r.owner,
+    ])
+
+    console.log(`--- token ${r.id} (${r.name}) -> owner ${r.owner} ---`)
+    console.log('to:   ', CITIZEN_TABLE_ADDRESS)
+    console.log('value:', '0')
+    console.log('data: ', data)
+    console.log('')
+  }
+
+  console.log(
+    'After execution, confirm each row materializes:\n' +
+      "  curl -s 'https://tableland.network/api/v1/query?statement=SELECT%20id,name%20FROM%20CITIZENTABLE_42161_126%20WHERE%20id%20IN%20(72,221,222)'"
+  )
+}
+
+main()


### PR DESCRIPTION
## Summary
- Escape single quotes (`'` → `''`) on all free-text fields passed to citizen/team mint paths, matching the existing profile-edit behavior in `cleanData()`. This prevents Tableland validator SQL parse failures when bios contain apostrophes (e.g. "Brazil's first lunar mission").
- Stop blocking citizen onboarding success on `waitForERC721`/Tableland indexing lag — seed the citizen from local mint data immediately after a successful on-chain mint.
- Add one-time repair scripts for the 3 orphaned citizen rows (tokens 72, 221, 222) to be executed via the CitizenTable owner Safe.

## Test plan
- [ ] Mint a citizen with an apostrophe in the bio (e.g. "Brazil's mission") and confirm onboarding completes without the "Failed to fetch NFT after 60 seconds" toast
- [ ] Confirm the citizen row appears in Tableland shortly after mint (`CITIZENTABLE_42161_126`)
- [ ] Verify sponsored/magic-link mint path (`/api/mission/freeMint`) also succeeds with apostrophe-containing bios
- [ ] Verify team mint with apostrophe in name/description succeeds
- [ ] After Safe backfill executes, confirm tokens 72, 221, 222 resolve in Tableland and Lucas (221) shows on wallet `0xe375…7693`


Made with [Cursor](https://cursor.com)