### PR TITLE
fix(proposals): make confirmation email next steps evergreen

### DIFF
--- a/ui/lib/utils/dates.ts
+++ b/ui/lib/utils/dates.ts
@@ -155,3 +155,35 @@ export function getThirdThursdayOfQuarterTimestamp(quarter: number, year: number
   date.setDate(date.getDate() + 14)
   return date
 }
+
+export function getSecondThursdayOfQuarter(quarter: number, year: number) {
+  const date = getThirdThursdayOfQuarterTimestamp(quarter, year)
+  date.setDate(date.getDate() - 7)
+  return date
+}
+
+export function formatQuarterCycleLabel(quarter: number, year: number) {
+  return `Q${quarter} ${year}`
+}
+
+export function formatLongDate(date: Date) {
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export function getSubmissionCycleInfo() {
+  const { quarter, year } = getSubmissionQuarter()
+  const deadline = getSecondThursdayOfQuarter(quarter, year)
+  const quarterLabel = formatQuarterCycleLabel(quarter, year)
+
+  return {
+    quarter,
+    year,
+    quarterLabel,
+    deadline,
+    deadlineFormatted: formatLongDate(deadline),
+  }
+}

--- a/ui/pages/api/proposals/send-confirmation-email.ts
+++ b/ui/pages/api/proposals/send-confirmation-email.ts
@@ -1,8 +1,10 @@
 import { authMiddleware } from 'middleware/authMiddleware'
 import withMiddleware from 'middleware/withMiddleware'
 import { getMoonDaoGmailTransport, opEmail } from '@/lib/nodemailer/nodemailer'
+import { getSubmissionCycleInfo } from 'lib/utils/dates'
 
 const generateHTML = (proposalId: string, proposalTitle: string) => {
+  const { quarterLabel, deadlineFormatted } = getSubmissionCycleInfo()
   const proposalUrl = `https://moondao.com/project/${proposalId}`
   const townHallCalendar = 'https://lu.ma/moondao'
   const ideationChannel =
@@ -52,9 +54,9 @@ const generateHTML = (proposalId: string, proposalTitle: string) => {
             <!-- Governance Cycle Notice -->
             <tr>
               <td style="background: #dbeafe; border-radius: 12px; padding: 20px; border: 1px solid #93c5fd; margin-bottom: 24px;">
-                <h3 style="color: #1e40af; font-size: 16px; margin: 0 0 8px 0;">📅 Q2 2026 Governance Cycle</h3>
+                <h3 style="color: #1e40af; font-size: 16px; margin: 0 0 8px 0;">📅 ${quarterLabel} Governance Cycle</h3>
                 <p style="color: #1e3a8a; font-size: 14px; margin: 0; line-height: 1.5;">
-                  Your proposal has been submitted for the <strong>Q2 2026</strong> governance cycle. The submission deadline for this cycle is <strong>April 16, 2026</strong>. Voting will begin shortly after the deadline closes.
+                  Your proposal has been submitted for the <strong>${quarterLabel}</strong> governance cycle. The submission deadline for this cycle is <strong>${deadlineFormatted}</strong> (2nd Thursday of the quarter). Voting will begin shortly after the deadline closes.
                 </p>
               </td>
             </tr>
@@ -114,7 +116,7 @@ const generateHTML = (proposalId: string, proposalTitle: string) => {
                     </td>
                     <td valign="top" style="padding-left: 12px;">
                       <h3 style="color: #1a1a2e; font-size: 16px; margin: 0 0 4px 0;">Prepare for Voting</h3>
-                      <p style="color: #666; font-size: 14px; margin: 0; line-height: 1.5;">Once the Q2 submission deadline passes, voting will begin. Ensure you have community support to pass the governance vote.</p>
+                      <p style="color: #666; font-size: 14px; margin: 0; line-height: 1.5;">Once the submission deadline passes for this cycle, voting will begin. Ensure you have community support to pass the governance vote.</p>
                     </td>
                   </tr>
                 </table>


### PR DESCRIPTION
## Summary
- Replace hardcoded Q2 2026 / April 16, 2026 copy in the proposal confirmation email with dynamically computed governance cycle info
- Add date helpers (`getSecondThursdayOfQuarter`, `getSubmissionCycleInfo`) that reuse existing `getSubmissionQuarter()` logic

## Test plan
- [ ] Submit a test proposal with an email address and confirm the confirmation email shows the current quarter label and 2nd-Thursday deadline
- [ ] Verify the on-screen post-submission Next Steps modal is unchanged (still generic Town Hall / Discord guidance)
- [ ] Spot-check that the email no longer references Q2 2026 or April 16, 2026


Made with [Cursor](https://cursor.com)