### PR TITLE
fix(mission): resolve Frank metadata + reopen SSR stage/deadline

### DIFF
--- a/ui/lib/ipfs/gateway.ts
+++ b/ui/lib/ipfs/gateway.ts
@@ -20,44 +20,100 @@ export function getIPFSGateway(ipfsString: string) {
 
   // Return known local asset paths as-is (e.g., /assets/, /images/, etc.)
   const localAssetPaths = ['/assets/', '/images/', '/public/']
-  if (ipfsString.startsWith('/') && localAssetPaths.some((path) => ipfsString.startsWith(path))) {
+  if (
+    ipfsString.startsWith('/') &&
+    localAssetPaths.some((path) => ipfsString.startsWith(path))
+  ) {
     return ipfsString
   }
 
   // Process IPFS hashes (including paths starting with / that aren't local assets)
-  let hash = ipfsString.startsWith('ipfs://') ? ipfsString.split('ipfs://')[1] : ipfsString
+  let hash = ipfsString.startsWith('ipfs://')
+    ? ipfsString.split('ipfs://')[1]
+    : ipfsString
   return `${IPFS_GATEWAY}${hash}`
 }
 
 const IPFS_GATEWAYS = [
   IPFS_GATEWAY,
-  'https://cf-ipfs.com/ipfs/',
   'https://gateway.pinata.cloud/ipfs/',
+  'https://ipfs.io/ipfs/',
+  'https://cloudflare-ipfs.com/ipfs/',
   'https://dweb.link/ipfs/',
 ]
 
-export async function fetchFromIPFSWithFallback(ipfsHash: string, timeout = 3000): Promise<any> {
-  // Normalize hash - remove ipfs:// prefix if present
-  const hash = ipfsHash.startsWith('ipfs://') ? ipfsHash.replace('ipfs://', '') : ipfsHash
+async function readJsonBody(response: Response): Promise<any> {
+  // Pinata (and some other gateways) often serve valid JSON metadata with
+  // Content-Type: text/html. Prefer parsing the body as JSON regardless of
+  // the declared type; only reject clear HTML documents.
+  const raw = await response.text()
+  const trimmed = raw.trim()
+  if (!trimmed) {
+    throw new Error('empty body')
+  }
+  if (trimmed.startsWith('<!DOCTYPE') || trimmed.startsWith('<html')) {
+    throw new Error('HTML document (not JSON metadata)')
+  }
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    throw new Error('body is not JSON')
+  }
+}
+
+/**
+ * Fetch JSON from IPFS, trying multiple gateways.
+ *
+ * Uses AbortController so a slow gateway is cancelled when the timeout fires.
+ * Default timeout is 8s — 3s was too aggressive for Vercel serverless → public
+ * gateway round-trips and was a common cause of "Mission Loading..." fallbacks.
+ *
+ * Important: do NOT reject responses solely because Content-Type is text/html.
+ * MoonDAO's Pinata gateway returns valid JSON metadata with that content type.
+ */
+export async function fetchFromIPFSWithFallback(
+  ipfsHash: string,
+  timeout = 8000
+): Promise<any> {
+  const hash = ipfsHash.startsWith('ipfs://')
+    ? ipfsHash.replace('ipfs://', '')
+    : ipfsHash
+
+  if (!hash || !hash.trim()) {
+    throw new Error('Empty IPFS hash')
+  }
+
+  const errors: string[] = []
 
   for (const gateway of IPFS_GATEWAYS) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeout)
     try {
-      const response = await Promise.race([
-        fetch(`${gateway}${hash}`),
-        new Promise<Response>((_, reject) =>
-          setTimeout(() => reject(new Error('IPFS fetch timeout')), timeout)
-        ),
-      ])
+      const response = await fetch(`${gateway}${hash}`, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json, text/plain, */*' },
+        redirect: 'follow',
+      })
 
-      if (response.ok) {
-        return await response.json()
+      if (!response.ok) {
+        errors.push(`${gateway}: HTTP ${response.status}`)
+        continue
       }
-    } catch (error) {
-      console.warn(`Failed to fetch from gateway ${gateway}:`, error)
-      continue // Try next gateway
+
+      return await readJsonBody(response)
+    } catch (error: any) {
+      const reason =
+        error?.name === 'AbortError'
+          ? 'timeout'
+          : error?.message || String(error)
+      errors.push(`${gateway}: ${reason}`)
+      continue
+    } finally {
+      clearTimeout(timer)
     }
   }
 
-  // All gateways failed
-  throw new Error(`All IPFS gateways failed for hash: ${hash}`)
+  throw new Error(
+    `All IPFS gateways failed for hash: ${hash} (${errors.join('; ')})`
+  )
 }

--- a/ui/lib/mission/extractActiveDataHook.ts
+++ b/ui/lib/mission/extractActiveDataHook.ts
@@ -1,0 +1,32 @@
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+/**
+ * Extract the active ruleset dataHook from a `currentRulesetOf` result.
+ * thirdweb may return either a 2-tuple `[ruleset, metadata]` or a named
+ * object `{ ruleset, metadata }`, and the metadata itself may be a named
+ * object or a positional array.
+ */
+export function extractActiveDataHook(ruleset: any): string | undefined {
+  if (!ruleset) return undefined
+  const metadata = Array.isArray(ruleset)
+    ? ruleset[1]
+    : ruleset?.metadata ?? ruleset?.[1] ?? null
+  if (!metadata) return undefined
+  if (typeof metadata === 'object' && !Array.isArray(metadata)) {
+    const hook = metadata.dataHook
+    return typeof hook === 'string' ? hook : hook?.toString?.()
+  }
+  if (Array.isArray(metadata)) {
+    // JBRulesetMetadata: dataHook is the 18th field (index 17).
+    const hook = metadata[17]
+    return typeof hook === 'string' ? hook : hook?.toString?.()
+  }
+  return undefined
+}
+
+export function isZeroAddress(addr: string | null | undefined): boolean {
+  if (!addr) return true
+  return addr.toLowerCase() === ZERO_ADDRESS
+}
+
+export { ZERO_ADDRESS }

--- a/ui/lib/mission/fetchMissionServerData.ts
+++ b/ui/lib/mission/fetchMissionServerData.ts
@@ -17,6 +17,10 @@ import type { Chain } from 'thirdweb/chains'
 import queryTable from '../tableland/queryTable'
 import { getChainSlug } from '../thirdweb/chain'
 import { serverClient } from '../thirdweb/serverClient'
+import {
+  extractActiveDataHook,
+  ZERO_ADDRESS,
+} from './extractActiveDataHook'
 
 export type MissionRow = {
   id: number
@@ -40,6 +44,7 @@ export type MissionContractData = {
   primaryTerminalAddress: string
   ruleset: any[]
 }
+
 
 /**
  * Fetch mission row from Tableland
@@ -206,21 +211,29 @@ export async function fetchMissionContracts(
       }).catch(() => null),
     ])
 
-  // If the current ruleset's dataHook differs from the original PayHook stored
-  // in MissionCreator, a new refund ruleset may have been queued. Read stage()
-  // from the active dataHook so the UI reflects the actual on-chain state.
+  // Prefer the active ruleset dataHook whenever it differs from the creation-time
+  // PayHook (or when the creation-time mapping is missing/0x0, as with Frank's
+  // mission on the current MissionCreator). That is the live ReopenPayHook after
+  // a re-open, and it is the only source of truth for stage/deadline.
+  const activeDataHook = extractActiveDataHook(ruleset)
+  const payHookStr = (payHookAddress as any)?.toString?.() ?? String(payHookAddress)
+  const useActiveHook =
+    !!activeDataHook &&
+    activeDataHook !== ZERO_ADDRESS &&
+    activeDataHook.toLowerCase() !== payHookStr.toLowerCase()
+
   let stage = missionCreatorStage
-  if (ruleset) {
+  let activePayHookAddress = payHookAddress
+  if (useActiveHook) {
+    activePayHookAddress = activeDataHook as string
     try {
-      const activeDataHook = (ruleset as any)[1]?.dataHook
       if (
-        activeDataHook &&
-        activeDataHook !== '0x0000000000000000000000000000000000000000' &&
-        activeDataHook.toLowerCase() !== payHookAddress.toString().toLowerCase()
+        primaryTerminalAddress &&
+        primaryTerminalAddress !== ZERO_ADDRESS
       ) {
         const activePayHookContract = getContract({
           client: serverClient,
-          address: activeDataHook,
+          address: activeDataHook as string,
           chain: chain,
           abi: LaunchPadPayHookABI.abi as any,
         })
@@ -231,22 +244,18 @@ export async function fetchMissionContracts(
         })
       }
     } catch (err) {
-      console.warn('Failed to read stage from active dataHook, using MissionCreator stage:', err)
+      console.warn(
+        'Failed to read stage from active dataHook, using MissionCreator stage:',
+        err
+      )
     }
-  }
-
-  // Determine which PayHook is actually active on the current ruleset
-  let activePayHookAddress = payHookAddress
-  if (ruleset) {
-    try {
-      const activeDataHook = (ruleset as any)[1]?.dataHook
-      if (
-        activeDataHook &&
-        activeDataHook !== '0x0000000000000000000000000000000000000000'
-      ) {
-        activePayHookAddress = activeDataHook
-      }
-    } catch {}
+  } else if (
+    activeDataHook &&
+    activeDataHook !== ZERO_ADDRESS
+  ) {
+    // Same address as the recorded PayHook — still treat it as the active one
+    // for deadline/time reads.
+    activePayHookAddress = activeDataHook
   }
 
   return {

--- a/ui/lib/mission/useMissionData.tsx
+++ b/ui/lib/mission/useMissionData.tsx
@@ -2,6 +2,10 @@ import LaunchPadPayHookABI from 'const/abis/LaunchPadPayHook.json'
 import { DEFAULT_CHAIN_V5, MISSION_TABLE_NAMES } from 'const/config'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { readContract, getContract } from 'thirdweb'
+import {
+  extractActiveDataHook,
+  isZeroAddress,
+} from './extractActiveDataHook'
 import client from '@/lib/thirdweb/client'
 import useJBProjectData from '../juicebox/useJBProjectData'
 import { useTablelandQuery } from '../swr/useTablelandQuery'
@@ -90,18 +94,19 @@ export default function useMissionData({
             method: 'currentRulesetOf' as string,
             params: [mission.projectId],
           })
-          const activeDataHook = ruleset?.[1]?.dataHook
+          const activeDataHook = extractActiveDataHook(ruleset)
           const originalPayHook: any = await readContract({
             contract: missionCreatorContract,
             method: 'missionIdToPayHook' as string,
             params: [mission.id],
           }).catch(() => null)
+          const originalStr = originalPayHook?.toString?.() ?? ''
 
           if (
             activeDataHook &&
-            activeDataHook !== '0x0000000000000000000000000000000000000000' &&
-            originalPayHook &&
-            activeDataHook.toLowerCase() !== originalPayHook.toString().toLowerCase()
+            !isZeroAddress(activeDataHook) &&
+            (isZeroAddress(originalStr) ||
+              activeDataHook.toLowerCase() !== originalStr.toLowerCase())
           ) {
             // Only call stage() if we have a real terminal address (not zero)
             const zeroAddr = '0x0000000000000000000000000000000000000000'
@@ -194,21 +199,38 @@ export default function useMissionData({
       }
 
       try {
-        const payHookAddressResult: any = await readContract({
-          contract: missionCreatorContract,
-          method: 'missionIdToPayHook' as string,
-          params: [mission.id],
-        }).catch(() => null)
+        // Prefer the active ruleset dataHook (re-open) over the creation-time
+        // MissionCreator mapping, which is 0x0 for Frank on the current creator.
+        let payHookAddress: string | null = null
+        if (jbControllerContract && mission?.projectId) {
+          try {
+            const ruleset: any = await readContract({
+              contract: jbControllerContract,
+              method: 'currentRulesetOf' as string,
+              params: [mission.projectId],
+            })
+            const active = extractActiveDataHook(ruleset)
+            if (active && !isZeroAddress(active)) {
+              payHookAddress = active
+            }
+          } catch {
+            // fall through to MissionCreator mapping
+          }
+        }
 
-        const payHookAddress =
-          typeof payHookAddressResult === 'string'
-            ? payHookAddressResult
-            : payHookAddressResult?.toString?.() ?? null
+        if (!payHookAddress) {
+          const payHookAddressResult: any = await readContract({
+            contract: missionCreatorContract,
+            method: 'missionIdToPayHook' as string,
+            params: [mission.id],
+          }).catch(() => null)
+          payHookAddress =
+            typeof payHookAddressResult === 'string'
+              ? payHookAddressResult
+              : payHookAddressResult?.toString?.() ?? null
+        }
 
-        if (
-          !payHookAddress ||
-          payHookAddress === '0x0000000000000000000000000000000000000000'
-        ) {
+        if (!payHookAddress || isZeroAddress(payHookAddress)) {
           return
         }
 
@@ -241,7 +263,14 @@ export default function useMissionData({
     if (missionCreatorContract && mission?.id !== undefined) {
       getDeadline()
     }
-  }, [missionCreatorContract, mission?.id, _deadline, _refundPeriod])
+  }, [
+    missionCreatorContract,
+    jbControllerContract,
+    mission?.id,
+    mission?.projectId,
+    _deadline,
+    _refundPeriod,
+  ])
 
   // Memoize return object to prevent unnecessary re-renders
   return useMemo(

--- a/ui/lib/mission/useMissionFundingStage.tsx
+++ b/ui/lib/mission/useMissionFundingStage.tsx
@@ -10,8 +10,10 @@ import { getChainSlug } from '../thirdweb/chain'
 import ChainContextV5 from '../thirdweb/chain-context-v5'
 import useContract from '../thirdweb/hooks/useContract'
 import useRead from '../thirdweb/hooks/useRead'
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+import {
+  extractActiveDataHook,
+  isZeroAddress,
+} from './extractActiveDataHook'
 
 /**
  * Returns the current funding stage for a mission.
@@ -61,16 +63,19 @@ export default function useMissionFundingStage(
     deps: [projectId],
   })
 
-  const activeDataHook = (ruleset as any)?.[1]?.dataHook as string | undefined
+  const activeDataHook = extractActiveDataHook(ruleset)
 
-  // Only defer to the active dataHook when it exists, differs from the original
-  // PayHook, and we have the terminal + projectId its stage() call requires.
+  // Prefer the active ruleset dataHook whenever it differs from the creation-time
+  // PayHook — including when the creation-time mapping is missing/0x0 (Frank).
+  const originalStr =
+    typeof originalPayHook === 'string'
+      ? originalPayHook
+      : (originalPayHook as any)?.toString?.() ?? ''
   const useActiveHook =
     !!activeDataHook &&
-    activeDataHook !== ZERO_ADDRESS &&
-    !!originalPayHook &&
-    activeDataHook.toLowerCase() !==
-      (originalPayHook as string).toLowerCase() &&
+    !isZeroAddress(activeDataHook) &&
+    (isZeroAddress(originalStr) ||
+      activeDataHook.toLowerCase() !== originalStr.toLowerCase()) &&
     !!primaryTerminalAddress &&
     projectId != null
 

--- a/ui/pages/mission/[tokenId].tsx
+++ b/ui/pages/mission/[tokenId].tsx
@@ -123,15 +123,46 @@ function parseCookies(cookieHeader?: string): Record<string, string> {
   )
 }
 
+function setNoStoreHeaders(res: {
+  setHeader: (name: string, value: string) => void
+}) {
+  // Cover browser, Vercel CDN, and intermediary caches. Setting only
+  // Cache-Control is not enough on Vercel — CDN-Cache-Control / Vercel-CDN-
+  // Cache-Control can still keep a public HIT of a pre-gate page.
+  const value = 'private, no-store, no-cache, must-revalidate, max-age=0'
+  res.setHeader('Cache-Control', value)
+  res.setHeader('CDN-Cache-Control', value)
+  res.setHeader('Vercel-CDN-Cache-Control', value)
+  res.setHeader('Pragma', 'no-cache')
+  res.setHeader('Expires', '0')
+  // Prevent any intermediary that ignores no-store from serving a
+  // cookie-authenticated response to an anonymous visitor (or vice versa).
+  res.setHeader('Vary', 'Cookie')
+}
+
 export const getServerSideProps: GetServerSideProps = async ({
   params,
   query,
   req,
   res,
 }) => {
-  res.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=120')
-
   const tokenId: any = params?.tokenId
+  const missionIdNumEarly =
+    tokenId !== undefined && !isNaN(Number(tokenId)) ? Number(tokenId) : NaN
+  const isGatedEarly =
+    Number.isFinite(missionIdNumEarly) && GATED_MISSIONS.has(missionIdNumEarly)
+
+  // Decide cache policy BEFORE any early return. Gated missions must never
+  // receive a public Cache-Control — a stale CDN HIT of the pre-gate page is
+  // exactly how /mission/4 stayed publicly reachable after the gate shipped.
+  if (isGatedEarly) {
+    setNoStoreHeaders(res)
+  } else {
+    res.setHeader(
+      'Cache-Control',
+      'public, s-maxage=60, stale-while-revalidate=120'
+    )
+  }
 
   // Handle dummy mission for testing
   if (tokenId === 'dummy') {
@@ -197,10 +228,9 @@ export const getServerSideProps: GetServerSideProps = async ({
     return { notFound: true }
   }
   if (isGated) {
-    // Gated responses (both the 404 and the authorized page) must never be shared by
-    // the CDN, or a cached anonymous 404 could be served to a valid visitor (or vice
-    // versa).
-    res.setHeader('Cache-Control', 'private, no-store')
+    // Headers already set above via isGatedEarly; re-assert so any later
+    // middleware/helper cannot reintroduce a public cache policy.
+    setNoStoreHeaders(res)
 
     const accessCode = process.env.MISSION_ACCESS_CODE
     if (!accessCode) {
@@ -284,14 +314,18 @@ export const getServerSideProps: GetServerSideProps = async ({
             })
           : Promise.resolve(undefined)
 
-      const metadata = await fetchFromIPFSWithFallback(ipfsHash).catch((error: any) => {
-        console.warn('All IPFS gateways failed:', error)
-        return {
-          name: 'Mission Loading...',
-          description: 'Metadata is loading...',
-          logoUri: '',
+      // Longer per-gateway timeout on SSR — 3s was too aggressive from Vercel
+      // regions and left mission pages stuck on the "Mission Loading..." fallback.
+      const metadata = await fetchFromIPFSWithFallback(ipfsHash, 8000).catch(
+        (error: any) => {
+          console.warn('All IPFS gateways failed:', error)
+          return {
+            name: 'Mission Loading...',
+            description: 'Metadata is loading...',
+            logoUri: '',
+          }
         }
-      })
+      )
 
       const tokenData = await fetchTokenMetadata(contractData.tokenAddress, chain)
 


### PR DESCRIPTION
## Summary
- Fix "Mission Loading..." by parsing Pinata JSON even when `Content-Type` is `text/html`, with an 8s AbortController timeout and more gateways.
- Fix Frank SSR stage/deadline: `missionIdToPayHook(4)` is `0x0` on the current MissionCreator, so prefer the active ruleset `dataHook` (`ReopenPayHook`) for stage + deadline on SSR and client.
- Harden gated-mission CDN headers (`private, no-store` + `CDN-Cache-Control` / `Vercel-CDN-Cache-Control` + `Vary: Cookie`) so a stale public cache cannot keep serving `/mission/4`.

## Why production still shows Mission Loading
Live props today: `name: Mission Loading...`, `_stage: 0`, `_deadline: null`, old Tableland goal. On-chain: `uriOf` is fine, `ReopenPayHook.stage=1`, but `MissionCreator.missionIdToPayHook(4)=0x0`. Pinata returns the metadata JSON with `Content-Type: text/html`.

## Test plan
- [ ] After deploy: `/mission/4?access=franktospace` shows **Go to Space with Frank White** (not Mission Loading)
- [ ] SSR `_stage` is `1` and deadline is ~Jan 2028
- [ ] Bare `/mission/4` still 404s without the access cookie
- [ ] Contribute UI still works for authorized visitors

Made with [Cursor](https://cursor.com)