### PR TITLE
feat(mission): open Frank's mission to the public for direct contributions

### DIFF
--- a/ui/const/whitelist.ts
+++ b/ui/const/whitelist.ts
@@ -1,19 +1,14 @@
 //https://docs.google.com/spreadsheets/d/1LsYxkI_1alFUD_NxM2a5RngeSRC5e5ElUpP6aR30DiM/edit?gid=0#gid=0
 export const BLOCKED_TEAMS: any = new Set([])
 export const BLOCKED_CITIZENS: any = new Set([48, 72, 140, 177])
-// Mission 4 (Frank) is hidden from every public listing on mainnet while its re-open is
-// validated end-to-end. It stays in BLOCKED_MISSIONS (so it never appears on the
-// launchpad/home/team pages) but is ALSO listed in GATED_MISSIONS, which lets the
-// /mission/[id] page render when the correct access code is supplied — a private,
-// shareable stealth test. See pages/mission/[tokenId].tsx.
 export const BLOCKED_MISSIONS: any = new Set(
-  process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [0, 1, 2, 4] : []
+  process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [0, 1, 2] : []
 )
 // Blocked missions that remain reachable on their page with an access code
-// (process.env.MISSION_ACCESS_CODE). Blocked-but-not-gated missions stay fully 404'd.
-export const GATED_MISSIONS: Set<number> = new Set(
-  process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [4] : []
-)
+// (process.env.MISSION_ACCESS_CODE) — a private, shareable stealth test for an
+// unannounced mission. Blocked-but-not-gated missions stay fully 404'd.
+// See pages/mission/[tokenId].tsx.
+export const GATED_MISSIONS: Set<number> = new Set()
 export const BLOCKED_PROJECTS: any = new Set(
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? [4, 10, 14, 90, 116, 118, 124] : [0, 3, 4, 5, 6, 7]
 )


### PR DESCRIPTION
## Summary
- Remove mission 4 (Frank / Overview Flight) from `BLOCKED_MISSIONS` on mainnet so it shows up on the launchpad, home page, dashboard, and team pages.
- Empty `GATED_MISSIONS` so `/mission/4` no longer requires the `MISSION_ACCESS_CODE` stealth access code — anyone can visit the page and contribute directly.
- The gating mechanism itself (access-code path in `pages/mission/[tokenId].tsx`) is left in place for future unannounced missions; only the flag entries are removed.

## Test plan
- [ ] On a mainnet preview deploy, load `/mission/4` in an incognito window (no cookie, no `?access=`) and confirm the page renders.
- [ ] Confirm mission 4 appears in the launchpad and home page mission listings.
- [ ] Complete a small test contribution end-to-end from the public page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which mission is visible and fundable on production mainnet; wrong IDs would expose or hide the wrong mission, but the diff is a small, explicit whitelist edit with no auth or payment logic changes.
> 
> **Overview**
> On **mainnet**, mission **4** (Frank / Overview Flight) is no longer treated as blocked or access-gated in `whitelist.ts`.
> 
> **`BLOCKED_MISSIONS`** no longer includes `4`, so mission 4 can appear in public mission listings (launchpad, home, team views) that filter on this set. **`GATED_MISSIONS`** is now empty instead of listing `4`, so `/mission/4` is served like other public missions and no longer depends on `MISSION_ACCESS_CODE` or stealth `?access=` flow. Comments were updated to describe gating as a future mechanism only; the page logic in `pages/mission/[tokenId].tsx` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7deee9f9efcd383a4d2ad16e91ec88b01554bff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->