### PR TITLE
fix(mission): keep card/Apple-Pay funding same-chain on Arbitrum

### DIFF
--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1021,6 +1021,36 @@ export default function MissionContributeModal({
       requiredWei > BigInt(0)
   )
 
+  // Card / Apple-Pay funding must stay same-chain. The Coinbase onramp delivers
+  // ETH to the *default* chain (Arbitrum), so if a contributor drops into the
+  // funding path while the modal is pointed at Ethereum, the money lands on
+  // Arbitrum while the contribution is built for the Ethereum cross-chain
+  // contract — the two diverge and the tx fails ("likely to fail" / not enough
+  // gas). Whenever the user lacks enough ETH on the selected chain to complete
+  // the contribution, snap the pay chain back to the default so funding,
+  // quoting, and the contribution all happen on Arbitrum. Users who genuinely
+  // hold enough ETH on Ethereum never enter this branch (hasEnoughBalance is
+  // true) and keep the cross-chain path.
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_TEST_ENV === 'true') return
+    if (!modalEnabled || !address) return
+    if (!fundingBalanceResolved) return
+    if (hasEnoughBalance) return
+    if (payChainStable.id === DEFAULT_CHAIN_V5.id) return
+    const target = chains.find((c) => c.id === DEFAULT_CHAIN_V5.id)
+    if (!target) return
+    setUserChosePayChainInModal(true)
+    setSelectedChain(target)
+  }, [
+    modalEnabled,
+    address,
+    fundingBalanceResolved,
+    hasEnoughBalance,
+    payChainStable.id,
+    chains,
+    setSelectedChain,
+  ])
+
   const applyMaxContribution = useCallback(() => {
     if (!ethUsdPrice || fundingBalanceWei === null || !address) return
     const maxUsd = computeContributionMaxUsd({
@@ -1262,6 +1292,29 @@ export default function MissionContributeModal({
 
       let receipt: any
       if (chainSlug !== defaultChainSlug) {
+        // Never fire a cross-chain tx the wallet can't fund. If the balance on
+        // this (non-default) chain doesn't cover the cross-chain cost, the tx
+        // is doomed ("likely to fail") — this happens when card funding landed
+        // on Arbitrum but the contribution is pointed at Ethereum. Abort with a
+        // clear message instead; the same-chain effect will move the flow to
+        // Arbitrum where the money actually is.
+        if (
+          fundingBalanceWei !== null &&
+          requiredWei > BigInt(0) &&
+          fundingBalanceWei < requiredWei
+        ) {
+          const networkLabel = (payChainStable.name ?? 'this network').replace(
+            ' One',
+            ''
+          )
+          toast.error(
+            `You don't have enough ETH on ${networkLabel} for a cross-chain contribution. Switch the network to Arbitrum to contribute with the ETH you have.`,
+            { style: toastStyle, duration: 8000 }
+          )
+          throw new Error(
+            `Insufficient balance on ${networkLabel} for cross-chain contribution`
+          )
+        }
         // The fresh LayerZero quote read can fail when the browser RPC is
         // rate-limited. Fall back to the cached quote already fetched for the
         // fee display instead of aborting the whole contribution.


### PR DESCRIPTION
## Summary
Fixes the repeated "This transaction is likely to fail" / insufficient-gas errors when contributing after funding with Apple Pay.

**Root cause — chain divergence:** the Coinbase onramp delivers ETH to the default chain (**Arbitrum**), but if the contribute modal is pointed at **Ethereum**, the contribution is built for the Ethereum **cross-chain** contract (`0x32D7c…`). Delivery chain and contribution chain disagree, so the tx tries to spend Ethereum ETH the user doesn't have (it's on Arbitrum) and fails. Switching the wallet to Ethereum (the prior fix) didn't help — there's no ETH there.

## Changes
- **Snap the pay chain to the default (Arbitrum) whenever a contributor lacks enough ETH on the selected chain** and enters the funding path. Funding, quoting, and the contribution then all happen on the same chain. Users who genuinely hold enough ETH on Ethereum never hit this branch (`hasEnoughBalance` is true) and keep the cross-chain path.
- **Defensively abort the cross-chain send** (with a clear toast) if the wallet's balance on that chain can't cover the cross-chain cost — so a doomed tx can never reach the wallet during the brief render window before the snap applies.

Ethereum stays fully supported for contributors who already hold mainnet ETH.

Follow-up to #1442 (keep Ethereum + wallet chain guard), #1441 (gas-reserve budget), #1439 (chain switch before send).

## Test plan
- [ ] **No ETH → Apple Pay**: funds land on Arbitrum, contribution completes same-chain with one signature (no "likely to fail")
- [ ] **ETH on Arbitrum, modal was on Ethereum**: opening/returning snaps to Arbitrum, contributes same-chain
- [ ] **Sufficient ETH on Ethereum, pick Ethereum**: cross-chain contribution still works
- [ ] **Insufficient ETH on Ethereum, pick Ethereum**: no doomed tx — clear toast to switch to Arbitrum
- [ ] Return from onramp while wallet reconnecting → no cross-chain tx fired on the wrong chain

Made with [Cursor](https://cursor.com)