### PR TITLE
fix(mission): survive rate-limited RPC during contribution

### DIFF
--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -482,7 +482,8 @@ export default function MissionContributeModal({
     getActiveWalletChainId,
   ])
 
-  const { effectiveGasPrice } = useGasPrice(payChainStable)
+  const { effectiveGasPrice, maxFeePerGas, maxPriorityFeePerGas } =
+    useGasPrice(payChainStable)
 
   // Check if LayerZero quote exceeds the protocol limit
   const layerZeroLimitExceeded = useMemo(() => {
@@ -1197,21 +1198,63 @@ export default function MissionContributeModal({
 
     try {
       flushSync(() => setContributeButtonPhase('wallet'))
+
+      // Explicit gas fields let thirdweb skip its own RPC lookups
+      // (eth_estimateGas + eth_getBlockByNumber) when serializing the tx.
+      // Those lookups hit the primary browser RPC, which can be rate-limited
+      // (429) — previously that aborted the contribution with "Block not
+      // found" even though the wallet could broadcast fine. The values come
+      // from our server gas APIs (which have RPC fallback) and are the same
+      // buffered numbers the modal already shows and budgets for.
+      const gasOverrides: {
+        gas?: bigint
+        maxFeePerGas?: bigint
+        maxPriorityFeePerGas?: bigint
+      } = {}
+      if (estimatedGas > BigInt(0)) gasOverrides.gas = estimatedGas
+      if (
+        maxFeePerGas &&
+        maxPriorityFeePerGas &&
+        maxFeePerGas > BigInt(0) &&
+        maxPriorityFeePerGas >= BigInt(0)
+      ) {
+        gasOverrides.maxFeePerGas = maxFeePerGas
+        gasOverrides.maxPriorityFeePerGas = maxPriorityFeePerGas
+      }
+
       let receipt: any
       if (chainSlug !== defaultChainSlug) {
-        const quoteCrossChainPay: any = await readContract({
-          contract: crossChainPayContract,
-          method: 'quoteCrossChainPay' as string,
-          params: [
-            LAYERZERO_SOURCE_CHAIN_TO_DESTINATION_EID[chainSlug].toString(),
-            toWei(inputValue),
-            mission?.projectId,
-            address || ZERO_ADDRESS,
-            toWei(output),
-            message,
-            '0x00',
-          ],
-        })
+        // The fresh LayerZero quote read can fail when the browser RPC is
+        // rate-limited. Fall back to the cached quote already fetched for the
+        // fee display instead of aborting the whole contribution.
+        let quoteCrossChainPay: bigint
+        try {
+          quoteCrossChainPay = BigInt(
+            await readContract({
+              contract: crossChainPayContract,
+              method: 'quoteCrossChainPay' as string,
+              params: [
+                LAYERZERO_SOURCE_CHAIN_TO_DESTINATION_EID[chainSlug].toString(),
+                toWei(inputValue),
+                mission?.projectId,
+                address || ZERO_ADDRESS,
+                toWei(output),
+                message,
+                '0x00',
+              ],
+            })
+          )
+        } catch (quoteError) {
+          if (crossChainQuote > BigInt(0)) {
+            console.warn(
+              'quoteCrossChainPay read failed; using cached quote:',
+              quoteError
+            )
+            quoteCrossChainPay = crossChainQuote
+          } else {
+            throw quoteError
+          }
+        }
         const transaction = prepareContractCall({
           contract: crossChainPayContract,
           method: 'crossChainPay' as string,
@@ -1224,7 +1267,8 @@ export default function MissionContributeModal({
             message,
             '0x00',
           ],
-          value: BigInt(quoteCrossChainPay),
+          value: quoteCrossChainPay,
+          ...gasOverrides,
         })
 
         const submittedOrigin = await sendTransaction({
@@ -1374,6 +1418,7 @@ export default function MissionContributeModal({
             '0x00',
           ],
           value: toWei(inputValue),
+          ...gasOverrides,
         })
 
         const submittedPay = await sendTransaction({
@@ -1528,6 +1573,10 @@ export default function MissionContributeModal({
     getActiveWalletChainId,
     switchWalletToPayChain,
     refetchNativeBalance,
+    estimatedGas,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    crossChainQuote,
   ])
 
   // Calculate quote when payment amount or ruleset changes (aligned with USD → ETH, not rounded `input`)

--- a/ui/lib/juicebox/tokenCalculations.ts
+++ b/ui/lib/juicebox/tokenCalculations.ts
@@ -1,6 +1,27 @@
 import { FixedInt } from 'fpnum'
 import { getTokenAToBQuote, ReservedPercent, RulesetWeight } from 'juice-sdk-core'
 
+/**
+ * Convert to bigint, tolerating JS numbers in scientific notation. Juicebox
+ * weights are typically 1e21, whose Number#toString() is "1e+21" — a string
+ * BigInt() rejects with "Cannot convert 1e+21 to a BigInt".
+ */
+function toBigIntSafe(value: string | number | bigint): bigint {
+  if (typeof value === 'bigint') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return BigInt(0)
+    if (Number.isSafeInteger(value)) return BigInt(value)
+    // Large numbers (beyond 2^53) stringify in exponent form; toLocaleString
+    // with fullwide renders all digits instead.
+    return BigInt(
+      value.toLocaleString('fullwide', { useGrouping: false, maximumFractionDigits: 0 })
+    )
+  }
+  const str = value.trim()
+  if (/e/i.test(str)) return toBigIntSafe(Number(str))
+  return BigInt(str)
+}
+
 export function calculateTokensFromPayment(
   paymentAmount: string | bigint,
   ruleset: readonly any[]
@@ -8,14 +29,10 @@ export function calculateTokensFromPayment(
   if (!paymentAmount || !ruleset || !ruleset[0] || !ruleset[1]) return '0'
 
   try {
-    const payment = new FixedInt(BigInt(paymentAmount.toString()), 18)
-    
-    const weightValue = typeof ruleset[0].weight === 'bigint' 
-      ? ruleset[0].weight
-      : BigInt(ruleset[0].weight.toString())
-    const reservedPercentValue = typeof ruleset[1].reservedPercent === 'bigint'
-      ? ruleset[1].reservedPercent
-      : BigInt(ruleset[1].reservedPercent.toString())
+    const payment = new FixedInt(toBigIntSafe(paymentAmount), 18)
+
+    const weightValue = toBigIntSafe(ruleset[0].weight)
+    const reservedPercentValue = toBigIntSafe(ruleset[1].reservedPercent)
     
     const weight = new RulesetWeight(weightValue)
     const reservedPercent = new ReservedPercent(reservedPercentValue)

--- a/ui/lib/rpc/serverJsonRpc.ts
+++ b/ui/lib/rpc/serverJsonRpc.ts
@@ -1,0 +1,114 @@
+/**
+ * Server-side JSON-RPC with per-chain fallback endpoints.
+ *
+ * The app's primary RPC (Infura) can hit its rate limit (HTTP 429), which used
+ * to make /api/rpc/* routes return 500 and broke gas estimation for mission
+ * contributions. Each call tries the primary key first, then public endpoints.
+ * Server-only: public endpoints here are not subject to the browser CSP.
+ */
+
+const infuraKey = process.env.NEXT_PUBLIC_INFURA_KEY
+
+function usableUrl(u: string): boolean {
+  return typeof u === 'string' && u.length > 0 && !u.includes('undefined')
+}
+
+const INFURA_SUBDOMAINS: Record<number, string> = {
+  1: 'mainnet',
+  42161: 'arbitrum-mainnet',
+  8453: 'base-mainnet',
+  11155111: 'sepolia',
+  421614: 'arbitrum-sepolia',
+  11155420: 'optimism-sepolia',
+}
+
+const PUBLIC_RPC_URLS: Record<number, string[]> = {
+  1: [
+    'https://cloudflare-eth.com',
+    'https://ethereum.publicnode.com',
+    'https://eth.llamarpc.com',
+    'https://1rpc.io/eth',
+  ],
+  42161: ['https://arb1.arbitrum.io/rpc', 'https://arbitrum-one.publicnode.com'],
+  8453: ['https://mainnet.base.org', 'https://base.publicnode.com'],
+  11155111: ['https://rpc.sepolia.org', 'https://ethereum-sepolia.publicnode.com'],
+  421614: ['https://sepolia-rollup.arbitrum.io/rpc'],
+  11155420: ['https://sepolia.optimism.io'],
+}
+
+export function serverRpcUrlsForChain(chainId: number): string[] {
+  const infuraSubdomain = INFURA_SUBDOMAINS[chainId]
+  const infuraUrl =
+    infuraSubdomain && infuraKey
+      ? `https://${infuraSubdomain}.infura.io/v3/${infuraKey}`
+      : ''
+  return [infuraUrl, ...(PUBLIC_RPC_URLS[chainId] ?? [])].filter(usableUrl)
+}
+
+export function isSupportedRpcChain(chainId: number): boolean {
+  return serverRpcUrlsForChain(chainId).length > 0
+}
+
+/** JSON-RPC error returned by a node (e.g. execution revert), as opposed to a transport failure. */
+export class JsonRpcNodeError extends Error {}
+
+type JsonRpcOptions = {
+  timeoutMs?: number
+  /**
+   * When true, a node-level JSON-RPC error (e.g. estimateGas revert) aborts
+   * immediately instead of trying the next endpoint, since the call would
+   * fail identically everywhere.
+   */
+  abortOnNodeError?: boolean
+}
+
+/**
+ * Run a JSON-RPC call against the chain's endpoints in order, returning the
+ * first successful `result`. Throws only when every endpoint fails (or on a
+ * node error with `abortOnNodeError`).
+ */
+export async function jsonRpcWithFallback(
+  chainId: number,
+  method: string,
+  params: unknown[],
+  { timeoutMs = 20_000, abortOnNodeError = false }: JsonRpcOptions = {}
+): Promise<any> {
+  const urls = serverRpcUrlsForChain(chainId)
+  if (urls.length === 0) {
+    throw new Error(`Unsupported chain ID: ${chainId}`)
+  }
+
+  let lastError: Error | null = null
+  for (const url of urls) {
+    let data: any
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 }),
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+      if (!response.ok) {
+        lastError = new Error(`RPC request failed: ${response.status}`)
+        continue
+      }
+      data = await response.json()
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error('Unknown RPC error')
+      continue
+    }
+
+    if (data?.error) {
+      lastError = new JsonRpcNodeError(data.error.message || 'RPC error')
+      if (abortOnNodeError) throw lastError
+      continue
+    }
+    if (data?.result === undefined || data?.result === null) {
+      lastError = new Error(`No result returned for ${method}`)
+      continue
+    }
+    return data.result
+  }
+
+  throw lastError ?? new Error(`All RPC endpoints failed for ${method}`)
+}

--- a/ui/pages/api/rpc/estimate-gas.ts
+++ b/ui/pages/api/rpc/estimate-gas.ts
@@ -6,23 +6,16 @@ import {
 import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
 import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  isSupportedRpcChain,
+  jsonRpcWithFallback,
+} from '@/lib/rpc/serverJsonRpc'
 
 type EstimateGasResponse = {
   gasEstimate: string // in hex
   gasEstimateDecimal: string
   chainId: number
   error?: string
-}
-
-const infuraKey = process.env.NEXT_PUBLIC_INFURA_KEY
-
-const CHAIN_RPC_URLS: { [key: number]: string } = {
-  1: `https://mainnet.infura.io/v3/${infuraKey}`,
-  42161: `https://arbitrum-mainnet.infura.io/v3/${infuraKey}`,
-  8453: `https://base-mainnet.infura.io/v3/${infuraKey}`,
-  11155111: `https://sepolia.infura.io/v3/${infuraKey}`,
-  421614: `https://arbitrum-sepolia.infura.io/v3/${infuraKey}`,
-  11155420: `https://optimism-sepolia.infura.io/v3/${infuraKey}`,
 }
 
 const FROM_ADDRESSES: { [key: number]: string } = {
@@ -83,19 +76,7 @@ export async function handler(
     })
   }
 
-  const rpcUrl = CHAIN_RPC_URLS[chainId]
-
-  if (!infuraKey) {
-    console.error('NEXT_PUBLIC_INFURA_KEY is not set')
-    return res.status(500).json({
-      gasEstimate: '0x0',
-      gasEstimateDecimal: '0',
-      chainId,
-      error: 'Infura API key not configured',
-    })
-  }
-
-  if (!rpcUrl) {
+  if (!isSupportedRpcChain(chainId)) {
     return res.status(400).json({
       gasEstimate: '0x0',
       gasEstimateDecimal: '0',
@@ -104,46 +85,27 @@ export async function handler(
     })
   }
 
-  const RPC_TIMEOUT_MS = 20_000
-
   try {
-    let response = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        method: 'eth_estimateGas',
-        params: [
-          {
-            from,
-            to,
-            data,
-            ...(value && { value }),
-          },
-        ],
-        id: 1,
-      }),
-      signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
-    })
+    // A node-level error (execution revert) would be identical on every
+    // endpoint, so abort instead of retrying the fallbacks.
+    const result: string = await jsonRpcWithFallback(
+      chainId,
+      'eth_estimateGas',
+      [
+        {
+          from,
+          to,
+          data,
+          ...(value && { value }),
+        },
+      ],
+      { abortOnNodeError: true }
+    )
 
-    if (!response.ok) {
-      throw new Error(`RPC request failed: ${response.status}`)
-    }
-
-    let responseData = await response.json()
-
-    if (responseData.error) {
-      throw new Error(responseData.error.message || 'RPC error')
-    }
-
-    if (!responseData.result) {
-      throw new Error('No gas estimate returned from RPC')
-    }
-
-    const gasEstimateDecimal = BigInt(responseData.result).toString()
+    const gasEstimateDecimal = BigInt(result).toString()
 
     return res.status(200).json({
-      gasEstimate: responseData.result,
+      gasEstimate: result,
       gasEstimateDecimal,
       chainId,
     })

--- a/ui/pages/api/rpc/gas-price.ts
+++ b/ui/pages/api/rpc/gas-price.ts
@@ -1,6 +1,10 @@
 import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
 import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  isSupportedRpcChain,
+  jsonRpcWithFallback,
+} from '@/lib/rpc/serverJsonRpc'
 
 type GasPriceResponse = {
   gasPrice: string // in wei (hex string)
@@ -14,18 +18,6 @@ type GasPriceResponse = {
   baseFeePerGasGwei?: string
   chainId: number
   error?: string
-}
-
-// Construct RPC URLs directly to ensure env vars work in API routes
-const infuraKey = process.env.NEXT_PUBLIC_INFURA_KEY
-
-const CHAIN_RPC_URLS: { [key: number]: string } = {
-  1: `https://mainnet.infura.io/v3/${infuraKey}`,
-  42161: `https://arbitrum-mainnet.infura.io/v3/${infuraKey}`,
-  8453: `https://base-mainnet.infura.io/v3/${infuraKey}`,
-  11155111: `https://sepolia.infura.io/v3/${infuraKey}`,
-  421614: `https://arbitrum-sepolia.infura.io/v3/${infuraKey}`,
-  11155420: `https://optimism-sepolia.infura.io/v3/${infuraKey}`,
 }
 
 export async function handler(
@@ -53,19 +45,8 @@ export async function handler(
   }
 
   const chainIdNum = parseInt(chainId)
-  const rpcUrl = CHAIN_RPC_URLS[chainIdNum]
 
-  if (!infuraKey) {
-    console.error('NEXT_PUBLIC_INFURA_KEY is not set')
-    return res.status(500).json({
-      gasPrice: '0',
-      gasPriceGwei: '0',
-      chainId: chainIdNum,
-      error: 'Infura API key not configured',
-    })
-  }
-
-  if (!rpcUrl) {
+  if (!isSupportedRpcChain(chainIdNum)) {
     return res.status(400).json({
       gasPrice: '0',
       gasPriceGwei: '0',
@@ -75,32 +56,13 @@ export async function handler(
   }
 
   try {
-    const gasPriceResponse = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        method: 'eth_gasPrice',
-        params: [],
-        id: 1,
-      }),
-    })
+    const gasPriceResult: string = await jsonRpcWithFallback(
+      chainIdNum,
+      'eth_gasPrice',
+      []
+    )
 
-    if (!gasPriceResponse.ok) {
-      throw new Error(`RPC request failed: ${gasPriceResponse.status}`)
-    }
-
-    const gasPriceData = await gasPriceResponse.json()
-
-    if (gasPriceData.error) {
-      throw new Error(gasPriceData.error.message || 'RPC error')
-    }
-
-    if (!gasPriceData.result) {
-      throw new Error('No gas price returned from RPC')
-    }
-
-    const gasPriceWei = BigInt(gasPriceData.result)
+    const gasPriceWei = BigInt(gasPriceResult)
     const gasPriceGwei = Number(gasPriceWei) / 1e9
 
     // Fetch EIP-1559 fee data for chains that support it
@@ -110,41 +72,22 @@ export async function handler(
 
     try {
       // Get latest block for base fee
-      const blockResponse = await fetch(rpcUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'eth_getBlockByNumber',
-          params: ['latest', false],
-          id: 2,
-        }),
-      })
-
-      if (blockResponse.ok) {
-        const blockData = await blockResponse.json()
-        if (blockData.result?.baseFeePerGas) {
-          baseFeePerGas = BigInt(blockData.result.baseFeePerGas)
-        }
+      const block = await jsonRpcWithFallback(chainIdNum, 'eth_getBlockByNumber', [
+        'latest',
+        false,
+      ])
+      if (block?.baseFeePerGas) {
+        baseFeePerGas = BigInt(block.baseFeePerGas)
       }
 
       // Get max priority fee per gas recommendation
-      const priorityFeeResponse = await fetch(rpcUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'eth_maxPriorityFeePerGas',
-          params: [],
-          id: 3,
-        }),
-      })
-
-      if (priorityFeeResponse.ok) {
-        const priorityFeeData = await priorityFeeResponse.json()
-        if (priorityFeeData.result) {
-          maxPriorityFeePerGas = BigInt(priorityFeeData.result)
-        }
+      const priorityFee = await jsonRpcWithFallback(
+        chainIdNum,
+        'eth_maxPriorityFeePerGas',
+        []
+      )
+      if (priorityFee) {
+        maxPriorityFeePerGas = BigInt(priorityFee)
       }
 
       // If both base fee and priority fee are available, calculate max fee
@@ -160,7 +103,7 @@ export async function handler(
     }
 
     const response: GasPriceResponse = {
-      gasPrice: gasPriceData.result,
+      gasPrice: gasPriceResult,
       gasPriceGwei: gasPriceGwei.toFixed(2),
       chainId: chainIdNum,
     }


### PR DESCRIPTION
## Summary
- Adds server-side RPC fallback for `/api/rpc/gas-price` and `/api/rpc/estimate-gas` so mission contributions keep working when the primary Infura key returns 429
- Passes explicit gas and EIP-1559 fee overrides into `buyMissionToken` so thirdweb does not call `eth_estimateGas` / `eth_getBlockByNumber` on the rate-limited browser RPC at send time
- Reuses the cached LayerZero quote when a fresh `quoteCrossChainPay` read fails during the post-onramp auto-contribution flow
- Fixes `calculateTokensFromPayment` for Juicebox weights in scientific notation (`1e+21`)

## Context
Follow-up to #1439, which merged the wallet chain-switch fix. The remaining Apple Pay contribution failures were caused by Infura rate limits (`429`) cascading into `Block not found` and `reading 'buffer'` errors during transaction preparation.

## Test plan
- [ ] Fund wallet via Apple Pay on a mission contribution
- [ ] Confirm auto-contribution completes after onramp reload (no "Failed to purchase tokens")
- [ ] Verify `/api/rpc/gas-price?chainId=42161` and `chainId=1` return 200 when Infura is rate-limited
- [ ] Test cross-chain contribution (Ethereum → Arbitrum) and confirm cached LayerZero quote is used if live quote read fails
- [ ] Confirm token quote displays correctly (no `Cannot convert 1e+21 to a BigInt` in console)


Made with [Cursor](https://cursor.com)