### PR TITLE
fix(mission): harden pre-send wallet chain guard (keep Ethereum)

### DIFF
--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -58,7 +58,7 @@ import { formatEthFiveSigFigs } from '@/lib/mission/formatEthFiveSigFigs'
 import type { FundingChainBalanceEntry } from '@/lib/mission/useMissionDefaultFundingChain'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
 import type { Chain } from '@/lib/rpc/chains'
-import { arbitrum, sepolia, optimismSepolia } from '@/lib/rpc/chains'
+import { arbitrum, ethereum, sepolia, optimismSepolia } from '@/lib/rpc/chains'
 import { useGasPrice } from '@/lib/rpc/useGasPrice'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import { addNetworkToWallet } from '@/lib/thirdweb/addNetworkToWallet'
@@ -132,15 +132,13 @@ export default function MissionContributeModal({
   const isCitizen = useCitizen(DEFAULT_CHAIN_V5)
   const router = useRouter()
   const isTestnet = process.env.NEXT_PUBLIC_CHAIN !== 'mainnet'
-  // Production contributions are same-chain (Arbitrum) only. The cross-chain
-  // LayerZero path from Ethereum repeatedly stranded contributors: the LZ
-  // messaging fee could exceed small contributions, the wallet often sat on a
-  // different network than the payment, and onramp purchases sized without the
-  // fee left wallets unable to sign. Users without ETH fund via Apple Pay /
-  // Google Pay directly on Arbitrum; users with mainnet ETH can bridge.
-  // Testnet keeps two chains so the cross-chain code path stays testable.
+  // Arbitrum + Ethereum are the supported funding chains. Arbitrum is the
+  // default and the same-chain path (cheap, no bridge). Ethereum is kept so
+  // the many contributors who already hold mainnet ETH can pay from there via
+  // the LayerZero cross-chain path. Base was removed earlier (users without
+  // ETH on Base were bouncing).
   const chains = useMemo(
-    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum]),
+    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum, ethereum]),
     [isTestnet]
   )
   const chainSlugs = chains.map((chain) => getChainSlug(chain))
@@ -1204,7 +1202,22 @@ export default function MissionContributeModal({
     // thirdweb's own switching handle it (embedded wallets, tests) rather than
     // blocking. If a required switch can't be confirmed, abort with a clear
     // error instead of signing on the wrong chain.
-    const activeChainId = getActiveWalletChainId()
+    // Resolve the signing wallet's live chain. Right after the onramp page
+    // reload the injected connector (MetaMask etc.) can still be reconnecting
+    // and momentarily report `undefined`. Previously we skipped the whole
+    // guard in that case and fell through to `sendTransaction`, which signs on
+    // whatever chain the wallet happens to be on — that is exactly how an
+    // Ethereum cross-chain tx got fired at a wallet still sitting on Arbitrum
+    // ("likely to fail"). Poll briefly so a real wallet's chain resolves before
+    // we decide. A chain that stays `undefined` means an embedded/mock wallet
+    // (chain-agnostic — thirdweb signs for the tx's chain), so we let it pass.
+    let activeChainId = getActiveWalletChainId()
+    if (activeChainId === undefined) {
+      for (let i = 0; i < 20 && activeChainId === undefined; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 150))
+        activeChainId = getActiveWalletChainId()
+      }
+    }
     if (activeChainId !== undefined && activeChainId !== payChainStable.id) {
       const switched = await switchWalletToPayChain()
       if (!switched) {
@@ -1982,10 +1995,7 @@ export default function MissionContributeModal({
                     <span className="font-semibold text-cyan-200">
                       {(payChainStable.name ?? 'network').replace(' One', '')}
                     </span>
-                    .{' '}
-                    {chains.length === 1
-                      ? "Use the button to switch your wallet — it's one click and costs nothing."
-                      : 'Use the button to switch your wallet, or pick another network in the selector.'}
+                    . Use the button to switch your wallet, or pick another network in the selector.
                   </p>
                   <div className="mt-3 flex flex-wrap items-center gap-3">
                     <StandardButton
@@ -2022,56 +2032,33 @@ export default function MissionContributeModal({
                 <label className="text-gray-300 font-medium text-sm uppercase tracking-wider">
                   Network
                 </label>
-                {chains.length === 1 ? (
-                  /* Single supported funding chain — show it as a static row
-                     instead of a one-option dropdown, so contributors never
-                     have to make (or second-guess) a network choice. */
-                  <div className="flex items-center gap-2">
-                    <div className="flex-1 min-w-0 flex items-center gap-3 p-3 bg-black/20 rounded-2xl border border-white/5 sm:max-w-[250px]">
-                      <Image
-                        className="h-6 w-6"
-                        src={`/icons/networks/${getChainSlug(payChainStable)}.svg`}
-                        width={24}
-                        height={24}
-                        alt={payChainStable.name || ''}
-                      />
-                      <span className="text-white text-sm font-medium">
-                        {(payChainStable.name ?? 'Arbitrum').replace(' One', '')}
-                      </span>
-                    </div>
-                    <Tooltip
-                      text="Contributions run on Arbitrum, an Ethereum network with near-zero fees. If you pay by card we'll deliver ETH straight to your wallet on Arbitrum — no network choice needed."
-                      compact
-                    >
-                      ?
-                    </Tooltip>
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 min-w-0">
+                    <NetworkSelector
+                      chains={chains}
+                      align="left"
+                      displayChain={
+                        !userChosePayChainInModal &&
+                        fundingDisplayChain != null &&
+                        selectedChain.id !== fundingDisplayChain.id
+                          ? fundingDisplayChain
+                          : undefined
+                      }
+                      onUserSelectChain={() =>
+                        setUserChosePayChainInModal(true)
+                      }
+                    />
                   </div>
-                ) : (
-                  <div className="flex items-center gap-2">
-                    <div className="flex-1 min-w-0">
-                      <NetworkSelector
-                        chains={chains}
-                        align="left"
-                        displayChain={
-                          !userChosePayChainInModal &&
-                          fundingDisplayChain != null &&
-                          selectedChain.id !== fundingDisplayChain.id
-                            ? fundingDisplayChain
-                            : undefined
-                        }
-                        onUserSelectChain={() =>
-                          setUserChosePayChainInModal(true)
-                        }
-                      />
-                    </div>
-                    <Tooltip
-                      text="Not sure what network? Choose whichever chain you have ETH on. If you don't have ETH then choose Arbitrum."
-                      compact
-                    >
-                      ?
-                    </Tooltip>
-                  </div>
-                )}
+                  {/* Help text aimed at first-time contributors who aren't
+                      sure which network to pick. If you don't have ETH,
+                      Arbitrum is the cheapest, most reliable choice. */}
+                  <Tooltip
+                    text="Not sure what network? Choose whichever chain you have ETH on. If you don't have ETH then choose Arbitrum."
+                    compact
+                  >
+                    ?
+                  </Tooltip>
+                </div>
               </div>
 
               {/* Contribution amount — primary input */}

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -58,7 +58,7 @@ import { formatEthFiveSigFigs } from '@/lib/mission/formatEthFiveSigFigs'
 import type { FundingChainBalanceEntry } from '@/lib/mission/useMissionDefaultFundingChain'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
 import type { Chain } from '@/lib/rpc/chains'
-import { arbitrum, ethereum, sepolia, optimismSepolia } from '@/lib/rpc/chains'
+import { arbitrum, sepolia, optimismSepolia } from '@/lib/rpc/chains'
 import { useGasPrice } from '@/lib/rpc/useGasPrice'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import { addNetworkToWallet } from '@/lib/thirdweb/addNetworkToWallet'
@@ -132,11 +132,15 @@ export default function MissionContributeModal({
   const isCitizen = useCitizen(DEFAULT_CHAIN_V5)
   const router = useRouter()
   const isTestnet = process.env.NEXT_PUBLIC_CHAIN !== 'mainnet'
-  // Base was previously offered here but caused confusion / abandonment for
-  // contributors who didn't have ETH on Base. Arbitrum + Ethereum are the
-  // supported funding chains; users on Base will be prompted to switch.
+  // Production contributions are same-chain (Arbitrum) only. The cross-chain
+  // LayerZero path from Ethereum repeatedly stranded contributors: the LZ
+  // messaging fee could exceed small contributions, the wallet often sat on a
+  // different network than the payment, and onramp purchases sized without the
+  // fee left wallets unable to sign. Users without ETH fund via Apple Pay /
+  // Google Pay directly on Arbitrum; users with mainnet ETH can bridge.
+  // Testnet keeps two chains so the cross-chain code path stays testable.
   const chains = useMemo(
-    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum, ethereum]),
+    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum]),
     [isTestnet]
   )
   const chainSlugs = chains.map((chain) => getChainSlug(chain))
@@ -179,9 +183,14 @@ export default function MissionContributeModal({
     stayOnSelectedAppChainRef,
   ])
 
-  /** Stable `Chain` reference for RPC hooks (avoids refetch when context swaps object identity). */
+  /**
+   * Stable `Chain` reference for RPC hooks (avoids refetch when context swaps object identity).
+   * Clamped to the supported funding chains: if the app-wide selection is on an unsupported
+   * network (e.g. Ethereum picked in the header selector), payment still runs on the
+   * mission chain rather than silently re-enabling the cross-chain path.
+   */
   const payChainStable = useMemo(
-    () => chains.find((c) => c.id === payChain.id) ?? payChain,
+    () => chains.find((c) => c.id === payChain.id) ?? chains[0],
     [chains, payChain]
   )
 
@@ -340,8 +349,8 @@ export default function MissionContributeModal({
     refetch: refetchNativeBalance,
   } = useNativeBalance()
   const walletOnPayChain = useMemo(
-    () => nativeBalanceChain != null && nativeBalanceChain.id === payChain.id,
-    [nativeBalanceChain, payChain.id]
+    () => nativeBalanceChain != null && nativeBalanceChain.id === payChainStable.id,
+    [nativeBalanceChain, payChainStable.id]
   )
 
   /** Balance on `payChain` (funding network). RPC when wallet is elsewhere. */
@@ -1018,7 +1027,7 @@ export default function MissionContributeModal({
     if (!ethUsdPrice || fundingBalanceWei === null || !address) return
     const maxUsd = computeContributionMaxUsd({
       balanceWei: fundingBalanceWei,
-      selectedChainId: payChain.id,
+      selectedChainId: payChainStable.id,
       chainSlug,
       defaultChainSlug,
       ethUsdPrice,
@@ -1030,7 +1039,7 @@ export default function MissionContributeModal({
     fundingBalanceWei,
     address,
     chainSlug,
-    payChain.id,
+    payChainStable.id,
     defaultChainSlug,
     formatInputWithCommas,
     setUsdInput,
@@ -1767,8 +1776,15 @@ export default function MissionContributeModal({
         return null
       }
     },
-    getChainSlugFromCache: (restored: any) =>
-      restored?.formData?.chainSlug ?? restored?.chainSlug,
+    getChainSlugFromCache: (restored: any) => {
+      const cached = restored?.formData?.chainSlug ?? restored?.chainSlug
+      // JWTs minted before a chain was removed from the supported list (e.g.
+      // the retired Ethereum cross-chain path) must not auto-fire on a chain
+      // we no longer pay on. Returning undefined makes the hook verify
+      // against the current chain instead, which mismatches the stale JWT
+      // and clears it — the user just sees the normal contribute form.
+      return chainSlugs.includes(cached) ? cached : undefined
+    },
     setSelectedWallet,
     waitForReady: () => {
       return !isLoadingGasEstimate && estimatedGas > BigInt(0) && effectiveGasPrice > BigInt(0)
@@ -1966,7 +1982,10 @@ export default function MissionContributeModal({
                     <span className="font-semibold text-cyan-200">
                       {(payChainStable.name ?? 'network').replace(' One', '')}
                     </span>
-                    . Use the button to switch your wallet, or pick another network in the selector.
+                    .{' '}
+                    {chains.length === 1
+                      ? "Use the button to switch your wallet — it's one click and costs nothing."
+                      : 'Use the button to switch your wallet, or pick another network in the selector.'}
                   </p>
                   <div className="mt-3 flex flex-wrap items-center gap-3">
                     <StandardButton
@@ -2003,36 +2022,56 @@ export default function MissionContributeModal({
                 <label className="text-gray-300 font-medium text-sm uppercase tracking-wider">
                   Network
                 </label>
-                <div className="flex items-center gap-2">
-                  <div className="flex-1 min-w-0">
-                    <NetworkSelector
-                      chains={chains}
-                      align="left"
-                      displayChain={
-                        !userChosePayChainInModal &&
-                        fundingDisplayChain != null &&
-                        selectedChain.id !== fundingDisplayChain.id
-                          ? fundingDisplayChain
-                          : undefined
-                      }
-                      onUserSelectChain={() =>
-                        setUserChosePayChainInModal(true)
-                      }
-                    />
+                {chains.length === 1 ? (
+                  /* Single supported funding chain — show it as a static row
+                     instead of a one-option dropdown, so contributors never
+                     have to make (or second-guess) a network choice. */
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0 flex items-center gap-3 p-3 bg-black/20 rounded-2xl border border-white/5 sm:max-w-[250px]">
+                      <Image
+                        className="h-6 w-6"
+                        src={`/icons/networks/${getChainSlug(payChainStable)}.svg`}
+                        width={24}
+                        height={24}
+                        alt={payChainStable.name || ''}
+                      />
+                      <span className="text-white text-sm font-medium">
+                        {(payChainStable.name ?? 'Arbitrum').replace(' One', '')}
+                      </span>
+                    </div>
+                    <Tooltip
+                      text="Contributions run on Arbitrum, an Ethereum network with near-zero fees. If you pay by card we'll deliver ETH straight to your wallet on Arbitrum — no network choice needed."
+                      compact
+                    >
+                      ?
+                    </Tooltip>
                   </div>
-                  {/* Help text aimed at first-time contributors who aren't
-                      sure which network to pick. Sits to the RIGHT of the
-                      dropdown as a follow-up "?" affordance. Uses the
-                      default 24px Tooltip trigger (no size override) so it
-                      reads as a clearly-tappable help button, larger than
-                      the small inline `?`s elsewhere on the mission card. */}
-                  <Tooltip
-                    text="Not sure what network? Choose whichever chain you have ETH on. If you don't have ETH then choose Arbitrum."
-                    compact
-                  >
-                    ?
-                  </Tooltip>
-                </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0">
+                      <NetworkSelector
+                        chains={chains}
+                        align="left"
+                        displayChain={
+                          !userChosePayChainInModal &&
+                          fundingDisplayChain != null &&
+                          selectedChain.id !== fundingDisplayChain.id
+                            ? fundingDisplayChain
+                            : undefined
+                        }
+                        onUserSelectChain={() =>
+                          setUserChosePayChainInModal(true)
+                        }
+                      />
+                    </div>
+                    <Tooltip
+                      text="Not sure what network? Choose whichever chain you have ETH on. If you don't have ETH then choose Arbitrum."
+                      compact
+                    >
+                      ?
+                    </Tooltip>
+                  </div>
+                )}
               </div>
 
               {/* Contribution amount — primary input */}
@@ -2148,7 +2187,7 @@ export default function MissionContributeModal({
                           </span>
                         )}
                       <span className="text-gray-500 text-[11px] sm:text-xs ml-1">
-                        on {(payChain.name ?? 'network').replace(' One', '')}
+                        on {(payChainStable.name ?? 'network').replace(' One', '')}
                         {!walletOnPayChain && fundingBalanceResolved ? (
                           <span className="text-cyan-400/90"> — switch wallet to this network to pay</span>
                         ) : null}
@@ -2259,7 +2298,7 @@ export default function MissionContributeModal({
                 <div className="flex flex-col items-center justify-center gap-3 py-10 text-gray-400">
                   <LoadingSpinner width="w-8" height="h-8" />
                   <p className="text-sm text-center max-w-sm">
-                    Checking your ETH balance on {(payChain.name ?? 'this network').replace(' One', '')}…
+                    Checking your ETH balance on {(payChainStable.name ?? 'this network').replace(' One', '')}…
                   </p>
                 </div>
               ) : hasEnoughBalance ? (
@@ -2550,7 +2589,7 @@ export default function MissionContributeModal({
                     <FundOnramp
                       fullWidth
                       address={address || ''}
-                      selectedChain={payChain}
+                      selectedChain={payChainStable}
                       ethAmount={adjustedEthDeficit}
                       isWaitingForGasEstimate={isLoadingGasEstimate}
                       onCoinbaseQuoteCalculated={handleCoinbaseQuote}

--- a/ui/components/mission/MissionProfile.tsx
+++ b/ui/components/mission/MissionProfile.tsx
@@ -166,12 +166,13 @@ export default function MissionProfile({
   const [deployTokenModalEnabled, setDeployTokenModalEnabled] = useState(false)
 
   const isTestnet = process.env.NEXT_PUBLIC_CHAIN !== 'mainnet'
-  // Keep this list in sync with MissionContributeModal — Base was removed
-  // from the supported funding chains (users without ETH on Base were
-  // bouncing). Mission funding-chain detection / "switch to richest chain"
-  // banners therefore won't suggest Base anymore.
+  // Keep this list in sync with MissionContributeModal. Production is
+  // Arbitrum-only: the cross-chain Ethereum path stranded contributors
+  // (LayerZero fees rivaling small contributions, wallet/network mismatches,
+  // underfunded onramp purchases). Testnet keeps two chains so the
+  // cross-chain code path stays testable.
   const chains = useMemo(
-    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum, ethereum]),
+    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum]),
     [isTestnet]
   )
   const chainSlugs = chains.map((chain) => getChainSlug(chain))
@@ -203,7 +204,13 @@ export default function MissionProfile({
    */
   const handleOpenContributeModal = useCallback(
     async (nextUsdInput?: string) => {
-      if (process.env.NEXT_PUBLIC_TEST_ENV !== 'true') {
+      if (chains.length === 1) {
+        // Single supported funding chain: silently align the app network and
+        // open the modal — no richest-chain comparison or confirmation gate.
+        if (selectedChain.id !== chains[0].id) {
+          setSelectedChain(chains[0])
+        }
+      } else if (process.env.NEXT_PUBLIC_TEST_ENV !== 'true') {
         const canResolveRichest =
           !!walletAddress &&
           mission?.projectId != null &&
@@ -236,6 +243,7 @@ export default function MissionProfile({
       _stage,
       chains,
       selectedChain.id,
+      setSelectedChain,
       setUsdInput,
       setContributeModalEnabled,
     ]

--- a/ui/components/mission/MissionProfile.tsx
+++ b/ui/components/mission/MissionProfile.tsx
@@ -166,13 +166,11 @@ export default function MissionProfile({
   const [deployTokenModalEnabled, setDeployTokenModalEnabled] = useState(false)
 
   const isTestnet = process.env.NEXT_PUBLIC_CHAIN !== 'mainnet'
-  // Keep this list in sync with MissionContributeModal. Production is
-  // Arbitrum-only: the cross-chain Ethereum path stranded contributors
-  // (LayerZero fees rivaling small contributions, wallet/network mismatches,
-  // underfunded onramp purchases). Testnet keeps two chains so the
-  // cross-chain code path stays testable.
+  // Keep this list in sync with MissionContributeModal. Arbitrum (default,
+  // same-chain) + Ethereum (cross-chain, for holders of mainnet ETH). Base
+  // was removed (users without ETH on Base were bouncing).
   const chains = useMemo(
-    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum]),
+    () => (isTestnet ? [sepolia, optimismSepolia] : [arbitrum, ethereum]),
     [isTestnet]
   )
   const chainSlugs = chains.map((chain) => getChainSlug(chain))
@@ -204,13 +202,7 @@ export default function MissionProfile({
    */
   const handleOpenContributeModal = useCallback(
     async (nextUsdInput?: string) => {
-      if (chains.length === 1) {
-        // Single supported funding chain: silently align the app network and
-        // open the modal — no richest-chain comparison or confirmation gate.
-        if (selectedChain.id !== chains[0].id) {
-          setSelectedChain(chains[0])
-        }
-      } else if (process.env.NEXT_PUBLIC_TEST_ENV !== 'true') {
+      if (process.env.NEXT_PUBLIC_TEST_ENV !== 'true') {
         const canResolveRichest =
           !!walletAddress &&
           mission?.projectId != null &&
@@ -243,7 +235,6 @@ export default function MissionProfile({
       _stage,
       chains,
       selectedChain.id,
-      setSelectedChain,
       setUsdInput,
       setContributeModalEnabled,
     ]


### PR DESCRIPTION
## Summary
Contributions from mainnet ETH holders (and top-ups) still need the Ethereum cross-chain path, so this **keeps Ethereum** as a funding option and instead fixes the actual cause of the failed/"likely to fail" contributions.

**Root cause:** thirdweb's `sendTransaction` signs on whatever chain the wallet is currently on — it does not force a chain switch. The pre-send guard in `buyMissionToken` was skipped whenever the wallet's chain id read as `undefined`, which happens while an injected connector (MetaMask) reconnects right after the Coinbase onramp page reload. That let an **Ethereum cross-chain tx fire at a wallet still sitting on Arbitrum**, producing MetaMask's "likely to fail" / "insufficient funds for network fees."

**Fix:** the guard now polls briefly for the wallet's chain to resolve before deciding. A real wallet is always switched to (or cleanly blocked off with a toast, never a doomed tx) the payment chain. Embedded/mock wallets (chain-agnostic — thirdweb signs for the tx's chain) still pass through, so tests and Privy embedded flows are unaffected.

Builds on #1441 (gas-reserve budgeting) and #1439 (chain-switch before send).

## Test plan
- [ ] **Arbitrum, no ETH** → Apple Pay funds Arbitrum → same-chain contribution, one signature
- [ ] **Ethereum selected, wallet on Arbitrum** → attempting to contribute switches the wallet to Ethereum (or aborts with a toast if declined) — no "likely to fail" tx on the wrong chain
- [ ] **Ethereum, existing mainnet ETH** → cross-chain contribution succeeds after the wallet is confirmed on Ethereum
- [ ] **Top-up case**: some mainnet ETH + Apple Pay for the rest → funds land on the selected chain, contribution completes
- [ ] Return from onramp while MetaMask is still reconnecting → guard waits for the chain to resolve before sending