### PR TITLE
fix(citizen): retry RPC reads that crash viem's ABI decoder during mint

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -145,6 +145,37 @@ const INPUT_IMAGE_SESSION_KEY = 'CreateCitizen_inputImage'
 
 const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60
 
+/**
+ * Under transient RPC hiccups thirdweb's batched eth_call can resolve with an
+ * empty/undefined body, which crashes viem's ABI decoder with a TypeError
+ * ("Cannot read properties of undefined (reading 'buffer')" / Safari:
+ * "undefined is not an object (evaluating 'e.buffer')"). A short retry clears
+ * it — same pattern as `computeMemberVoteOutcome.readContractWithRetry`.
+ */
+async function readContractWithRetry<T>(
+  options: { contract: any; method: string; params: any[] },
+  maxRetries = 3,
+  baseDelayMs = 500
+): Promise<T> {
+  let lastError: any
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      return (await readContract(options as any)) as T
+    } catch (error) {
+      lastError = error
+      const isRetryableDecodeError =
+        error instanceof TypeError && String(error.message).includes('buffer')
+      if (!isRetryableDecodeError || attempt === maxRetries - 1) {
+        throw error
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, baseDelayMs * Math.pow(2, attempt))
+      )
+    }
+  }
+  throw lastError
+}
+
 /** Format small ETH amounts for display without noisy trailing zeros. */
 function formatEthAmount(eth: number): string {
   if (!Number.isFinite(eth) || eth <= 0) return '0'
@@ -957,7 +988,7 @@ export default function CreateCitizen({
     setIsLoadingGasEstimate(true)
 
     try {
-      const cost: any = await readContract({
+      const cost: any = await readContractWithRetry({
         contract: citizenContract,
         method: 'getRenewalPrice' as string,
         params: [address, 365 * 24 * 60 * 60],
@@ -1340,7 +1371,7 @@ export default function CreateCitizen({
 
     try {
       // Get cost and check balance
-      const cost: any = await readContract({
+      const cost: any = await readContractWithRetry({
         contract: citizenContract,
         method: 'getRenewalPrice' as string,
         params: [address, 365 * 24 * 60 * 60],
@@ -1405,7 +1436,15 @@ export default function CreateCitizen({
       }
     } catch (err: any) {
       console.error(err)
-      toast.error(err?.message || 'Something went wrong during minting.')
+      // A TypeError mentioning "buffer" is viem failing to decode an empty RPC
+      // response — a transient network issue, not a user-actionable error.
+      const isRpcDecodeError =
+        err instanceof TypeError && String(err?.message).includes('buffer')
+      toast.error(
+        isRpcDecodeError
+          ? 'Network hiccup while reading the mint price. Please try again.'
+          : err?.message || 'Something went wrong during minting.'
+      )
       setIsLoadingMint(false)
     }
   }, [
@@ -1432,7 +1471,7 @@ export default function CreateCitizen({
   // Balance Check Handler
   const checkBalanceSufficient = useCallback(async () => {
     try {
-      const cost: any = await readContract({
+      const cost: any = await readContractWithRetry({
         contract: citizenContract,
         method: 'getRenewalPrice' as string,
         params: [address, 365 * 24 * 60 * 60],
@@ -1734,7 +1773,7 @@ export default function CreateCitizen({
 
     let cancelled = false
     setIsLoadingRenewalPrice(true)
-    readContract({
+    readContractWithRetry({
       contract: citizenContract,
       method: 'getRenewalPrice' as string,
       params: [address, ONE_YEAR_SECONDS],

--- a/ui/lib/rpc/serverJsonRpc.ts
+++ b/ui/lib/rpc/serverJsonRpc.ts
@@ -122,6 +122,31 @@ export type JsonRpcProxyResult = {
   body: unknown
 }
 
+function hasResultOrError(entry: unknown): boolean {
+  return (
+    !!entry &&
+    typeof entry === 'object' &&
+    ('result' in (entry as object) || 'error' in (entry as object))
+  )
+}
+
+/**
+ * Validate that an upstream body is a well-formed JSON-RPC response for the
+ * given request. Public fallback RPCs sometimes answer a batch with a single
+ * error object, drop entries, or return entries with neither `result` nor
+ * `error`. Forwarding those to the browser makes thirdweb resolve individual
+ * eth_calls with `undefined`, which crashes viem's ABI decoder ("Cannot read
+ * properties of undefined (reading 'buffer')" / Safari: "undefined is not an
+ * object (evaluating 'e.buffer')") — seen in citizen onboarding reads.
+ */
+function isWellFormedJsonRpcResponse(request: unknown, body: unknown): boolean {
+  if (Array.isArray(request)) {
+    if (!Array.isArray(body) || body.length !== request.length) return false
+    return body.every(hasResultOrError)
+  }
+  return hasResultOrError(body)
+}
+
 /**
  * Forward a raw JSON-RPC payload (single call or batch array) through the
  * chain's endpoint list. Used by `/api/rpc/[chainId]` so browser thirdweb
@@ -179,6 +204,15 @@ export async function proxyJsonRpcRequest(
       if (data == null) {
         lastStatus = 502
         lastBody = { error: 'Empty RPC response' }
+        continue
+      }
+
+      // Malformed batch responses (single object for a batch request, missing
+      // entries, entries with neither result nor error) crash viem the same
+      // way — try the next endpoint instead of forwarding them.
+      if (!isWellFormedJsonRpcResponse(payload, data)) {
+        lastStatus = 502
+        lastBody = { error: 'Malformed JSON-RPC response from upstream' }
         continue
       }
 


### PR DESCRIPTION
## Summary
- Users hit `undefined is not an object (evaluating 'ea.buffer')` (Safari wording of viem's `createCursor` crash on empty/malformed RPC responses) during citizen creation.
- Root cause: when Infura is rate-limited, `/api/rpc/<chainId>` falls back to public RPCs, and some of those answer thirdweb's batched requests with a single error object or an incomplete batch. The proxy forwarded these as-is, thirdweb resolved individual `eth_call`s with `undefined`, and viem's ABI decoder crashed.
- `proxyJsonRpcRequest` now validates upstream response shape (batch request must return an array of the same length where every entry has `result` or `error`; single request must return an object with one of those fields) and advances to the next fallback endpoint on malformed bodies.
- `CreateCitizen` now retries the four `getRenewalPrice` reads (gas estimation, mint, balance check, stage-2 renewal price) up to 3x with backoff on this specific `TypeError` — same pattern as the existing `readContractWithRetry` in `computeMemberVoteOutcome.ts` — and shows a friendly "network hiccup" toast instead of the raw decoder error if it still fails during mint.

## Test plan
- [ ] Run through citizen onboarding to stage 2 and confirm renewal price + gas estimate load
- [ ] Complete a mint (or a testnet mint) and confirm no decoder error toast
- [ ] Simulate a malformed upstream response (e.g. stub a fallback RPC) and confirm the proxy skips to the next endpoint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared `/api/rpc` proxy and citizen mint/checkout pricing paths; mis-validation could skip valid RPC responses, though behavior is limited to fallback endpoints and read retries.
> 
> **Overview**
> Fixes citizen onboarding crashes when **viem** fails to decode empty or malformed RPC bodies (the familiar `reading 'buffer'` / Safari `e.buffer` **TypeError**).
> 
> **Server:** `proxyJsonRpcRequest` now rejects upstream JSON-RPC bodies that do not match the request shape (batch length and per-entry `result`/`error`) and tries the next endpoint instead of forwarding them to the browser.
> 
> **Client:** `CreateCitizen` adds `readContractWithRetry` for all `getRenewalPrice` reads (gas estimate, mint, balance check, checkout renewal price) with exponential backoff on that decode **TypeError**, and mint failures from the same issue show a “network hiccup” toast instead of the raw decoder error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 861bc08ab2b2e2a574296db40ce66641a699f022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->