### PR TITLE
fix(mission): keep Apple Pay onramp on one screen after purchase

### DIFF
--- a/ui/components/coinbase/CBHeadlessOnramp.tsx
+++ b/ui/components/coinbase/CBHeadlessOnramp.tsx
@@ -34,6 +34,10 @@ interface CBHeadlessOnrampProps {
   refetchBalance?: () => Promise<void>
   /** Called after a successful purchase (e.g. to resume the parent flow). */
   onSuccess?: () => void
+  /** In-app mode: when funds are purchased, skip the "Continue" confirmation
+   *  screen and hand off to the parent (which polls for the balance and shows
+   *  its own action) instead of reloading. Keeps the whole flow on one screen. */
+  waitForFundsInApp?: boolean
   /** Called when the device doesn't support Apple Pay or Google Pay so the
    *  parent can fall back to MoonPay automatically. */
   onUnsupported?: () => void
@@ -100,6 +104,7 @@ export function CBHeadlessOnramp({
   onSuccess,
   onUnsupported,
   onUseAccountFlow,
+  waitForFundsInApp = false,
 }: CBHeadlessOnrampProps) {
   const { user } = usePrivy()
   const verification = useOnrampVerification()
@@ -423,8 +428,16 @@ export function CBHeadlessOnramp({
           } catch {
             // ignore
           }
-          // onBalanceSufficient / onSuccess are deferred to handleSuccessAck so
-          // the confirmation screen stays up until the user acknowledges it.
+          if (waitForFundsInApp) {
+            // In-app mode: no manual "Continue" step. Hand off to the parent
+            // immediately so it can poll for the funds and reveal its action
+            // (e.g. the Contribute button) as soon as they land — all on the
+            // same screen, no reload.
+            onSuccessRef.current?.()
+          }
+          // Otherwise onBalanceSufficient / onSuccess are deferred to
+          // handleSuccessAck so the confirmation screen stays up until the
+          // user acknowledges it.
           break
         case 'onramp_api.polling_error':
           setError(
@@ -443,10 +456,38 @@ export function CBHeadlessOnramp({
 
     window.addEventListener('message', handleMessage)
     return () => window.removeEventListener('message', handleMessage)
-  }, [fundingState, useGooglePay])
+  }, [fundingState, useGooglePay, waitForFundsInApp])
 
   // --- Success state ---
   if (fundingState === 'success') {
+    // In-app mode: no manual "Continue" step. Show a passive confirmation while
+    // the parent polls for the funds and reveals its own action (e.g. the
+    // Contribute button) automatically the moment they land.
+    if (waitForFundsInApp) {
+      return (
+        <div className={shellChrome}>
+          <div className="p-6 space-y-5 text-center">
+            <div className="w-12 h-12 mx-auto rounded-full bg-emerald-500/20 flex items-center justify-center">
+              <svg className="w-7 h-7 text-emerald-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <h2 className="text-lg font-semibold text-white">Payment complete</h2>
+            <p className="text-gray-300 text-sm">
+              Your funds are on the way — this usually takes about a minute. The
+              contribute button will appear automatically as soon as they land.
+            </p>
+            <div className="flex items-center justify-center gap-2 text-gray-400 text-sm">
+              <svg className="animate-spin h-4 w-4 text-blue-300" viewBox="0 0 24 24" fill="none">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              <span>Waiting for your funds…</span>
+            </div>
+          </div>
+        </div>
+      )
+    }
     return (
       <div className={shellChrome}>
         <div className="flex items-center justify-between p-6 border-b border-white/10">

--- a/ui/components/coinbase/CBOnramp.tsx
+++ b/ui/components/coinbase/CBOnramp.tsx
@@ -40,6 +40,11 @@ interface CBOnrampProps {
   /** Region already resolved by a parent (e.g. FundOnramp). When provided,
    *  skips the duplicate /api/coinbase/region request. */
   initialIsUS?: boolean | null
+  /** In-app (headless / Apple Pay) success handler. When provided, a successful
+   *  purchase calls this instead of reloading the page — keeping the flow on a
+   *  single screen. The parent is expected to poll for the funds and reveal its
+   *  own action (e.g. a Contribute button) once they arrive. */
+  onHeadlessSuccessInApp?: () => void
 }
 
 const GUEST_CHECKOUT_LIMIT = 500
@@ -60,6 +65,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
   headerSlot,
   onUnsupported,
   initialIsUS,
+  onHeadlessSuccessInApp,
 }) => {
   const shellWidthClass = fullWidth ? 'w-full' : 'w-full max-w-md mx-auto'
 
@@ -90,6 +96,12 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
   // (cache state via onBeforeNavigate, then reload with the onrampSuccess flag
   // that callers already handle on return).
   const handleHeadlessSuccess = useCallback(async () => {
+    // In-app mode: hand off to the parent (which polls for the funds and shows
+    // its own action) instead of reloading. Keeps the whole flow on one screen.
+    if (onHeadlessSuccessInApp) {
+      onHeadlessSuccessInApp()
+      return
+    }
     try {
       await onBeforeNavigate?.()
     } catch (error) {
@@ -99,7 +111,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
     url.searchParams.set('onrampSuccess', 'true')
     window.history.replaceState({}, '', url.toString())
     window.location.reload()
-  }, [onBeforeNavigate])
+  }, [onBeforeNavigate, onHeadlessSuccessInApp])
 
   const [isLoading, setIsLoading] = useState(false)
   const [isLoadingQuote, setIsLoadingQuote] = useState(false)
@@ -616,6 +628,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
         onSuccess={handleHeadlessSuccess}
         onUnsupported={onUnsupported}
         onUseAccountFlow={handleHostedFallback}
+        waitForFundsInApp={!!onHeadlessSuccessInApp}
       />
     )
   }

--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -374,6 +374,10 @@ export default function MissionContributeModal({
   /** Balance on `payChain` (funding network). RPC when wallet is elsewhere. */
   const [rpcFundingChainWei, setRpcFundingChainWei] = useState<bigint | null>(null)
   const [isLoadingRpcFundingBalance, setIsLoadingRpcFundingBalance] = useState(false)
+  /** True while an in-app Apple/Google Pay purchase is settling. We poll the
+   *  balance in place (no reload) so the Contribute button appears the moment
+   *  the funds land. */
+  const [awaitingOnrampFunds, setAwaitingOnrampFunds] = useState(false)
 
   useEffect(() => {
     if (!modalEnabled || !address) {
@@ -1033,6 +1037,55 @@ export default function MissionContributeModal({
     if (!fundingBalanceResolved || fundingBalanceWei === null) return false
     return requiredWei > BigInt(0) && fundingBalanceWei >= requiredWei
   }, [fundingBalanceResolved, fundingBalanceWei, requiredWei])
+
+  // In-app onramp settling: poll the balance in place until the purchased funds
+  // land, then stop. No reload and no auto-contribute — once the balance is
+  // sufficient the normal Contribute button renders and the user taps it.
+  useEffect(() => {
+    if (!awaitingOnrampFunds) return
+    if (!address) return
+    if (hasEnoughBalance) {
+      setAwaitingOnrampFunds(false)
+      return
+    }
+    let cancelled = false
+    const poll = async () => {
+      try {
+        await refetchNativeBalance()
+      } catch {
+        // ignore
+      }
+      if (!cancelled && !walletOnPayChain) {
+        try {
+          const wei = await fetchNativeBalanceWei(payChainStable, address)
+          if (!cancelled) setRpcFundingChainWei(wei)
+        } catch {
+          // ignore
+        }
+      }
+    }
+    void poll()
+    const intervalId = setInterval(() => {
+      void poll()
+    }, 4000)
+    // Funds essentially always arrive within a couple of minutes; stop polling
+    // after a generous window so we don't loop forever if something stalls.
+    const stopId = setTimeout(() => {
+      if (!cancelled) setAwaitingOnrampFunds(false)
+    }, 8 * 60 * 1000)
+    return () => {
+      cancelled = true
+      clearInterval(intervalId)
+      clearTimeout(stopId)
+    }
+  }, [
+    awaitingOnrampFunds,
+    hasEnoughBalance,
+    address,
+    walletOnPayChain,
+    payChainStable,
+    refetchNativeBalance,
+  ])
 
   const showFundingBalanceWait = Boolean(
     address &&
@@ -2732,6 +2785,12 @@ export default function MissionContributeModal({
                       }}
                       onBalanceSufficient={() => {
                         buyMissionToken()
+                      }}
+                      onCoinbaseSuccessInApp={() => {
+                        // In-app Apple/Google Pay: no reload, no auto-contribute.
+                        // Poll for the funds in place; when they land the normal
+                        // Contribute button appears and the user taps it.
+                        setAwaitingOnrampFunds(true)
                       }}
                     />
                   )}

--- a/ui/components/onramp/FundOnramp.tsx
+++ b/ui/components/onramp/FundOnramp.tsx
@@ -27,6 +27,10 @@ interface FundOnrampProps {
   // Coinbase-specific
   coinbaseRedirectUrl?: string
   onCoinbaseBeforeNavigate?: () => Promise<void>
+  /** In-app Coinbase (Apple/Google Pay) success handler. When provided, a
+   *  successful purchase stays on the same screen and calls this instead of
+   *  reloading — the caller polls for funds and reveals its own action. */
+  onCoinbaseSuccessInApp?: () => void
   onCoinbaseQuoteCalculated?: (
     ethAmount: number,
     paymentSubtotal: number,
@@ -57,6 +61,7 @@ export function FundOnramp({
   pollMaxMinutes,
   coinbaseRedirectUrl,
   onCoinbaseBeforeNavigate,
+  onCoinbaseSuccessInApp,
   onCoinbaseQuoteCalculated,
   allowAmountInput = false,
 }: FundOnrampProps) {
@@ -220,6 +225,7 @@ export function FundOnramp({
           allowAmountInput={allowAmountInput}
           onQuoteCalculated={onCoinbaseQuoteCalculated}
           onBeforeNavigate={onCoinbaseBeforeNavigate}
+          onHeadlessSuccessInApp={onCoinbaseSuccessInApp}
           redirectUrl={coinbaseRedirectUrl}
         />
       )}


### PR DESCRIPTION
## Summary
- Removes the confusing post-onramp **Continue** step and the auto-contribute loading modal after Apple Pay / Google Pay funding in the mission contribute flow.
- After payment, the modal stays on the same screen, shows a passive "funds on the way" state, polls the balance in place, and reveals the normal **Contribute** button once ETH lands — matching the simpler manual flow users already prefer.

## Changes
- **CBHeadlessOnramp**: add `waitForFundsInApp` mode that skips the Continue confirmation and hands off immediately.
- **CBOnramp / FundOnramp**: thread `onHeadlessSuccessInApp` / `onCoinbaseSuccessInApp` so success no longer reloads the page when a parent handles in-app settling.
- **MissionContributeModal**: poll wallet + funding-chain balances every 4s (up to 8 min) after in-app purchase; user taps Contribute when ready.

Scope is limited to the mission Apple/Google Pay path. MoonPay and onboarding onramp flows are unchanged.

## Test plan
- [ ] Apple Pay mission contribution: after payment, no Continue button and no auto-contribute loading modal
- [ ] Modal shows "Payment complete / Waiting for your funds…" while balance settles
- [ ] Contribute button appears automatically once funds land; user taps it to finish
- [ ] Manual contribution (existing ETH) still works as before
- [ ] MoonPay / hosted Coinbase redirect flows unchanged


Made with [Cursor](https://cursor.com)