### PR TITLE
Improve project proposal template and Project System landing

### DIFF
--- a/ui/components/layout/ExpandedFooter.tsx
+++ b/ui/components/layout/ExpandedFooter.tsx
@@ -163,6 +163,7 @@ export function ExpandedFooter({
 
   const projectsLinks = [
     { text: 'Propose Project', href: '/proposals' },
+    { text: 'Proposal Template', href: '/proposal-template' },
     { text: 'Explore Projects', href: '/projects' },
     { text: 'Submit Contribution', href: '/contributions' },
     { text: 'Projects Overview', href: '/projects-overview' },

--- a/ui/components/layout/GlobalSearch.tsx
+++ b/ui/components/layout/GlobalSearch.tsx
@@ -47,6 +47,26 @@ const searchMappings = [
   },
   {
     keywords: [
+      'proposal template', 'project template', 'novelty prior art', 'lunar bridge',
+      'proposal checklist', 'how to write proposal', 'grant template',
+    ],
+    title: 'Project Proposal Template',
+    description: 'Canonical markdown template with novelty, lunar bridge, budget classes, and checklist',
+    link: '/proposal-template',
+    category: 'Governance',
+  },
+  {
+    keywords: [
+      'projects overview', 'project system', 'how projects work', 'project grants',
+      'quarterly grants', 'what we fund',
+    ],
+    title: 'Project System Overview',
+    description: 'How MoonDAO funds projects, max budget, what we fund, and how to submit',
+    link: '/projects-overview',
+    category: 'Governance',
+  },
+  {
+    keywords: [
       'projects', 'project rewards', 'fund project', 'active projects', 'current projects',
       'project voting', 'vote project', 'project funding', 'rewards cycle', 'distributions',
     ],

--- a/ui/components/layout/ProjectBanner.tsx
+++ b/ui/components/layout/ProjectBanner.tsx
@@ -3,7 +3,13 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 
-const PROJECT_PAGES = ['/projects-overview', '/projects', '/proposals', '/submit']
+const PROJECT_PAGES = [
+  '/projects-overview',
+  '/projects',
+  '/proposals',
+  '/proposal-template',
+  '/submit',
+]
 
 // Check if deadline has passed (computed once on module load)
 const SUBMISSION_DEADLINE = new Date(PROJECT_SYSTEM_CONFIG.submissionDeadline)

--- a/ui/components/layout/Sidebar/ProjectsNavDropdown.tsx
+++ b/ui/components/layout/Sidebar/ProjectsNavDropdown.tsx
@@ -112,6 +112,11 @@ export function ProjectsNavDropdown({
           Projects Overview
         </Link>
       )}
+      {wrapMobile(
+        <Link href="/proposal-template" className={baseLinkClass} onClick={onNavigate}>
+          Proposal Template
+        </Link>
+      )}
       {isDesktop ? (
         <div className="pt-2">
           <div className="px-4 py-2 mx-2 text-xs text-gray-400 font-medium uppercase tracking-wider">

--- a/ui/lib/nance/index.ts
+++ b/ui/lib/nance/index.ts
@@ -33,7 +33,7 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 
 # Solution
 
-*Describe the work that will be done this quarter. Keep scope to inspectable deliverables. Note open questions and future directions separately from funded objectives. Do not list entity formation, buying a general computer, or clearing tax bills as solutions.*
+*Describe the work that will be done this quarter. Keep scope to inspectable deliverables. Note open questions and future directions separately from funded objectives. Do not list entity formation or buying a general computer as solutions.*
 
 **If success depends on a partner** *(university, launch provider, facility, platform):* *Name them and attach LOI, quote, ICD, or access MOU before the vote.*
 
@@ -136,7 +136,7 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 
 **What MoonDAO funds:** labor for inspectable deliverables, and specialized equipment/services the work uniquely needs (with ownership/access terms).
 
-**What MoonDAO does not fund:** general computers/monitors/printers/furniture; LLC/sole-prop formation; tax bills, re-registration, or private company runway bailouts.
+**What MoonDAO does not fund:** general computers/monitors/printers/furniture; LLC/sole-prop formation; re-registration, or private company runway bailouts.
 
 | Description | Class (A–E) | Amount (USD) | Justification |
 | :---- | :---- | :---- | :---- |
@@ -160,18 +160,13 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 # Pre-submit checklist
 
 - [ ] Ask ≤ posted quarterly max ($${maxFormatted})
-- [ ] Novelty & Prior Art filled with links
-- [ ] Lunar Bridge paragraph completed
-- [ ] Community standing / engagement noted
+- [ ] All required sections completed; italicized instructions removed
 - [ ] Key Results are non-empty and testable
-- [ ] Budget classes filled; (C) and (D) are $0
-- [ ] Specialized gear has ownership/access terms
-- [ ] Same-type prior work linked per major deliverable
-- [ ] IP disclosure completed
+- [ ] Budget justified and within allowed categories
+- [ ] Team, timeline, and IP disclosure filled in
 - [ ] Only one primary proposal from this Lead this quarter
-- [ ] Partner LOIs/quotes attached if the plan depends on them
-- [ ] Hardware asks include COTS / why-not-existing rationale
-- [ ] No megaproject OKRs mixed into this quarter’s funded scope
+- [ ] Supporting docs attached if the plan depends on partners
+- [ ] Scope limited to this quarter’s inspectable deliverables
 `
 }
 

--- a/ui/lib/nance/index.ts
+++ b/ui/lib/nance/index.ts
@@ -1,5 +1,4 @@
-import { MOONDAO_ARBITRUM_TREASURY, MOONDAO_TREASURY } from 'const/config'
-import { v4 } from 'uuid'
+import { MAX_BUDGET_USD, MOONDAO_ARBITRUM_TREASURY, MOONDAO_TREASURY } from 'const/config'
 
 export function formatNumberUSStyle(n: string | number | bigint, compact: boolean = false) {
   return new Intl.NumberFormat('en-US', {
@@ -8,63 +7,105 @@ export function formatNumberUSStyle(n: string | number | bigint, compact: boolea
   }).format(n as any)
 }
 
-export const TEMPLATE = `\n*Note: Please remove the italicized instructions before submitting*\n
+/** Markdown project proposal template shown to authors and used as the canonical form. */
+export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): string {
+  const maxFormatted = maxBudgetUsd.toLocaleString('en-US')
+
+  return `\n*Note: Please remove the italicized instructions before submitting. Incomplete Key Results, missing Novelty & Prior Art, or asks above the quarterly max will be returned for rewrite.*\n
 
 **Author:**
+**Discord:**
 **Date:**
+**Other proposals from this Lead this quarter:** *None / list titles — one primary ask per Lead per quarter is strongly preferred.*
 
 # Abstract
 
-*This is a high-level description of the idea. Please use ELI5 (explain like I’m five years old) wording and summarize things for anyone to understand what you want to achieve.*
+*This is a high-level description of the idea. Use ELI5 wording. Summarize what you will deliver in this quarter and how it advances lunar settlement.*
 
 # Problem
 
-*Describe the problem your proposal solves.*
+*Describe the specific problem. Avoid vague “space is hard” framing. If this is hardware, state the operational failure (who, when, environment). If MoonDAO has funded related work before, acknowledge it and explain what is new.*
 
 # Solution
 
-*Describe the “meat & potatoes” of the proposal. Go into necessary detail about the work that needs to be done, alternative solutions considered, open questions, and future directions. Keep it concise.*
+*Describe the work that will be done this quarter. Keep scope to inspectable deliverables. Note open questions and future directions separately from funded objectives. Do not list entity formation, buying a general computer, or clearing tax bills as solutions.*
+
+# Novelty & Prior Art
+
+*Required. “This is innovative” without citations is not enough.*
+
+**What already exists?**
+*List the most relevant public prior art: papers, NASA/ESA/agency docs, open tools/datasets, commercial products, and prior MoonDAO projects. Link where possible.*
+
+**What is new about this project?**
+*State the specific deliverable or question that prior work does not already provide (new method, open pack for MoonDAO, integration, audience, test, etc.).*
+
+**Why not just use the existing work?**
+*Explain why pointing members at the citations above is insufficient for MoonDAO’s need this quarter.*
+
+**Honesty check**
+*If your contribution is mainly synthesis, translation, localization, education, or packaging of known ideas, say so. Do not claim “first ever,” “no open methodology exists,” or “completely unique” unless you can defend it against the literature.*
+
+# Lunar Bridge
+
+*Required. In 3–5 sentences, explain how this quarter’s outputs change MoonDAO’s path to a sustained human presence on the Moon. LEO tourism, generic STEAM branding, or “space is inspiring” alone are not enough.*
 
 # Benefits
 
-*Point out the core benefits of the proposal implementation and how it will affect MoonDAO. If the proposal can create revenue please create justification for how much revenue it could generate.*
+*Core benefits for MoonDAO members and the mission. If you claim revenue potential, separate long-term upside from what this grant actually buys. Do not promise megaproject outcomes from a single quarterly ask.*
 
 # Risks
 
-*Highlight any risks from implementing the proposal, how could this go wrong? How are you addressing those risks?*
+*Highlight risks (technical, schedule, partner dependency, safety). How are you mitigating them?*
 
 # Objectives
 
-*You can write as many OKRs as you think are needed. One focused goal is preferred instead of many. OKRs should use SMART principles (Specific, Measurable, Achievable, Relevant, and Time-Bound).*
+*Prefer one focused objective. OKRs must use SMART principles. Key Results cannot be empty.*
 
-**Objective \#1:** *What do you want to achieve with this project. Be specific.*  
-**Key Results for Objective \#1**: 
+**Objective #1:** *What will exist at the end of this project that does not exist today?*
 
-- *What is a measurable result that indicates this objective has been met?*  
-- *Include 3-4 relevant metrics that indicate success for the objective*
+**Key Results for Objective #1:**
 
-**Member(s) responsible for OKR** **and their role:**
+- *Measurable result #1 (artifact, metric, or demo)*
+- *Measurable result #2*
+- *Measurable result #3*
 
-- *Is there a specific member or set of members that are responsible for this particular objective? If all of them are responsible for this just say “All”*
+**Member(s) responsible for OKR and their role:**
+
+- *Name / role*
+
+**Non-goals this quarter:**
+- *Explicitly list what you will not build (e.g. full habitat design, flight hardware, company formation).*
 
 # Team (Table A)
 
 ***Project Lead:** The Project Lead and representative for the project within the MoonDAO Senate. The Project Lead is responsible for:*
 
-1. *Attending weekly town hall meetings, reviewing incoming proposals and voting on them within the Senate. Missed attendance will result in a 5% penalty to the rocketeer’s retroactive rewards.*  
-2. *Creating weekly updates to the community on the progress of the project in the “progress” channel on DIscord.*  
-3. *Adding team members, removing team members, and making decisions about the use of the budget throughout the lifetime of the project.*  
+1. *Attending weekly town hall meetings, reviewing incoming proposals and voting on them within the Senate. Missed attendance will result in a 5% penalty to the rocketeer’s retroactive rewards.*
+2. *Creating weekly updates to the community on the progress of the project in the “progress” channel on Discord.*
+3. *Adding team members, removing team members, and making decisions about the use of the budget throughout the lifetime of the project.*
 4. *Managing the multi-sig Treasury for the project as well as the payments for each of the members.*
 5. *Creating the Final Report and returning unused funds to the MoonDAO Treasury.*
 
-***Initial Team:** Projects may not need an initial team. It can just be an individual submitting a proposal. You may also create generic roles and hire other teammates after the project is approved. As a general rule of thumb, try to keep teams small and focused in the beginning, **with clear roles, deliverables, and OKRs for each member**. Team members are responsible for:*
+***Same-type prior work (required):** For each major deliverable, link prior work of that same type (e.g. prior course if promising a course; prior device build if promising hardware; prior report if promising a study). Domain expertise alone is not enough.*
 
-1. *Posting a weekly update in the “progress” channel on Discord with their contributions that week. Not posting a weekly update will result in a 5% penalty to their retroactive rewards.*
+***Initial Team:** Keep teams small and focused, with clear roles and deliverables. Prefer people who already work together over recruiting strangers after funding for technical Zoom brainstorms.*
 
 | Project Lead | *@DiscordUsername* |
 | :---- | :---- |
 | **Initial Team** | *Role 1: “Developer” @DiscordUsername1: eth:0x0...1. “Description of the role and deliverable for this member” Role 2: “Designer” @DiscordUsername2: eth:0x0...2. “Description of the role and deliverable for this member”* |
-| **Multi-sig signers\*** | *Five required with their ETH addresses listed. “@DiscordUsername1: eth:0x0...1” “@DiscordUsername2: eth:0x0...2” “@DiscordUsername3: eth:0x0...3” “@DiscordUsername4: eth:0x0...4” “@DiscordUsername5: eth:0x0...5” Multi-sig will be automatically created after proposal is submitted. |
+| **Same-type prior work links** | *Deliverable → link to prior same-type work* |
+| **Multi-sig signers\\*** | *Five required with their ETH addresses listed. “@DiscordUsername1: eth:0x0...1” … Multi-sig will be automatically created after proposal is submitted.* |
+
+# Intellectual Property
+
+*Required. Choose one and fill in details.*
+
+- **Open (default):** Creative Commons / open-source license: *e.g. CC BY 4.0 / MIT*
+- **Retained / patented:** *What the Lead or company keeps; what MoonDAO and the public still receive (report, demo, limited license, open subsets).*
+- **Mixed:** *Describe the split.*
+
+*Undisclosed proprietary lock-up is not acceptable. Retained IP is allowed when stated upfront with clear community-facing outputs.*
 
 # Timeline (Table B)
 
@@ -72,23 +113,62 @@ export const TEMPLATE = `\n*Note: Please remove the italicized instructions befo
 | :---- | :---- |
 | 0 | Proposal Passes |
 | 7 | *Insert your milestones here.* |
-|  |  |
+| 30 |  |
+| 60 |  |
+| 90 | *Final deliverables, Town Hall presentation, return unused funds* |
 
-**Deadline for the project: End of Q3.**
+**Deadline for the project:** *End of the funded quarter (confirm on the Project System page).*
 
-# Transactions (Table C)
+# Budget (Table C)
 
-*Please write out the specific transactions that need to be executed if this proposal passes. Please include the exact amount and token type and the receiving address (this is the multi-sig if there is more than one transaction that needs to be executed throughout the lifetime of this project.)*
+*Total ask must be ≤ **$${maxFormatted}** (1/5 of this quarter’s project budget — confirm the live figure on moondao.com/propose). Classify every dollar.*
+
+**What MoonDAO funds:** labor for inspectable deliverables, and specialized equipment/services the work uniquely needs (with ownership/access terms).
+
+**What MoonDAO does not fund:** general computers/monitors/printers/furniture; LLC/sole-prop formation; tax bills, re-registration, or private company runway bailouts.
+
+| Description | Class (A–E) | Amount (USD) | Justification |
+| :---- | :---- | :---- | :---- |
+| *e.g. Lead labor — report + simulations* | *A = labor* | *$* | *Hours × rate; tied to which KR* |
+| *e.g. Specialized test fixture* | *B = specialized gear / DAO-retained tool* | *$* | *Why not ordinary personal kit; ownership/access terms* |
+| *Foundational PC / home office* | *C — not allowed* | *$0* | *Remove* |
+| *Entity formation / tax / bailout* | *D — not allowed* | *$0* | *Remove* |
+| *Other overhead* | *E* | *$* | *Scrutinize* |
+| **Total** |  | *≤ $${maxFormatted}* |  |
+
+*If success depends on a university, launch provider, or other partner: attach LOI, quote, or access MOU before the vote.*
+
+# Transactions (Table D)
+
+*Please write out the specific transactions that need to be executed if this proposal passes. Include the exact amount, token type, and receiving address (the multi-sig if there is more than one transaction over the project lifetime).*
 
 | Transaction Type | Amount | Token Type | Receiving Address |
 | :---- | :---- | :---- | :---- |
 | *Send* | *0* | *ETH* | *TBD* |
+
+# Pre-submit checklist
+
+- [ ] Ask ≤ posted quarterly max ($${maxFormatted})
+- [ ] Novelty & Prior Art filled with links
+- [ ] Lunar Bridge paragraph completed
+- [ ] Key Results are non-empty and testable
+- [ ] Budget classes filled; (C) and (D) are $0
+- [ ] Specialized gear has ownership/access terms
+- [ ] Same-type prior work linked per major deliverable
+- [ ] IP disclosure completed
+- [ ] Only one primary proposal from this Lead this quarter
+- [ ] Partner LOIs/quotes attached if the plan depends on them
+- [ ] No megaproject OKRs mixed into this quarter’s funded scope
 `
+}
+
+/** @deprecated Prefer getProposalTemplate(MAX_BUDGET_USD) so the max stays current. */
+export const TEMPLATE = getProposalTemplate()
 
 export const FINAL_REPORT_TEMPLATE = `
 *The title of the project will be included at the top of the file."
 
-*\*Please read [Projects System v6: Completion](https://docs.moondao.com/Projects/Project-System#completion) before submitting to understand the process of submitting a project final report. When ready, download this doc as a markdown file (File \> Download \> Markdown (.md)) and then upload and submit it at [https://moondao.com/report](https://moondao.com/report)*
+*\\*Please read [Projects System v6: Completion](https://docs.moondao.com/Projects/Project-System#completion) before submitting to understand the process of submitting a project final report. When ready, download this doc as a markdown file (File \\> Download \\> Markdown (.md)) and then upload and submit it at [https://moondao.com/report](https://moondao.com/report)*
 
 ## Original Proposal
 
@@ -114,14 +194,14 @@ export const FINAL_REPORT_TEMPLATE = `
    2. **Key Result**: *Original key result as it appears in your initial proposal.*  
       **Results**: *The actual quantitative result or a link to the work completed.*
 
-   **Grade (Do not fill out \- Exec Leads will review):** *Overall Grade For The Objective*  
-      *Superb \= This is reserved for if the project went incredibly well without any flaws and vastly surpassed all original metrics. Very few projects will meet this grade.*
+   **Grade (Do not fill out \\- Exec Leads will review):** *Overall Grade For The Objective*  
+      *Superb \\= This is reserved for if the project went incredibly well without any flaws and vastly surpassed all original metrics. Very few projects will meet this grade.*
 
-   *Exceeds Expectations \= Did better than expected. The team surpassed expectations and went above and beyond the original scope of the project.*
+   *Exceeds Expectations \\= Did better than expected. The team surpassed expectations and went above and beyond the original scope of the project.*
 
-   *Meets Expectations \= The project met all its original goals and sufficiently hit all the criteria.*
+   *Meets Expectations \\= The project met all its original goals and sufficiently hit all the criteria.*
 
-   *Does Not Meet Expectations \= The project did not achieve its original goal.*
+   *Does Not Meet Expectations \\= The project did not achieve its original goal.*
 
 ## Member Contributions
 
@@ -139,7 +219,7 @@ export const FINAL_REPORT_TEMPLATE = `
 
 | Member Name | % of total rewards | Upfront Payment Received | Wallet to receive ETH |
 | :---- | :---- | :---- | :---- |
-| *@TeamMemberName* | *21%* | *3,000 DAI, 50,000 MOONEY* |  |
+| *@TeamMemberName* | *21%* | *3,000 DAI, 50,000 MOONEY* |  |
 
 ## Treasury Transparency (Table B)
 
@@ -152,5 +232,5 @@ export const FINAL_REPORT_TEMPLATE = `
 
 | Txn Title | Reason | Amount | Recipient | Etherscan Link or Gnosis Link | Deliverable |
 | :---- | :---- | :---- | :---- | :---- | :---- |
-| Legal Retainer | Retainer for contract lawyer | 3,000 DAI | Lawyers Inc. | **\<link\>** | **\<link\>** or if nothing to show please include a description of what was delivered. |
+| Legal Retainer | Retainer for contract lawyer | 3,000 DAI | Lawyers Inc. | **\\<link\\>** | **\\<link\\>** or if nothing to show please include a description of what was delivered. |
 `

--- a/ui/lib/nance/index.ts
+++ b/ui/lib/nance/index.ts
@@ -67,7 +67,7 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 
 # Risks
 
-*Highlight risks (technical, schedule, partner dependency, safety, collaboration method). How are you mitigating them? Avoid relying on ad-hoc Zoom with part-time strangers as the primary method for technical design—prefer a named synthesizer + named reviewers, or a team that already works together.*
+*Highlight risks (technical, schedule, partner dependency, safety, collaboration method). How are you mitigating them? Prefer a named synthesizer with named reviewers, or a team that already works together, over assembling ad-hoc contributors after funding for technical design.*
 
 # Objectives
 
@@ -100,7 +100,7 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 
 ***Same-type prior work (required):** For each major deliverable, link prior work of that same type (e.g. prior course if promising a course; prior device build if promising hardware; prior report if promising a study). Domain expertise alone is not enough.*
 
-***Initial Team:** Keep teams small and focused, with clear roles and deliverables. Prefer people who already work together over recruiting strangers after funding for technical Zoom brainstorms.*
+***Initial Team:** Keep teams small and focused, with clear roles and deliverables. Prefer people who already work together over recruiting contributors after funding for technical brainstorms.*
 
 | Project Lead | *@DiscordUsername* |
 | :---- | :---- |

--- a/ui/lib/nance/index.ts
+++ b/ui/lib/nance/index.ts
@@ -24,11 +24,18 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 
 # Problem
 
-*Describe the specific problem. Avoid vague “space is hard” framing. If this is hardware, state the operational failure (who, when, environment). If MoonDAO has funded related work before, acknowledge it and explain what is new.*
+*Describe the specific problem. Avoid vague “space is hard” framing. If MoonDAO has funded related work before, acknowledge it and explain what is new—do not claim a false “first” or “never funded.”*
+
+**If this is hardware / a product (required):**
+1. *What exact operational failure happens today (who, when, environment)?*
+2. *Why are commercial off-the-shelf (COTS) tools insufficient—especially in micro‑g / suit / vacuum / lunar conditions?*
+3. *What is novel relative to COTS + prior art?*
 
 # Solution
 
 *Describe the work that will be done this quarter. Keep scope to inspectable deliverables. Note open questions and future directions separately from funded objectives. Do not list entity formation, buying a general computer, or clearing tax bills as solutions.*
+
+**If success depends on a partner** *(university, launch provider, facility, platform):* *Name them and attach LOI, quote, ICD, or access MOU before the vote.*
 
 # Novelty & Prior Art
 
@@ -50,13 +57,17 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 
 *Required. In 3–5 sentences, explain how this quarter’s outputs change MoonDAO’s path to a sustained human presence on the Moon. LEO tourism, generic STEAM branding, or “space is inspiring” alone are not enough.*
 
+# Community Standing
+
+*Briefly: How have you engaged with MoonDAO in the last 1–2 quarters (Discord, Town Halls, prior contributions)? If you lead an adjacent org, what ongoing bridge work exists beyond this funding ask? MoonDAO prefers builders who participate—not parachute treasury asks.*
+
 # Benefits
 
 *Core benefits for MoonDAO members and the mission. If you claim revenue potential, separate long-term upside from what this grant actually buys. Do not promise megaproject outcomes from a single quarterly ask.*
 
 # Risks
 
-*Highlight risks (technical, schedule, partner dependency, safety). How are you mitigating them?*
+*Highlight risks (technical, schedule, partner dependency, safety, collaboration method). How are you mitigating them? Avoid relying on ad-hoc Zoom with part-time strangers as the primary method for technical design—prefer a named synthesizer + named reviewers, or a team that already works together.*
 
 # Objectives
 
@@ -151,6 +162,7 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 - [ ] Ask ≤ posted quarterly max ($${maxFormatted})
 - [ ] Novelty & Prior Art filled with links
 - [ ] Lunar Bridge paragraph completed
+- [ ] Community standing / engagement noted
 - [ ] Key Results are non-empty and testable
 - [ ] Budget classes filled; (C) and (D) are $0
 - [ ] Specialized gear has ownership/access terms
@@ -158,6 +170,7 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 - [ ] IP disclosure completed
 - [ ] Only one primary proposal from this Lead this quarter
 - [ ] Partner LOIs/quotes attached if the plan depends on them
+- [ ] Hardware asks include COTS / why-not-existing rationale
 - [ ] No megaproject OKRs mixed into this quarter’s funded scope
 `
 }

--- a/ui/pages/projects-overview.tsx
+++ b/ui/pages/projects-overview.tsx
@@ -11,6 +11,7 @@ import { GetServerSideProps } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import React, { useMemo, useEffect, useState } from 'react'
+import { motion, useReducedMotion } from 'framer-motion'
 import { useAssets } from '@/lib/dashboard/hooks'
 import { enrichProjectNames } from '@/lib/project/enrichProjectNames'
 import { Project } from '@/lib/project/useProjectData'
@@ -22,52 +23,80 @@ import WebsiteHead from '../components/layout/Head'
 import StandardButton from '../components/layout/StandardButton'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import DashboardActiveProjects from '@/components/project/DashboardActiveProjects'
+import Reveal from '@/components/home/landing/Reveal'
 import { PROJECT_ACTIVE, PROJECT_ENDED } from '@/lib/nance/types'
+
+const EASE: [number, number, number, number] = [0.21, 0.47, 0.32, 0.98]
 
 const STEPS = [
   {
     n: '01',
     title: 'Ideate',
-    body: 'Share the problem and draft solution in Discord. Get feedback before you lock a budget.',
+    body: 'Post the problem in Discord first. Feedback before a locked budget saves rewrite cycles.',
   },
   {
     n: '02',
     title: 'Propose',
-    body: 'Fill the template—novelty, lunar bridge, SMART key results, and a work-only budget under the max.',
+    body: 'Use the template: novelty, lunar bridge, SMART key results, work-only budget under the max.',
   },
   {
     n: '03',
     title: 'Present & vote',
-    body: 'Pitch at Town Hall. Senate diligence, then member vote. Funded leads join the Senate for the project.',
+    body: 'Town Hall pitch, Senate diligence, then member vote. Funded leads join the Senate for the project.',
   },
   {
     n: '04',
     title: 'Ship & rewards',
-    body: 'Weekly updates, final report, return unused funds. Completed work can earn quarterly retroactive rewards.',
+    body: 'Weekly updates, final report, return unused funds. Completed work can earn quarterly retro rewards.',
   },
 ]
 
 const FUND_YES = [
-  'Labor tied to inspectable deliverables',
-  'Specialized gear the work uniquely needs (with ownership/access terms)',
-  'Open reports, protocols, software, and member-usable tools',
+  {
+    title: 'Labor for deliverables',
+    body: 'Time that produces reports, code, protocols, curricula, or hardware you can inspect.',
+  },
+  {
+    title: 'Specialized tools',
+    body: 'Gear the work uniquely needs—with ownership or member-access terms—not a home office.',
+  },
+  {
+    title: 'Open community assets',
+    body: 'Methods, data, and software other MoonDAO projects can reuse.',
+  },
 ]
 
 const FUND_NO = [
-  'General computers, monitors, printers, or home-office setup',
-  'LLC / sole-prop formation or company registration fees',
+  'General computers, monitors, printers, or furniture',
+  'LLC / sole-prop formation or registration fees',
   'Tax bills, re-registration, or private runway bailouts',
+]
+
+const FIT_YES = [
+  'You can name a lunar settlement outcome this quarter’s work changes',
+  'You have shipped something of the same type before (or named a teammate who has)',
+  'You can cite prior art and say honestly what is new',
+  'You are active in MoonDAO—or bringing an engaged co-lead',
+]
+
+const FIT_NO = [
+  'The ask is mostly company setup, taxes, or a general workstation',
+  'The pitch is LEO tourism, generic STEAM branding, or inspiration alone',
+  'Key Results are empty or the plan is a megaproject OKR in one quarter',
+  'You are submitting multiple primary asks as the same Lead this quarter',
 ]
 
 const CHECKLIST = [
   'Ask ≤ quarterly max',
   'Novelty & Prior Art with citations',
   'Explicit lunar bridge',
+  'Community standing noted',
   'Non-empty SMART key results',
   'Budget classes A–E (C/D = $0)',
   'IP disclosed (open or retained)',
   'One primary ask per Lead this quarter',
   'Same-type prior work linked',
+  'Partner LOIs if the plan depends on them',
 ]
 
 const ProjectsOverview: React.FC<{
@@ -77,9 +106,10 @@ const ProjectsOverview: React.FC<{
 }> = ({ currentProjects }) => {
   const title = 'MoonDAO Project System'
   const description =
-    "Fund mission-aligned work that advances a permanent lunar settlement. See this quarter's max budget, what we fund, and how to submit a strong proposal."
+    "Quarterly grants for lunar-settlement work. See this quarter's max, what we fund, and how to submit a strong proposal."
 
   const { quarter, year } = getRelativeQuarter(0)
+  const reduceMotion = useReducedMotion()
 
   const { tokens: mainnetTokens } = useAssets()
   const { tokens: arbitrumTokens } = useAssets(ARBITRUM_ASSETS_URL)
@@ -148,166 +178,262 @@ const ProjectsOverview: React.FC<{
     <>
       <WebsiteHead title={title} description={description} image="/assets/moondao-og.jpg" />
 
-      {/* Hero — one composition */}
+      {/* Hero — one composition: brand, headline, line, CTAs, full-bleed image */}
       <section className="relative min-h-[100svh] w-full overflow-hidden bg-[#010208]">
-        <Image
-          src="/assets/projects-hero.png"
-          alt=""
-          fill
-          className="object-cover"
-          priority
-          sizes="100vw"
-        />
-        <div className="absolute inset-0 bg-gradient-to-b from-[#010208]/70 via-[#010208]/35 to-[#010208]" />
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_20%,rgba(56,120,220,0.22),transparent_55%)]" />
+        <motion.div
+          className="absolute inset-0"
+          initial={{ scale: reduceMotion ? 1 : 1.06 }}
+          animate={{ scale: 1 }}
+          transition={{ duration: 1.6, ease: EASE }}
+        >
+          <Image
+            src="/assets/projects-hero.png"
+            alt=""
+            fill
+            className="object-cover object-center"
+            priority
+            sizes="100vw"
+          />
+        </motion.div>
+        <div className="absolute inset-0 bg-gradient-to-b from-[#010208]/75 via-[#010208]/40 to-[#010208]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_30%_20%,rgba(34,211,238,0.18),transparent_50%)]" />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-[#010208] to-transparent" />
 
         <Container>
-          <div className="relative z-10 flex min-h-[100svh] flex-col justify-center px-4 py-28 md:px-8">
-            <p className="mb-4 font-GoodTimes text-xs tracking-[0.35em] text-white/70 md:text-sm">
-              MOONDAO
-            </p>
-            <h1 className="max-w-4xl font-GoodTimes text-4xl leading-tight text-white md:text-6xl lg:text-7xl">
-              Project System
-            </h1>
-            <p className="mt-5 max-w-xl text-lg text-white/85 md:text-xl">
-              Quarterly grants for work that moves a self-sustaining lunar settlement forward—open
-              tools, research, and hardware, not company setup.
-            </p>
-            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
-              <StandardButton
-                className="!px-6 !py-3"
-                backgroundColor="bg-white"
-                textColor="text-black"
-                borderRadius="rounded-xl"
-                hoverEffect={false}
-                link="/propose"
-              >
-                Submit a proposal
-              </StandardButton>
-              <StandardButton
-                className="!px-6 !py-3 border border-white/25"
-                backgroundColor="bg-transparent"
-                textColor="text-white"
-                borderRadius="rounded-xl"
-                hoverEffect={false}
-                link="/proposal-template"
-              >
-                View template
-              </StandardButton>
-            </div>
+          <div className="relative z-10 flex min-h-[100svh] flex-col justify-end px-4 pb-16 pt-32 md:justify-center md:px-8 md:pb-28 md:pt-24">
+            <motion.div
+              initial={{ opacity: 0, y: reduceMotion ? 0 : 24 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.9, delay: 0.15, ease: EASE }}
+            >
+              <p className="mb-5 font-GoodTimes text-xs tracking-[0.4em] text-cyan-200/80 md:text-sm">
+                MOONDAO
+              </p>
+              <h1 className="max-w-4xl font-GoodTimes text-4xl leading-[1.05] text-white md:text-6xl lg:text-7xl">
+                Fund the work
+                <span className="mt-2 block bg-gradient-to-r from-cyan-200 to-sky-400 bg-clip-text text-transparent">
+                  that settles the Moon
+                </span>
+              </h1>
+              <p className="mt-6 max-w-lg text-lg leading-relaxed text-white/80 md:text-xl">
+                Quarterly project grants for open tools, research, and specialized hardware—not
+                company setup or baseline gear.
+              </p>
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
+                <StandardButton
+                  className="!px-7 !py-3.5"
+                  backgroundColor="bg-white"
+                  textColor="text-black"
+                  borderRadius="rounded-xl"
+                  hoverEffect={false}
+                  link="/propose"
+                >
+                  Submit a proposal
+                </StandardButton>
+                <StandardButton
+                  className="!px-7 !py-3.5 border border-white/30"
+                  backgroundColor="bg-white/5"
+                  textColor="text-white"
+                  borderRadius="rounded-xl"
+                  hoverEffect={false}
+                  link="/proposal-template"
+                >
+                  Get the template
+                </StandardButton>
+              </div>
+            </motion.div>
           </div>
         </Container>
       </section>
 
-      {/* Quarter facts */}
-      <section className="border-y border-white/10 bg-[#060a14] px-4 py-10 md:px-8">
+      {/* Quarter facts — single strip */}
+      <section className="border-y border-white/10 bg-[#050810] px-4 py-12 md:px-8">
         <Container>
-          <div className="mx-auto grid max-w-6xl gap-6 md:grid-cols-3">
-            <div>
-              <p className="text-sm text-white/50">Max per project · Q{quarter} {year}</p>
-              <p className="mt-1 font-GoodTimes text-3xl text-white md:text-4xl">
-                ${MAX_BUDGET_USD.toLocaleString()}
-              </p>
-              <p className="mt-1 text-sm text-white/45">1/5 of quarterly project budget</p>
+          <Reveal>
+            <div className="mx-auto grid max-w-6xl gap-10 md:grid-cols-3">
+              <div>
+                <p className="text-xs uppercase tracking-[0.2em] text-white/45">
+                  Max per project · Q{quarter} {year}
+                </p>
+                <p className="mt-2 font-GoodTimes text-4xl text-white md:text-5xl">
+                  ${MAX_BUDGET_USD.toLocaleString()}
+                </p>
+                <p className="mt-2 text-sm text-white/45">1/5 of the quarterly project budget</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.2em] text-white/45">Submit by</p>
+                <p className="mt-2 font-GoodTimes text-2xl text-white md:text-3xl">
+                  {PROJECT_SYSTEM_CONFIG.submissionDeadline}
+                </p>
+                <p className="mt-2 text-sm text-white/45">2nd Thursday of the quarter</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.2em] text-white/45">Member vote</p>
+                <p className="mt-2 font-GoodTimes text-2xl text-white md:text-3xl">
+                  {PROJECT_SYSTEM_CONFIG.votingDate}
+                </p>
+                <p className="mt-2 text-sm text-white/45">After Town Hall presentations</p>
+              </div>
             </div>
-            <div>
-              <p className="text-sm text-white/50">Submission deadline</p>
-              <p className="mt-1 font-GoodTimes text-2xl text-white md:text-3xl">
-                {PROJECT_SYSTEM_CONFIG.submissionDeadline}
-              </p>
-              <p className="mt-1 text-sm text-white/45">2nd Thursday of the quarter</p>
-            </div>
-            <div>
-              <p className="text-sm text-white/50">Member voting</p>
-              <p className="mt-1 font-GoodTimes text-2xl text-white md:text-3xl">
-                {PROJECT_SYSTEM_CONFIG.votingDate}
-              </p>
-              <p className="mt-1 text-sm text-white/45">After Town Hall presentations</p>
-            </div>
-          </div>
+          </Reveal>
+        </Container>
+      </section>
+
+      {/* Mission line */}
+      <section className="px-4 py-20 md:px-8 md:py-28">
+        <Container>
+          <Reveal className="mx-auto max-w-3xl text-center">
+            <h2 className="font-GoodTimes text-3xl leading-tight text-white md:text-5xl">
+              Self-sustaining lunar settlement by 2030
+            </h2>
+            <p className="mt-6 text-lg leading-relaxed text-gray-300">
+              Every funded project should leave an inspectable artifact that other members can use
+              on that path—protocols, sims, hardware tests, open research—not a private company
+              runway.
+            </p>
+          </Reveal>
         </Container>
       </section>
 
       {/* What we fund */}
-      <section className="px-4 py-16 md:px-8 md:py-24">
+      <section className="relative overflow-hidden bg-[#050810] px-4 py-20 md:px-8 md:py-28">
+        <div className="pointer-events-none absolute -right-24 top-0 h-72 w-72 rounded-full bg-cyan-500/10 blur-3xl" />
         <Container>
           <div className="mx-auto max-w-6xl">
-            <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">What we fund</h2>
-            <p className="mt-4 max-w-2xl text-lg text-gray-300">
-              MoonDAO pays for mission outputs and specialized tools that work uniquely needs. We do
-              not subsidize private company setup or baseline personal computing.
-            </p>
+            <Reveal>
+              <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">What we fund</h2>
+              <p className="mt-4 max-w-2xl text-lg text-gray-300">
+                Pay for mission outputs and tools the work uniquely needs. Do not ask for setup.
+              </p>
+            </Reveal>
 
-            <div className="mt-10 grid gap-8 md:grid-cols-2">
-              <div className="border-l-2 border-cyan-400/60 pl-6">
-                <h3 className="font-GoodTimes text-lg text-cyan-200">Fund</h3>
-                <ul className="mt-4 space-y-3 text-gray-300">
-                  {FUND_YES.map((item) => (
-                    <li key={item} className="flex gap-3">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-400" />
-                      <span>{item}</span>
+            <div className="mt-14 grid gap-12 lg:grid-cols-2">
+              <Reveal delay={0.1}>
+                <div className="space-y-10">
+                  {FUND_YES.map((item, i) => (
+                    <div key={item.title} className="border-l border-cyan-400/50 pl-6">
+                      <p className="font-GoodTimes text-xs tracking-widest text-cyan-300/70">
+                        0{i + 1}
+                      </p>
+                      <h3 className="mt-2 font-GoodTimes text-xl text-white">{item.title}</h3>
+                      <p className="mt-2 text-gray-400">{item.body}</p>
+                    </div>
+                  ))}
+                </div>
+              </Reveal>
+              <Reveal delay={0.2}>
+                <div className="border border-white/10 bg-black/30 p-8 md:p-10">
+                  <h3 className="font-GoodTimes text-lg text-white/80">Do not fund</h3>
+                  <ul className="mt-6 space-y-4">
+                    {FUND_NO.map((item) => (
+                      <li key={item} className="flex gap-3 text-gray-400">
+                        <span className="mt-1 text-white/30">—</span>
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="mt-8 text-sm leading-relaxed text-white/45">
+                    Specialized mission gear is allowed when itemized with ownership or access
+                    terms. A new desktop for writing is not.
+                  </p>
+                </div>
+              </Reveal>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      {/* Fit check */}
+      <section className="px-4 py-20 md:px-8 md:py-28">
+        <Container>
+          <div className="mx-auto max-w-6xl">
+            <Reveal>
+              <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">Is this for you?</h2>
+              <p className="mt-4 max-w-2xl text-lg text-gray-300">
+                Strong proposals clear these bars before Senate review. Weak ones get returned for
+                rewrite.
+              </p>
+            </Reveal>
+            <div className="mt-12 grid gap-12 md:grid-cols-2">
+              <Reveal delay={0.1}>
+                <h3 className="font-GoodTimes text-sm tracking-[0.2em] text-cyan-300/80">
+                  GOOD FIT
+                </h3>
+                <ul className="mt-6 space-y-4">
+                  {FIT_YES.map((item) => (
+                    <li key={item} className="border-b border-white/10 pb-4 text-gray-200">
+                      {item}
                     </li>
                   ))}
                 </ul>
-              </div>
-              <div className="border-l-2 border-white/20 pl-6">
-                <h3 className="font-GoodTimes text-lg text-white/70">Do not fund</h3>
-                <ul className="mt-4 space-y-3 text-gray-400">
-                  {FUND_NO.map((item) => (
-                    <li key={item} className="flex gap-3">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-white/30" />
-                      <span>{item}</span>
+              </Reveal>
+              <Reveal delay={0.2}>
+                <h3 className="font-GoodTimes text-sm tracking-[0.2em] text-white/40">
+                  NOT A FIT
+                </h3>
+                <ul className="mt-6 space-y-4">
+                  {FIT_NO.map((item) => (
+                    <li key={item} className="border-b border-white/10 pb-4 text-gray-400">
+                      {item}
                     </li>
                   ))}
                 </ul>
-              </div>
+              </Reveal>
             </div>
           </div>
         </Container>
       </section>
 
       {/* How it works */}
-      <section className="bg-[#060a14] px-4 py-16 md:px-8 md:py-24">
+      <section className="bg-[#050810] px-4 py-20 md:px-8 md:py-28">
         <Container>
           <div className="mx-auto max-w-6xl">
-            <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">How it works</h2>
-            <div className="mt-12 grid gap-10 md:grid-cols-2 lg:grid-cols-4">
-              {STEPS.map((step) => (
-                <div key={step.n}>
-                  <p className="font-GoodTimes text-sm tracking-widest text-blue-300/70">{step.n}</p>
-                  <h3 className="mt-2 font-GoodTimes text-xl text-white">{step.title}</h3>
+            <Reveal>
+              <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">How it works</h2>
+            </Reveal>
+            <div className="mt-14 grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
+              {STEPS.map((step, i) => (
+                <Reveal key={step.n} delay={0.08 * i}>
+                  <p className="font-GoodTimes text-sm tracking-[0.25em] text-cyan-300/60">
+                    {step.n}
+                  </p>
+                  <h3 className="mt-3 font-GoodTimes text-xl text-white">{step.title}</h3>
                   <p className="mt-3 text-sm leading-relaxed text-gray-400">{step.body}</p>
-                </div>
+                </Reveal>
               ))}
             </div>
           </div>
         </Container>
       </section>
 
-      {/* Rewards + checklist */}
-      <section className="px-4 py-16 md:px-8 md:py-24">
+      {/* Pool + checklist */}
+      <section className="px-4 py-20 md:px-8 md:py-28">
         <Container>
-          <div className="mx-auto grid max-w-6xl gap-12 lg:grid-cols-2">
-            <div>
+          <div className="mx-auto grid max-w-6xl gap-16 lg:grid-cols-2">
+            <Reveal>
               <h2 className="font-GoodTimes text-3xl text-white">This quarter&apos;s pool</h2>
               <p className="mt-4 text-gray-300">
-                Retroactive rewards for completed projects sit alongside proposal budgets. Proposal
-                asks must stay at or under the per-project max above.
+                Proposal asks stay at or under the per-project max. Retroactive rewards for
+                completed work sit alongside that pool.
               </p>
-              <div className="mt-8 space-y-6">
+              <div className="mt-10 space-y-8">
                 <div>
-                  <p className="text-sm text-white/50">Stablecoin retro pool</p>
-                  <p className="font-GoodTimes text-3xl text-white">
+                  <p className="text-xs uppercase tracking-[0.2em] text-white/45">
+                    Stablecoin retro pool
+                  </p>
+                  <p className="mt-2 font-GoodTimes text-4xl text-white">
                     ${NEXT_QUARTER_BUDGET_USD.toLocaleString()}
                   </p>
                 </div>
                 <div>
-                  <p className="text-sm text-white/50">vMOONEY retro pool</p>
-                  <p className="font-GoodTimes text-2xl text-white">
+                  <p className="text-xs uppercase tracking-[0.2em] text-white/45">
+                    vMOONEY retro pool
+                  </p>
+                  <p className="mt-2 font-GoodTimes text-3xl text-white">
                     {mooneyBudget > 0 ? (
                       <>
                         {Number(mooneyBudget.toPrecision(3)).toLocaleString()}
-                        <span className="ml-2 text-base font-sans text-white/50">
+                        <span className="ml-2 font-sans text-base text-white/45">
                           {isLoadingMooneyUSD
                             ? '…'
                             : mooneyBudgetUSD && mooneyBudgetUSD > 0
@@ -321,32 +447,33 @@ const ProjectsOverview: React.FC<{
                       '…'
                     )}
                   </p>
-                  <p className="mt-1 text-sm text-white/40">Locked 4 years as delegated vMOONEY</p>
+                  <p className="mt-2 text-sm text-white/40">Locked 4 years as delegated vMOONEY</p>
                 </div>
               </div>
-            </div>
+            </Reveal>
 
-            <div>
+            <Reveal delay={0.15}>
               <h2 className="font-GoodTimes text-3xl text-white">Before you submit</h2>
               <p className="mt-4 text-gray-300">
-                Senate review returns incomplete proposals. Use the template checklist so your ask
-                is ready for diligence.
+                Incomplete proposals are returned. Work through the template checklist first.
               </p>
-              <ul className="mt-6 space-y-2">
+              <ul className="mt-8 space-y-0">
                 {CHECKLIST.map((item) => (
                   <li
                     key={item}
-                    className="flex items-start gap-3 border-b border-white/5 py-2 text-gray-300"
+                    className="flex items-start gap-3 border-b border-white/10 py-3 text-gray-300"
                   >
-                    <span className="mt-1 text-cyan-400/80">✓</span>
+                    <span className="mt-0.5 text-cyan-400/90" aria-hidden>
+                      ✓
+                    </span>
                     <span>{item}</span>
                   </li>
                 ))}
               </ul>
-              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <div className="mt-10 flex flex-col gap-3 sm:flex-row">
                 <StandardButton
-                  backgroundColor="bg-gradient-to-r from-blue-600 to-cyan-600"
-                  textColor="text-white"
+                  backgroundColor="bg-white"
+                  textColor="text-black"
                   borderRadius="rounded-xl"
                   hoverEffect={false}
                   link="/proposal-template"
@@ -354,34 +481,41 @@ const ProjectsOverview: React.FC<{
                   Open template
                 </StandardButton>
                 <StandardButton
-                  backgroundColor="bg-white/10"
+                  backgroundColor="bg-transparent"
                   textColor="text-white"
                   borderRadius="rounded-xl"
                   hoverEffect={false}
                   link={PROJECT_SYSTEM_CONFIG.docsUrl}
-                  className="border border-white/15"
+                  className="border border-white/20"
                 >
                   Full documentation
                 </StandardButton>
               </div>
-            </div>
+            </Reveal>
           </div>
         </Container>
       </section>
 
       {/* Active projects */}
-      <section className="bg-[#060a14] px-4 py-16 md:px-8 md:py-24">
+      <section className="bg-[#050810] px-4 py-20 md:px-8 md:py-28">
         <Container>
           <div className="mx-auto max-w-6xl">
-            <div className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-              <div>
-                <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">Active projects</h2>
-                <p className="mt-3 text-gray-400">Work already funded this cycle.</p>
+            <Reveal>
+              <div className="mb-12 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">
+                    Active projects
+                  </h2>
+                  <p className="mt-3 text-gray-400">Work already funded this cycle.</p>
+                </div>
+                <Link
+                  href="/projects"
+                  className="text-sm text-cyan-300 transition-colors hover:text-cyan-200"
+                >
+                  View all projects →
+                </Link>
               </div>
-              <Link href="/projects" className="text-sm text-blue-300 hover:text-blue-200">
-                View all projects →
-              </Link>
-            </div>
+            </Reveal>
             <DashboardActiveProjects
               currentProjects={currentProjects}
               usdBudget={usdBudget}
@@ -393,20 +527,20 @@ const ProjectsOverview: React.FC<{
       </section>
 
       {/* Final CTA */}
-      <section className="relative overflow-hidden px-4 py-20 md:px-8 md:py-28">
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(56,120,220,0.15),transparent_60%)]" />
+      <section className="relative overflow-hidden px-4 py-24 md:px-8 md:py-32">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_40%,rgba(34,211,238,0.12),transparent_55%)]" />
         <Container>
-          <div className="relative z-10 mx-auto max-w-3xl text-center">
+          <Reveal className="relative z-10 mx-auto max-w-3xl text-center">
             <h2 className="font-GoodTimes text-3xl text-white md:text-5xl">
-              Ready to propose?
+              Bring a lunar-ready idea
             </h2>
-            <p className="mx-auto mt-5 max-w-xl text-lg text-gray-300">
-              Start from the template, keep the ask under ${MAX_BUDGET_USD.toLocaleString()}, and
-              show how the work serves lunar settlement.
+            <p className="mx-auto mt-6 max-w-xl text-lg text-gray-300">
+              Start from the template, keep the ask under ${MAX_BUDGET_USD.toLocaleString()}, cite
+              prior art, and show the lunar bridge.
             </p>
-            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <StandardButton
-                className="!px-6 !py-3"
+                className="!px-7 !py-3.5"
                 backgroundColor="bg-white"
                 textColor="text-black"
                 borderRadius="rounded-xl"
@@ -416,17 +550,17 @@ const ProjectsOverview: React.FC<{
                 Submit proposal
               </StandardButton>
               <StandardButton
-                className="!px-6 !py-3 border border-white/20"
+                className="!px-7 !py-3.5 border border-white/25"
                 backgroundColor="bg-transparent"
                 textColor="text-white"
                 borderRadius="rounded-xl"
                 hoverEffect={false}
                 link="https://moondao.com/discord"
               >
-                Join Discord
+                Ideate in Discord
               </StandardButton>
             </div>
-          </div>
+          </Reveal>
         </Container>
       </section>
 

--- a/ui/pages/projects-overview.tsx
+++ b/ui/pages/projects-overview.tsx
@@ -24,7 +24,7 @@ import StandardButton from '../components/layout/StandardButton'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import DashboardActiveProjects from '@/components/project/DashboardActiveProjects'
 import Reveal from '@/components/home/landing/Reveal'
-import { PROJECT_ACTIVE, PROJECT_ENDED } from '@/lib/nance/types'
+import { PROJECT_ACTIVE } from '@/lib/nance/types'
 
 const EASE: [number, number, number, number] = [0.21, 0.47, 0.32, 0.98]
 
@@ -101,8 +101,6 @@ const CHECKLIST = [
 
 const ProjectsOverview: React.FC<{
   currentProjects: Project[]
-  pastProjects: Project[]
-  distributions: any[]
 }> = ({ currentProjects }) => {
   const title = 'MoonDAO Project System'
   const description =
@@ -585,58 +583,42 @@ export default ProjectsOverview
 
 export const getServerSideProps: GetServerSideProps = async () => {
   try {
-    const { DEFAULT_CHAIN_V5, DISTRIBUTION_TABLE_NAMES, PROJECT_TABLE_NAMES } = await import(
-      'const/config'
-    )
+    const { DEFAULT_CHAIN_V5, PROJECT_TABLE_NAMES } = await import('const/config')
     const { getChainSlug } = await import('@/lib/thirdweb/chain')
 
     const chain = DEFAULT_CHAIN_V5
     const chainSlug = getChainSlug(chain)
-    const { quarter, year } = getRelativeQuarter(0)
 
     const statement = `SELECT * FROM ${PROJECT_TABLE_NAMES[chainSlug]}`
     const projects = await queryTable(chain, statement)
 
     const currentProjects = []
-    const pastProjects = []
 
     if (projects && projects.length > 0) {
       for (let i = 0; i < projects.length; i++) {
-        if (projects[i]) {
-          const activeStatus = projects[i].active
-          if (activeStatus == PROJECT_ACTIVE) {
-            currentProjects.push(projects[i])
-          } else if (activeStatus == PROJECT_ENDED) {
-            pastProjects.push(projects[i])
-          }
+        if (projects[i] && projects[i].active == PROJECT_ACTIVE) {
+          currentProjects.push(projects[i])
         }
       }
     }
 
-    await enrichProjectNames([...currentProjects, ...pastProjects])
+    await enrichProjectNames(currentProjects)
 
     currentProjects.sort((a, b) => {
       if (a.eligible === b.eligible) return 0
       return a.eligible ? 1 : -1
     })
 
-    const distributionStatement = `SELECT * FROM ${DISTRIBUTION_TABLE_NAMES[chainSlug]} WHERE year = ${year} AND quarter = ${quarter}`
-    const distributions = await queryTable(chain, distributionStatement)
-
     return {
       props: {
         currentProjects: currentProjects.reverse(),
-        pastProjects: pastProjects.reverse(),
-        distributions,
       },
     }
   } catch (error) {
-    console.error('Error fetching projects or distributions:', error)
+    console.error('Error fetching projects:', error)
     return {
       props: {
         currentProjects: [],
-        pastProjects: [],
-        distributions: [],
       },
     }
   }

--- a/ui/pages/projects-overview.tsx
+++ b/ui/pages/projects-overview.tsx
@@ -5,16 +5,15 @@ import {
   BASE_ASSETS_URL,
   PROJECT_SYSTEM_CONFIG,
   NEXT_QUARTER_BUDGET_USD,
-  USD_BUDGET,
 } from 'const/config'
 import useStakedEth from 'lib/utils/hooks/useStakedEth'
 import { GetServerSideProps } from 'next'
 import Image from 'next/image'
+import Link from 'next/link'
 import React, { useMemo, useEffect, useState } from 'react'
 import { useAssets } from '@/lib/dashboard/hooks'
 import { enrichProjectNames } from '@/lib/project/enrichProjectNames'
 import { Project } from '@/lib/project/useProjectData'
-import { ethereum } from '@/lib/rpc/chains'
 import queryTable from '@/lib/tableland/queryTable'
 import { getRelativeQuarter } from '@/lib/utils/dates'
 import { getBudget } from '@/lib/utils/rewards'
@@ -23,43 +22,65 @@ import WebsiteHead from '../components/layout/Head'
 import StandardButton from '../components/layout/StandardButton'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import DashboardActiveProjects from '@/components/project/DashboardActiveProjects'
-import ProjectCard from '@/components/project/ProjectCard'
 import { PROJECT_ACTIVE, PROJECT_ENDED } from '@/lib/nance/types'
 
-// Project System Explainer Card Component
-const ProjectExplainerCard = ({
-  icon,
-  title,
-  description,
-}: {
-  icon: React.ReactNode
-  title: string
-  description: string
-}) => {
-  return (
-    <div className="bg-gradient-to-b from-slate-700/20 to-slate-800/30 rounded-2xl border border-slate-600/30 hover:border-slate-500/50 transition-all duration-200 hover:scale-[1.02] p-6">
-      <div className="w-16 h-16 mx-auto mb-6 bg-gradient-to-br from-blue-400 to-purple-600 rounded-full flex items-center justify-center">
-        {icon}
-      </div>
-      <h3 className="text-xl font-GoodTimes text-white mb-4 text-center">{title}</h3>
-      <p className="text-gray-300 leading-relaxed text-center">{description}</p>
-    </div>
-  )
-}
+const STEPS = [
+  {
+    n: '01',
+    title: 'Ideate',
+    body: 'Share the problem and draft solution in Discord. Get feedback before you lock a budget.',
+  },
+  {
+    n: '02',
+    title: 'Propose',
+    body: 'Fill the template—novelty, lunar bridge, SMART key results, and a work-only budget under the max.',
+  },
+  {
+    n: '03',
+    title: 'Present & vote',
+    body: 'Pitch at Town Hall. Senate diligence, then member vote. Funded leads join the Senate for the project.',
+  },
+  {
+    n: '04',
+    title: 'Ship & rewards',
+    body: 'Weekly updates, final report, return unused funds. Completed work can earn quarterly retroactive rewards.',
+  },
+]
+
+const FUND_YES = [
+  'Labor tied to inspectable deliverables',
+  'Specialized gear the work uniquely needs (with ownership/access terms)',
+  'Open reports, protocols, software, and member-usable tools',
+]
+
+const FUND_NO = [
+  'General computers, monitors, printers, or home-office setup',
+  'LLC / sole-prop formation or company registration fees',
+  'Tax bills, re-registration, or private runway bailouts',
+]
+
+const CHECKLIST = [
+  'Ask ≤ quarterly max',
+  'Novelty & Prior Art with citations',
+  'Explicit lunar bridge',
+  'Non-empty SMART key results',
+  'Budget classes A–E (C/D = $0)',
+  'IP disclosed (open or retained)',
+  'One primary ask per Lead this quarter',
+  'Same-type prior work linked',
+]
 
 const ProjectsOverview: React.FC<{
   currentProjects: Project[]
   pastProjects: Project[]
   distributions: any[]
-}> = ({ currentProjects, pastProjects, distributions }) => {
-  const title = 'Project System Overview'
+}> = ({ currentProjects }) => {
+  const title = 'MoonDAO Project System'
   const description =
-    "Learn about MoonDAO's decentralized project system. From proposal submission to retroactive rewards, discover how we fund and support space-related initiatives that advance our mission to establish a permanent settlement on the Moon."
+    "Fund mission-aligned work that advances a permanent lunar settlement. See this quarter's max budget, what we fund, and how to submit a strong proposal."
 
-  // Get current quarter info
   const { quarter, year } = getRelativeQuarter(0)
 
-  // Hook to get token data for budget calculations
   const { tokens: mainnetTokens } = useAssets()
   const { tokens: arbitrumTokens } = useAssets(ARBITRUM_ASSETS_URL)
   const { tokens: polygonTokens } = useAssets(POLYGON_ASSETS_URL)
@@ -69,7 +90,6 @@ const ProjectsOverview: React.FC<{
   const [mooneyBudgetUSD, setMooneyBudgetUSD] = useState<number | null>(null)
   const [isLoadingMooneyUSD, setIsLoadingMooneyUSD] = useState(true)
 
-  // Combine all tokens
   const tokens = useMemo(() => {
     return mainnetTokens
       .concat(arbitrumTokens)
@@ -79,24 +99,10 @@ const ProjectsOverview: React.FC<{
       .concat([{ symbol: 'stETH', balance: stakedEth }])
   }, [mainnetTokens, arbitrumTokens, polygonTokens, baseTokens, stakedEth])
 
-  // Calculate budget
-  const {
-    usdBudget: usdBudgetCalculated,
-    mooneyBudget,
-    ethPrice,
-  } = useMemo(() => getBudget(tokens, year, quarter), [tokens, year, quarter])
+  const { mooneyBudget } = useMemo(() => getBudget(tokens, year, quarter), [tokens, year, quarter])
 
-  // Log budget for quarterly update (see docs/RETRO.md step 0)
-  useEffect(() => {
-    if (usdBudgetCalculated > 0) {
-      console.log(`[Q${quarter} ${year} Budget] usdBudget: $${usdBudgetCalculated.toFixed(0)}, mooneyBudget: ${mooneyBudget?.toFixed(0)}`)
-    }
-  }, [usdBudgetCalculated, mooneyBudget, quarter, year])
-
-  // Use hardcoded value like in RetroactiveRewards for current quarter
   const usdBudget = NEXT_QUARTER_BUDGET_USD
 
-  // Calculate MOONEY USD value
   useEffect(() => {
     let isCancelled = false
 
@@ -109,20 +115,15 @@ const ProjectsOverview: React.FC<{
         }
 
         const response = await fetch('/api/mooney/price')
-        if (!response.ok) {
-          throw new Error('Failed to fetch MOONEY price')
-        }
+        if (!response.ok) throw new Error('Failed to fetch MOONEY price')
 
         const data = await response.json()
         const mooneyPriceUSD = data.result?.price || 0
 
         if (!isCancelled && mooneyPriceUSD > 0) {
-          const usd = mooneyBudget * mooneyPriceUSD
-          setMooneyBudgetUSD(usd)
-          setIsLoadingMooneyUSD(false)
-        } else {
-          setIsLoadingMooneyUSD(false)
+          setMooneyBudgetUSD(mooneyBudget * mooneyPriceUSD)
         }
+        if (!isCancelled) setIsLoadingMooneyUSD(false)
       } catch (error) {
         console.error('Error fetching Mooney budget USD:', error)
         if (!isCancelled) {
@@ -147,492 +148,299 @@ const ProjectsOverview: React.FC<{
     <>
       <WebsiteHead title={title} description={description} image="/assets/moondao-og.jpg" />
 
-      {/* Hero Section */}
-      <Container>
-        <div className="relative w-full h-screen rounded-3xl overflow-hidden">
-          <Image
-            src="/assets/projects-hero.png"
-            alt="MoonDAO Projects"
-            fill
-            className="object-cover"
-            priority
-          />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="text-center max-w-4xl px-8">
-              <h1 className="header font-GoodTimes text-white drop-shadow-lg mb-4">
-                Project System
-              </h1>
-              <p className="sub-header text-white/90 drop-shadow-lg">
-                MoonDAO's decentralized project system funds mission-aligned initiatives that
-                advance our goal of establishing a permanent settlement on the Moon.
-              </p>
+      {/* Hero — one composition */}
+      <section className="relative min-h-[100svh] w-full overflow-hidden bg-[#010208]">
+        <Image
+          src="/assets/projects-hero.png"
+          alt=""
+          fill
+          className="object-cover"
+          priority
+          sizes="100vw"
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-[#010208]/70 via-[#010208]/35 to-[#010208]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_20%,rgba(56,120,220,0.22),transparent_55%)]" />
+
+        <Container>
+          <div className="relative z-10 flex min-h-[100svh] flex-col justify-center px-4 py-28 md:px-8">
+            <p className="mb-4 font-GoodTimes text-xs tracking-[0.35em] text-white/70 md:text-sm">
+              MOONDAO
+            </p>
+            <h1 className="max-w-4xl font-GoodTimes text-4xl leading-tight text-white md:text-6xl lg:text-7xl">
+              Project System
+            </h1>
+            <p className="mt-5 max-w-xl text-lg text-white/85 md:text-xl">
+              Quarterly grants for work that moves a self-sustaining lunar settlement forward—open
+              tools, research, and hardware, not company setup.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
               <StandardButton
-                className="gradient-2 hover:opacity-90 transition-opacity"
+                className="!px-6 !py-3"
+                backgroundColor="bg-white"
+                textColor="text-black"
+                borderRadius="rounded-xl"
+                hoverEffect={false}
+                link="/propose"
+              >
+                Submit a proposal
+              </StandardButton>
+              <StandardButton
+                className="!px-6 !py-3 border border-white/25"
+                backgroundColor="bg-transparent"
                 textColor="text-white"
                 borderRadius="rounded-xl"
                 hoverEffect={false}
-                link="/proposals"
+                link="/proposal-template"
               >
-                Submit Proposal
+                View template
               </StandardButton>
             </div>
           </div>
-        </div>
-      </Container>
+        </Container>
+      </section>
 
-      {/* Project System Explainer Section */}
-      <section className="relative py-16 md:py-24 px-4 sm:px-6 lg:px-8">
+      {/* Quarter facts */}
+      <section className="border-y border-white/10 bg-[#060a14] px-4 py-10 md:px-8">
         <Container>
-          <div className="max-w-6xl mx-auto">
-            {/* Section Header */}
-            <div className="text-center mb-16 px-4">
-              <h2 className="text-3xl md:text-4xl lg:text-5xl font-GoodTimes text-white mb-6">
-                How Our Project System Works
-              </h2>
-              <p className="text-lg md:text-xl text-gray-300 max-w-4xl mx-auto">
-                MoonDAO Projects are goal-oriented teams working on mission-aligned objectives. Our
-                comprehensive framework supports project funding, progress tracking, and provides
-                retroactive incentives for successful contributions.
+          <div className="mx-auto grid max-w-6xl gap-6 md:grid-cols-3">
+            <div>
+              <p className="text-sm text-white/50">Max per project · Q{quarter} {year}</p>
+              <p className="mt-1 font-GoodTimes text-3xl text-white md:text-4xl">
+                ${MAX_BUDGET_USD.toLocaleString()}
               </p>
+              <p className="mt-1 text-sm text-white/45">1/5 of quarterly project budget</p>
             </div>
-
-            {/* Project Process Steps */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16 mx-4">
-              <ProjectExplainerCard
-                icon={
-                  <svg
-                    className="w-8 h-8 text-white"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
-                    />
-                  </svg>
-                }
-                title="1. Ideation"
-                description="Share your space-related ideas in our Discord ideation channel. Get feedback from the community and refine your concept."
-              />
-
-              <ProjectExplainerCard
-                icon={
-                  <svg
-                    className="w-8 h-8 text-white"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                    />
-                  </svg>
-                }
-                title="2. Proposal"
-                description="Submit a detailed project proposal using our template. Include objectives, timeline, budget, and team structure."
-              />
-
-              <ProjectExplainerCard
-                icon={
-                  <svg
-                    className="w-8 h-8 text-white"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M13 10V3L4 14h7v7l9-11h-7z"
-                    />
-                  </svg>
-                }
-                title="3. Execution"
-                description="Once approved, project leads join the Senate and receive funding. Teams provide weekly updates and progress reports."
-              />
-
-              <ProjectExplainerCard
-                icon={
-                  <svg
-                    className="w-12 h-12 text-white"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"
-                    />
-                  </svg>
-                }
-                title="4. Rewards"
-                description="Completed projects receive quarterly retroactive rewards based on community evaluation and impact assessment."
-              />
+            <div>
+              <p className="text-sm text-white/50">Submission deadline</p>
+              <p className="mt-1 font-GoodTimes text-2xl text-white md:text-3xl">
+                {PROJECT_SYSTEM_CONFIG.submissionDeadline}
+              </p>
+              <p className="mt-1 text-sm text-white/45">2nd Thursday of the quarter</p>
             </div>
+            <div>
+              <p className="text-sm text-white/50">Member voting</p>
+              <p className="mt-1 font-GoodTimes text-2xl text-white md:text-3xl">
+                {PROJECT_SYSTEM_CONFIG.votingDate}
+              </p>
+              <p className="mt-1 text-sm text-white/45">After Town Hall presentations</p>
+            </div>
+          </div>
+        </Container>
+      </section>
 
-            {/* Quarterly Rewards System */}
-            <div className="relative mx-4 mb-16">
-              <div className="absolute inset-0 bg-gradient-to-br from-blue-900/10 via-purple-900/10 to-teal-900/10 rounded-3xl" />
-              <div className="relative p-6 md:p-12 bg-gradient-to-br from-white/5 via-white/10 to-white/5 backdrop-blur-xl border border-white/20 rounded-3xl shadow-2xl">
-                <div className="text-center mb-8">
-                  <h3 className="text-2xl md:text-3xl font-GoodTimes text-white mb-4">
-                    Quarterly Rewards System
-                  </h3>
-                  <p className="text-gray-300 max-w-3xl mx-auto">
-                    MoonDAO incentivizes innovation through our quarterly rewards program,
-                    distributing both ETH and vMOONEY to successful project contributors.
+      {/* What we fund */}
+      <section className="px-4 py-16 md:px-8 md:py-24">
+        <Container>
+          <div className="mx-auto max-w-6xl">
+            <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">What we fund</h2>
+            <p className="mt-4 max-w-2xl text-lg text-gray-300">
+              MoonDAO pays for mission outputs and specialized tools that work uniquely needs. We do
+              not subsidize private company setup or baseline personal computing.
+            </p>
+
+            <div className="mt-10 grid gap-8 md:grid-cols-2">
+              <div className="border-l-2 border-cyan-400/60 pl-6">
+                <h3 className="font-GoodTimes text-lg text-cyan-200">Fund</h3>
+                <ul className="mt-4 space-y-3 text-gray-300">
+                  {FUND_YES.map((item) => (
+                    <li key={item} className="flex gap-3">
+                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-400" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="border-l-2 border-white/20 pl-6">
+                <h3 className="font-GoodTimes text-lg text-white/70">Do not fund</h3>
+                <ul className="mt-4 space-y-3 text-gray-400">
+                  {FUND_NO.map((item) => (
+                    <li key={item} className="flex gap-3">
+                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-white/30" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      {/* How it works */}
+      <section className="bg-[#060a14] px-4 py-16 md:px-8 md:py-24">
+        <Container>
+          <div className="mx-auto max-w-6xl">
+            <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">How it works</h2>
+            <div className="mt-12 grid gap-10 md:grid-cols-2 lg:grid-cols-4">
+              {STEPS.map((step) => (
+                <div key={step.n}>
+                  <p className="font-GoodTimes text-sm tracking-widest text-blue-300/70">{step.n}</p>
+                  <h3 className="mt-2 font-GoodTimes text-xl text-white">{step.title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-gray-400">{step.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      {/* Rewards + checklist */}
+      <section className="px-4 py-16 md:px-8 md:py-24">
+        <Container>
+          <div className="mx-auto grid max-w-6xl gap-12 lg:grid-cols-2">
+            <div>
+              <h2 className="font-GoodTimes text-3xl text-white">This quarter&apos;s pool</h2>
+              <p className="mt-4 text-gray-300">
+                Retroactive rewards for completed projects sit alongside proposal budgets. Proposal
+                asks must stay at or under the per-project max above.
+              </p>
+              <div className="mt-8 space-y-6">
+                <div>
+                  <p className="text-sm text-white/50">Stablecoin retro pool</p>
+                  <p className="font-GoodTimes text-3xl text-white">
+                    ${NEXT_QUARTER_BUDGET_USD.toLocaleString()}
                   </p>
                 </div>
-
-                <div className="grid md:grid-cols-2 gap-8">
-                  {/* Stablecoin Rewards */}
-                  <div className="bg-gradient-to-br from-green-900/20 to-emerald-900/20 rounded-2xl p-6 border border-green-500/20">
-                    <div className="w-12 h-12 bg-gradient-to-br from-green-400 to-emerald-500 rounded-lg flex items-center justify-center mb-4">
-                      <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1" />
-                      </svg>
-                    </div>
-                    <h4 className="text-xl font-bold text-white mb-3">Stablecoin Rewards</h4>
-                    <div className="bg-gradient-to-r from-green-500/10 to-emerald-500/10 rounded-lg p-3 mb-3 border border-green-400/20">
-                      <div className="text-2xl font-bold text-green-400">
-                        ${USD_BUDGET.toLocaleString()}
-                      </div>
-                      <div className="text-sm text-green-300">
-                        Available Q{quarter} {year}
-                      </div>
-                    </div>
-                    <p className="text-gray-300 mb-3">
-                      5% of liquid non-MOONEY assets distributed quarterly to completed projects
-                      based on community evaluation.
-                    </p>
-                    <p className="text-sm text-green-400">
-                      Paid as lump-sum within a month of quarter end
-                    </p>
-                  </div>
-
-                  {/* vMOONEY Rewards */}
-                  <div className="bg-gradient-to-br from-blue-900/20 to-purple-900/20 rounded-2xl p-6 border border-blue-500/20">
-                    <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-purple-500 rounded-lg flex items-center justify-center mb-4">
-                      <svg
-                        className="w-6 h-6 text-white"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-                        />
-                      </svg>
-                    </div>
-                    <h4 className="text-xl font-bold text-white mb-3">vMOONEY Rewards</h4>
-                    <div className="bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-lg p-3 mb-3 border border-blue-400/20">
-                      <div className="text-2xl font-bold text-blue-400">
-                        {mooneyBudget > 0 ? (
-                          <>
-                            {Number(mooneyBudget.toPrecision(3)).toLocaleString()}
-                            <span className="text-lg text-blue-300">
-                              {isLoadingMooneyUSD ? (
-                                <span className="ml-2 opacity-70">(...)</span>
-                              ) : mooneyBudgetUSD !== null && mooneyBudgetUSD > 0 ? (
-                                ` ($${mooneyBudgetUSD.toLocaleString(undefined, {
+                <div>
+                  <p className="text-sm text-white/50">vMOONEY retro pool</p>
+                  <p className="font-GoodTimes text-2xl text-white">
+                    {mooneyBudget > 0 ? (
+                      <>
+                        {Number(mooneyBudget.toPrecision(3)).toLocaleString()}
+                        <span className="ml-2 text-base font-sans text-white/50">
+                          {isLoadingMooneyUSD
+                            ? '…'
+                            : mooneyBudgetUSD && mooneyBudgetUSD > 0
+                              ? `(~$${mooneyBudgetUSD.toLocaleString(undefined, {
                                   maximumFractionDigits: 0,
                                 })})`
-                              ) : null}
-                            </span>
-                          </>
-                        ) : (
-                          <span className="text-blue-300">Loading...</span>
-                        )}
-                      </div>
-                      <div className="text-sm text-blue-300">
-                        vMOONEY Available Q{quarter} {year}
-                      </div>
-                    </div>
-                    <p className="text-gray-300 mb-3">
-                      Geometric series of MOONEY tokens decreasing by 5% each quarter, distributed
-                      based on project impact and community evaluation.
-                    </p>
-                    <p className="text-sm text-blue-400">Locked for 4 years as delegated vMOONEY</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Project Submission Information Section */}
-            <div className="relative mx-4 mb-16">
-              <div className="absolute inset-0 bg-gradient-to-br from-green-900/10 via-teal-900/10 to-blue-900/10 rounded-3xl" />
-              <div className="relative p-6 md:p-12 bg-gradient-to-br from-white/5 via-white/10 to-white/5 backdrop-blur-xl border border-white/20 rounded-3xl shadow-2xl">
-                <div className="text-center mb-10">
-                  <div className="inline-block bg-gradient-to-r from-green-400 to-teal-500 text-white px-4 py-1 rounded-full text-sm font-bold mb-4">
-                    📝 APPLICATIONS OPEN
-                  </div>
-                  <h3 className="text-2xl md:text-3xl font-GoodTimes text-white mb-4">
-                    Submit Your Project Proposal
-                  </h3>
-                  <p className="text-gray-300 max-w-3xl mx-auto">
-                    Everything you need to know about submitting a project proposal to MoonDAO.
+                              : null}
+                        </span>
+                      </>
+                    ) : (
+                      '…'
+                    )}
                   </p>
-                </div>
-
-                {/* Key Information Grid */}
-                <div className="grid md:grid-cols-3 gap-6 mb-10">
-                  {/* Deadline */}
-                  <div className="bg-gradient-to-br from-red-900/20 to-orange-900/20 rounded-xl p-6 border border-red-500/20 text-center">
-                    <div className="w-12 h-12 bg-gradient-to-br from-red-400 to-orange-500 rounded-lg flex items-center justify-center mx-auto mb-4">
-                      <svg
-                        className="w-6 h-6 text-white"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                        />
-                      </svg>
-                    </div>
-                    <h4 className="text-lg font-bold text-white mb-2">Submission Deadline</h4>
-                    <p className="text-xl font-bold text-orange-400">
-                      {PROJECT_SYSTEM_CONFIG.submissionDeadline}
-                    </p>
-                    <p className="text-xs text-orange-300 mt-1">2nd Thursday of Quarter</p>
-                  </div>
-
-                  {/* Maximum Budget */}
-                  <div className="bg-gradient-to-br from-yellow-900/20 to-amber-900/20 rounded-xl p-6 border border-yellow-500/20 text-center">
-                    <div className="w-12 h-12 bg-gradient-to-br from-yellow-400 to-amber-500 rounded-lg flex items-center justify-center mx-auto mb-4">
-                      <svg
-                        className="w-6 h-6 text-white"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"
-                        />
-                      </svg>
-                    </div>
-                    <h4 className="text-lg font-bold text-white mb-2">Max Budget/Project</h4>
-                    <p className="text-xl font-bold text-yellow-400">
-                      ${MAX_BUDGET_USD.toLocaleString()}
-                    </p>
-                    <p className="text-sm text-yellow-300 mt-1">(1/5 of quarterly budget)</p>
-                  </div>
-
-                  {/* Approval Timeline */}
-                  <div className="bg-gradient-to-br from-green-900/20 to-teal-900/20 rounded-xl p-6 border border-green-500/20 text-center">
-                    <div className="w-12 h-12 bg-gradient-to-br from-green-400 to-teal-500 rounded-lg flex items-center justify-center mx-auto mb-4">
-                      <svg
-                        className="w-6 h-6 text-white"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
-                    </div>
-                    <h4 className="text-lg font-bold text-white mb-2">Voting Date</h4>
-                    <p className="text-xl font-bold text-green-400">
-                      {PROJECT_SYSTEM_CONFIG.votingDate}
-                    </p>
-                    <p className="text-xs text-green-300 mt-1">3rd Thursday of Quarter</p>
-                  </div>
-                </div>
-
-                {/* Total Budget Available */}
-                <div className="bg-gradient-to-r from-purple-900/30 to-blue-900/30 rounded-xl p-6 border border-purple-500/30 mb-8">
-                  <div className="text-center">
-                    <p className="text-sm text-purple-300 mb-2">
-                      Total Quarterly Retroactive Rewards
-                    </p>
-                    <p className="text-3xl md:text-4xl font-bold text-white">
-                      ${NEXT_QUARTER_BUDGET_USD.toLocaleString()}
-                    </p>
-                    <p className="text-xs text-purple-400 mt-2">
-                      Plus{' '}
-                      {mooneyBudget > 0
-                        ? Number(mooneyBudget.toPrecision(3)).toLocaleString()
-                        : '...'}{' '}
-                      vMOONEY
-                    </p>
-                    <p className="text-xs text-purple-400 mt-1">
-                      5% of liquid non-MOONEY assets minus approved project budgets
-                    </p>
-                  </div>
-                </div>
-
-                {/* Submission Steps */}
-                <div className="space-y-4 mb-8">
-                  <h4 className="text-xl font-bold text-white text-center mb-6">How to Submit</h4>
-
-                  <div className="grid md:grid-cols-2 gap-4">
-                    {/* Step 1 */}
-                    <div className="flex gap-4 p-4 bg-white/5 rounded-xl border border-white/10">
-                      <div className="flex-shrink-0">
-                        <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-bold">
-                          1
-                        </div>
-                      </div>
-                      <div>
-                        <h5 className="font-bold text-white mb-1">Post in Ideation Channel</h5>
-                        <p className="text-sm text-gray-300">
-                          Share your problem and proposed solution in Discord's ideation channel.
-                          Get feedback and coordinate with others informally.
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Step 2 */}
-                    <div className="flex gap-4 p-4 bg-white/5 rounded-xl border border-white/10">
-                      <div className="flex-shrink-0">
-                        <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-bold">
-                          2
-                        </div>
-                      </div>
-                      <div>
-                        <h5 className="font-bold text-white mb-1">Review Documentation</h5>
-                        <p className="text-sm text-gray-300">
-                          Read our comprehensive project system guide to understand requirements,
-                          evaluation criteria, and best practices.
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Step 3 */}
-                    <div className="flex gap-4 p-4 bg-white/5 rounded-xl border border-white/10">
-                      <div className="flex-shrink-0">
-                        <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-bold">
-                          3
-                        </div>
-                      </div>
-                      <div>
-                        <h5 className="font-bold text-white mb-1">Submit Full Proposal</h5>
-                        <p className="text-sm text-gray-300">
-                          Fill out the Project Proposal Template and submit by the 2nd Thursday of
-                          the Quarter. Budget must be ≤20% of quarterly rewards.
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Step 4 */}
-                    <div className="flex gap-4 p-4 bg-white/5 rounded-xl border border-white/10">
-                      <div className="flex-shrink-0">
-                        <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center text-white font-bold">
-                          4
-                        </div>
-                      </div>
-                      <div>
-                        <h5 className="font-bold text-white mb-1">Present & Vote</h5>
-                        <p className="text-sm text-gray-300">
-                          Present at the Town Hall meeting. Members vote to allocate funding. Top 50%
-                          of proposals get funded (budget permitting).
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Action Buttons */}
-                <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                  <StandardButton
-                    backgroundColor="bg-gradient-to-r from-green-600 to-teal-600"
-                    textColor="text-white"
-                    borderRadius="rounded-full"
-                    hoverEffect={false}
-                    link={PROJECT_SYSTEM_CONFIG.submissionUrl}
-                  >
-                    Submit Your Proposal
-                  </StandardButton>
-                  <StandardButton
-                    backgroundColor="bg-gradient-to-r from-blue-600 to-purple-600"
-                    textColor="text-white"
-                    borderRadius="rounded-full"
-                    hoverEffect={false}
-                    link={PROJECT_SYSTEM_CONFIG.docsUrl}
-                  >
-                    Read Full Documentation
-                  </StandardButton>
-                  <StandardButton
-                    backgroundColor="bg-gradient-to-r from-purple-600 to-pink-600"
-                    textColor="text-white"
-                    borderRadius="rounded-full"
-                    hoverEffect={false}
-                    link="https://moondao.com/discord"
-                  >
-                    Join Discord
-                  </StandardButton>
+                  <p className="mt-1 text-sm text-white/40">Locked 4 years as delegated vMOONEY</p>
                 </div>
               </div>
             </div>
 
-            {/* Active Projects Section */}
-            <div className="relative mx-4 mb-16">
-              <DashboardActiveProjects
-                currentProjects={currentProjects}
-                usdBudget={usdBudget}
-                showBudget={true}
-                maxProjects={6}
-              />
-            </div>
-
-            {/* Call to Action */}
-            <div className="text-center px-4">
-              <h3 className="text-2xl md:text-3xl font-GoodTimes text-white mb-6">
-                Ready to Build the Future?
-              </h3>
-              <p className="text-lg text-gray-300 max-w-2xl mx-auto mb-8">
-                Join our community of space entrepreneurs and contribute to humanity's
-                multiplanetary future.
+            <div>
+              <h2 className="font-GoodTimes text-3xl text-white">Before you submit</h2>
+              <p className="mt-4 text-gray-300">
+                Senate review returns incomplete proposals. Use the template checklist so your ask
+                is ready for diligence.
               </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <ul className="mt-6 space-y-2">
+                {CHECKLIST.map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-start gap-3 border-b border-white/5 py-2 text-gray-300"
+                  >
+                    <span className="mt-1 text-cyan-400/80">✓</span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
                 <StandardButton
-                  backgroundColor="bg-gradient-to-r from-blue-600 to-purple-600"
+                  backgroundColor="bg-gradient-to-r from-blue-600 to-cyan-600"
                   textColor="text-white"
-                  borderRadius="rounded-full"
+                  borderRadius="rounded-xl"
                   hoverEffect={false}
-                  link="/projects"
+                  link="/proposal-template"
                 >
-                  Explore Active Projects
+                  Open template
+                </StandardButton>
+                <StandardButton
+                  backgroundColor="bg-white/10"
+                  textColor="text-white"
+                  borderRadius="rounded-xl"
+                  hoverEffect={false}
+                  link={PROJECT_SYSTEM_CONFIG.docsUrl}
+                  className="border border-white/15"
+                >
+                  Full documentation
                 </StandardButton>
               </div>
             </div>
+          </div>
+        </Container>
+      </section>
 
-            {/* Notice Footer */}
-            <div className="mt-16">
-              <NoticeFooter
-                defaultImage="../assets/MoonDAO-Logo-White.svg"
-                defaultTitle="Questions About Projects?"
-                defaultDescription="Join our Discord community to discuss project ideas and get support from fellow space entrepreneurs!"
-                defaultButtonText="Join Discord"
-                defaultButtonLink="https://moondao.com/discord"
-                imageWidth={200}
-                imageHeight={200}
-              />
+      {/* Active projects */}
+      <section className="bg-[#060a14] px-4 py-16 md:px-8 md:py-24">
+        <Container>
+          <div className="mx-auto max-w-6xl">
+            <div className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 className="font-GoodTimes text-3xl text-white md:text-4xl">Active projects</h2>
+                <p className="mt-3 text-gray-400">Work already funded this cycle.</p>
+              </div>
+              <Link href="/projects" className="text-sm text-blue-300 hover:text-blue-200">
+                View all projects →
+              </Link>
+            </div>
+            <DashboardActiveProjects
+              currentProjects={currentProjects}
+              usdBudget={usdBudget}
+              showBudget={true}
+              maxProjects={6}
+            />
+          </div>
+        </Container>
+      </section>
+
+      {/* Final CTA */}
+      <section className="relative overflow-hidden px-4 py-20 md:px-8 md:py-28">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(56,120,220,0.15),transparent_60%)]" />
+        <Container>
+          <div className="relative z-10 mx-auto max-w-3xl text-center">
+            <h2 className="font-GoodTimes text-3xl text-white md:text-5xl">
+              Ready to propose?
+            </h2>
+            <p className="mx-auto mt-5 max-w-xl text-lg text-gray-300">
+              Start from the template, keep the ask under ${MAX_BUDGET_USD.toLocaleString()}, and
+              show how the work serves lunar settlement.
+            </p>
+            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <StandardButton
+                className="!px-6 !py-3"
+                backgroundColor="bg-white"
+                textColor="text-black"
+                borderRadius="rounded-xl"
+                hoverEffect={false}
+                link="/propose"
+              >
+                Submit proposal
+              </StandardButton>
+              <StandardButton
+                className="!px-6 !py-3 border border-white/20"
+                backgroundColor="bg-transparent"
+                textColor="text-white"
+                borderRadius="rounded-xl"
+                hoverEffect={false}
+                link="https://moondao.com/discord"
+              >
+                Join Discord
+              </StandardButton>
             </div>
           </div>
+        </Container>
+      </section>
+
+      <section className="px-4 pb-16">
+        <Container>
+          <NoticeFooter
+            defaultImage="../assets/MoonDAO-Logo-White.svg"
+            defaultTitle="Questions about projects?"
+            defaultDescription="Ask in Discord ideation before you submit—strong proposals start with community feedback."
+            defaultButtonText="Join Discord"
+            defaultButtonLink="https://moondao.com/discord"
+            imageWidth={200}
+            imageHeight={200}
+          />
         </Container>
       </section>
     </>
@@ -643,7 +451,6 @@ export default ProjectsOverview
 
 export const getServerSideProps: GetServerSideProps = async () => {
   try {
-    // Import the same constants and functions used in the projects page
     const { DEFAULT_CHAIN_V5, DISTRIBUTION_TABLE_NAMES, PROJECT_TABLE_NAMES } = await import(
       'const/config'
     )
@@ -653,7 +460,6 @@ export const getServerSideProps: GetServerSideProps = async () => {
     const chainSlug = getChainSlug(chain)
     const { quarter, year } = getRelativeQuarter(0)
 
-    // Get current and past projects
     const statement = `SELECT * FROM ${PROJECT_TABLE_NAMES[chainSlug]}`
     const projects = await queryTable(chain, statement)
 
@@ -663,7 +469,6 @@ export const getServerSideProps: GetServerSideProps = async () => {
     if (projects && projects.length > 0) {
       for (let i = 0; i < projects.length; i++) {
         if (projects[i]) {
-          const project = projects[i] as any
           const activeStatus = projects[i].active
           if (activeStatus == PROJECT_ACTIVE) {
             currentProjects.push(projects[i])
@@ -677,13 +482,10 @@ export const getServerSideProps: GetServerSideProps = async () => {
     await enrichProjectNames([...currentProjects, ...pastProjects])
 
     currentProjects.sort((a, b) => {
-      if (a.eligible === b.eligible) {
-        return 0
-      }
+      if (a.eligible === b.eligible) return 0
       return a.eligible ? 1 : -1
     })
 
-    // Get distributions for budget calculations
     const distributionStatement = `SELECT * FROM ${DISTRIBUTION_TABLE_NAMES[chainSlug]} WHERE year = ${year} AND quarter = ${quarter}`
     const distributions = await queryTable(chain, distributionStatement)
 

--- a/ui/pages/projects-overview.tsx
+++ b/ui/pages/projects-overview.tsx
@@ -69,7 +69,7 @@ const FUND_YES = [
 const FUND_NO = [
   'General computers, monitors, printers, or furniture',
   'LLC / sole-prop formation or registration fees',
-  'Tax bills, re-registration, or private runway bailouts',
+  'Re-registration or private runway bailouts',
 ]
 
 const FIT_YES = [
@@ -80,7 +80,7 @@ const FIT_YES = [
 ]
 
 const FIT_NO = [
-  'The ask is mostly company setup, taxes, or a general workstation',
+  'The ask is mostly company setup or a general workstation',
   'The pitch is LEO tourism, generic STEAM branding, or inspiration alone',
   'Key Results are empty or the plan is a megaproject OKR in one quarter',
   'You are submitting multiple primary asks as the same Lead this quarter',
@@ -88,15 +88,13 @@ const FIT_NO = [
 
 const CHECKLIST = [
   'Ask ≤ quarterly max',
-  'Novelty & Prior Art with citations',
-  'Explicit lunar bridge',
-  'Community standing noted',
+  'All required sections completed',
   'Non-empty SMART key results',
-  'Budget classes A–E (C/D = $0)',
-  'IP disclosed (open or retained)',
+  'Budget justified and within allowed categories',
+  'Team, timeline, and IP filled in',
   'One primary ask per Lead this quarter',
-  'Same-type prior work linked',
-  'Partner LOIs if the plan depends on them',
+  'Supporting docs if the plan depends on partners',
+  'Scope limited to this quarter’s deliverables',
 ]
 
 const ProjectsOverview: React.FC<{

--- a/ui/pages/proposal-template.tsx
+++ b/ui/pages/proposal-template.tsx
@@ -51,7 +51,9 @@ export default function ProposalTemplatePage() {
             </h1>
             <p className="mb-8 max-w-2xl text-lg text-gray-300">
               Copy this markdown into a Google Doc or editor, fill every required section, then
-              import it on the propose page. Current max ask:{' '}
+              import it on the propose page. Includes Novelty &amp; Prior Art, Lunar Bridge,
+              Community Standing, budget classes, IP, COTS (for hardware), and a pre-submit
+              checklist. Current max ask:{' '}
               <span className="font-semibold text-white">
                 ${MAX_BUDGET_USD.toLocaleString()}
               </span>

--- a/ui/pages/proposal-template.tsx
+++ b/ui/pages/proposal-template.tsx
@@ -1,0 +1,98 @@
+import { MAX_BUDGET_USD } from 'const/config'
+import { useMemo, useState } from 'react'
+import toast from 'react-hot-toast'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import Container from '@/components/layout/Container'
+import WebsiteHead from '@/components/layout/Head'
+import StandardButton from '@/components/layout/StandardButton'
+import { getProposalTemplate } from '@/lib/nance'
+import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+
+export default function ProposalTemplatePage() {
+  const template = useMemo(() => getProposalTemplate(MAX_BUDGET_USD), [])
+  const [copied, setCopied] = useState(false)
+
+  async function copyTemplate() {
+    try {
+      await navigator.clipboard.writeText(template)
+      setCopied(true)
+      toast.success('Template copied to clipboard.', { style: toastStyle })
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast.error('Could not copy. Select the text below instead.', { style: toastStyle })
+    }
+  }
+
+  function downloadTemplate() {
+    const blob = new Blob([template], { type: 'text/markdown;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'moondao-project-proposal-template.md'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <>
+      <WebsiteHead
+        title="Project Proposal Template"
+        description="Canonical MoonDAO project proposal template: novelty & prior art, lunar bridge, budget classes, IP disclosure, and pre-submit checklist."
+      />
+      <section className="w-full px-4 py-10 md:px-8 md:py-16">
+        <Container>
+          <div className="mx-auto max-w-4xl">
+            <p className="mb-3 font-GoodTimes text-sm tracking-[0.2em] text-blue-300/80">
+              PROJECT SYSTEM
+            </p>
+            <h1 className="mb-4 font-GoodTimes text-3xl text-white md:text-5xl">
+              Proposal Template
+            </h1>
+            <p className="mb-8 max-w-2xl text-lg text-gray-300">
+              Copy this markdown into a Google Doc or editor, fill every required section, then
+              import it on the propose page. Current max ask:{' '}
+              <span className="font-semibold text-white">
+                ${MAX_BUDGET_USD.toLocaleString()}
+              </span>
+              .
+            </p>
+
+            <div className="mb-8 flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={copyTemplate}
+                className="rounded-xl bg-gradient-to-r from-blue-600 to-cyan-600 px-5 py-3 font-medium text-white shadow-lg transition hover:opacity-90"
+              >
+                {copied ? 'Copied' : 'Copy markdown'}
+              </button>
+              <button
+                type="button"
+                onClick={downloadTemplate}
+                className="rounded-xl border border-white/20 bg-white/5 px-5 py-3 font-medium text-white transition hover:bg-white/10"
+              >
+                Download .md
+              </button>
+              <StandardButton
+                backgroundColor="bg-white/10"
+                textColor="text-white"
+                borderRadius="rounded-xl"
+                hoverEffect={false}
+                link="/propose"
+                className="border border-white/20"
+              >
+                Go to Propose
+              </StandardButton>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-black/40 p-5 md:p-8">
+              <article className="prose prose-invert max-w-none prose-headings:font-GoodTimes prose-a:text-blue-300">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{template}</ReactMarkdown>
+              </article>
+            </div>
+          </div>
+        </Container>
+      </section>
+    </>
+  )
+}

--- a/ui/pages/proposals.tsx
+++ b/ui/pages/proposals.tsx
@@ -123,8 +123,9 @@ export default function ProposalsPage({ project }: { project: Project }) {
                   </div>
                   <div className="p-3 md:p-4 bg-white/5 border border-white/10 rounded-lg">
                     <p className="text-sm text-gray-300">
-                      <strong>Required sections:</strong> Novelty &amp; Prior Art, Lunar Bridge, SMART Key
-                      Results, Budget classes (no foundational PCs / tax / entity fees), IP disclosure.
+                      <strong>Required sections:</strong> Novelty &amp; Prior Art, Lunar Bridge, Community
+                      Standing, SMART Key Results, Budget classes (no foundational PCs / tax /
+                      entity fees), IP disclosure, COTS rationale for hardware.
                     </p>
                   </div>
                 </div>

--- a/ui/pages/proposals.tsx
+++ b/ui/pages/proposals.tsx
@@ -124,7 +124,7 @@ export default function ProposalsPage({ project }: { project: Project }) {
                   <div className="p-3 md:p-4 bg-white/5 border border-white/10 rounded-lg">
                     <p className="text-sm text-gray-300">
                       <strong>Required sections:</strong> Novelty &amp; Prior Art, Lunar Bridge, Community
-                      Standing, SMART Key Results, Budget classes (no foundational PCs / tax /
+                      Standing, SMART Key Results, Budget classes (no foundational PCs /
                       entity fees), IP disclosure, COTS rationale for hardware.
                     </p>
                   </div>

--- a/ui/pages/proposals.tsx
+++ b/ui/pages/proposals.tsx
@@ -71,44 +71,62 @@ export default function ProposalsPage({ project }: { project: Project }) {
               </div>
 
               {/* Step 1: Get the Template - Most Prominent */}
-              <div className="bg-gradient-to-br from-blue-900/40 via-indigo-900/30 to-purple-900/30 backdrop-blur-xl border border-blue-500/30 rounded-2xl p-4 md:p-8 shadow-xl">
+              <div className="bg-gradient-to-br from-slate-900/80 via-blue-950/40 to-slate-900/80 backdrop-blur-xl border border-blue-500/25 rounded-2xl p-4 md:p-8 shadow-xl">
                 <div className="flex items-start gap-3 md:gap-4 mb-4 md:mb-6">
-                  <div className="flex-shrink-0 w-10 h-10 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center text-white font-bold text-lg">
+                  <div className="flex-shrink-0 w-10 h-10 rounded-full bg-gradient-to-r from-blue-500 to-cyan-600 flex items-center justify-center text-white font-bold text-lg">
                     1
                   </div>
                   <div className="flex-1">
                     <h2 className="text-xl md:text-2xl font-bold text-white mb-2">Get the Proposal Template</h2>
                     <p className="text-gray-300">
-                      Start by making a copy of our Google Doc template. Fill it out with your project details.
+                      Use the canonical markdown template (novelty &amp; prior art, lunar bridge, budget
+                      classes, IP, checklist). Ask must be ≤ ${MAX_BUDGET_USD.toLocaleString()}.
                     </p>
                   </div>
                 </div>
-                
+
                 <div className="flex flex-col sm:flex-row gap-3 md:gap-4">
+                  <Link
+                    href="/proposal-template"
+                    className="flex-1 inline-flex items-center justify-center gap-2 md:gap-3 px-4 md:px-6 py-3 md:py-4 bg-gradient-to-r from-blue-600 to-cyan-600 hover:opacity-90 text-white rounded-xl transition-all duration-300 shadow-lg text-sm md:text-base font-semibold group"
+                  >
+                    <DocumentDuplicateIcon className="w-6 h-6 group-hover:scale-110 transition-transform" />
+                    Open template &amp; copy
+                  </Link>
+
                   <Link
                     href="https://docs.google.com/document/d/1p8rV9RlvFk6nAJzWh-tvroyPvasjjrvgKpyX8ibGX3I/edit?usp=sharing"
                     target="_blank"
                     rel="noreferrer"
-                    className="flex-1 inline-flex items-center justify-center gap-2 md:gap-3 px-4 md:px-6 py-3 md:py-4 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white rounded-xl transition-all duration-300 shadow-lg hover:shadow-xl text-sm md:text-base font-semibold group"
+                    className="inline-flex items-center justify-center gap-2 px-4 md:px-5 py-3 md:py-4 bg-white/10 hover:bg-white/20 text-white rounded-xl transition-all duration-200 text-sm font-medium border border-white/20"
                   >
-                    <DocumentDuplicateIcon className="w-6 h-6 group-hover:scale-110 transition-transform" />
-                    Open & Copy Template
-                    <ArrowTopRightOnSquareIcon className="w-5 h-5 opacity-70" />
+                    Google Doc
+                    <ArrowTopRightOnSquareIcon className="w-4 h-4 opacity-70" />
                   </Link>
-                  
+
                   <Link
                     href="/project-system-docs"
                     className="inline-flex items-center justify-center gap-2 px-4 md:px-5 py-3 md:py-4 bg-white/10 hover:bg-white/20 text-white rounded-xl transition-all duration-200 text-sm font-medium border border-white/20"
                   >
                     <QuestionMarkCircleIcon className="w-5 h-5" />
-                    View Documentation
+                    Docs
                   </Link>
                 </div>
 
-                <div className="mt-4 md:mt-5 p-3 md:p-4 bg-blue-500/10 border border-blue-500/20 rounded-lg">
-                  <p className="text-sm text-blue-200">
-                    <strong>Important:</strong> After filling out the template, set sharing to <span className="font-semibold">&quot;Anyone with the link can view&quot;</span> so we can import it.
-                  </p>
+                <div className="mt-4 md:mt-5 grid gap-3 md:grid-cols-2">
+                  <div className="p-3 md:p-4 bg-blue-500/10 border border-blue-500/20 rounded-lg">
+                    <p className="text-sm text-blue-200">
+                      <strong>Import tip:</strong> Paste into a Google Doc, set sharing to{' '}
+                      <span className="font-semibold">&quot;Anyone with the link can view&quot;</span>, then
+                      import below.
+                    </p>
+                  </div>
+                  <div className="p-3 md:p-4 bg-white/5 border border-white/10 rounded-lg">
+                    <p className="text-sm text-gray-300">
+                      <strong>Required sections:</strong> Novelty &amp; Prior Art, Lunar Bridge, SMART Key
+                      Results, Budget classes (no foundational PCs / tax / entity fees), IP disclosure.
+                    </p>
+                  </div>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- Expand the canonical project proposal markdown template (`getProposalTemplate`) with Senate diligence requirements: Novelty & Prior Art, Lunar Bridge, Community Standing, budget classes A–E (block foundational PCs / tax / entity fees), IP disclosure, same-type prior work, hardware COTS prompts, one-ask attestation, and a pre-submit checklist. Max ask is injected from `MAX_BUDGET_USD`.
- Add `/proposal-template` with copy/download of the live template; wire it into Propose, nav, footer, and search.
- Redesign `/projects-overview` as a stronger Project System landing: full-bleed hero, quarter facts, fund / do-not-fund rules, fit check, process steps, checklist, active projects, and clearer CTAs (with scroll/hero motion).

**Follow-up (manual):** Sync the Google Doc template at the existing share link to match the new markdown so authors who still use Docs get the same sections. Update `PROJECT_SYSTEM_CONFIG` submission/voting dates for the active quarter if they are stale.

## Test plan
- [ ] Open `/proposal-template` — copy and download work; max budget matches `MAX_BUDGET_USD`; new sections (Community Standing, COTS, checklist) appear
- [ ] Open `/propose` — primary CTA goes to in-app template; Google Doc still linked; required-sections blurb matches template
- [ ] Open `/projects-overview` — hero, fund rules, fit check, checklist, and active projects render on desktop and mobile; motion respects reduced-motion
- [ ] Confirm nav/footer/search find “Proposal Template” and “Projects Overview”
- [ ] Spot-check that proposal Google Doc import flow still works after pasting the new markdown into a Doc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI, copy, and static template content only—no auth, treasury, or submission pipeline logic changes beyond linking to existing propose/import flows.
> 
> **Overview**
> Introduces a **canonical in-app project proposal template** and surfaces it across the project funnel. `getProposalTemplate(maxBudgetUsd)` replaces the static `TEMPLATE` string with Senate-style diligence sections (Novelty & Prior Art, Lunar Bridge, Community Standing, budget classes A–E, IP, same-type prior work, hardware COTS prompts, pre-submit checklist) and injects the live max ask from `MAX_BUDGET_USD`.
> 
> Adds **`/proposal-template`** with rendered markdown, copy, and download; **`/proposals`** now leads with that page (Google Doc kept as secondary). Footer, Projects nav, global search, and the project banner include links to the template and treat `/proposal-template` as a project-system page.
> 
> **`/projects-overview`** is rebuilt as a mission-focused landing (hero with motion, quarter facts, fund/do-not-fund, fit check, process steps, checklist, retro pool, active projects) with CTAs to `/propose` and the template. SSR for that page only loads active projects (drops past projects and distribution queries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b6911e2423c72cb5c1e0057a8f39a824c5b63b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->