### PR TITLE
feat(ui): reopen Overview Flight mission page with $250k goal

### DIFF
--- a/ui/components/mission/MissionInfo.tsx
+++ b/ui/components/mission/MissionInfo.tsx
@@ -1,3 +1,4 @@
+import { getMissionDescription } from 'const/missionMilestones'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
@@ -234,7 +235,10 @@ export default function MissionInfo({
               <div
                 className="prose prose-invert prose-lg max-w-none [&>p]:text-gray-300 [&>p]:leading-relaxed [&>h1]:text-white [&>h2]:text-white [&>h3]:text-white [&>ul]:text-gray-300 [&>ol]:text-gray-300 [&>a]:text-indigo-400"
                 dangerouslySetInnerHTML={{
-                  __html: mission?.metadata?.description || '',
+                  __html: getMissionDescription(
+                    mission?.id,
+                    mission?.metadata?.description
+                  ),
                 }}
               />
               {mission?.projectId != null && mission?.projectId !== '' && (

--- a/ui/components/mission/MissionProfile.tsx
+++ b/ui/components/mission/MissionProfile.tsx
@@ -18,6 +18,7 @@ import {
   JBV5_TOKENS_ADDRESS,
   MISSION_CREATOR_ADDRESSES,
   MISSION_TABLE_ADDRESSES,
+  OVERVIEW_FLIGHT_RAISE_CLOSED,
   TEAM_ADDRESSES,
 } from 'const/config'
 import Image from 'next/image'
@@ -468,6 +469,10 @@ export default function MissionProfile({
           mission?.id === 4 || String(mission?.id) === '4'
             ? _overviewStats ?? null
             : undefined
+        }
+        overviewRaiseClosed={
+          (mission?.id === 4 || String(mission?.id) === '4') &&
+          OVERVIEW_FLIGHT_RAISE_CLOSED
         }
         contributeButton={
           !deadlinePassed && Number(effectiveStage) !== 3 && (

--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -3,6 +3,7 @@ import { DEFAULT_CHAIN_V5 } from 'const/config'
 import {
   getMissionMinimumUsdGoal,
   getMissionOffChainCommittedUsd,
+  getMissionTagline,
   MISSION_FUNDING_MILESTONES_USD,
   MISSION_MINIMUM_GOAL_TOOLTIP,
 } from 'const/missionMilestones'
@@ -136,6 +137,10 @@ const MissionProfileHeader = React.memo(
     const account = useActiveAccount()
     const { ethPrice } = useETHPrice(1, 'ETH_TO_USD')
 
+    const missionTagline = getMissionTagline(
+      mission?.id,
+      mission?.metadata?.tagline
+    )
     const minUsdGoal = getMissionMinimumUsdGoal(mission?.id)
     const offChainCommittedUsd = getMissionOffChainCommittedUsd(mission?.id)
     const terminalWei = totalFunding ?? BigInt(0)
@@ -268,7 +273,7 @@ const MissionProfileHeader = React.memo(
             </button>
           )}
         </div>
-        {mission?.metadata?.tagline && (
+        {missionTagline && (
           <p
             className={
               isOverviewMission
@@ -276,7 +281,7 @@ const MissionProfileHeader = React.memo(
                 : 'text-base sm:text-lg text-gray-400 leading-relaxed max-w-2xl'
             }
           >
-            {mission.metadata.tagline}
+            {missionTagline}
           </p>
         )}
         {/* Team Attribution sits with the title in the Overview layout so it

--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -84,11 +84,17 @@ interface MissionProfileHeaderProps {
   setDeployTokenModalEnabled?: (enabled: boolean) => void
   contributeButton: React.ReactNode
   /** SSR-aggregated funding stats (median contribution, unique backers,
-   *  total contributions). Provided only for the wrapped-up Overview Flight
-   *  mission (id 4); when present, the header swaps the live progress
-   *  bar / milestones / goal tile for a "campaign success" stat row plus a
-   *  30-day seat procurement countdown. */
+   *  total contributions). Provided only for the Overview Flight mission
+   *  (id 4). When the raise is closed (see `overviewRaiseClosed`) the header
+   *  uses these to render the "campaign success" stat row plus a 30-day seat
+   *  procurement countdown. */
   overviewStats?: MissionFundingStats | null
+  /** True only for the Overview Flight mission (id 4) while its raise is
+   *  wrapped up. When true the header swaps the live progress bar / milestones
+   *  / Goal + Deadline tiles for the success-stats + Seat Procurement layout.
+   *  When false (raise re-opened) the header renders the standard live funding
+   *  UI while keeping the Overview-specific page layout. */
+  overviewRaiseClosed?: boolean
 }
 
 /** 30-day post-deadline window during which Frank's team works to convert
@@ -125,6 +131,7 @@ const MissionProfileHeader = React.memo(
     setDeployTokenModalEnabled,
     contributeButton,
     overviewStats,
+    overviewRaiseClosed,
   }: MissionProfileHeaderProps) => {
     const account = useActiveAccount()
     const { ethPrice } = useETHPrice(1, 'ETH_TO_USD')
@@ -143,14 +150,19 @@ const MissionProfileHeader = React.memo(
     const isOverviewMission =
       mission?.id === 4 || String(mission?.id) === '4'
 
+    /** The Overview Flight (mission 4) raise being wrapped up. Only this drives
+     *  the "closed" funding UI (success stats + Seat Procurement panel);
+     *  `isOverviewMission` alone drives the page layout so the special layout
+     *  is preserved whether the raise is open or closed. */
+    const isOverviewRaiseClosed = isOverviewMission && !!overviewRaiseClosed
+
     const milestoneBar = useMemo(() => {
-      // The Overview Flight raise is wrapped up — the funding card now
-      // shows success stats + a seat procurement countdown instead of the
-      // milestone progress bar / list. Skip the milestone computation for
-      // mission 4 entirely so the bar/list never render even momentarily
-      // (and `MISSION_FUNDING_MILESTONES_USD` can keep its mission-4 entry
-      // for places like the home/featured sections that still want it).
-      if (isOverviewMission) return null
+      // While the Overview Flight raise is wrapped up the funding card shows
+      // success stats + a seat procurement countdown instead of the milestone
+      // progress bar / list, so skip the milestone computation entirely (the
+      // bar/list never render even momentarily). Once the raise re-opens this
+      // guard clears and mission 4 gets the standard live milestone UI.
+      if (isOverviewRaiseClosed) return null
       const steps =
         mission?.id != null ? MISSION_FUNDING_MILESTONES_USD[mission.id] : undefined
       if (!steps?.length || !ethPrice || ethPrice <= 0 || isLoadingTotalFunding) return null
@@ -163,7 +175,7 @@ const MissionProfileHeader = React.memo(
           )} to go`
       return { seg, raisedUsd, steps, caption }
     }, [
-      isOverviewMission,
+      isOverviewRaiseClosed,
       mission?.id,
       ethPrice,
       isLoadingTotalFunding,
@@ -177,14 +189,14 @@ const MissionProfileHeader = React.memo(
      *  the user's local Date. */
     const [now, setNow] = useState<number | null>(null)
     useEffect(() => {
-      if (!isOverviewMission || deadline == null || deadline <= 0) return
+      if (!isOverviewRaiseClosed || deadline == null || deadline <= 0) return
       setNow(Date.now())
       const id = window.setInterval(() => setNow(Date.now()), 60_000)
       return () => window.clearInterval(id)
-    }, [isOverviewMission, deadline])
+    }, [isOverviewRaiseClosed, deadline])
 
     const seatProcurement = useMemo(() => {
-      if (!isOverviewMission || deadline == null || deadline <= 0) return null
+      if (!isOverviewRaiseClosed || deadline == null || deadline <= 0) return null
       const procurementEndMs = deadline + SEAT_PROCUREMENT_MS
       const procurementEndDate = new Date(procurementEndMs)
       const procurementEndLabel = procurementEndDate.toLocaleDateString(
@@ -212,7 +224,7 @@ const MissionProfileHeader = React.memo(
         periodElapsed,
         countdownLabel,
       }
-    }, [isOverviewMission, deadline, now])
+    }, [isOverviewRaiseClosed, deadline, now])
 
     const overviewMedianUsd = useMemo(() => {
       if (!overviewStats || !ethPrice || ethPrice <= 0) return null
@@ -523,10 +535,10 @@ const MissionProfileHeader = React.memo(
                   </div>
                 </div>
 
-                {/* Progress Bar — hidden on the wrapped-up Overview Flight
-                    page (mission 4). Other missions still get the live bar
-                    + milestone list. */}
-                {!isOverviewMission && (
+                {/* Progress Bar — hidden while the Overview Flight raise is
+                    wrapped up (mission 4). All other missions, and mission 4
+                    once its raise re-opens, get the live bar + milestone list. */}
+                {!isOverviewRaiseClosed && (
                   <div className="mb-4">
                     <MissionFundingProgressBar
                       fundingGoal={fundingGoal}
@@ -551,7 +563,7 @@ const MissionProfileHeader = React.memo(
                     directly above the Seat Procurement panel so the reader
                     immediately understands why the live progress / pay UI
                     is gone before reading about the 30-day refund window. */}
-                {isOverviewMission && (
+                {isOverviewRaiseClosed && (
                   <div
                     data-testid="overview-contributions-closed-banner"
                     className="mb-3 rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 flex items-start gap-3"
@@ -576,7 +588,7 @@ const MissionProfileHeader = React.memo(
                     the milestone progress UI now that the raise has wrapped
                     up. Anchored to the on-chain deadline, hydrated client
                     side so SSR doesn't bake a stale countdown into HTML. */}
-                {isOverviewMission && seatProcurement && (
+                {isOverviewRaiseClosed && seatProcurement && (
                   <div
                     data-testid="overview-seat-procurement-panel"
                     className="mb-4 rounded-2xl border border-indigo-400/20 bg-gradient-to-br from-indigo-500/10 via-indigo-500/5 to-transparent p-4 sm:p-5"
@@ -641,12 +653,13 @@ const MissionProfileHeader = React.memo(
                       : 'grid-cols-3'
                   } ${isOverviewMission ? 'lg:mt-auto' : ''}`}
                   data-testid={
-                    isOverviewMission ? 'overview-stats-row' : undefined
+                    isOverviewRaiseClosed ? 'overview-stats-row' : undefined
                   }
                 >
-                  {/* Goal — hidden on mission 4 (the page has been cleaned
-                      up post-raise; goal/progress no longer relevant). */}
-                  {!isOverviewMission && (
+                  {/* Goal — hidden only while the Overview raise is wrapped up
+                      (goal/progress not relevant then); shown for every other
+                      mission and for mission 4 once the raise re-opens. */}
+                  {!isOverviewRaiseClosed && (
                     <div className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0">
                       <div className="flex items-center gap-1 sm:gap-1.5 mb-1.5 min-w-0">
                         <Image src="/assets/launchpad/target.svg" alt="Goal" width={14} height={14} className="opacity-60 flex-shrink-0" />
@@ -686,9 +699,10 @@ const MissionProfileHeader = React.memo(
                     </div>
                   )}
 
-                  {/* Deadline — hidden on mission 4 (the Seat Procurement
-                      Period panel renders the relevant closing context). */}
-                  {!isOverviewMission && (
+                  {/* Deadline — hidden only while the Overview raise is wrapped
+                      up (the Seat Procurement Period panel renders the relevant
+                      closing context then). Shown again once it re-opens. */}
+                  {!isOverviewRaiseClosed && (
                     <div className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0">
                       <div className="flex items-center gap-1 sm:gap-1.5 mb-1.5 min-w-0">
                         <Image src="/assets/launchpad/clock.svg" alt="Deadline" width={14} height={14} className="opacity-60 flex-shrink-0" />
@@ -744,14 +758,14 @@ const MissionProfileHeader = React.memo(
                       </span>
                     </div>
                     <p className="text-white font-GoodTimes text-[11px] sm:text-sm">
-                      {(isOverviewMission && overviewStats?.totalContributions != null
+                      {(isOverviewRaiseClosed && overviewStats?.totalContributions != null
                         ? overviewStats.totalContributions
                         : paymentsCount) || 0}
                     </p>
                   </div>
 
-                  {/* Unique Backers — Overview Flight only */}
-                  {isOverviewMission && (
+                  {/* Unique Backers — Overview Flight, wrapped-up raise only */}
+                  {isOverviewRaiseClosed && (
                     <div
                       className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0"
                       data-testid="overview-unique-backers"
@@ -779,8 +793,8 @@ const MissionProfileHeader = React.memo(
                     </div>
                   )}
 
-                  {/* Median Contribution — Overview Flight only */}
-                  {isOverviewMission && (
+                  {/* Median Contribution — Overview Flight, wrapped-up raise only */}
+                  {isOverviewRaiseClosed && (
                     <div
                       className="bg-white/[0.03] rounded-xl p-2 sm:p-3 border border-white/[0.05] min-w-0"
                       data-testid="overview-median-contribution"

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -228,6 +228,13 @@ export const OVERVIEW_PATH_VOTE_DEADLINE: string | null = null
 // re-tallying live balances, so the published outcome never drifts afterward.
 // Regenerate the snapshot with `yarn snapshot:path-vote` before flipping this.
 export const OVERVIEW_PATH_VOTE_CLOSED = true
+// Hard close for the Overview Flight fundraiser (mission id 4). When true the
+// mission page swaps its live progress bar / milestones / Goal + Deadline tiles
+// for the wrapped-up "success metrics + Seat Procurement" layout. Set to false
+// to re-open the raise (restores the live funding UI). The contribute button
+// and deadline countdown are additionally gated on the on-chain deadline/stage,
+// so re-opening also requires the re-open ruleset to be live on-chain.
+export const OVERVIEW_FLIGHT_RAISE_CLOSED = false
 // TODO: Replace with actual $OVERVIEW token address from team
 export const OVERVIEW_TOKEN_ADDRESS = '0xc868dFc4Ad388F5d7A8A5c3ECa0cff226d77152a'
 export const OVERVIEW_TOKEN_DECIMALS = 18

--- a/ui/const/missionMilestones.ts
+++ b/ui/const/missionMilestones.ts
@@ -62,6 +62,47 @@ export function getMissionTagline(
 }
 
 /**
+ * Description (About tab) HTML overrides (mission id → HTML). Same precedence
+ * semantics as {@link MISSION_TAGLINE_OVERRIDES}: takes priority over the
+ * on-chain metadata description so the mission "About" section reflects the
+ * Frank re-open campaign until the on-chain metadata is refreshed. Remove a
+ * mission's entry once its on-chain description is updated. Rendered via
+ * dangerouslySetInnerHTML, so this must stay trusted, author-controlled markup.
+ */
+export const MISSION_DESCRIPTION_OVERRIDES: Partial<Record<number, string>> = {
+  4: `
+<h2>The competition is back on</h2>
+<p>The campaign to send Frank White to space is live again — and the contest to fly alongside him is back on. This isn&#39;t a reset; it&#39;s step two. Nothing from the first raise has been spent: every dollar is still held, and every original backer keeps their place in the story.</p>
+<p>After a month of calls with spaceflight providers across three continents and a community vote on where to go next, the answer came back loud and clear: finish what we started.</p>
+<h3>What&#39;s new this round</h3>
+<ul>
+<li><strong>A reachable goal.</strong> Our near-term target is <strong>$250,000</strong> — enough to lock in a guaranteed second stratospheric seat. Frank&#39;s seat is the floor we&#39;re building on; this milestone is about sending a member of our community up with him.</li>
+<li><strong>A bigger, contingent prize.</strong> Pending live negotiations, reaching <strong>$500,000</strong> could unlock a dedicated, premium two-seat mission with Virgin Galactic — Frank and a community flier, together.</li>
+<li><strong>Early backers win.</strong> $OVERVIEW opens at <strong>500 per ETH</strong> and steps down 50% every month. The earlier you contribute, the more voice you get.</li>
+<li><strong>Contributing is effortless.</strong> We rebuilt the flow end to end, including an Apple Pay on-ramp — backing a real spaceflight now takes seconds, whether or not you&#39;ve ever touched crypto.</li>
+</ul>
+<h3>A flight forty years in the making</h3>
+<p>For nearly four decades, Frank White has been the world&#39;s most patient witness to an experience he never had. He interviewed more than fifty astronauts and gave the feeling they described a name: the Overview Effect. He wrote the language the entire industry now speaks — and he has never been to space.</p>
+<p>In the first round, supporters raised over <strong>$172,000 from 157 contributions</strong> worldwide, with <strong>$0 spent</strong>. We said from the start that if we couldn&#39;t secure at least one seat for Frank, all funds would be returned. That promise still stands.</p>
+<h3>How to fly with Frank</h3>
+<p>One community member will fly alongside Frank. Any contribution of <strong>$100 or more</strong> grants free MoonDAO citizenship, which is required to enter. From there it&#39;s merit-based: community backing, an essay on what the Overview Effect means to you, review by a committee of professional and commercial astronauts, and a final community governance vote.</p>
+<p>The competition is back on. Frank could be next. Let&#39;s get him there.</p>
+`.trim(),
+}
+
+export function getMissionDescription(
+  missionId: unknown,
+  onChainDescription: string | undefined | null
+): string {
+  const id = Number(missionId)
+  if (Number.isFinite(id)) {
+    const override = MISSION_DESCRIPTION_OVERRIDES[id]
+    if (typeof override === 'string' && override.trim()) return override
+  }
+  return onChainDescription || ''
+}
+
+/**
  * Token symbol overrides for missions where the on-chain ERC20 hasn't been deployed via
  * Juicebox yet but the intended symbol is known (e.g. mission 4 / Overview Flight → OVERVIEW).
  */

--- a/ui/const/missionMilestones.ts
+++ b/ui/const/missionMilestones.ts
@@ -6,10 +6,8 @@ export type MissionFundingMilestone = {
 
 export const MISSION_FUNDING_MILESTONES_USD: Record<number, MissionFundingMilestone[]> = {
   4: [
-    { usd: 250_000, label: 'Stratospheric balloon seat #1' },
-    { usd: 500_000, label: 'Stratospheric balloon seat #2' },
-    { usd: 1_000_000, label: 'Suborbital seat #1' },
-    { usd: 2_000_000, label: 'Suborbital seat #2' },
+    { usd: 250_000, label: 'Community seat' },
+    { usd: 500_000, label: 'Virgin Galactic seat' },
   ],
 }
 

--- a/ui/const/missionMilestones.ts
+++ b/ui/const/missionMilestones.ts
@@ -37,6 +37,31 @@ export const MISSION_MINIMUM_GOAL_TOOLTIP =
   'Our near-term goal is $250,000 — enough to lock in a guaranteed second stratospheric seat so a community member can fly alongside Frank. Reaching $500,000 unlocks a dedicated two-seat Virgin Galactic mission. Nothing raised in the first round has been spent, and refunds are made available if a seat cannot be secured.'
 
 /**
+ * Tagline overrides (mission id → tagline). Takes precedence over the on-chain
+ * metadata tagline so the mission page can reflect campaign copy that isn't yet
+ * reflected on-chain — currently the Frank re-open for mission 4. Remove a
+ * mission's entry once its on-chain metadata is updated so the on-chain value
+ * (team-editable via the Edit Mission flow) becomes the source of truth again.
+ */
+export const MISSION_TAGLINE_OVERRIDES: Partial<Record<number, string>> = {
+  4: 'The competition is back on. Every dollar from round one is still held — now we’re raising to send a member of our community to space alongside Frank White.',
+}
+
+export function getMissionTagline(
+  missionId: unknown,
+  onChainTagline: string | undefined | null
+): string | undefined {
+  const id = Number(missionId)
+  if (Number.isFinite(id)) {
+    const override = MISSION_TAGLINE_OVERRIDES[id]
+    if (typeof override === 'string' && override.trim()) return override
+  }
+  const normalized =
+    typeof onChainTagline === 'string' ? onChainTagline.trim() : undefined
+  return normalized || undefined
+}
+
+/**
  * Token symbol overrides for missions where the on-chain ERC20 hasn't been deployed via
  * Juicebox yet but the intended symbol is known (e.g. mission 4 / Overview Flight → OVERVIEW).
  */

--- a/ui/const/missionMilestones.ts
+++ b/ui/const/missionMilestones.ts
@@ -6,8 +6,8 @@ export type MissionFundingMilestone = {
 
 export const MISSION_FUNDING_MILESTONES_USD: Record<number, MissionFundingMilestone[]> = {
   4: [
-    { usd: 250_000, label: 'Community seat' },
-    { usd: 500_000, label: 'Virgin Galactic seat' },
+    { usd: 250_000, label: 'Guaranteed 2nd stratospheric seat' },
+    { usd: 500_000, label: 'Virgin Galactic two-seat mission' },
   ],
 }
 
@@ -34,7 +34,7 @@ export function getMissionMinimumUsdGoal(missionId: unknown): number | undefined
 }
 
 export const MISSION_MINIMUM_GOAL_TOOLTIP =
-  'This is our minimum goal, if we raise beyond this amount we will expand our ambition to other flight profiles. If we do not achieve our minimum goal refunds will be made available.'
+  'Our near-term goal is $250,000 — enough to lock in a guaranteed second stratospheric seat so a community member can fly alongside Frank. Reaching $500,000 unlocks a dedicated two-seat Virgin Galactic mission. Nothing raised in the first round has been spent, and refunds are made available if a seat cannot be secured.'
 
 /**
  * Token symbol overrides for missions where the on-chain ERC20 hasn't been deployed via

--- a/ui/cypress/integration/mission/mission-profile-header-overview.cy.tsx
+++ b/ui/cypress/integration/mission/mission-profile-header-overview.cy.tsx
@@ -81,6 +81,11 @@ function buildOverviewProps(overrides: Partial<any> = {}) {
     setDeployTokenModalEnabled: undefined,
     contributeButton: <button id="mock-contribute-btn">Contribute</button>,
     overviewStats,
+    // These tests specifically cover the wrapped-up ("closed") Overview layout,
+    // which is now gated on the `overviewRaiseClosed` prop (config flag
+    // OVERVIEW_FLIGHT_RAISE_CLOSED). Opt into it so the closed-state coverage
+    // stays valid for when the raise is re-closed after the re-open campaign.
+    overviewRaiseClosed: true,
     ...overrides,
   }
 }
@@ -219,6 +224,50 @@ describe('MissionProfileHeader — Overview Flight (mission 4) wrapped-up layout
     )
     cy.contains('raised').should('be.visible')
     cy.get('#mock-contribute-btn').should('exist')
+  })
+})
+
+describe('MissionProfileHeader — Overview Flight (mission 4) re-opened raise', () => {
+  beforeEach(() => {
+    cy.mountNextRouter('/')
+    setupMocks()
+  })
+
+  // With the raise re-opened (overviewRaiseClosed=false) mission 4 keeps its
+  // Overview-specific layout but restores the standard live funding UI:
+  // progress bar + milestone list + Goal tile, and no closed-state panels.
+  const openProps = (overrides: Partial<any> = {}) => {
+    const deadline = Date.now() + 10 * 86400000 // 10 days out
+    return buildOverviewProps({
+      overviewRaiseClosed: false,
+      deadline,
+      deadlinePassed: false,
+      duration: '10d 0h',
+      stage: 1,
+      ...overrides,
+    })
+  }
+
+  it('restores the live funding UI and drops the closed-state panels', () => {
+    cy.mount(
+      <TestnetProviders>
+        <MissionProfileHeader {...openProps()} />
+      </TestnetProviders>
+    )
+    // Live milestone progress bar + Goal tile are back.
+    cy.get('.from-blue-500.via-purple-600.to-blue-500').should('exist')
+    cy.contains('Goal').should('be.visible')
+    // New re-open milestone labels render.
+    cy.contains('Community seat').should('exist')
+    cy.contains('Virgin Galactic seat').should('exist')
+    // Closed-state UI is gone.
+    cy.get('[data-testid="overview-contributions-closed-banner"]').should(
+      'not.exist'
+    )
+    cy.get('[data-testid="overview-seat-procurement-panel"]').should(
+      'not.exist'
+    )
+    cy.get('[data-testid="overview-stats-row"]').should('not.exist')
   })
 })
 

--- a/ui/cypress/integration/mission/mission-profile-header-overview.cy.tsx
+++ b/ui/cypress/integration/mission/mission-profile-header-overview.cy.tsx
@@ -258,8 +258,8 @@ describe('MissionProfileHeader — Overview Flight (mission 4) re-opened raise',
     cy.get('.from-blue-500.via-purple-600.to-blue-500').should('exist')
     cy.contains('Goal').should('be.visible')
     // New re-open milestone labels render.
-    cy.contains('Community seat').should('exist')
-    cy.contains('Virgin Galactic seat').should('exist')
+    cy.contains('Guaranteed 2nd stratospheric seat').should('exist')
+    cy.contains('Virgin Galactic two-seat mission').should('exist')
     // Closed-state UI is gone.
     cy.get('[data-testid="overview-contributions-closed-banner"]').should(
       'not.exist'


### PR DESCRIPTION
## Summary
Re-lands the UI changes from #1435 (closed unmerged), rebased onto current main, so the now-public `/mission/4` page reflects the second raise instead of the wrapped-up layout:

- Restores the live funding UI (progress bar, milestone list, Goal tile, Deadline countdown) by defaulting `OVERVIEW_FLIGHT_RAISE_CLOSED` to `false`; the closed layout stays one flag flip away.
- Sets the new goal to **$250k** (guaranteed 2nd stratospheric seat), with a **$500k** Virgin Galactic two-seat stretch milestone.
- Keeps the off-chain committed amount in the raised total.
- Adds re-open campaign tagline and About-section narrative overrides for mission 4 (take precedence until on-chain metadata is refreshed).

## Test plan
- [ ] Visit `/mission/4` on the preview deploy: no "contributions closed" banner; live progress bar, $250k goal, milestones, and deadline countdown render.
- [ ] About tab shows the re-open narrative; header shows the new tagline.
- [ ] `yarn cypress run --spec cypress/integration/mission/mission-profile-header-overview.cy.tsx` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and trusted marketing copy only; no payment or auth changes. Re-closing the raise remains a single config toggle.
> 
> **Overview**
> Re-opens the **Overview Flight** (`/mission/4`) page for round two by defaulting **`OVERVIEW_FLIGHT_RAISE_CLOSED`** to `false`, so users see live fundraising again while the wrapped-up layout (closed banner, seat procurement, success stat row) stays available when that flag is flipped back to `true`.
> 
> The header no longer treats every mission 4 view as “closed”: **`overviewRaiseClosed`** (wired from config in `MissionProfile`) gates only the post-raise UI, while the Overview-specific layout still follows mission id 4.
> 
> **Campaign copy and goals** are updated in `missionMilestones.ts`: milestones are **$250k** (guaranteed 2nd stratospheric seat) and **$500k** (Virgin Galactic two-seat stretch), plus refreshed minimum-goal tooltip. **`getMissionTagline`** and **`getMissionDescription`** override on-chain metadata for mission 4 until chain metadata is updated; the About tab uses **`getMissionDescription`** instead of raw `metadata.description`.
> 
> Cypress coverage keeps closed-layout tests behind **`overviewRaiseClosed: true`** and adds a case that the re-opened state restores progress bar, Goal tile, and new milestone labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ea36f6e5b47783504a5fc46398cd5a972b5989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->