### PR TITLE
fix(reopen): guard setDeadline + include it in the Safe rollout batch

### DIFF
--- a/frank-reopen-deploy-plan.md
+++ b/frank-reopen-deploy-plan.md
@@ -148,13 +148,17 @@ forge script script/QueueReopenRuleset.s.sol \
 
 **What:** A single **Transaction Builder batch** (atomic multisend) with these actions in order:
 
-1. `ReopenPayHook.seedContributions(holders, ethAmounts, tokenAmounts)` — one or more batches (calldata from Pre-step B). **To:** the hook address, **Value:** 0.
-2. `ReopenPayHook.lockLedger()` — freezes the seed. **To:** the hook, **Value:** 0.
-3. `JBController.queueRulesetsOf(...)` — activates the re-open ruleset (calldata from Option A below). **To:** `0x27da30646502e2f642bE5281322Ae8C394F7668a`, **Value:** 0.
+1. `ReopenPayHook.setDeadline(newDeadline)` — resets the campaign countdown to Safe execution time. **To:** the hook, **Value:** 0.
+   - `newDeadline = safe_execution_unix_time + CAMPAIGN_DURATION_DAYS * 86400`.
+   - Required because the hook's `deadline` was stamped at Transaction 1 deploy time; without this call the live campaign loses every second between the EOA deploy and Safe execution.
+   - The forge script (Option A below) prints ready-to-paste calldata for this action. If Safe execution is materially delayed (e.g. days after deploy), recompute the `uint256` argument in the calldata to reflect the actual execution timestamp — the on-chain guard requires the new deadline to be in the future but before the current on-chain deadline.
+2. `ReopenPayHook.seedContributions(holders, ethAmounts, tokenAmounts)` — one or more batches (calldata from Pre-step B). **To:** the hook address, **Value:** 0.
+3. `ReopenPayHook.lockLedger()` — freezes the seed. **To:** the hook, **Value:** 0.
+4. `JBController.queueRulesetsOf(...)` — activates the re-open ruleset (calldata from Option A below). **To:** `0x27da30646502e2f642bE5281322Ae8C394F7668a`, **Value:** 0.
 
-Doing all three in one batch guarantees the ledger is seeded and frozen **before** the ruleset goes live, so no contribution can slip in against an unseeded ledger. Because the current ruleset has `duration=0` and `approvalHook=0x0`, the new ruleset takes effect **immediately** on the next terminal interaction.
+Doing all four in one batch guarantees the deadline is anchored to the go-live moment and the ledger is seeded and frozen **before** the ruleset goes live, so no contribution can slip in against an unseeded ledger or a stale deadline. Because the current ruleset has `duration=0` and `approvalHook=0x0`, the new ruleset takes effect **immediately** on the next terminal interaction.
 
-> If original backers are **not** being made refundable, skip actions 1–2 and do only the `queueRulesetsOf` call.
+> If original backers are **not** being made refundable, skip actions 2–3 and do only the `setDeadline` + `queueRulesetsOf` calls.
 
 #### Option A — Use the script to generate the queueRulesetsOf calldata (recommended)
 
@@ -183,10 +187,11 @@ forge script script/QueueReopenRuleset.s.sol \
 Copy the printed calldata and:
 1. Go to [app.safe.global](https://app.safe.global) → `0xaA1Bd6d001C0000420090EDb36bEAE0D9393B5EA`
 2. New Transaction → **Transaction Builder**
-3. Add the Pre-step B actions first (seedContributions batches → lockLedger, **To:** the hook address), then add this final action:
-   - **To:** `0x27da30646502e2f642bE5281322Ae8C394F7668a` (JB Controller)
-   - **Value:** 0
-   - **Data:** paste the `queueRulesetsOf` calldata
+3. Add actions in this order:
+   1. `setDeadline` (**To:** the hook address, **Data:** printed by the forge script; anchor the `uint256` to Safe execution time if materially delayed).
+   2. Pre-step B `seedContributions` batches (**To:** the hook address, **Data:** printed by `resolve-contributions.mjs`).
+   3. `lockLedger` (**To:** the hook address, **Data:** printed by `resolve-contributions.mjs`).
+   4. `queueRulesetsOf` (**To:** `0x27da30646502e2f642bE5281322Ae8C394F7668a`, **Data:** the `queueRulesetsOf` calldata printed by the forge script).
 4. Collect 3 signatures and execute the batch.
 
 #### Option B — Build the transaction manually in Safe Transaction Builder

--- a/subscription-contracts/script/QueueReopenRuleset.s.sol
+++ b/subscription-contracts/script/QueueReopenRuleset.s.sol
@@ -250,11 +250,46 @@ contract QueueReopenRulesetScript is Script, Config {
                 rulesetConfigurations,
                 memo
             );
+
             console.log("");
-            console.log("Propose this transaction from the team Safe (Transaction Builder):");
-            console.log("To (JB Controller):", JB_V5_CONTROLLER);
-            console.log("Value: 0");
-            console.log("Data:");
+            console.log("Propose these transactions from the team Safe (Transaction Builder), in this order:");
+            console.log("");
+
+            if (existingPayHook == address(0)) {
+                // Fresh hook: the deadline was stamped at deploy time. If Safe
+                // execution happens minutes/hours/days later, the live campaign
+                // loses that gap unless setDeadline is included in the same batch
+                // that activates the re-open ruleset. Emit it as Action 1 so the
+                // countdown is reset at Safe execution time.
+                //
+                // NOTE: the `newDeadline` below is anchored to *this script's*
+                // block.timestamp. If Safe execution is materially delayed,
+                // replace the encoded uint256 with
+                // `<safe_exec_unix_time> + campaignDurationDays * 86400` (still
+                // enforced to be in the future and before the current on-chain
+                // deadline by ReopenPayHook.setDeadline).
+                bytes memory setDeadlineCalldata = abi.encodeWithSelector(
+                    ReopenPayHook.setDeadline.selector,
+                    newDeadline
+                );
+                console.log("Action 1 - ReopenPayHook.setDeadline(newDeadline):");
+                console.log("  To (ReopenPayHook):", payHookAddress);
+                console.log("  Value: 0");
+                console.log("  newDeadline (anchor to Safe exec time if delayed):", newDeadline);
+                console.log("  Data:");
+                console.logBytes(setDeadlineCalldata);
+                console.log("");
+                console.log("Action 2 - seedContributions batches (from script/backfill/resolve-contributions.mjs)");
+                console.log("Action 3 - ReopenPayHook.lockLedger()");
+                console.log("Action 4 - JBController.queueRulesetsOf:");
+            } else {
+                // Rate update: reusing an already-configured hook, so its deadline
+                // is unchanged. Only queue the new ruleset.
+                console.log("Action 1 - JBController.queueRulesetsOf:");
+            }
+            console.log("  To (JB Controller):", JB_V5_CONTROLLER);
+            console.log("  Value: 0");
+            console.log("  Data:");
             console.logBytes(queueCalldata);
         }
 

--- a/subscription-contracts/src/ReopenPayHook.sol
+++ b/subscription-contracts/src/ReopenPayHook.sol
@@ -169,7 +169,12 @@ contract ReopenPayHook is IJBRulesetDataHook, IJBPayHook, IJBCashOutHook, Ownabl
     ///         activation happen in separate transactions (e.g. deploy via EOA then
     ///         queue via a Safe). Must be called before the campaign starts
     ///         accepting contributions (i.e. before the new ruleset is active).
+    ///
+    ///         Blocked once the current deadline has passed so the owner cannot
+    ///         retroactively reopen the campaign or abort the refund window that
+    ///         `refundPeriod` was measured against.
     function setDeadline(uint256 _deadline) external onlyOwner {
+        require(block.timestamp < deadline, "Deadline has already passed.");
         require(_deadline > block.timestamp, "Deadline must be in the future.");
         deadline = _deadline;
     }

--- a/subscription-contracts/test/ReopenRulesetTest.t.sol
+++ b/subscription-contracts/test/ReopenRulesetTest.t.sol
@@ -873,6 +873,85 @@ contract ReopenRulesetTest is Test, Config {
         hook.seedContributions(holders, eth, toks);
     }
 
+    /// @notice `setDeadline` lets the owner reset the countdown to Safe execution
+    ///         time (deploy-time deadline → go-live deadline), but only while the
+    ///         current deadline is still in the future. Once the deadline has
+    ///         passed the campaign is either goal-met or in the refund window, and
+    ///         resetting would let the owner block refunds and re-open payments.
+    function testSetDeadlineIsOwnerGatedAndTimeBounded() public {
+        _createTeam();
+        uint256 missionId = _createMission(1_000 ether);
+        uint256 projectId = missionCreator.missionIdToProjectId(missionId);
+        IJBTerminal terminal = jbDirectory.primaryTerminalOf(projectId, JBConstants.NATIVE_TOKEN);
+
+        skip(28 days + 28 days + 1);
+        ReopenPayHook hook = _reopen(missionId, projectId, terminal, REOPEN_WEIGHT);
+
+        uint256 initialDeadline = hook.deadline();
+        assertEq(initialDeadline, block.timestamp + CAMPAIGN_DURATION, "Initial deadline is deploy-time + duration");
+
+        // Non-owner cannot reset the deadline.
+        vm.prank(randomCaller);
+        vm.expectRevert();
+        hook.setDeadline(block.timestamp + CAMPAIGN_DURATION);
+
+        // Owner extends the deadline while the campaign is still live.
+        skip(1 days);
+        uint256 extended = block.timestamp + CAMPAIGN_DURATION;
+        vm.prank(teamAddress);
+        hook.setDeadline(extended);
+        assertEq(hook.deadline(), extended, "Owner can shift the deadline while campaign is live");
+
+        // A deadline in the past (or now) is still rejected on the future-check.
+        vm.prank(teamAddress);
+        vm.expectRevert("Deadline must be in the future.");
+        hook.setDeadline(block.timestamp);
+
+        // Once the current deadline passes, setDeadline is blocked so the owner
+        // cannot retroactively reopen the campaign or abort the refund window.
+        skip(CAMPAIGN_DURATION + 1);
+        vm.prank(teamAddress);
+        vm.expectRevert("Deadline has already passed.");
+        hook.setDeadline(block.timestamp + CAMPAIGN_DURATION);
+    }
+
+    /// @notice Deadline reset after the refund window opens would block refunds
+    ///         (`beforeCashOutRecordedWith` requires `block.timestamp >= deadline`)
+    ///         and re-open pays (`beforePayRecordedWith` only rejects once
+    ///         `block.timestamp >= deadline`). The `setDeadline` guard prevents
+    ///         that abuse path; a refund attempted after a reset attempt still
+    ///         succeeds against the ORIGINAL deadline.
+    function testSetDeadlineCannotAbortRefundWindow() public {
+        _createTeam();
+        uint256 missionId = _createMission(1_000 ether);
+        uint256 projectId = missionCreator.missionIdToProjectId(missionId);
+        IJBTerminal terminal = jbDirectory.primaryTerminalOf(projectId, JBConstants.NATIVE_TOKEN);
+
+        skip(28 days + 28 days + 1);
+        ReopenPayHook hook = _reopen(missionId, projectId, terminal, REOPEN_WEIGHT);
+
+        _pay(contributor1, 1 ether, terminal, projectId);
+        uint256 tokens = jbTokens.totalBalanceOf(contributor1, projectId);
+
+        // Refund window opens once the deadline passes with the goal unmet.
+        skip(CAMPAIGN_DURATION + 1);
+        assertEq(hook.stage(address(terminal), projectId), 3, "Refund stage should be open");
+
+        // Owner tries to reset the deadline into the future — must revert so the
+        // refund window stays open and no new pay slips in against a stale deadline.
+        vm.prank(teamAddress);
+        vm.expectRevert("Deadline has already passed.");
+        hook.setDeadline(block.timestamp + CAMPAIGN_DURATION);
+
+        // The refund still goes through under the original deadline.
+        uint256 balanceBefore = contributor1.balance;
+        vm.prank(contributor1);
+        IJBMultiTerminal(address(terminal)).cashOutTokensOf(
+            contributor1, projectId, tokens, JBConstants.NATIVE_TOKEN, 0, payable(contributor1), bytes("")
+        );
+        assertApproxEqAbs(contributor1.balance - balanceBefore, 1 ether, 10, "Refund honored against original deadline");
+    }
+
     /// @notice REENTRANCY: a malicious contributor whose `receive()` re-enters
     ///         `cashOutTokensOf` during the refund ETH transfer cannot drain more
     ///         than they contributed. The refund price is derived only from the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacks on top of #1426 to address the two Cursor Bugbot review comments that are still real issues on `feat/frank-reopen-ruleset`. The other 8 bugbot findings on the current tip (`55ef3d5`) were verified to be already resolved by earlier fix commits (`REOPEN_PAY_HOOK_ADDRESS` reuse, `refundPeriodDays > 0`, `hasLiveContributions` guard, resolver total-mismatch abort, DePrize ledger consistency, etc.) or are the accepted trust-in-multisig tradeoff documented in the security summary.

## Real issues fixed

### High — "Deadline reset aborts refund window"
`ReopenPayHook.setDeadline` only required `_deadline > block.timestamp`, so the owner could push `deadline` forward while the mission was already in the post-deadline refund window. That flipped both guards:
- `beforeCashOutRecordedWith` reverts when `block.timestamp < deadline` → refunds blocked.
- `beforePayRecordedWith` only rejects new pays when `block.timestamp >= deadline` → payments accepted again against a stale `refundPeriod` anchor.

Added `require(block.timestamp < deadline, "Deadline has already passed.");` so the countdown can only be reset while the campaign is still live. That is the sole intended use case (aligning the countdown from EOA deploy time to Safe execution time), and the guard doesn't interfere with it.

### Medium — "Safe batch omits deadline reset"
Now that `setDeadline` exists, the deploy plan's Safe batch and the forge script's dry-run output need to actually call it. Otherwise the hook's `deadline` stays anchored to the EOA deploy time in Transaction 1 and the live campaign silently loses every second between deploy and Safe execution.

- `QueueReopenRuleset.s.sol` now prints ready-to-paste `setDeadline` calldata as Action 1 alongside the `queueRulesetsOf` calldata in the default dry-run path, and skips it when reusing an existing hook for a rate update (deadline is unchanged there).
- `frank-reopen-deploy-plan.md` documents `setDeadline` as step 1 of the Transaction 2 batch (before `seedContributions` / `lockLedger` / `queueRulesetsOf`) and updates the Option A instructions to match.

## Test coverage

New tests added to `ReopenRulesetTest.t.sol`:

- `testSetDeadlineIsOwnerGatedAndTimeBounded` — owner gate, future-check, and the new post-deadline block.
- `testSetDeadlineCannotAbortRefundWindow` — proves a reset attempt during the refund stage reverts and the honest refund still completes against the original deadline.

Full suite:

```
Ran 20 tests for test/ReopenRulesetTest.t.sol:ReopenRulesetTest
Suite result: ok. 20 passed; 0 failed; 0 skipped
```

`forge test --match-contract ReopenRulesetTest --via-ir --fork-url https://arb1.arbitrum.io/rpc`

## Bugbot comments verified as already resolved

For completeness, the review comments on the current tip that this PR does **not** touch (all confirmed against the code and marked resolved on-chain by prior commits):

| Comment | Severity | Resolved by |
|---|---|---|
| Safe calldata wrong hook address | High | `REOPEN_PAY_HOOK_ADDRESS` env var (script L126-129, L197-198) |
| Zero refund period blocks refunds | Medium | `require(refundPeriodDays > 0, ...)` (script L163) |
| New hook drops refund ledger | High | Hook reuse via `REOPEN_PAY_HOOK_ADDRESS` + explicit warning + docs |
| Deadline starts at deploy | Medium | `setDeadline()` (this PR hardens it further) |
| Seeder ignores total mismatch | Medium | `process.exit(1)` on grandTotal != payTotal in resolver |
| Seeding can overwrite live credits | High | `hasLiveContributions` flag guarding `seedContributions` |
| DePrize refunds use deposit ledger | Medium | Intentional — DePrize now uses the deposit-ledger path by design |
| Seeding lacks balance sanity checks | Medium | Accepted trust-in-multisig tradeoff (see PR #1426 security summary); a token-side balance cap doesn't prevent an inflated-ETH seed, so the resolver's on-chain-derived seed + Safe review are the effective defense |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f39ee-9225-7e9d-9df0-50320df1a360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f39ee-9225-7e9d-9df0-50320df1a360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

