### PR TITLE
fix(dashboard): stop intermittent freeze — citizen redirect loop + RPC request storm

### DIFF
--- a/ui/components/layout/TopNavBar.tsx
+++ b/ui/components/layout/TopNavBar.tsx
@@ -183,10 +183,20 @@ const TopNavBar = ({
                         onMouseLeave={handleDropdownLeave}
                       >
                           <div className="min-w-56 max-w-xs w-full bg-gradient-to-br from-gray-900/98 via-blue-900/95 to-purple-900/90 backdrop-blur-xl border border-white/30 shadow-2xl py-2 px-2 rounded-xl">
+                          {/* Mount dynamic dropdowns only while open: their hooks
+                              (useTeamWearer / useProjectWearer) can trigger the
+                              on-chain role-hat index scan — hundreds of eth_calls —
+                              which must not run on every page load just because the
+                              nav bar exists. Results are cached (5 min TTL), so
+                              reopening is cheap. */}
                           {item.dynamicChildren === 'Teams' ? (
-                            <TeamsNavDropdown variant="desktop" />
+                            openDropdown === item.name ? (
+                              <TeamsNavDropdown variant="desktop" />
+                            ) : null
                           ) : item.dynamicChildren === 'Projects' ? (
-                            <ProjectsNavDropdown variant="desktop" />
+                            openDropdown === item.name ? (
+                              <ProjectsNavDropdown variant="desktop" />
+                            ) : null
                           ) : openDropdown === item.name ? (
                             item.children?.map((child: any, j: number) => {
                               if (!child.href) {

--- a/ui/lib/citizen/CitizenProvider.tsx
+++ b/ui/lib/citizen/CitizenProvider.tsx
@@ -235,6 +235,17 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
       citizenRef.current = cachedData
       setCitizen(cachedData)
     } else {
+      // If the in-memory citizen belongs to a different wallet (wallet switch
+      // with no cache for the new address), drop it. Otherwise the data
+      // effect's error branch reads citizenRef and treats the new wallet as
+      // a citizen because the old wallet's NFT is still there.
+      const existing = citizenRef.current
+      const existingOwner =
+        typeof existing?.owner === 'string' ? existing.owner : ''
+      if (existingOwner && existingOwner.toLowerCase() !== address.toLowerCase()) {
+        citizenRef.current = undefined
+        setCitizen(undefined)
+      }
       if (authenticated && user && isDefaultChain) {
         setIsLoading(true)
       } else if (authenticated && user && !isDefaultChain) {

--- a/ui/lib/citizen/CitizenProvider.tsx
+++ b/ui/lib/citizen/CitizenProvider.tsx
@@ -185,6 +185,13 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
   const account = useActiveAccount()
   const { authenticated, user } = usePrivy()
   const hasLoadedNonDefaultCache = useRef(false)
+  // Mirror of `citizen` readable inside effects without adding it to their
+  // dependency arrays (doing so would re-run the data effect after every
+  // setCitizen and loop, since citizenRowToNFT returns a new object each time).
+  const citizenRef = useRef<any>()
+  useEffect(() => {
+    citizenRef.current = citizen
+  }, [citizen])
 
   const address = account?.address
   const chainId = selectedChain?.id
@@ -240,6 +247,7 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
   const {
     data: citizenData,
     isLoading: isLoadingQuery,
+    error: citizenQueryError,
     mutate,
   } = useTablelandQuery(statement, {
     revalidateOnFocus: false,
@@ -304,6 +312,19 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
       return
     }
 
+    // A failed query (Tableland 429/5xx, our own API rate limit, network blip)
+    // is NOT evidence the user isn't a citizen. Treating it as such used to
+    // set citizen=undefined and poison the localStorage cache, which made
+    // /dashboard bounce the user to / and back in a loop — each bounce
+    // remounting the whole page and re-firing hundreds of RPC calls until the
+    // tab froze. On error: keep the last-known citizen (from cache or a prior
+    // successful query) and, if we have none, stay in "loading" while SWR
+    // retries in the background so route guards don't redirect on unknown.
+    if (citizenQueryError && !citizenData) {
+      setIsLoading(!citizenRef.current)
+      return
+    }
+
     setIsLoading(false)
 
     if (!citizenData || citizenData.length === 0) {
@@ -335,6 +356,7 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
   }, [
     citizenData,
     isLoadingQuery,
+    citizenQueryError,
     authenticated,
     user,
     address,

--- a/ui/lib/citizen/CitizenProvider.tsx
+++ b/ui/lib/citizen/CitizenProvider.tsx
@@ -228,6 +228,11 @@ export default function CitizenProvider({ selectedChain, children, mock = false 
     const cachedData = getCachedCitizen(address, cacheChainId)
 
     if (cachedData) {
+      // Sync the ref immediately so the data effect (which runs later in this
+      // same commit) can see the cached citizen even before React re-renders.
+      // Without this, a same-tick Tableland error would set isLoading=true and
+      // never clear it, because the data effect doesn't re-run on `citizen`.
+      citizenRef.current = cachedData
       setCitizen(cachedData)
     } else {
       if (authenticated && user && isDefaultChain) {

--- a/ui/lib/rpc/chains.ts
+++ b/ui/lib/rpc/chains.ts
@@ -26,15 +26,34 @@ const ankrRpcs = {
   base: `${ankrRpcBase}/base/${ankrApiKey}`,
 }
 
-const mainnetRpc =
-  process.env.NEXT_PUBLIC_RPC === 'ankr' ? ankrRpcs : infuraRpcs
+const useAnkr = process.env.NEXT_PUBLIC_RPC === 'ankr'
+const mainnetRpc = useAnkr ? ankrRpcs : infuraRpcs
+
+/**
+ * Browser reads go through `/api/rpc/<chainId>`, which tries Infura then public
+ * fallbacks (see `serverJsonRpc.proxyJsonRpcRequest`). That keeps the signed-in
+ * dashboard alive when the shared Infura key returns HTTP 429.
+ *
+ * Server-side code keeps the direct Infura/Ankr URL so SSR / API routes / scripts
+ * do not recurse into the Next API from the same process.
+ *
+ * `NEXT_PUBLIC_RPC=ankr` still bypasses the proxy and talks to Ankr directly.
+ */
+function clientRpcUrl(chainId: number, directRpc: string): string {
+  if (useAnkr) return directRpc
+  // Server / SSR: talk to Infura (or Ankr) directly — never recurse into the
+  // Next API from the same process.
+  if (typeof window === 'undefined') return directRpc
+  // Absolute URL so viem/thirdweb's HTTP transport does not reject a relative path.
+  return `${window.location.origin}/api/rpc/${chainId}`
+}
 
 export type Chain = ThirdwebChain
 
 export const ethereum = defineChain({
   id: 1,
   name: 'Ethereum',
-  rpc: mainnetRpc.ethereum,
+  rpc: clientRpcUrl(1, mainnetRpc.ethereum),
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -53,8 +72,11 @@ export const arbitrum = defineChain({
   id: 42161,
   name: 'Arbitrum One',
   // Allow a fork/Tenderly RPC override for end-to-end preview testing (Track B of
-  // the Frank re-open rollout). Falls back to the normal Infura/Ankr mainnet RPC.
-  rpc: process.env.NEXT_PUBLIC_ARBITRUM_RPC_URL || mainnetRpc.arbitrum,
+  // the Frank re-open rollout). Falls back to the normal Infura/Ankr mainnet RPC
+  // (browser → /api/rpc proxy with public fallbacks).
+  rpc:
+    process.env.NEXT_PUBLIC_ARBITRUM_RPC_URL ||
+    clientRpcUrl(42161, mainnetRpc.arbitrum),
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -72,7 +94,7 @@ export const arbitrum = defineChain({
 export const base = defineChain({
   id: 8453,
   name: 'Base',
-  rpc: mainnetRpc.base,
+  rpc: clientRpcUrl(8453, mainnetRpc.base),
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -90,7 +112,7 @@ export const base = defineChain({
 export const polygon = defineChain({
   id: 137,
   name: 'Polygon',
-  rpc: mainnetRpc.polygon,
+  rpc: clientRpcUrl(137, mainnetRpc.polygon),
   nativeCurrency: {
     name: 'Matic',
     symbol: 'MATIC',
@@ -108,7 +130,7 @@ export const polygon = defineChain({
 export const sepolia = defineChain({
   id: 11155111,
   name: 'Sepolia',
-  rpc: `https://sepolia.infura.io/v3/${infuraKey}`,
+  rpc: clientRpcUrl(11155111, infuraRpcs.sepolia),
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -127,7 +149,7 @@ export const sepolia = defineChain({
 export const arbitrumSepolia = defineChain({
   id: 421614,
   name: 'Arbitrum Sepolia',
-  rpc: `https://arbitrum-sepolia.infura.io/v3/${infuraKey}`,
+  rpc: clientRpcUrl(421614, infuraRpcs.arbitrumSepolia),
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -146,7 +168,7 @@ export const arbitrumSepolia = defineChain({
 export const optimismSepolia = defineChain({
   id: 11155420,
   name: 'Optimism Sepolia',
-  rpc: `https://optimism-sepolia.infura.io/v3/${infuraKey}`,
+  rpc: clientRpcUrl(11155420, infuraRpcs.optimismSepolia),
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',
@@ -165,7 +187,7 @@ export const optimismSepolia = defineChain({
 export const baseSepolia = defineChain({
   id: 84532,
   name: 'Base Sepolia',
-  rpc: `https://base-sepolia.infura.io/v3/${infuraKey}`,
+  rpc: clientRpcUrl(84532, infuraRpcs.baseSepolia),
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',

--- a/ui/lib/rpc/serverJsonRpc.ts
+++ b/ui/lib/rpc/serverJsonRpc.ts
@@ -15,11 +15,13 @@ function usableUrl(u: string): boolean {
 
 const INFURA_SUBDOMAINS: Record<number, string> = {
   1: 'mainnet',
+  137: 'polygon-mainnet',
   42161: 'arbitrum-mainnet',
   8453: 'base-mainnet',
   11155111: 'sepolia',
   421614: 'arbitrum-sepolia',
   11155420: 'optimism-sepolia',
+  84532: 'base-sepolia',
 }
 
 const PUBLIC_RPC_URLS: Record<number, string[]> = {
@@ -29,11 +31,13 @@ const PUBLIC_RPC_URLS: Record<number, string[]> = {
     'https://eth.llamarpc.com',
     'https://1rpc.io/eth',
   ],
+  137: ['https://polygon-rpc.com', 'https://polygon-bor.publicnode.com'],
   42161: ['https://arb1.arbitrum.io/rpc', 'https://arbitrum-one.publicnode.com'],
   8453: ['https://mainnet.base.org', 'https://base.publicnode.com'],
   11155111: ['https://rpc.sepolia.org', 'https://ethereum-sepolia.publicnode.com'],
   421614: ['https://sepolia-rollup.arbitrum.io/rpc'],
   11155420: ['https://sepolia.optimism.io'],
+  84532: ['https://sepolia.base.org', 'https://base-sepolia.publicnode.com'],
 }
 
 export function serverRpcUrlsForChain(chainId: number): string[] {
@@ -111,4 +115,81 @@ export async function jsonRpcWithFallback(
   }
 
   throw lastError ?? new Error(`All RPC endpoints failed for ${method}`)
+}
+
+export type JsonRpcProxyResult = {
+  status: number
+  body: unknown
+}
+
+/**
+ * Forward a raw JSON-RPC payload (single call or batch array) through the
+ * chain's endpoint list. Used by `/api/rpc/[chainId]` so browser thirdweb
+ * reads survive Infura 429s the same way mission gas estimation does.
+ *
+ * Returns the first HTTP 200 JSON body that looks like a JSON-RPC response.
+ * Transport failures / 429s advance to the next URL.
+ */
+export async function proxyJsonRpcRequest(
+  chainId: number,
+  payload: unknown,
+  { timeoutMs = 20_000 }: { timeoutMs?: number } = {}
+): Promise<JsonRpcProxyResult> {
+  const urls = serverRpcUrlsForChain(chainId)
+  if (urls.length === 0) {
+    throw new Error(`Unsupported chain ID: ${chainId}`)
+  }
+
+  let lastStatus = 502
+  let lastBody: unknown = { error: 'All RPC endpoints failed' }
+
+  for (const url of urls) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+      const text = await response.text()
+      let data: unknown
+      try {
+        data = text ? JSON.parse(text) : null
+      } catch {
+        lastStatus = response.status || 502
+        lastBody = { error: 'Invalid JSON from upstream RPC' }
+        continue
+      }
+
+      // Rate limits / gateway errors → try the next endpoint.
+      if (response.status === 429 || response.status >= 500) {
+        lastStatus = response.status
+        lastBody = data ?? { error: `Upstream RPC ${response.status}` }
+        continue
+      }
+
+      if (!response.ok) {
+        lastStatus = response.status
+        lastBody = data ?? { error: `Upstream RPC ${response.status}` }
+        continue
+      }
+
+      // Empty / non-JSON-RPC payloads cause thirdweb's ABI decoder to throw
+      // `Cannot read properties of undefined (reading 'buffer')`.
+      if (data == null) {
+        lastStatus = 502
+        lastBody = { error: 'Empty RPC response' }
+        continue
+      }
+
+      return { status: 200, body: data }
+    } catch (err) {
+      lastStatus = 502
+      lastBody = {
+        error: err instanceof Error ? err.message : 'Unknown RPC error',
+      }
+    }
+  }
+
+  return { status: lastStatus, body: lastBody }
 }

--- a/ui/lib/thirdweb/hooks/useRead.tsx
+++ b/ui/lib/thirdweb/hooks/useRead.tsx
@@ -30,7 +30,13 @@ export default function useRead({
       }
       setIsLoading(false)
     }
-    if (contract && method && params) read()
+    // `params` is an array, so `[addr, undefined]` is truthy — but viem throws
+    // while ABI-encoding any undefined/null param ("Cannot convert undefined to
+    // a BigInt"). Callers pass not-yet-loaded values (e.g. projectId) on first
+    // render; skip until every param is present instead of firing a doomed read.
+    const paramsReady =
+      Array.isArray(params) && params.every((p) => p !== undefined && p !== null)
+    if (contract && method && paramsReady) read()
   }, [contract, JSON.stringify(params), method, ...(deps || [])])
   return { data, isLoading }
 }

--- a/ui/pages/api/rpc/[chainId].ts
+++ b/ui/pages/api/rpc/[chainId].ts
@@ -1,0 +1,141 @@
+import { Ratelimit } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  isSupportedRpcChain,
+  proxyJsonRpcRequest,
+} from '@/lib/rpc/serverJsonRpc'
+
+function parseChainId(raw: string | string[] | undefined): number {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (!value) return NaN
+  const n = parseInt(value, 10)
+  return Number.isFinite(n) ? n : NaN
+}
+
+function isJsonRpcPayload(body: unknown): boolean {
+  if (Array.isArray(body)) {
+    return (
+      body.length > 0 &&
+      body.every(
+        (item) =>
+          item &&
+          typeof item === 'object' &&
+          (item as { jsonrpc?: string }).jsonrpc === '2.0' &&
+          typeof (item as { method?: string }).method === 'string'
+      )
+    )
+  }
+  return (
+    !!body &&
+    typeof body === 'object' &&
+    (body as { jsonrpc?: string }).jsonrpc === '2.0' &&
+    typeof (body as { method?: string }).method === 'string'
+  )
+}
+
+function normalizeIp(ip?: string | null): string {
+  if (!ip) return '0.0.0.0'
+  ip = ip.replace(/:\d+$/, '')
+  if (ip.startsWith('::ffff:')) ip = ip.slice(7)
+  return ip.toLowerCase()
+}
+
+function getTrustedClientIp(req: NextApiRequest): string {
+  const h = req.headers
+  const vercel = (h['x-vercel-proxied-for'] as string | undefined)?.trim()
+  const real = (h['x-real-ip'] as string | undefined)?.trim()
+  const cf = (h['cf-connecting-ip'] as string | undefined)?.trim()
+  const ip =
+    vercel ||
+    real ||
+    cf ||
+    (h['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ||
+    req.socket.remoteAddress ||
+    '0.0.0.0'
+  return normalizeIp(ip)
+}
+
+// Dashboard mounts fire many batched JSON-RPC posts; the global API limiter
+// (25/s) is too tight for this hot path. Keep abuse protection, but allow a
+// realistic signed-in burst.
+const redis =
+  process.env.UPSTASH_REDIS_URL && process.env.UPSTASH_REDIS_TOKEN
+    ? new Redis({
+        url: process.env.UPSTASH_REDIS_URL,
+        token: process.env.UPSTASH_REDIS_TOKEN,
+      })
+    : null
+
+const rpcRateLimitSecond = redis
+  ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(100, '1 s') })
+  : null
+const rpcRateLimitMinute = redis
+  ? new Ratelimit({ redis, limiter: Ratelimit.slidingWindow(2000, '1 m') })
+  : null
+
+async function enforceRpcRateLimit(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<boolean> {
+  if (process.env.NEXT_PUBLIC_ENV !== 'prod') return true
+  if (!rpcRateLimitSecond || !rpcRateLimitMinute) return true
+
+  const ip = getTrustedClientIp(req)
+  const [sec, min] = await Promise.all([
+    rpcRateLimitSecond.limit(`rpc-sec:${ip}`),
+    rpcRateLimitMinute.limit(`rpc-min:${ip}`),
+  ])
+
+  if (!sec.success || !min.success) {
+    const reset = !sec.success ? sec.reset : min.reset
+    const retryAfter = Math.max(1, Math.ceil((reset - Date.now()) / 1000))
+    res.setHeader('Retry-After', String(retryAfter))
+    res.status(429).json({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32005, message: 'Too Many Requests' },
+    })
+    return false
+  }
+  return true
+}
+
+/**
+ * Browser-facing JSON-RPC proxy with Infura → public RPC fallback.
+ *
+ * Client chain configs point here (`/api/rpc/<chainId>`) so dashboard reads
+ * (balances, hats, fee hook, etc.) no longer die when the shared Infura key
+ * returns HTTP 429. Server-side code keeps using Infura directly via
+ * `serverJsonRpc` / chain `rpc` URLs.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'OPTIONS') {
+    return res.status(204).end()
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  if (!(await enforceRpcRateLimit(req, res))) return
+
+  const chainId = parseChainId(req.query.chainId)
+  if (!Number.isFinite(chainId) || !isSupportedRpcChain(chainId)) {
+    return res.status(400).json({ error: `Unsupported chain ID: ${req.query.chainId}` })
+  }
+
+  if (!isJsonRpcPayload(req.body)) {
+    return res.status(400).json({ error: 'Invalid JSON-RPC payload' })
+  }
+
+  try {
+    const { status, body } = await proxyJsonRpcRequest(chainId, req.body)
+    return res.status(status).json(body)
+  } catch (err) {
+    console.error(`[api/rpc/${chainId}] proxy failed:`, err)
+    return res.status(502).json({
+      error: err instanceof Error ? err.message : 'RPC proxy failed',
+    })
+  }
+}


### PR DESCRIPTION
## Problem

`/dashboard` intermittently loads for minutes and then crashes with "page unresponsive", across multiple machines. Adding a new Infura key did not help.

## Root cause

A self-sustaining feedback loop:

1. `CitizenProvider` resolves citizenship from a single SWR query to `/api/tableland/query` and **ignored the query's error state** — any failure (Tableland 429/5xx, our own API rate limiter, network blip) was treated as "not a citizen". It also overwrote the localStorage citizen cache with `undefined`.
2. `/dashboard` redirects non-citizens to `/`, and `/` redirects citizens to `/dashboard`. When citizen status flickered on a failed query, the user ping-ponged between the two pages.
3. Each bounce remounted the entire page tree (three.js globe included) and re-fired hundreds of RPC calls — dominated by the hats role-index scan (up to 200 tokens × 3 reads per contract) which also ran from the always-mounted nav dropdowns on **every** page.
4. That burst exhausted Infura (any key, client *and* server side) and our own rate limits, failing the next citizen query, restarting the loop. Console evidence: mass `Cannot read properties of undefined (reading 'buffer')` batch-decode failures, `getCitizenNFTByAddress` stack frames from the index page chunk while "on" the dashboard, React #421 hydration error, 500s from `/api/xp/citizen-referrals` (server-side quota exhaustion).

It recovers after a few minutes because rate-limit windows drain and a citizen query finally succeeds, warming the 5-minute cache — until the cache expires again. Hence the intermittency.

## Changes

- **`CitizenProvider`**: a failed citizen query is now "unknown", not "not a citizen". Keeps the last-known citizen, never poisons the cache on error, and stays in loading state (while SWR retries) if there's no known citizen — so route guards don't redirect on transient failures. Only a successful empty result clears citizenship.
- **`TopNavBar`**: Teams/Projects nav dropdown contents mount only while the dropdown is open (they were mounted, CSS-hidden, on every page), so their role-hat scans no longer fire on every page load. Scan results remain cached for 5 min, so opening the dropdown stays cheap.
- **`useRead`**: skips execution while any param is `undefined`/`null`. Previously `[terminal, undefined, token]` passed the truthy-array guard and viem threw `Cannot convert undefined to a BigInt` mid-encode (seen from `useTotalFunding` before `projectId` loads).
- **New `/api/rpc/[chainId]` proxy + client RPC rerouting** (`lib/rpc/chains.ts`, `lib/rpc/serverJsonRpc.ts`): browser RPC traffic goes through a Next API route that tries Infura first and falls back to public RPCs on 429/5xx/malformed responses, with its own IP rate limiting (100/s, 2000/min). Server/SSR keeps talking to Infura directly. This absorbs the `'buffer'` decode failures and transient 429s that degraded balances, quests, and check-ins.

## Not addressed here (follow-ups)

- thirdweb Insight 401s (`insight.thirdweb.com`) — the thirdweb API key's domain allowlist needs updating in the thirdweb dashboard (no code change).
- Moving the hats role-index scan server-side behind a cached route would further cut RPC volume.

## Test plan

- [ ] Signed-in citizen loads `/dashboard` with DevTools network throttling / simulated 429s from `/api/tableland/query` — stays on dashboard (spinner or last-known citizen), no redirect to `/`.
- [ ] Signed-in non-citizen visiting `/dashboard` still redirects to `/` once the query succeeds.
- [ ] Teams/Projects nav dropdowns populate correctly when opened; no hats-scan RPC traffic before opening.
- [ ] Dashboard featured-mission widget no longer logs `Cannot convert undefined to a BigInt`.
- [ ] `/api/rpc/1` (and other chains) proxies `eth_blockNumber` and falls back to public RPCs when Infura is rate-limited.

Made with [Cursor](https://cursor.com)