### PR TITLE
fix(mission): show Fund UI when wallet balance is still unresolved

### DIFF
--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -1179,11 +1179,16 @@ export default function MissionContributeModal({
     }
   }, [crossChainQuote, usdInput, ethUsdPrice, chainSlug, defaultChainSlug, layerZeroLimitExceeded])
 
-  // Calculate how much ETH the user needs to buy
+  // Calculate how much ETH the user needs to buy.
+  // Treat an unresolved balance as 0 for deficit purposes — PaymentBreakdown
+  // already displays null as $0 / "Add via Coinbase", and gating FundOnramp on
+  // a resolved balance left users stuck with only a Close button when the
+  // balance fetch was slow or failed.
   const ethDeficit = useMemo(() => {
-    if (fundingBalanceWei === null || requiredWei === BigInt(0)) return 0
-    if (fundingBalanceWei >= requiredWei) return 0
-    const deficitWei = requiredWei - fundingBalanceWei
+    if (requiredWei === BigInt(0)) return 0
+    const balanceWei = fundingBalanceWei ?? BigInt(0)
+    if (balanceWei >= requiredWei) return 0
+    const deficitWei = requiredWei - balanceWei
     return parseFloat(formatUnits(deficitWei.toString(), 18))
   }, [fundingBalanceWei, requiredWei])
 
@@ -2793,6 +2798,18 @@ export default function MissionContributeModal({
                         setAwaitingOnrampFunds(true)
                       }}
                     />
+                  )}
+
+                  {usdInput &&
+                    ethDeficit <= 0 &&
+                    agreedToCondition &&
+                    isValidContributorEmail(contributorEmail.trim()) && (
+                    <div className="bg-blue-500/10 backdrop-blur-sm border border-blue-500/30 rounded-xl p-4">
+                      <p className="text-blue-200 text-sm">
+                        Calculating how much ETH you need to add. This usually takes a few
+                        seconds — if nothing appears, refresh the page and try again.
+                      </p>
+                    </div>
                   )}
 
                   {/* Show warning if checkbox not agreed */}


### PR DESCRIPTION
## Summary
- Fixes the stuck contribute modal where users saw “Add via Coinbase” / email + terms, but only a **Close** button and no Apple Pay / Fund UI.
- Root cause: `ethDeficit` returned `0` while the wallet balance was still `null` (slow or failed balance fetch), so `FundOnramp` never mounted even though the payment breakdown already treated that as a $0 wallet needing funding.

## Changes
- Treat an unresolved funding balance as `0` when computing `ethDeficit`, so Fund / Apple Pay mounts as soon as email + terms are ready.
- Add a short fallback message if the amount still can’t be calculated, instead of leaving users with only Close.

## Test plan
- [ ] Open contribute with a $0 / empty wallet: after email + terms, Fund / Apple Pay appears
- [ ] Slow or failed balance fetch still shows Fund UI (not only Close)
- [ ] Users with enough ETH still see Contribute, not Fund
- [ ] Gas “—” display does not block Fund from appearing


Made with [Cursor](https://cursor.com)