### PR TITLE
feat(ui): single $250k goal for mission 4 — drop $500k stretch, show Open deadline

### DIFF
--- a/ui/components/mission/MissionProfileHeader.tsx
+++ b/ui/components/mission/MissionProfileHeader.tsx
@@ -718,7 +718,13 @@ const MissionProfileHeader = React.memo(
                             ? 'Closed'
                             : 'Deadline'}
                         </span>
-                        {deadline != null && deadline > 0 ? (
+                        {/* Hide the exact-closing tooltip for the Overview
+                            mission while it's open — the tile reads "Open"
+                            (no meaningful closing date), so surfacing the
+                            far-out on-chain deadline would contradict it. */}
+                        {deadline != null &&
+                        deadline > 0 &&
+                        (!isOverviewMission || deadlinePassed) ? (
                           <span className="flex-shrink-0">
                             <Tooltip
                               text={exactClosingTooltipText(deadline)}
@@ -743,6 +749,14 @@ const MissionProfileHeader = React.memo(
                       ) : Number(stage) === 3 ? (
                         <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
                           REFUND
+                        </p>
+                      ) : isOverviewMission ? (
+                        // The Overview Flight re-open runs without a meaningful
+                        // closing date (the on-chain deadline is set far out),
+                        // so a day-countdown would read as noise. Show a simple
+                        // open status instead.
+                        <p className="text-white font-GoodTimes text-[10px] sm:text-sm break-words leading-tight">
+                          Open
                         </p>
                       ) : deadline != null && deadline > 0 ? (
                         <MissionDeadlineCountdown deadline={deadline} />

--- a/ui/const/missionMilestones.ts
+++ b/ui/const/missionMilestones.ts
@@ -7,7 +7,6 @@ export type MissionFundingMilestone = {
 export const MISSION_FUNDING_MILESTONES_USD: Record<number, MissionFundingMilestone[]> = {
   4: [
     { usd: 250_000, label: 'Guaranteed 2nd stratospheric seat' },
-    { usd: 500_000, label: 'Virgin Galactic two-seat mission' },
   ],
 }
 
@@ -34,7 +33,7 @@ export function getMissionMinimumUsdGoal(missionId: unknown): number | undefined
 }
 
 export const MISSION_MINIMUM_GOAL_TOOLTIP =
-  'Our near-term goal is $250,000 — enough to lock in a guaranteed second stratospheric seat so a community member can fly alongside Frank. Reaching $500,000 unlocks a dedicated two-seat Virgin Galactic mission. Nothing raised in the first round has been spent, and refunds are made available if a seat cannot be secured.'
+  'Our near-term goal is $250,000 — enough to lock in a guaranteed second stratospheric seat so a community member can fly alongside Frank. Nothing raised in the first round has been spent, and refunds are made available if a seat cannot be secured.'
 
 /**
  * Tagline overrides (mission id → tagline). Takes precedence over the on-chain
@@ -76,9 +75,8 @@ export const MISSION_DESCRIPTION_OVERRIDES: Partial<Record<number, string>> = {
 <p>After a month of calls with spaceflight providers across three continents and a community vote on where to go next, the answer came back loud and clear: finish what we started.</p>
 <h3>What&#39;s new this round</h3>
 <ul>
-<li><strong>A reachable goal.</strong> Our near-term target is <strong>$250,000</strong> — enough to lock in a guaranteed second stratospheric seat. Frank&#39;s seat is the floor we&#39;re building on; this milestone is about sending a member of our community up with him.</li>
-<li><strong>A bigger, contingent prize.</strong> Pending live negotiations, reaching <strong>$500,000</strong> could unlock a dedicated, premium two-seat mission with Virgin Galactic — Frank and a community flier, together.</li>
-<li><strong>Early backers win.</strong> $OVERVIEW opens at <strong>500 per ETH</strong> and steps down 50% every month. The earlier you contribute, the more voice you get.</li>
+<li><strong>A reachable goal.</strong> Our near-term target is <strong>$250,000</strong> — enough to lock in a guaranteed second seat on a stratospheric flight. Frank&#39;s seat is the floor we&#39;re building on; this milestone is about making good on the original promise: sending a member of our community up with him.</li>
+<li><strong>Early backers win.</strong> $OVERVIEW now opens at <strong>500 per ETH</strong>. As we reach milestones, we will reduce the rate of $OVERVIEW contributors get. The earlier you contribute, the more voice you get.</li>
 <li><strong>Contributing is effortless.</strong> We rebuilt the flow end to end, including an Apple Pay on-ramp — backing a real spaceflight now takes seconds, whether or not you&#39;ve ever touched crypto.</li>
 </ul>
 <h3>A flight forty years in the making</h3>

--- a/ui/cypress/integration/mission/mission-profile-header-overview.cy.tsx
+++ b/ui/cypress/integration/mission/mission-profile-header-overview.cy.tsx
@@ -257,9 +257,13 @@ describe('MissionProfileHeader — Overview Flight (mission 4) re-opened raise',
     // Live milestone progress bar + Goal tile are back.
     cy.get('.from-blue-500.via-purple-600.to-blue-500').should('exist')
     cy.contains('Goal').should('be.visible')
-    // New re-open milestone labels render.
+    // The single re-open milestone renders (the $500k Virgin Galactic
+    // stretch milestone was dropped from the campaign).
     cy.contains('Guaranteed 2nd stratospheric seat').should('exist')
-    cy.contains('Virgin Galactic two-seat mission').should('exist')
+    cy.contains('Virgin Galactic two-seat mission').should('not.exist')
+    // The deadline tile reads "Open" instead of a day countdown — the
+    // re-open runs without a meaningful closing date.
+    cy.contains('Open').should('be.visible')
     // Closed-state UI is gone.
     cy.get('[data-testid="overview-contributions-closed-banner"]').should(
       'not.exist'


### PR DESCRIPTION
## Summary
Follow-up to #1452 with the latest campaign copy changes for the now-live `/mission/4` page:

- Drop the $500k Virgin Galactic stretch milestone — the campaign now targets a single **$250k** goal (guaranteed 2nd stratospheric seat). Removed from the milestone list, the Goal tooltip, and the About narrative.
- Deadline tile on mission 4 now reads **"Open"** instead of a ~546-day countdown (scoped to the Overview mission; other missions keep their countdowns). The exact-closing-date tooltip is hidden there too so it doesn't contradict "Open".
- About-tab copy updated: revised "reachable goal" bullet and new early-backers wording (rate reduces as milestones are reached, instead of 50% monthly).
- Updated the Overview header Cypress test to match (single milestone, "Open" deadline tile).

## Test plan
- [ ] On the preview deploy, `/mission/4` shows only the $250k milestone; no $500k / Virgin Galactic references in the goal tooltip or About tab.
- [ ] Deadline tile reads "Open" with no countdown and no exact-date tooltip.
- [ ] `yarn cypress run --spec cypress/integration/mission/mission-profile-header-overview.cy.tsx` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and static campaign copy for mission 4 only; no auth, payments, or on-chain logic changes.
> 
> **Overview**
> Mission 4 (Overview Flight) campaign messaging now targets a **single $250k** milestone—the **$500k Virgin Galactic stretch** is removed from `MISSION_FUNDING_MILESTONES_USD`, the Goal tooltip, and the About-tab HTML override (reachable-goal and early-backers bullets revised).
> 
> While the re-opened raise is live, the header **deadline tile shows "Open"** instead of a long on-chain countdown, and the **exact closing-date tooltip is hidden** so it does not contradict that status; other missions are unchanged.
> 
> Cypress coverage for the re-opened Overview header is updated for one milestone and the **Open** deadline label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7bc165b2ec9fb98139448d5b236676382e41190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->