### PR TITLE
fix(mission): size onramp purchase to wallet gas reserve requirement

### DIFF
--- a/ui/components/mission/MissionContributeAutoTriggeringView.tsx
+++ b/ui/components/mission/MissionContributeAutoTriggeringView.tsx
@@ -30,6 +30,11 @@ export function MissionContributeAutoTriggeringView({
   router,
   formatWithCommas,
 }: MissionContributeAutoTriggeringViewProps) {
+  const isPreparingStep =
+    !!account &&
+    !jwtVerificationError &&
+    (!hasEnoughBalance || isLoadingGasEstimate)
+
   return (
     <div className="flex flex-col items-center justify-center py-12 px-6 space-y-6">
       <div className="w-16 h-16 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
@@ -74,6 +79,15 @@ export function MissionContributeAutoTriggeringView({
           </button>
         )}
       </div>
+
+      {isPreparingStep && (
+        <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4 w-full max-w-md">
+          <p className="text-amber-200/90 text-sm text-center leading-relaxed">
+            One more step after this: you&apos;ll be asked to confirm a transaction in your
+            wallet to complete your contribution.
+          </p>
+        </div>
+      )}
 
       <div className="w-full max-w-md">
         <ProgressBar

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -953,7 +953,10 @@ export default function MissionContributeModal({
 
     let transactionWei: bigint
     if (isCrossChain && crossChainQuote > BigInt(0) && !layerZeroLimitExceeded) {
-      transactionWei = crossChainQuote
+      // The LayerZero quote is re-read fresh at send time and can drift up
+      // between the onramp purchase and the auto-contribution, so budget a
+      // little above the current quote. Any excess simply stays in the wallet.
+      transactionWei = (crossChainQuote * BigInt(103)) / BigInt(100)
     } else {
       const usdNum = Number(cleanUsdInput)
       if (usdInput && ethUsdPrice && Number.isFinite(usdNum) && usdNum > 0) {
@@ -964,8 +967,20 @@ export default function MissionContributeModal({
       }
     }
 
+    // Budget gas at the wallet's reserve price, not the expected price.
+    // Wallets (MetaMask etc.) refuse to sign unless
+    // balance >= value + gasLimit * maxFeePerGas, and the tx we submit uses
+    // maxFeePerGas (~2.4x base fee). Sizing the onramp purchase on
+    // effectiveGasPrice (base + priority) covered the expected cost but left
+    // the balance below the wallet's own check, producing "not enough gas"
+    // right after a successful onramp. The reserve is mostly refunded — the
+    // user only pays the actual fee.
+    const gasPriceForBudget =
+      maxFeePerGas && maxFeePerGas > effectiveGasPrice
+        ? maxFeePerGas
+        : effectiveGasPrice
     const baseGasCostWei =
-      effectiveGasPrice && estimatedGas ? estimatedGas * effectiveGasPrice : BigInt(0)
+      gasPriceForBudget && estimatedGas ? estimatedGas * gasPriceForBudget : BigInt(0)
     const safetyBuffer = BigInt(103) // 3% on gas for base-fee drift
     const gasCostWei = (baseGasCostWei * safetyBuffer) / BigInt(100)
 
@@ -975,6 +990,7 @@ export default function MissionContributeModal({
     ethUsdPrice,
     estimatedGas,
     effectiveGasPrice,
+    maxFeePerGas,
     crossChainQuote,
     chainSlug,
     defaultChainSlug,


### PR DESCRIPTION
## Summary
- Sizes the onramp deficit (`requiredWei`) using `maxFeePerGas` (MetaMask's reserve price) instead of the lower expected gas price, so Apple Pay contributors have enough ETH to pass the wallet's signing check
- Adds a 3% pad on the LayerZero cross-chain quote when budgeting the onramp purchase, since the quote can drift up between funding and auto-contribution

## Context
Follow-up to #1440 (RPC fallback + explicit gas overrides, already merged) and #1439 (wallet chain-switch fix, already merged).

Users completing the post-onramp auto-contribution on **Ethereum cross-chain** were hitting MetaMask "not enough gas" / "Review alert" even after a successful Apple Pay purchase. The onramp bought enough ETH to pay the actual fee, but not enough to satisfy `balance >= value + gasLimit × maxFeePerGas`. The extra headroom stays in the wallet — users only pay the real gas cost.

For a typical ~$10 Ethereum → Arbitrum contribution, the onramp asks for roughly **$0.70–0.75 more** than before (mostly LayerZero quote pad + gas reserve). Same-chain Arbitrum contributions are essentially unchanged.

## Test plan
- [ ] Contribute via Apple Pay on a mission with Ethereum selected — confirm MetaMask no longer shows "Review alert" / insufficient gas after onramp
- [ ] Confirm payment breakdown "need to buy" amount reflects the higher reserve before onramp
- [ ] Verify same-chain Arbitrum contribution still works with minimal extra onramp headroom
- [ ] Confirm excess ETH remains in wallet after a successful contribution


Made with [Cursor](https://cursor.com)