### PR TITLE
Stop HSM wallet paying renewal fee on magic link citizen mints

### DIFF
--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -286,12 +286,45 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     // on actual mint failures, not on subsequent response serialization errors.
     let mintSucceeded = false
     try {
+      const account = await createHSMWallet()
+
+      // For invite-token redeemers, attempt to add the recipient to the
+      // DiscountList so that getRenewalPrice() returns 0 and the HSM wallet
+      // only covers gas — not the renewal fee — when calling mintTo.
+      // PREREQUISITE: the DiscountList contract's owner must be the HSM wallet
+      // (0xb206325E6562517532686dFeeEaD4C104D9F5d32). Until that one-time Safe
+      // transaction is done (transferOwnership on 0x755D48e6C3744B723bd0326C57F99A92a3Ca3287),
+      // this step will fail silently and the HSM will continue paying the
+      // renewal fee as before — no regression in behavior.
+      if (consumedInvite && CITIZEN_DISCOUNTLIST_ADDRESSES[chainSlug]) {
+        try {
+          const discountListContract = getContract({
+            client: serverClient,
+            address: CITIZEN_DISCOUNTLIST_ADDRESSES[chainSlug],
+            abi: WhitelistABI as any,
+            chain,
+          })
+          const addToDiscountListTx = prepareContractCall({
+            contract: discountListContract,
+            method: 'addToWhitelist' as string,
+            params: [address],
+          })
+          await sendAndConfirmTransaction({ transaction: addToDiscountListTx, account })
+          console.log(`[freeMint] Added ${address} to DiscountList — mint will be gas-only`)
+        } catch (discountErr: any) {
+          console.warn(
+            `[freeMint] Could not add ${address} to DiscountList (HSM may not own it yet): ${discountErr?.message ?? discountErr}. ` +
+              `Transfer DiscountList ownership (0x755D48e6C3744B723bd0326C57F99A92a3Ca3287) to HSM ` +
+              `(0xb206325E6562517532686dFeeEaD4C104D9F5d32) to eliminate renewal-fee payments.`
+          )
+        }
+      }
+
       const cost: any = await readContract({
         contract: citizenContract,
         method: 'getRenewalPrice' as string,
         params: [address, 365 * 24 * 60 * 60],
       })
-      const account = await createHSMWallet()
       const transaction = prepareContractCall({
         contract: citizenContract,
         method: 'mintTo' as string,


### PR DESCRIPTION
## Summary

- Magic link invite redemptions previously caused the HSM relayer wallet to pay ~0.011 ETH (~$33) per mint as the renewal fee passed to `mintTo`. This steadily drained the wallet and required frequent manual top-ups.
- The HSM wallet now owns the Citizen `DiscountList` contract (ownership transferred via Safe tx in this session).
- Before calling `mintTo` for an invite-token redemption, the server adds the recipient's address to the `DiscountList`. This makes `getRenewalPrice()` return `0` for that address, so `mintTo` is called with `value: 0` — the HSM pays gas only.
- The `addToWhitelist` call is wrapped in a non-blocking `try/catch`, so if it ever fails the mint proceeds as before (no regression).

## On-chain changes (already done)
- `DiscountList` contract (`0x755D48e6C3744B723bd0326C57F99A92a3Ca3287` on Arbitrum) ownership transferred to HSM wallet (`0xb206325E6562517532686dFeeEaD4C104D9F5d32`) via Safe multisig.

## Test plan
- [ ] Redeem a magic link invite on testnet and confirm the server log shows `[freeMint] Added <address> to DiscountList — mint will be gas-only`
- [ ] Confirm the minted citizen's address appears on the DiscountList (`isWhitelisted` returns `true`)
- [ ] Confirm `mintTo` was called with `value: 0` (check tx on Arbiscan)
- [ ] Confirm invite token is correctly consumed and cannot be reused

Made with [Cursor](https://cursor.com)