### PR TITLE
chore(mission): add $5k off-chain contribution to Frank campaign

### DIFF
--- a/ui/const/missionMilestones.ts
+++ b/ui/const/missionMilestones.ts
@@ -15,7 +15,7 @@ export const MISSION_FUNDING_MILESTONES_USD: Record<number, MissionFundingMilest
 
 /** USD pledged off-chain but counted toward campaign “raised” in the UI (mission id → USD). */
 export const MISSION_OFF_CHAIN_COMMITTED_USD: Partial<Record<number, number>> = {
-  4: 111_500,
+  4: 116_500,
 }
 
 export function getMissionOffChainCommittedUsd(missionId: unknown): number {


### PR DESCRIPTION
## Summary
- Bump Frank’s (mission 4) off-chain committed USD total from $111,500 to $116,500 to reflect an additional $5,000 contribution.

## Test plan
- [ ] Confirm Frank mission raised total in UI includes the updated off-chain amount ($116,500)
- [ ] Confirm tooltip/copy still shows on-chain vs off-chain breakdown correctly


Made with [Cursor](https://cursor.com)