### PR TITLE
fix(mission): ensure signing wallet is on pay chain before contributing

### DIFF
--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -36,7 +36,11 @@ import {
   readContract,
   waitForReceipt,
 } from 'thirdweb'
-import { useActiveAccount } from 'thirdweb/react'
+import {
+  useActiveAccount,
+  useActiveWallet,
+  useActiveWalletChain,
+} from 'thirdweb/react'
 import { useCitizen } from '@/lib/citizen/useCitizen'
 import { getIPFSGateway } from '@/lib/ipfs/gateway'
 import { useOnrampAutoTransaction } from '@/lib/coinbase/useOnrampAutoTransaction'
@@ -257,6 +261,12 @@ export default function MissionContributeModal({
   )
 
   const account = useActiveAccount()
+  // The wallet thirdweb will actually SIGN with. We must switch/verify the
+  // chain on *this* wallet (not `wallets[selectedWallet]`, which can be a
+  // different connector) before sending, otherwise the signing wallet can stay
+  // on the wrong network and the tx fails with "underlying network changed".
+  const activeWallet = useActiveWallet()
+  const activeWalletChain = useActiveWalletChain()
   // In test mode (Cypress), use mock address from window if available
   const mockAddress = typeof window !== 'undefined' && (window as any).__CYPRESS_MOCK_ADDRESS__
   const address = account?.address || mockAddress
@@ -403,32 +413,74 @@ export default function MissionContributeModal({
     [address, fundingBalanceResolved, walletOnPayChain, chains, payChainStable.id]
   )
 
+  /** Live chain id of the wallet thirdweb signs with (falls back to the hook). */
+  const getActiveWalletChainId = useCallback((): number | undefined => {
+    try {
+      return activeWallet?.getChain?.()?.id ?? activeWalletChain?.id
+    } catch {
+      return activeWalletChain?.id
+    }
+  }, [activeWallet, activeWalletChain])
+
   const switchWalletToPayChain = useCallback(async (): Promise<boolean> => {
     const target = chains.find((c) => c.id === payChainStable.id) ?? payChainStable
-    const wallet = wallets?.[selectedWallet]
-    if (!wallet || typeof wallet.switchChain !== 'function') return false
-    try {
+
+    // Already there — nothing to do.
+    if (getActiveWalletChainId() === target.id) return true
+
+    // Switch the *active* (signing) wallet when available; otherwise fall back
+    // to the Privy-selected wallet. Switching the active wallet guarantees the
+    // network change applies to the connector that will sign the contribution.
+    const runSwitch = async (): Promise<void> => {
+      if (activeWallet && typeof activeWallet.switchChain === 'function') {
+        await activeWallet.switchChain(target)
+        return
+      }
+      const wallet = wallets?.[selectedWallet]
+      if (!wallet || typeof wallet.switchChain !== 'function') {
+        throw new Error('No switchable wallet available')
+      }
       await wallet.switchChain(target.id)
-      return true
+    }
+
+    try {
+      await runSwitch()
     } catch (err: any) {
       if (err?.code === 4902 || err?.message?.includes('Unrecognized chain')) {
         const ok = await addNetworkToWallet(target)
-        if (ok) {
-          try {
-            await wallet.switchChain(target.id)
-            return true
-          } catch {
-            return false
-          }
+        if (!ok) return false
+        try {
+          await runSwitch()
+        } catch {
+          return false
         }
-      } else if (err?.code !== 4001) {
+      } else if (err?.code === 4001) {
+        // User rejected the network switch.
+        return false
+      } else {
         toast.error('Failed to switch network. Please try again.', {
           style: toastStyle,
         })
+        return false
       }
-      return false
     }
-  }, [chains, payChainStable, wallets, selectedWallet])
+
+    // Injected wallets (e.g. MetaMask) report the switch asynchronously.
+    // Confirm the signing wallet actually landed on the pay chain before we
+    // build/send the tx — sending too early throws "underlying network changed".
+    for (let i = 0; i < 20; i++) {
+      if (getActiveWalletChainId() === target.id) return true
+      await new Promise((resolve) => setTimeout(resolve, 150))
+    }
+    return getActiveWalletChainId() === target.id
+  }, [
+    chains,
+    payChainStable,
+    wallets,
+    selectedWallet,
+    activeWallet,
+    getActiveWalletChainId,
+  ])
 
   const { effectiveGasPrice } = useGasPrice(payChainStable)
 
@@ -1117,11 +1169,28 @@ export default function MissionContributeModal({
     // Reset rejection state when attempting a new transaction
     setTransactionRejected(false)
 
-    // If wallet is on a different chain than the selected pay network, switch first
-    if (!walletOnPayChain) {
+    // Ensure the wallet that will SIGN is on the pay chain. We check the active
+    // wallet's live chain (not the cached balance chain) because those can
+    // diverge — e.g. MetaMask still on Ethereum while the pay tx targets
+    // Arbitrum, which fails with "underlying network changed" or an
+    // insufficient-gas prompt on the wrong network. Only act when the wallet is
+    // on a *known* different chain: when the chain is unknown (undefined) we let
+    // thirdweb's own switching handle it (embedded wallets, tests) rather than
+    // blocking. If a required switch can't be confirmed, abort with a clear
+    // error instead of signing on the wrong chain.
+    const activeChainId = getActiveWalletChainId()
+    if (activeChainId !== undefined && activeChainId !== payChainStable.id) {
       const switched = await switchWalletToPayChain()
       if (!switched) {
-        return
+        const networkLabel = (payChainStable.name ?? 'the correct network').replace(
+          ' One',
+          ''
+        )
+        toast.error(
+          `Please switch your wallet to ${networkLabel} to complete your contribution.`,
+          { style: toastStyle }
+        )
+        throw new Error(`Wallet is not on the payment network (${networkLabel})`)
       }
       await refetchNativeBalance()
     }
@@ -1456,7 +1525,7 @@ export default function MissionContributeModal({
     newsletterOptIn,
     isOverviewMission,
     toWei,
-    walletOnPayChain,
+    getActiveWalletChainId,
     switchWalletToPayChain,
     refetchNativeBalance,
   ])


### PR DESCRIPTION
## Summary

Fixes Apple Pay (Coinbase onramp) mission contributions failing at the **contribution** step after the wallet is successfully funded.

Funding works and Coinbase delivers ETH to the selected chain, but the on-chain contribution failed with:

```
Error purchasing tokens: Error: underlying network changed
(network={chainId:42161 arbitrum}, detectedNetwork={chainId:1 homestead})
```

The wallet that actually signs (e.g. MetaMask) was still on Ethereum while the pay transaction targeted Arbitrum. On the Ethereum-selected attempt this surfaced as MetaMask's "not enough gas" (funds had landed on the pay chain, not where the wallet was pointed).

The previous guard was unreliable because it:
- switched `wallets[selectedWallet]` and read an ethers-derived balance chain — neither necessarily the wallet thirdweb signs with, and
- silently `return`ed on failure, so the post-onramp auto-flow either sent on the wrong chain or hung on the "Processing Your Contribution" spinner.

## Changes

- Use thirdweb's `useActiveWallet()` / `useActiveWalletChain()` to determine the **signing** wallet's live chain.
- Rewrite `switchWalletToPayChain` to switch the active wallet (fallback to the Privy-selected wallet) and **poll until the switch actually lands** before sending — injected wallets report the switch asynchronously, and sending too early is what triggered `underlying network changed`.
- `buyMissionToken` now verifies the signing wallet is on the pay chain and **throws a clear error** ("Please switch your wallet to Arbitrum…") instead of silently proceeding, so the auto-transaction surfaces a proper failure notice instead of hanging.
- The guard only acts when the wallet is on a *known different* chain, so embedded wallets (auto-switched by thirdweb) and tests aren't blocked.

## Test plan

- [ ] US user, Apple Pay fund on **Arbitrum** with wallet initially on Ethereum → after funding, contribution auto-switches wallet to Arbitrum and completes.
- [ ] Same flow selecting **Ethereum** → wallet ends up on Ethereum (origin chain) and the cross-chain pay completes.
- [ ] Rejecting the network switch shows a clear "switch your wallet" error rather than a stuck spinner.
- [ ] Normal (already-funded, correct-chain) contribution still works with no extra prompt.

## Notes

The console for this session also showed heavy RPC degradation (`/api/rpc/gas-price` → 500, thirdweb insight → 401, bendystraw `.../undefined/graphql` → 401, plus 429 rate-limits). Those look like missing/invalid API keys in the environment and can independently break contributions (a failing gas-price API also zeroes the gas headroom in the onramp funding calc). They're out of scope for this PR but worth verifying in the deploy env.

Made with [Cursor](https://cursor.com)