### PR TITLE
Fix GitHub quest cards showing Link GitHub Account after linking

### DIFF
--- a/ui/components/xp/Quest.tsx
+++ b/ui/components/xp/Quest.tsx
@@ -806,14 +806,42 @@ export default function Quest({
               onClick={async () => {
                 try {
                   await linkGithub()
-                  // After linking, refresh the quest data
-                  if (quest.verifier.type === 'staged') {
-                    await fetchStagedProgress()
-                  } else {
-                    await refreshSingleQuestEligibility()
+                  // Privy may take a moment to propagate the new GitHub link
+                  // server-side. Retry the eligibility check with backoff so
+                  // the quest card reflects the linked account without requiring
+                  // a manual page refresh.
+                  toast.success(
+                    'GitHub linked! Verifying quest status…',
+                    { style: toastStyle, duration: 3000 }
+                  )
+                  const maxAttempts = 5
+                  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+                    const delay = 1500 * Math.pow(2, attempt) // 1.5s, 3s, 6s, 12s, 24s
+                    await new Promise((resolve) => setTimeout(resolve, delay))
+
+                    const { metric, eligible } = await fetchUserMetric()
+                    if (eligible || metric >= 1) {
+                      setUserMetric(metric)
+                      setSingleQuestEligible(eligible ?? metric >= 1)
+                      setNeedsGitHubLink(false)
+                      setError(null)
+                      if (quest.verifier.type === 'staged') {
+                        await fetchStagedProgress()
+                      }
+                      break
+                    }
+
+                    // On the last attempt, do a final refresh regardless
+                    if (attempt === maxAttempts - 1) {
+                      if (quest.verifier.type === 'staged') {
+                        await fetchStagedProgress()
+                      } else {
+                        await refreshSingleQuestEligibility()
+                      }
+                      setNeedsGitHubLink(false)
+                      setError(null)
+                    }
                   }
-                  setNeedsGitHubLink(false)
-                  setError(null) // Clear any errors after successful GitHub linking
                 } catch (error) {
                   console.error('Error linking GitHub:', error)
                   toast.error(

--- a/ui/lib/privy/index.ts
+++ b/ui/lib/privy/index.ts
@@ -45,7 +45,10 @@ export async function getPrivyUserData(accessToken: string): Promise<PrivyUserDa
     // Extract wallet addresses from the user's linked accounts
     if (userData.linked_accounts) {
       for (const account of userData.linked_accounts) {
-        if (account.type === 'wallet' && account.address) {
+        if (
+          (account.type === 'wallet' || account.type === 'smart_wallet') &&
+          account.address
+        ) {
           walletAddresses.push(account.address)
         }
         // Find the Discord account

--- a/ui/pages/api/xp/has-submitted-issue-proof.ts
+++ b/ui/pages/api/xp/has-submitted-issue-proof.ts
@@ -52,7 +52,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
     }
 
-    if (!privyUserData.walletAddresses.includes(user)) {
+    if (
+      !privyUserData.walletAddresses
+        .map((a) => a.toLowerCase())
+        .includes(user.toLowerCase())
+    ) {
       return res.status(200).json({
         eligible: false,
         issueCount: '0',

--- a/ui/pages/api/xp/has-submitted-issue-proof.ts
+++ b/ui/pages/api/xp/has-submitted-issue-proof.ts
@@ -64,9 +64,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
     }
 
-    // Check if user has a GitHub account linked
+    // Check if user has a GitHub account linked. Privy generally returns
+    // `github_oauth`, but older/client-side objects may use `github`.
     const githubAccount = privyUserData.userData?.linked_accounts?.find(
-      (account: any) => account.type === 'github_oauth'
+      (account: any) =>
+        account.type === 'github_oauth' || account.type === 'github'
     )
 
     if (!githubAccount) {

--- a/ui/pages/api/xp/has-submitted-pr-proof.ts
+++ b/ui/pages/api/xp/has-submitted-pr-proof.ts
@@ -52,7 +52,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
     }
 
-    if (!privyUserData.walletAddresses.includes(user)) {
+    if (
+      !privyUserData.walletAddresses
+        .map((a) => a.toLowerCase())
+        .includes(user.toLowerCase())
+    ) {
       return res.status(200).json({
         eligible: false,
         prCount: '0',

--- a/ui/pages/api/xp/has-submitted-pr-proof.ts
+++ b/ui/pages/api/xp/has-submitted-pr-proof.ts
@@ -64,9 +64,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
     }
 
-    // Check if user has a GitHub account linked
+    // Check if user has a GitHub account linked. Privy generally returns
+    // `github_oauth`, but older/client-side objects may use `github`.
     const githubAccount = privyUserData.userData?.linked_accounts?.find(
-      (account: any) => account.type === 'github_oauth'
+      (account: any) =>
+        account.type === 'github_oauth' || account.type === 'github'
     )
 
     if (!githubAccount) {


### PR DESCRIPTION
## Summary
- Fix GitHub issue/PR quest proof routes to match wallet addresses case-insensitively, preventing false "User not found" responses when Privy stores a different checksum casing.
- Include `smart_wallet` linked accounts in `getPrivyUserData`, so users on ERC-4337 smart wallets are recognized by the quest proof APIs.
- After linking GitHub from a quest card, retry eligibility checks with exponential backoff so the UI updates once Privy propagates the linked account server-side.

## Test plan
- [ ] Connect with a wallet whose address casing differs from Privy storage and confirm GitHub quests no longer show "Link GitHub Account" when GitHub is already linked.
- [ ] Connect with a smart wallet and confirm GitHub quests load progress instead of failing wallet lookup.
- [ ] Link GitHub from a quest card and confirm the card refreshes to show progress/claim state without a manual page reload.
- [ ] Confirm users without GitHub linked still see the "Link GitHub Account" button and can complete OAuth successfully.


Made with [Cursor](https://cursor.com)