### PR TITLE
feat(proposals): Groq MVP for Senate-style AI review

### DIFF
--- a/ui/components/nance/ProposalAIReview.tsx
+++ b/ui/components/nance/ProposalAIReview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { ProposalAIReviewResult, ProvisionalVote } from '@/lib/proposals/aiReview'
 
 type Props = {
@@ -42,6 +42,7 @@ export default function ProposalAIReview({
   const [error, setError] = useState<string | undefined>()
   const [review, setReview] = useState<ProposalAIReviewResult | undefined>()
   const [quarterlyMaxUsd, setQuarterlyMaxUsd] = useState<number | undefined>()
+  const requestIdRef = useRef(0)
 
   async function runReview() {
     setError(undefined)
@@ -54,6 +55,7 @@ export default function ProposalAIReview({
       return
     }
 
+    const requestId = ++requestIdRef.current
     setLoading(true)
     try {
       const res = await fetch('/api/proposals/ai-review', {
@@ -66,6 +68,7 @@ export default function ProposalAIReview({
         }),
       })
       const data = await res.json()
+      if (requestId !== requestIdRef.current) return
       if (!res.ok) {
         throw new Error(data?.error || 'AI review failed.')
       }
@@ -73,9 +76,12 @@ export default function ProposalAIReview({
       setQuarterlyMaxUsd(data.quarterlyMaxUsd)
       onReview?.(data.review)
     } catch (e: any) {
+      if (requestId !== requestIdRef.current) return
       setError(e?.message || 'AI review failed.')
     } finally {
-      setLoading(false)
+      if (requestId === requestIdRef.current) {
+        setLoading(false)
+      }
     }
   }
 

--- a/ui/components/nance/ProposalAIReview.tsx
+++ b/ui/components/nance/ProposalAIReview.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { ProposalAIReviewResult, ProvisionalVote } from '@/lib/proposals/aiReview'
 
 type Props = {
@@ -6,7 +6,7 @@ type Props = {
   body?: string
   budgetHintUsd?: number
   disabled?: boolean
-  onReview?: (review: ProposalAIReviewResult) => void
+  onReview?: (review: ProposalAIReviewResult | undefined) => void
 }
 
 function voteStyles(vote: ProvisionalVote): string {
@@ -43,6 +43,17 @@ export default function ProposalAIReview({
   const [review, setReview] = useState<ProposalAIReviewResult | undefined>()
   const [quarterlyMaxUsd, setQuarterlyMaxUsd] = useState<number | undefined>()
   const requestIdRef = useRef(0)
+
+  // Drop any prior review when the draft changes so the UI and post-submit
+  // snapshot never present scores for an older title/body/budget.
+  useEffect(() => {
+    requestIdRef.current += 1
+    setLoading(false)
+    setError(undefined)
+    setReview(undefined)
+    setQuarterlyMaxUsd(undefined)
+    onReview?.(undefined)
+  }, [title, body, budgetHintUsd])
 
   async function runReview() {
     setError(undefined)

--- a/ui/components/nance/ProposalAIReview.tsx
+++ b/ui/components/nance/ProposalAIReview.tsx
@@ -1,0 +1,244 @@
+import { useState } from 'react'
+import type { ProposalAIReviewResult, ProvisionalVote } from '@/lib/proposals/aiReview'
+
+type Props = {
+  title?: string
+  body?: string
+  budgetHintUsd?: number
+  disabled?: boolean
+  onReview?: (review: ProposalAIReviewResult) => void
+}
+
+function voteStyles(vote: ProvisionalVote): string {
+  switch (vote) {
+    case 'Approve':
+      return 'bg-green-500/20 text-green-300 border-green-500/40'
+    case 'Approve with conditions':
+      return 'bg-yellow-500/20 text-yellow-200 border-yellow-500/40'
+    case 'Request rewrite':
+      return 'bg-orange-500/20 text-orange-200 border-orange-500/40'
+    case 'Reject':
+      return 'bg-red-500/20 text-red-300 border-red-500/40'
+    default:
+      return 'bg-white/10 text-gray-200 border-white/20'
+  }
+}
+
+function scoreColor(score: number): string {
+  if (score <= 3) return 'text-red-400'
+  if (score <= 5) return 'text-orange-300'
+  if (score <= 7) return 'text-yellow-200'
+  return 'text-green-300'
+}
+
+export default function ProposalAIReview({
+  title,
+  body,
+  budgetHintUsd,
+  disabled,
+  onReview,
+}: Props) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+  const [review, setReview] = useState<ProposalAIReviewResult | undefined>()
+  const [quarterlyMaxUsd, setQuarterlyMaxUsd] = useState<number | undefined>()
+
+  async function runReview() {
+    setError(undefined)
+    if (!title?.trim()) {
+      setError('Add a proposal title before running AI review.')
+      return
+    }
+    if (!body?.trim()) {
+      setError('Import your proposal body before running AI review.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const res = await fetch('/api/proposals/ai-review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          budgetHintUsd: budgetHintUsd && budgetHintUsd > 0 ? budgetHintUsd : undefined,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data?.error || 'AI review failed.')
+      }
+      setReview(data.review)
+      setQuarterlyMaxUsd(data.quarterlyMaxUsd)
+      onReview?.(data.review)
+    } catch (e: any) {
+      setError(e?.message || 'AI review failed.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mt-4 md:mt-5 rounded-xl border border-white/10 bg-black/20 overflow-hidden">
+      <div className="px-4 py-3 border-b border-white/10 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h3 className="text-white font-medium">AI Senate-style Review</h3>
+          <p className="text-xs text-gray-400 mt-1">
+            Advisory only — scores your draft against the Senate rubric before you submit.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={runReview}
+          disabled={disabled || loading}
+          className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          {loading ? 'Reviewing…' : review ? 'Re-run AI Review' : 'Get AI Review'}
+        </button>
+      </div>
+
+      <div className="p-4 space-y-4">
+        {error && (
+          <p className="text-sm text-red-400 bg-red-900/20 border border-red-500/30 rounded-lg px-3 py-2">
+            {error}
+          </p>
+        )}
+
+        {!review && !error && !loading && (
+          <p className="text-sm text-gray-400">
+            Run a quick check for budget cap, Novelty &amp; Prior Art, hard flags, and rewrite risk
+            before Senate discussion.
+          </p>
+        )}
+
+        {loading && (
+          <div className="flex items-center gap-3 text-sm text-gray-300">
+            <svg
+              className="animate-spin h-4 w-4 text-indigo-300"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            Scoring against Mission, Team, Objectives, Budget, Impact, Feasibility,
+            Accountability, Fiduciary…
+          </div>
+        )}
+
+        {review && (
+          <>
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className={`inline-flex items-center px-3 py-1 rounded-lg border text-sm font-medium ${voteStyles(
+                  review.provisionalVote
+                )}`}
+              >
+                {review.provisionalVote}
+              </span>
+              <span className="text-sm text-gray-300">
+                Avg <span className={`font-semibold ${scoreColor(review.average)}`}>{review.average}</span>
+                /10
+              </span>
+              {review.askUsd != null && (
+                <span className="text-sm text-gray-400">
+                  Ask ${Math.round(review.askUsd).toLocaleString()}
+                  {quarterlyMaxUsd != null && (
+                    <>
+                      {' '}
+                      · max ${quarterlyMaxUsd.toLocaleString()}
+                      {review.askWithinMax === false && (
+                        <span className="text-red-400"> (over)</span>
+                      )}
+                    </>
+                  )}
+                </span>
+              )}
+            </div>
+
+            <p className="text-sm text-gray-300 leading-relaxed">{review.finding}</p>
+
+            {review.hardFlags.length > 0 && (
+              <div>
+                <h4 className="text-xs uppercase tracking-wide text-red-300 mb-2">Hard flags</h4>
+                <ul className="space-y-1">
+                  {review.hardFlags.map((flag) => (
+                    <li key={flag} className="text-sm text-red-200/90 flex gap-2">
+                      <span className="text-red-400">•</span>
+                      <span>{flag}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {review.topIssues.length > 0 && (
+              <div>
+                <h4 className="text-xs uppercase tracking-wide text-yellow-200/80 mb-2">
+                  Top fixes
+                </h4>
+                <ol className="list-decimal list-inside space-y-1">
+                  {review.topIssues.map((issue) => (
+                    <li key={issue} className="text-sm text-gray-300">
+                      {issue}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            )}
+
+            {review.conditions.length > 0 && (
+              <div>
+                <h4 className="text-xs uppercase tracking-wide text-indigo-200/80 mb-2">
+                  Conditions
+                </h4>
+                <ul className="space-y-1">
+                  {review.conditions.map((c) => (
+                    <li key={c} className="text-sm text-gray-300 flex gap-2">
+                      <span className="text-indigo-300">•</span>
+                      <span>{c}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {review.dimensions.map((d) => (
+                <div
+                  key={d.key}
+                  className="rounded-lg border border-white/10 bg-black/20 px-3 py-2"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs text-gray-400">{d.label}</span>
+                    <span className={`text-sm font-semibold ${scoreColor(d.score)}`}>
+                      {d.score}/10
+                    </span>
+                  </div>
+                  {d.note && <p className="text-xs text-gray-500 mt-1 line-clamp-2">{d.note}</p>}
+                </div>
+              ))}
+            </div>
+
+            <p className="text-[11px] text-gray-500">
+              Advisory preview via {review.model}. Senate vote is independent.
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui/components/nance/ProposalEditor.tsx
+++ b/ui/components/nance/ProposalEditor.tsx
@@ -155,13 +155,13 @@ export default function ProposalEditor({ project }: { project: Project }) {
   const { wallet } = useAccount()
   const buttonsDisabled = !address || signingStatus === 'loading' || isUploadingImage
 
+  const watchedBudget = watch('budget') as
+    | Array<{ token: string; amount: string }>
+    | undefined
   const budgetHintUsd = (() => {
-    const budgetItems = getValues()['budget'] as
-      | Array<{ token: string; amount: string }>
-      | undefined
-    if (!budgetItems || !Array.isArray(budgetItems)) return undefined
+    if (!watchedBudget || !Array.isArray(watchedBudget)) return undefined
     let total = 0
-    for (const item of budgetItems) {
+    for (const item of watchedBudget) {
       if (
         item.token === 'USD' ||
         item.token === 'USDC' ||

--- a/ui/components/nance/ProposalEditor.tsx
+++ b/ui/components/nance/ProposalEditor.tsx
@@ -23,7 +23,9 @@ import useAccount from '@/lib/nance/useAccountAddress'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
 import { classNames } from '@/lib/utils/tailwind'
 import ProposalTitleInput from '@/components/nance/ProposalTitleInput'
+import type { ProposalAIReviewResult } from '@/lib/proposals/aiReview'
 import GoogleDocsImport from './GoogleDocsImport'
+import ProposalAIReview from './ProposalAIReview'
 import ProposalSubmissionCTA from './ProposalSubmissionCTA'
 import RequestBudgetActionForm from './RequestBudgetActionForm'
 import ReactMarkdown from 'react-markdown'
@@ -61,6 +63,7 @@ export default function ProposalEditor({ project }: { project: Project }) {
   const [submittedProposalId, setSubmittedProposalId] = useState<string | undefined>()
   const [submitterEmail, setSubmitterEmail] = useState<string>('')
   const [emailError, setEmailError] = useState<string | undefined>()
+  const [latestAIReview, setLatestAIReview] = useState<ProposalAIReviewResult | undefined>()
 
   useEffect(() => {
     async function getProposalJSON() {
@@ -151,6 +154,25 @@ export default function ProposalEditor({ project }: { project: Project }) {
 
   const { wallet } = useAccount()
   const buttonsDisabled = !address || signingStatus === 'loading' || isUploadingImage
+
+  const budgetHintUsd = (() => {
+    const budgetItems = getValues()['budget'] as
+      | Array<{ token: string; amount: string }>
+      | undefined
+    if (!budgetItems || !Array.isArray(budgetItems)) return undefined
+    let total = 0
+    for (const item of budgetItems) {
+      if (
+        item.token === 'USD' ||
+        item.token === 'USDC' ||
+        item.token === 'USDT' ||
+        item.token === 'DAI'
+      ) {
+        total += Number(item.amount) || 0
+      }
+    }
+    return total > 0 ? total : undefined
+  })()
 
   // Email validation helper
   const validateEmail = (email: string): boolean => {
@@ -503,6 +525,14 @@ export default function ProposalEditor({ project }: { project: Project }) {
               </div>
             </div>
 
+            <ProposalAIReview
+              title={proposalTitle}
+              body={proposalBody}
+              budgetHintUsd={budgetHintUsd}
+              disabled={isUploadingImage || signingStatus === 'loading'}
+              onReview={setLatestAIReview}
+            />
+
             {/* Loading Overlay - Document Import */}
             {isUploadingImage && (
               <div className="fixed inset-0 bg-black bg-opacity-75 flex flex-col items-center justify-center z-50">
@@ -615,6 +645,7 @@ export default function ProposalEditor({ project }: { project: Project }) {
       {showSubmissionCTA && (
         <ProposalSubmissionCTA
           proposalId={submittedProposalId}
+          aiReview={latestAIReview}
           onClose={() => {
             setShowSubmissionCTA(false)
             // Redirect to proposal page after closing CTA

--- a/ui/components/nance/ProposalSubmissionCTA.tsx
+++ b/ui/components/nance/ProposalSubmissionCTA.tsx
@@ -1,19 +1,25 @@
 import React from 'react'
 import { CalendarIcon, ChatBubbleLeftIcon } from '@heroicons/react/24/outline'
+import type { ProposalAIReviewResult } from '@/lib/proposals/aiReview'
 
 interface ProposalSubmissionCTAProps {
   proposalId?: string
+  aiReview?: ProposalAIReviewResult
   onClose?: () => void
 }
 
-export default function ProposalSubmissionCTA({ proposalId, onClose }: ProposalSubmissionCTAProps) {
+export default function ProposalSubmissionCTA({
+  proposalId,
+  aiReview,
+  onClose,
+}: ProposalSubmissionCTAProps) {
   // Discord URLs for MoonDAO
   const PROPOSALS_CHANNEL = 'https://discord.com/channels/914720248140279868/1027658256706961509'
   const LUMA_CALENDAR = 'https://lu.ma/moondao'
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl p-8 shadow-2xl max-w-2xl w-full">
+      <div className="bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 rounded-2xl p-8 shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         <div className="text-center mb-8">
           <div className="w-16 h-16 bg-gradient-to-r from-green-500 to-blue-600 rounded-full flex items-center justify-center mx-auto mb-4">
             <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -29,6 +35,26 @@ export default function ProposalSubmissionCTA({ proposalId, onClose }: ProposalS
         </div>
 
         <div className="space-y-6">
+          {aiReview && (
+            <div className="bg-black/20 rounded-xl p-6 border border-white/10">
+              <h4 className="text-lg font-semibold text-white mb-2">AI review snapshot</h4>
+              <p className="text-sm text-gray-400 mb-3">
+                Advisory only — not a Senate vote. Avg {aiReview.average}/10 ·{' '}
+                {aiReview.provisionalVote}
+              </p>
+              {aiReview.topIssues.length > 0 && (
+                <ul className="space-y-1">
+                  {aiReview.topIssues.map((issue) => (
+                    <li key={issue} className="text-sm text-gray-300 flex gap-2">
+                      <span className="text-yellow-400">•</span>
+                      <span>{issue}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
           {/* Next Steps Header */}
           <div className="text-center">
             <h3 className="text-xl font-semibold text-white mb-4">

--- a/ui/cypress/integration/unit/proposal-ai-review.cy.tsx
+++ b/ui/cypress/integration/unit/proposal-ai-review.cy.tsx
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for Senate-style AI proposal review normalizer (MVP).
+ */
+import {
+  hasNoveltySection,
+  normalizeReviewResult,
+} from '@/lib/proposals/aiReview'
+
+describe('proposal AI review normalizer', () => {
+  const quarterlyMaxUsd = 4682
+
+  it('detects Novelty & Prior Art section', () => {
+    expect(hasNoveltySection('## Novelty & Prior Art\n\nStuff')).to.eq(true)
+    expect(hasNoveltySection('## Abstract\n\nHello')).to.eq(false)
+  })
+
+  it('forces budget ≤2 and rewrite when ask exceeds max', () => {
+    const review = normalizeReviewResult({
+      raw: {
+        provisionalVote: 'Approve',
+        askUsd: 9000,
+        dimensions: [
+          { key: 'mission', score: 8, note: 'ok' },
+          { key: 'team', score: 8, note: 'ok' },
+          { key: 'objectives', score: 8, note: 'ok' },
+          { key: 'budget', score: 8, note: 'ok' },
+          { key: 'impact', score: 8, note: 'ok' },
+          { key: 'feasibility', score: 8, note: 'ok' },
+          { key: 'accountability', score: 8, note: 'ok' },
+          { key: 'fiduciary', score: 8, note: 'ok' },
+        ],
+        hardFlags: [],
+        topIssues: ['Trim budget'],
+        conditions: [],
+        finding: 'Looks fine',
+      },
+      body: '## Novelty & Prior Art\n\nPrior work exists.',
+      quarterlyMaxUsd,
+      model: 'openai/gpt-oss-120b',
+    })
+
+    expect(review.askWithinMax).to.eq(false)
+    expect(review.dimensions.find((d) => d.key === 'budget')?.score).to.be.at.most(2)
+    expect(review.provisionalVote).to.eq('Request rewrite')
+    expect(review.hardFlags.some((f) => /exceeds quarterly max/i.test(f))).to.eq(true)
+    expect(review.advisory).to.eq(true)
+  })
+
+  it('flags missing Novelty & Prior Art and caps impact ≤3', () => {
+    const review = normalizeReviewResult({
+      raw: {
+        provisionalVote: 'Approve',
+        askUsd: 2000,
+        dimensions: [
+          { key: 'mission', score: 7, note: 'ok' },
+          { key: 'team', score: 7, note: 'ok' },
+          { key: 'objectives', score: 7, note: 'ok' },
+          { key: 'budget', score: 7, note: 'ok' },
+          { key: 'impact', score: 7, note: 'ok' },
+          { key: 'feasibility', score: 7, note: 'ok' },
+          { key: 'accountability', score: 7, note: 'ok' },
+          { key: 'fiduciary', score: 7, note: 'ok' },
+        ],
+        hardFlags: [],
+        topIssues: [],
+        conditions: [],
+        finding: 'Missing novelty',
+      },
+      body: '## Abstract\n\nNo novelty section here.',
+      quarterlyMaxUsd,
+      model: 'openai/gpt-oss-120b',
+    })
+
+    expect(review.dimensions.find((d) => d.key === 'impact')?.score).to.be.at.most(3)
+    expect(review.hardFlags.some((f) => /novelty/i.test(f))).to.eq(true)
+    expect(review.provisionalVote).to.not.eq('Approve')
+  })
+})

--- a/ui/cypress/integration/unit/proposal-ai-review.cy.tsx
+++ b/ui/cypress/integration/unit/proposal-ai-review.cy.tsx
@@ -1,42 +1,91 @@
 /**
- * Unit tests for Senate-style AI proposal review normalizer (MVP).
+ * Unit tests for Senate-style AI proposal review (MVP).
+ *
+ * Covers three layers:
+ *   1. Pure helpers (novelty detection, JSON extraction, prompt building).
+ *   2. The normalizer's deterministic hard rules (budget cap, novelty,
+ *      score clamping, missing-dimension defaults, vote downgrades, dedupe).
+ *   3. `performGroqReview` end-to-end with a mocked Groq fetch (success and
+ *      every failure branch), verifying the exact response shape.
  */
 import {
+  AI_REVIEW_MODEL,
+  buildReviewSystemPrompt,
+  buildReviewUserPrompt,
+  extractJsonObject,
   hasNoveltySection,
   normalizeReviewResult,
+  performGroqReview,
+  type DimensionKey,
 } from '@/lib/proposals/aiReview'
 
-describe('proposal AI review normalizer', () => {
-  const quarterlyMaxUsd = 4682
+const QUARTERLY_MAX = 4682
 
-  it('detects Novelty & Prior Art section', () => {
+function makeDims(score: number) {
+  const keys: DimensionKey[] = [
+    'mission',
+    'team',
+    'objectives',
+    'budget',
+    'impact',
+    'feasibility',
+    'accountability',
+    'fiduciary',
+  ]
+  return keys.map((key) => ({ key, score, note: `${key} ok` }))
+}
+
+const NOVELTY_BODY = '## Novelty & Prior Art\n\nPrior work: NASA X. New: Y. Why not existing: Z.'
+
+describe('proposal AI review — helpers', () => {
+  it('detects Novelty & Prior Art section (and variants)', () => {
     expect(hasNoveltySection('## Novelty & Prior Art\n\nStuff')).to.eq(true)
+    expect(hasNoveltySection('### novelty and prior art')).to.eq(true)
+    expect(hasNoveltySection('Novelty  &  Prior  Art')).to.eq(true)
     expect(hasNoveltySection('## Abstract\n\nHello')).to.eq(false)
+    expect(hasNoveltySection('we are novel')).to.eq(false)
   })
 
+  it('extracts JSON from fenced, prefixed, and raw responses', () => {
+    expect(extractJsonObject('{"a":1}')).to.deep.eq({ a: 1 })
+    expect(extractJsonObject('```json\n{"a":2}\n```')).to.deep.eq({ a: 2 })
+    expect(extractJsonObject('Here is the review:\n{"a":3}\nThanks')).to.deep.eq({ a: 3 })
+    expect(extractJsonObject('```\n{"a":{"b":4}}\n```')).to.deep.eq({ a: { b: 4 } })
+  })
+
+  it('throws when there is no JSON object', () => {
+    expect(() => extractJsonObject('no json here')).to.throw()
+  })
+
+  it('embeds the quarterly max in prompts', () => {
+    expect(buildReviewSystemPrompt(QUARTERLY_MAX)).to.contain(String(QUARTERLY_MAX))
+    const user = buildReviewUserPrompt({
+      title: 'T',
+      body: 'B',
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      budgetHintUsd: 3000,
+    })
+    expect(user).to.contain(String(QUARTERLY_MAX))
+    expect(user).to.contain('$3000')
+    expect(user).to.contain('T')
+  })
+})
+
+describe('proposal AI review — normalizer hard rules', () => {
   it('forces budget ≤2 and rewrite when ask exceeds max', () => {
     const review = normalizeReviewResult({
       raw: {
         provisionalVote: 'Approve',
         askUsd: 9000,
-        dimensions: [
-          { key: 'mission', score: 8, note: 'ok' },
-          { key: 'team', score: 8, note: 'ok' },
-          { key: 'objectives', score: 8, note: 'ok' },
-          { key: 'budget', score: 8, note: 'ok' },
-          { key: 'impact', score: 8, note: 'ok' },
-          { key: 'feasibility', score: 8, note: 'ok' },
-          { key: 'accountability', score: 8, note: 'ok' },
-          { key: 'fiduciary', score: 8, note: 'ok' },
-        ],
+        dimensions: makeDims(8),
         hardFlags: [],
         topIssues: ['Trim budget'],
         conditions: [],
         finding: 'Looks fine',
       },
-      body: '## Novelty & Prior Art\n\nPrior work exists.',
-      quarterlyMaxUsd,
-      model: 'openai/gpt-oss-120b',
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      model: AI_REVIEW_MODEL,
     })
 
     expect(review.askWithinMax).to.eq(false)
@@ -44,6 +93,7 @@ describe('proposal AI review normalizer', () => {
     expect(review.provisionalVote).to.eq('Request rewrite')
     expect(review.hardFlags.some((f) => /exceeds quarterly max/i.test(f))).to.eq(true)
     expect(review.advisory).to.eq(true)
+    expect(review.model).to.eq(AI_REVIEW_MODEL)
   })
 
   it('flags missing Novelty & Prior Art and caps impact ≤3', () => {
@@ -51,28 +101,278 @@ describe('proposal AI review normalizer', () => {
       raw: {
         provisionalVote: 'Approve',
         askUsd: 2000,
-        dimensions: [
-          { key: 'mission', score: 7, note: 'ok' },
-          { key: 'team', score: 7, note: 'ok' },
-          { key: 'objectives', score: 7, note: 'ok' },
-          { key: 'budget', score: 7, note: 'ok' },
-          { key: 'impact', score: 7, note: 'ok' },
-          { key: 'feasibility', score: 7, note: 'ok' },
-          { key: 'accountability', score: 7, note: 'ok' },
-          { key: 'fiduciary', score: 7, note: 'ok' },
-        ],
+        dimensions: makeDims(7),
         hardFlags: [],
         topIssues: [],
         conditions: [],
         finding: 'Missing novelty',
       },
       body: '## Abstract\n\nNo novelty section here.',
-      quarterlyMaxUsd,
-      model: 'openai/gpt-oss-120b',
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      model: AI_REVIEW_MODEL,
     })
 
     expect(review.dimensions.find((d) => d.key === 'impact')?.score).to.be.at.most(3)
     expect(review.hardFlags.some((f) => /novelty/i.test(f))).to.eq(true)
     expect(review.provisionalVote).to.not.eq('Approve')
+  })
+
+  it('keeps a clean proposal as Approve', () => {
+    const review = normalizeReviewResult({
+      raw: {
+        provisionalVote: 'Approve',
+        askUsd: 3000,
+        dimensions: makeDims(8),
+        hardFlags: [],
+        topIssues: [],
+        conditions: [],
+        finding: 'Strong pack.',
+      },
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      model: AI_REVIEW_MODEL,
+    })
+
+    expect(review.provisionalVote).to.eq('Approve')
+    expect(review.hardFlags).to.have.length(0)
+    expect(review.askWithinMax).to.eq(true)
+    expect(review.average).to.eq(8)
+  })
+
+  it('preserves a Reject verdict from the model', () => {
+    const review = normalizeReviewResult({
+      raw: {
+        provisionalVote: 'Reject',
+        askUsd: 4000,
+        dimensions: makeDims(2),
+        hardFlags: ['Tax bailout'],
+        topIssues: ['Withdraw'],
+        conditions: [],
+        finding: 'No mission tie.',
+      },
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      model: AI_REVIEW_MODEL,
+    })
+    expect(review.provisionalVote).to.eq('Reject')
+    // Every low dimension should surface as a hard flag.
+    expect(review.hardFlags.length).to.be.greaterThan(1)
+  })
+
+  it('clamps out-of-range scores to 1..10 integers', () => {
+    const review = normalizeReviewResult({
+      raw: {
+        provisionalVote: 'Approve with conditions',
+        askUsd: 1000,
+        dimensions: [
+          { key: 'mission', score: 99, note: '' },
+          { key: 'team', score: -5, note: '' },
+          { key: 'objectives', score: 7.6, note: '' },
+        ],
+        hardFlags: [],
+        topIssues: [],
+        conditions: ['x'],
+        finding: 'f',
+      },
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      model: AI_REVIEW_MODEL,
+    })
+    const byKey = Object.fromEntries(review.dimensions.map((d) => [d.key, d.score]))
+    expect(byKey.mission).to.eq(10)
+    expect(byKey.team).to.eq(1)
+    expect(byKey.objectives).to.eq(8) // rounded
+    // Missing dimensions default to a neutral 5.
+    expect(byKey.fiduciary).to.eq(5)
+    expect(review.dimensions).to.have.length(8)
+  })
+
+  it('falls back to the budget hint when the model omits askUsd', () => {
+    const review = normalizeReviewResult({
+      raw: {
+        provisionalVote: 'Approve',
+        dimensions: makeDims(8),
+        hardFlags: [],
+        topIssues: [],
+        conditions: [],
+        finding: 'f',
+      },
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      budgetHintUsd: 12000,
+      model: AI_REVIEW_MODEL,
+    })
+    expect(review.askUsd).to.eq(12000)
+    expect(review.askWithinMax).to.eq(false)
+    expect(review.provisionalVote).to.eq('Request rewrite')
+  })
+
+  it('does not emit duplicate hard flags', () => {
+    const review = normalizeReviewResult({
+      raw: {
+        provisionalVote: 'Reject',
+        askUsd: 9000,
+        dimensions: makeDims(2),
+        hardFlags: ['Ask exceeds quarterly max ($4682).', 'ASK EXCEEDS QUARTERLY MAX ($4682).'],
+        topIssues: [],
+        conditions: [],
+        finding: 'f',
+      },
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      model: AI_REVIEW_MODEL,
+    })
+    const lower = review.hardFlags.map((f) => f.toLowerCase())
+    expect(new Set(lower).size).to.eq(lower.length)
+  })
+})
+
+describe('performGroqReview — mocked Groq', () => {
+  const validModelJson = JSON.stringify({
+    provisionalVote: 'Approve with conditions',
+    askUsd: 2900,
+    dimensions: makeDims(6),
+    hardFlags: [],
+    topIssues: ['Add key results'],
+    conditions: ['Fill empty Key Results'],
+    finding: 'Solid but incomplete.',
+  })
+
+  function mockFetch(response: { ok: boolean; body: any }) {
+    return async () => ({
+      ok: response.ok,
+      json: async () => response.body,
+    })
+  }
+
+  it('returns a normalized review on success', async () => {
+    const outcome = await performGroqReview({
+      title: 'LunCoSim',
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      budgetHintUsd: 2900,
+      apiKey: 'test-key',
+      fetchImpl: mockFetch({
+        ok: true,
+        body: { choices: [{ message: { content: validModelJson } }] },
+      }),
+    })
+
+    expect(outcome.ok).to.eq(true)
+    if (outcome.ok) {
+      expect(outcome.review.provisionalVote).to.eq('Approve with conditions')
+      expect(outcome.review.askUsd).to.eq(2900)
+      expect(outcome.review.dimensions).to.have.length(8)
+      expect(outcome.review.advisory).to.eq(true)
+      expect(outcome.review.conditions).to.include('Fill empty Key Results')
+    }
+  })
+
+  it('parses model output wrapped in markdown fences', async () => {
+    const outcome = await performGroqReview({
+      title: 'T',
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      apiKey: 'test-key',
+      fetchImpl: mockFetch({
+        ok: true,
+        body: { choices: [{ message: { content: '```json\n' + validModelJson + '\n```' } }] },
+      }),
+    })
+    expect(outcome.ok).to.eq(true)
+  })
+
+  it('maps provider errors to 502', async () => {
+    const outcome = await performGroqReview({
+      title: 'T',
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      apiKey: 'bad-key',
+      fetchImpl: mockFetch({ ok: false, body: { error: { message: 'invalid_api_key' } } }),
+    })
+    expect(outcome.ok).to.eq(false)
+    if (!outcome.ok) {
+      expect(outcome.status).to.eq(502)
+      expect(outcome.error).to.contain('invalid_api_key')
+    }
+  })
+
+  it('errors when the model returns empty content', async () => {
+    const outcome = await performGroqReview({
+      title: 'T',
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      apiKey: 'test-key',
+      fetchImpl: mockFetch({ ok: true, body: { choices: [{ message: { content: '' } }] } }),
+    })
+    expect(outcome.ok).to.eq(false)
+    if (!outcome.ok) expect(outcome.status).to.eq(502)
+  })
+
+  it('errors when the model returns non-JSON content', async () => {
+    const outcome = await performGroqReview({
+      title: 'T',
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      apiKey: 'test-key',
+      fetchImpl: mockFetch({
+        ok: true,
+        body: { choices: [{ message: { content: 'I cannot help with that.' } }] },
+      }),
+    })
+    expect(outcome.ok).to.eq(false)
+    if (!outcome.ok) {
+      expect(outcome.status).to.eq(502)
+      expect(outcome.error).to.contain('invalid JSON')
+    }
+  })
+
+  it('handles a network/fetch throw as a 500', async () => {
+    const outcome = await performGroqReview({
+      title: 'T',
+      body: NOVELTY_BODY,
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      apiKey: 'test-key',
+      fetchImpl: async () => {
+        throw new Error('network down')
+      },
+    })
+    expect(outcome.ok).to.eq(false)
+    if (!outcome.ok) {
+      expect(outcome.status).to.eq(500)
+      expect(outcome.error).to.contain('network down')
+    }
+  })
+
+  it('applies deterministic hard rules to a real-looking model response', async () => {
+    // Model over-scores an over-budget proposal with no novelty section.
+    const overBudgetJson = JSON.stringify({
+      provisionalVote: 'Approve',
+      askUsd: 5500,
+      dimensions: makeDims(8),
+      hardFlags: [],
+      topIssues: [],
+      conditions: [],
+      finding: 'Model was too generous.',
+    })
+    const outcome = await performGroqReview({
+      title: 'MDRS analog seat',
+      body: '## Abstract\n\nNo novelty section, over budget.',
+      quarterlyMaxUsd: QUARTERLY_MAX,
+      apiKey: 'test-key',
+      fetchImpl: mockFetch({
+        ok: true,
+        body: { choices: [{ message: { content: overBudgetJson } }] },
+      }),
+    })
+
+    expect(outcome.ok).to.eq(true)
+    if (outcome.ok) {
+      // Guardrails override the model's optimism.
+      expect(outcome.review.provisionalVote).to.eq('Request rewrite')
+      expect(outcome.review.askWithinMax).to.eq(false)
+      expect(outcome.review.dimensions.find((d) => d.key === 'budget')?.score).to.be.at.most(2)
+      expect(outcome.review.dimensions.find((d) => d.key === 'impact')?.score).to.be.at.most(3)
+    }
   })
 })

--- a/ui/cypress/integration/unit/proposal-ai-review.cy.tsx
+++ b/ui/cypress/integration/unit/proposal-ai-review.cy.tsx
@@ -42,6 +42,8 @@ describe('proposal AI review — helpers', () => {
     expect(hasNoveltySection('## Novelty & Prior Art\n\nStuff')).to.eq(true)
     expect(hasNoveltySection('### novelty and prior art')).to.eq(true)
     expect(hasNoveltySection('Novelty  &  Prior  Art')).to.eq(true)
+    expect(hasNoveltySection('## Prior Art and Novelty\n\nStuff')).to.eq(true)
+    expect(hasNoveltySection('### prior art & novelty')).to.eq(true)
     expect(hasNoveltySection('## Abstract\n\nHello')).to.eq(false)
     expect(hasNoveltySection('we are novel')).to.eq(false)
   })

--- a/ui/lib/proposals/aiReview.ts
+++ b/ui/lib/proposals/aiReview.ts
@@ -170,6 +170,103 @@ export function extractJsonObject(text: string): unknown {
   return JSON.parse(clean.slice(start, end + 1))
 }
 
+export type GroqReviewOutcome =
+  | { ok: true; review: ProposalAIReviewResult }
+  | { ok: false; status: number; error: string }
+
+type MinimalResponse = {
+  ok: boolean
+  json: () => Promise<any>
+}
+
+type FetchImpl = (url: string, init: any) => Promise<MinimalResponse>
+
+/**
+ * Calls Groq's chat completions endpoint and returns a normalized review.
+ * The network client is injectable so this can be unit-tested without a
+ * live API key. Returns a discriminated outcome so the API route can map
+ * failures to HTTP status codes without try/catch gymnastics.
+ */
+export async function performGroqReview(params: {
+  title: string
+  body: string
+  quarterlyMaxUsd: number
+  budgetHintUsd?: number | null
+  apiKey: string
+  model?: string
+  fetchImpl?: FetchImpl
+}): Promise<GroqReviewOutcome> {
+  const model = params.model || AI_REVIEW_MODEL
+  const doFetch: FetchImpl = params.fetchImpl || (fetch as unknown as FetchImpl)
+
+  let res: MinimalResponse
+  try {
+    res = await doFetch('https://api.groq.com/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 0,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: buildReviewSystemPrompt(params.quarterlyMaxUsd) },
+          {
+            role: 'user',
+            content: buildReviewUserPrompt({
+              title: params.title,
+              body: params.body,
+              quarterlyMaxUsd: params.quarterlyMaxUsd,
+              budgetHintUsd: params.budgetHintUsd,
+            }),
+          },
+        ],
+      }),
+    })
+  } catch (e: any) {
+    return { ok: false, status: 500, error: e?.message || 'AI review request failed.' }
+  }
+
+  let data: any
+  try {
+    data = await res.json()
+  } catch (e) {
+    return { ok: false, status: 502, error: 'AI review returned a non-JSON response.' }
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      status: 502,
+      error: data?.error?.message || 'AI review provider returned an error.',
+    }
+  }
+
+  const text = data?.choices?.[0]?.message?.content?.trim()
+  if (!text) {
+    return { ok: false, status: 502, error: 'AI review returned an empty response.' }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = extractJsonObject(text)
+  } catch (e) {
+    return { ok: false, status: 502, error: 'AI review returned invalid JSON.' }
+  }
+
+  const review = normalizeReviewResult({
+    raw: parsed,
+    body: params.body,
+    quarterlyMaxUsd: params.quarterlyMaxUsd,
+    budgetHintUsd: params.budgetHintUsd,
+    model,
+  })
+
+  return { ok: true, review }
+}
+
 export function normalizeReviewResult(params: {
   raw: unknown
   body: string
@@ -260,6 +357,17 @@ export function normalizeReviewResult(params: {
   if (hasHard && provisionalVote === 'Approve') {
     provisionalVote = 'Approve with conditions'
   }
+
+  // Dedupe hard flags case-insensitively, preserving first-seen order.
+  const seenFlags = new Set<string>()
+  const dedupedFlags = hardFlags.filter((f) => {
+    const key = f.trim().toLowerCase()
+    if (!key || seenFlags.has(key)) return false
+    seenFlags.add(key)
+    return true
+  })
+  hardFlags.length = 0
+  hardFlags.push(...dedupedFlags)
 
   const average =
     Math.round(

--- a/ui/lib/proposals/aiReview.ts
+++ b/ui/lib/proposals/aiReview.ts
@@ -1,0 +1,290 @@
+/**
+ * Shared types + prompt for Senate-style AI proposal review (MVP).
+ * Rubric mirrors the MoonDAO Senate Proposal Review Pack (Appendix A).
+ */
+
+export type ProvisionalVote =
+  | 'Approve'
+  | 'Approve with conditions'
+  | 'Request rewrite'
+  | 'Reject'
+
+export type DimensionKey =
+  | 'mission'
+  | 'team'
+  | 'objectives'
+  | 'budget'
+  | 'impact'
+  | 'feasibility'
+  | 'accountability'
+  | 'fiduciary'
+
+export type DimensionScore = {
+  key: DimensionKey
+  label: string
+  score: number
+  note: string
+}
+
+export type ProposalAIReviewResult = {
+  provisionalVote: ProvisionalVote
+  average: number
+  askUsd: number | null
+  askWithinMax: boolean | null
+  dimensions: DimensionScore[]
+  hardFlags: string[]
+  topIssues: string[]
+  conditions: string[]
+  finding: string
+  advisory: true
+  model: string
+}
+
+export const DIMENSION_LABELS: Record<DimensionKey, string> = {
+  mission: 'Mission/Constitution',
+  team: 'Team',
+  objectives: 'Objectives/Deliverables',
+  budget: 'Budget',
+  impact: 'Impact/Novelty',
+  feasibility: 'Feasibility',
+  accountability: 'Accountability/IP',
+  fiduciary: 'Fiduciary DD',
+}
+
+const DIMENSION_KEYS: DimensionKey[] = [
+  'mission',
+  'team',
+  'objectives',
+  'budget',
+  'impact',
+  'feasibility',
+  'accountability',
+  'fiduciary',
+]
+
+export const AI_REVIEW_MODEL = 'openai/gpt-oss-120b'
+
+export function buildReviewSystemPrompt(quarterlyMaxUsd: number): string {
+  return `You are an impersonal MoonDAO Senate proposal reviewer. Score proposals using the official Senate review rubric. Be strict, evidence-tied, and concise. This review is ADVISORY only — not a Senate vote.
+
+CORE FUNDING RULE
+Pay for mission outputs and specialized tools the work uniquely needs. Do not fund: general computers/monitors/printers/furniture; LLC/sole-prop formation; tax bills, re-registration, or private runway bailouts.
+
+EIGHT DIMENSIONS (score each 1–10; average = overall)
+1. mission — lunar settlement by 2030; values; community standing; one ask/quarter.
+2. team — same-type prior delivery; not résumé-only.
+3. objectives — SMART; accurate claims; no setup-as-objective; no megaproject OKRs in the grant.
+4. budget — ≤ $${quarterlyMaxUsd}; classify spend; foundational/setup gear and entity fees should score ≤3 until removed. Over max → budget ≤2.
+5. impact — prior art map; what's new; why not existing work. Require Novelty & Prior Art honesty.
+6. feasibility — timeline; method risk (no stranger-Zoom technical design).
+7. accountability — reporting; IP disclosed (open default or explicit retention).
+8. fiduciary — COI structure; partner proof; no false history claims.
+
+HARD FLAGS
+- Any dimension ≤3 is a hard flag.
+- Ask > $${quarterlyMaxUsd} → budget ≤2 and provisionalVote must be "Request rewrite" or "Reject" until cut.
+- Missing Novelty & Prior Art section (what exists / what's new / why not use existing) is a hard flag on impact.
+- Foundational PC / LLC fees / tax bailouts → hard flag.
+
+PROVISIONAL VOTE LABELS (pick exactly one)
+- Approve
+- Approve with conditions
+- Request rewrite
+- Reject
+
+OUTPUT
+Return ONLY valid JSON (no markdown fences) matching this schema:
+{
+  "provisionalVote": "Approve" | "Approve with conditions" | "Request rewrite" | "Reject",
+  "askUsd": number | null,
+  "dimensions": [
+    { "key": "mission"|"team"|"objectives"|"budget"|"impact"|"feasibility"|"accountability"|"fiduciary", "score": 1-10, "note": "≤20 words evidence" }
+  ],
+  "hardFlags": ["short flag strings"],
+  "topIssues": ["up to 3 author-facing fixes"],
+  "conditions": ["up to 3 conditions if Approve with conditions, else []"],
+  "finding": "1-3 sentence impersonal finding"
+}
+
+Rules:
+- Include ALL 8 dimension keys exactly once.
+- Scores are integers 1–10.
+- topIssues must be actionable for the author.
+- Do not invent citations; if prior art is missing, say so.`
+}
+
+export function buildReviewUserPrompt(params: {
+  title: string
+  body: string
+  quarterlyMaxUsd: number
+  budgetHintUsd?: number | null
+}): string {
+  const budgetLine =
+    params.budgetHintUsd != null && params.budgetHintUsd > 0
+      ? `Structured budget hint (from form/parser): $${params.budgetHintUsd} USD\n`
+      : ''
+
+  return (
+    `Quarterly per-proposal maximum: $${params.quarterlyMaxUsd}\n` +
+    budgetLine +
+    `Title: ${params.title}\n\n` +
+    `Proposal markdown:\n${params.body}`
+  )
+}
+
+function clampScore(n: unknown): number {
+  const v = typeof n === 'number' ? n : Number(n)
+  if (!Number.isFinite(v)) return 1
+  return Math.max(1, Math.min(10, Math.round(v)))
+}
+
+function asStringArray(value: unknown, max = 5): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
+    .map((x) => x.trim())
+    .slice(0, max)
+}
+
+function parseVote(raw: unknown): ProvisionalVote {
+  const s = typeof raw === 'string' ? raw.trim() : ''
+  if (s === 'Approve') return 'Approve'
+  if (s === 'Approve with conditions') return 'Approve with conditions'
+  if (s === 'Reject') return 'Reject'
+  return 'Request rewrite'
+}
+
+export function hasNoveltySection(body: string): boolean {
+  return /novelty\s*(&|and)?\s*prior\s*art/i.test(body)
+}
+
+export function extractJsonObject(text: string): unknown {
+  let clean = text.trim()
+  const fenced = clean.match(/```(?:json)?\s*([\s\S]*?)```/)
+  if (fenced) clean = fenced[1].trim()
+  const start = clean.indexOf('{')
+  const end = clean.lastIndexOf('}')
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error('No JSON object in model response')
+  }
+  return JSON.parse(clean.slice(start, end + 1))
+}
+
+export function normalizeReviewResult(params: {
+  raw: unknown
+  body: string
+  quarterlyMaxUsd: number
+  budgetHintUsd?: number | null
+  model: string
+}): ProposalAIReviewResult {
+  const raw = (params.raw && typeof params.raw === 'object' ? params.raw : {}) as Record<
+    string,
+    unknown
+  >
+
+  const dimMap = new Map<DimensionKey, { score: number; note: string }>()
+  const rawDims = Array.isArray(raw.dimensions) ? raw.dimensions : []
+  for (const item of rawDims) {
+    if (!item || typeof item !== 'object') continue
+    const d = item as Record<string, unknown>
+    const key = d.key as DimensionKey
+    if (!DIMENSION_KEYS.includes(key)) continue
+    dimMap.set(key, {
+      score: clampScore(d.score),
+      note: typeof d.note === 'string' ? d.note.trim().slice(0, 200) : '',
+    })
+  }
+
+  let askUsd: number | null =
+    typeof raw.askUsd === 'number' && Number.isFinite(raw.askUsd) ? raw.askUsd : null
+  if (
+    (askUsd == null || askUsd <= 0) &&
+    params.budgetHintUsd != null &&
+    params.budgetHintUsd > 0
+  ) {
+    askUsd = params.budgetHintUsd
+  }
+
+  const hardFlags = asStringArray(raw.hardFlags, 8)
+  const topIssues = asStringArray(raw.topIssues, 3)
+  const conditions = asStringArray(raw.conditions, 3)
+
+  // Deterministic hard rules
+  if (askUsd != null && askUsd > params.quarterlyMaxUsd) {
+    const existing = dimMap.get('budget')
+    dimMap.set('budget', {
+      score: Math.min(existing?.score ?? 2, 2),
+      note:
+        existing?.note ||
+        `Ask $${Math.round(askUsd)} exceeds quarterly max $${params.quarterlyMaxUsd}.`,
+    })
+    if (!hardFlags.some((f) => /over|exceed|max/i.test(f))) {
+      hardFlags.unshift(`Ask exceeds quarterly max ($${params.quarterlyMaxUsd}).`)
+    }
+  }
+
+  if (!hasNoveltySection(params.body)) {
+    const existing = dimMap.get('impact')
+    dimMap.set('impact', {
+      score: Math.min(existing?.score ?? 3, 3),
+      note: existing?.note || 'Missing Novelty & Prior Art section.',
+    })
+    if (!hardFlags.some((f) => /novelty|prior art/i.test(f))) {
+      hardFlags.unshift('Missing Novelty & Prior Art section.')
+    }
+  }
+
+  const dimensions: DimensionScore[] = DIMENSION_KEYS.map((key) => {
+    const found = dimMap.get(key)
+    return {
+      key,
+      label: DIMENSION_LABELS[key],
+      score: found?.score ?? 5,
+      note: found?.note || '',
+    }
+  })
+
+  // Any ≤3 is a hard flag
+  for (const d of dimensions) {
+    if (d.score <= 3 && !hardFlags.some((f) => f.toLowerCase().includes(d.label.toLowerCase()))) {
+      hardFlags.push(`${d.label} ≤3 (${d.score}).`)
+    }
+  }
+
+  let provisionalVote = parseVote(raw.provisionalVote)
+  const overMax = askUsd != null && askUsd > params.quarterlyMaxUsd
+  const hasHard = hardFlags.length > 0 || dimensions.some((d) => d.score <= 3)
+  if (overMax && provisionalVote === 'Approve') {
+    provisionalVote = 'Request rewrite'
+  }
+  if (hasHard && provisionalVote === 'Approve') {
+    provisionalVote = 'Approve with conditions'
+  }
+
+  const average =
+    Math.round(
+      (dimensions.reduce((sum, d) => sum + d.score, 0) / dimensions.length) * 10
+    ) / 10
+
+  const finding =
+    typeof raw.finding === 'string' && raw.finding.trim()
+      ? raw.finding.trim().slice(0, 600)
+      : 'Advisory review complete. Address hard flags before Senate discussion.'
+
+  return {
+    provisionalVote,
+    average,
+    askUsd,
+    askWithinMax: askUsd == null ? null : askUsd <= params.quarterlyMaxUsd,
+    dimensions,
+    hardFlags: hardFlags.slice(0, 8),
+    topIssues:
+      topIssues.length > 0
+        ? topIssues
+        : hardFlags.slice(0, 3).map((f) => `Fix: ${f}`),
+    conditions: provisionalVote === 'Approve with conditions' ? conditions : conditions.slice(0, 3),
+    finding,
+    advisory: true,
+    model: params.model,
+  }
+}

--- a/ui/lib/proposals/aiReview.ts
+++ b/ui/lib/proposals/aiReview.ts
@@ -3,11 +3,7 @@
  * Rubric mirrors the MoonDAO Senate Proposal Review Pack (Appendix A).
  */
 
-export type ProvisionalVote =
-  | 'Approve'
-  | 'Approve with conditions'
-  | 'Request rewrite'
-  | 'Reject'
+export type ProvisionalVote = 'Approve' | 'Approve with conditions' | 'Request rewrite' | 'Reject'
 
 export type DimensionKey =
   | 'mission'
@@ -155,7 +151,7 @@ function parseVote(raw: unknown): ProvisionalVote {
 }
 
 export function hasNoveltySection(body: string): boolean {
-  return /novelty\s*(&|and)?\s*prior\s*art/i.test(body)
+  return /novelty\s*(&|and)?\s*prior\s*art|prior\s*art\s*(&|and)?\s*novelty/i.test(body)
 }
 
 export function extractJsonObject(text: string): unknown {
@@ -171,8 +167,7 @@ export function extractJsonObject(text: string): unknown {
 }
 
 export type GroqReviewOutcome =
-  | { ok: true; review: ProposalAIReviewResult }
-  | { ok: false; status: number; error: string }
+  { ok: true; review: ProposalAIReviewResult } | { ok: false; status: number; error: string }
 
 type MinimalResponse = {
   ok: boolean
@@ -294,11 +289,7 @@ export function normalizeReviewResult(params: {
 
   let askUsd: number | null =
     typeof raw.askUsd === 'number' && Number.isFinite(raw.askUsd) ? raw.askUsd : null
-  if (
-    (askUsd == null || askUsd <= 0) &&
-    params.budgetHintUsd != null &&
-    params.budgetHintUsd > 0
-  ) {
+  if ((askUsd == null || askUsd <= 0) && params.budgetHintUsd != null && params.budgetHintUsd > 0) {
     askUsd = params.budgetHintUsd
   }
 
@@ -351,10 +342,7 @@ export function normalizeReviewResult(params: {
   let provisionalVote = parseVote(raw.provisionalVote)
   const overMax = askUsd != null && askUsd > params.quarterlyMaxUsd
   const hasHard = hardFlags.length > 0 || dimensions.some((d) => d.score <= 3)
-  if (
-    overMax &&
-    (provisionalVote === 'Approve' || provisionalVote === 'Approve with conditions')
-  ) {
+  if (overMax && (provisionalVote === 'Approve' || provisionalVote === 'Approve with conditions')) {
     provisionalVote = 'Request rewrite'
   }
   if (hasHard && provisionalVote === 'Approve') {
@@ -373,9 +361,7 @@ export function normalizeReviewResult(params: {
   hardFlags.push(...dedupedFlags)
 
   const average =
-    Math.round(
-      (dimensions.reduce((sum, d) => sum + d.score, 0) / dimensions.length) * 10
-    ) / 10
+    Math.round((dimensions.reduce((sum, d) => sum + d.score, 0) / dimensions.length) * 10) / 10
 
   const finding =
     typeof raw.finding === 'string' && raw.finding.trim()
@@ -389,10 +375,7 @@ export function normalizeReviewResult(params: {
     askWithinMax: askUsd == null ? null : askUsd <= params.quarterlyMaxUsd,
     dimensions,
     hardFlags: hardFlags.slice(0, 8),
-    topIssues:
-      topIssues.length > 0
-        ? topIssues
-        : hardFlags.slice(0, 3).map((f) => `Fix: ${f}`),
+    topIssues: topIssues.length > 0 ? topIssues : hardFlags.slice(0, 3).map((f) => `Fix: ${f}`),
     conditions: provisionalVote === 'Approve with conditions' ? conditions : [],
     finding,
     advisory: true,

--- a/ui/lib/proposals/aiReview.ts
+++ b/ui/lib/proposals/aiReview.ts
@@ -351,7 +351,10 @@ export function normalizeReviewResult(params: {
   let provisionalVote = parseVote(raw.provisionalVote)
   const overMax = askUsd != null && askUsd > params.quarterlyMaxUsd
   const hasHard = hardFlags.length > 0 || dimensions.some((d) => d.score <= 3)
-  if (overMax && provisionalVote === 'Approve') {
+  if (
+    overMax &&
+    (provisionalVote === 'Approve' || provisionalVote === 'Approve with conditions')
+  ) {
     provisionalVote = 'Request rewrite'
   }
   if (hasHard && provisionalVote === 'Approve') {
@@ -390,7 +393,7 @@ export function normalizeReviewResult(params: {
       topIssues.length > 0
         ? topIssues
         : hardFlags.slice(0, 3).map((f) => `Fix: ${f}`),
-    conditions: provisionalVote === 'Approve with conditions' ? conditions : conditions.slice(0, 3),
+    conditions: provisionalVote === 'Approve with conditions' ? conditions : [],
     finding,
     advisory: true,
     model: params.model,

--- a/ui/pages/api/proposals/ai-review.ts
+++ b/ui/pages/api/proposals/ai-review.ts
@@ -2,14 +2,7 @@ import { MAX_BUDGET_USD } from 'const/config'
 import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  AI_REVIEW_MODEL,
-  buildReviewSystemPrompt,
-  buildReviewUserPrompt,
-  extractJsonObject,
-  normalizeReviewResult,
-  ProposalAIReviewResult,
-} from '@/lib/proposals/aiReview'
+import { performGroqReview } from '@/lib/proposals/aiReview'
 
 const MAX_BODY_CHARS = 80_000
 
@@ -44,69 +37,22 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   const quarterlyMaxUsd = MAX_BUDGET_USD
 
-  try {
-    const groqRes = await fetch('https://api.groq.com/openai/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
-      },
-      body: JSON.stringify({
-        model: AI_REVIEW_MODEL,
-        temperature: 0,
-        response_format: { type: 'json_object' },
-        messages: [
-          { role: 'system', content: buildReviewSystemPrompt(quarterlyMaxUsd) },
-          {
-            role: 'user',
-            content: buildReviewUserPrompt({
-              title,
-              body: proposalBody,
-              quarterlyMaxUsd,
-              budgetHintUsd,
-            }),
-          },
-        ],
-      }),
-    })
+  const outcome = await performGroqReview({
+    title,
+    body: proposalBody,
+    quarterlyMaxUsd,
+    budgetHintUsd,
+    apiKey: process.env.GROQ_API_KEY,
+  })
 
-    const data = await groqRes.json()
-    if (!groqRes.ok) {
-      console.error('Groq AI review failed:', data)
-      return res.status(502).json({
-        error: data?.error?.message || 'AI review provider returned an error.',
-      })
-    }
-
-    const text = data.choices?.[0]?.message?.content?.trim()
-    if (!text) {
-      return res.status(502).json({ error: 'AI review returned an empty response.' })
-    }
-
-    let parsed: unknown
-    try {
-      parsed = extractJsonObject(text)
-    } catch (e) {
-      console.error('Failed to parse AI review JSON:', text)
-      return res.status(502).json({ error: 'AI review returned invalid JSON.' })
-    }
-
-    const review: ProposalAIReviewResult = normalizeReviewResult({
-      raw: parsed,
-      body: proposalBody,
-      quarterlyMaxUsd,
-      budgetHintUsd,
-      model: AI_REVIEW_MODEL,
-    })
-
-    return res.status(200).json({
-      review,
-      quarterlyMaxUsd,
-    })
-  } catch (error: any) {
-    console.error('AI review error:', error)
-    return res.status(500).json({ error: error?.message || 'AI review failed.' })
+  if (!outcome.ok) {
+    return res.status(outcome.status).json({ error: outcome.error })
   }
+
+  return res.status(200).json({
+    review: outcome.review,
+    quarterlyMaxUsd,
+  })
 }
 
 export default withMiddleware(handler, rateLimit)

--- a/ui/pages/api/proposals/ai-review.ts
+++ b/ui/pages/api/proposals/ai-review.ts
@@ -1,0 +1,112 @@
+import { MAX_BUDGET_USD } from 'const/config'
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import { NextApiRequest, NextApiResponse } from 'next'
+import {
+  AI_REVIEW_MODEL,
+  buildReviewSystemPrompt,
+  buildReviewUserPrompt,
+  extractJsonObject,
+  normalizeReviewResult,
+  ProposalAIReviewResult,
+} from '@/lib/proposals/aiReview'
+
+const MAX_BODY_CHARS = 80_000
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  if (!process.env.GROQ_API_KEY) {
+    return res.status(503).json({ error: 'AI review is not configured (missing GROQ_API_KEY).' })
+  }
+
+  const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body
+  const title = typeof body?.title === 'string' ? body.title.trim() : ''
+  const proposalBody = typeof body?.body === 'string' ? body.body.trim() : ''
+  const budgetHintUsd =
+    typeof body?.budgetHintUsd === 'number' && Number.isFinite(body.budgetHintUsd)
+      ? body.budgetHintUsd
+      : null
+
+  if (!title) {
+    return res.status(400).json({ error: 'Proposal title is required.' })
+  }
+  if (!proposalBody) {
+    return res.status(400).json({ error: 'Proposal body is required.' })
+  }
+  if (proposalBody.length > MAX_BODY_CHARS) {
+    return res.status(400).json({
+      error: `Proposal body is too long for AI review (max ${MAX_BODY_CHARS} characters).`,
+    })
+  }
+
+  const quarterlyMaxUsd = MAX_BUDGET_USD
+
+  try {
+    const groqRes = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: AI_REVIEW_MODEL,
+        temperature: 0,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: buildReviewSystemPrompt(quarterlyMaxUsd) },
+          {
+            role: 'user',
+            content: buildReviewUserPrompt({
+              title,
+              body: proposalBody,
+              quarterlyMaxUsd,
+              budgetHintUsd,
+            }),
+          },
+        ],
+      }),
+    })
+
+    const data = await groqRes.json()
+    if (!groqRes.ok) {
+      console.error('Groq AI review failed:', data)
+      return res.status(502).json({
+        error: data?.error?.message || 'AI review provider returned an error.',
+      })
+    }
+
+    const text = data.choices?.[0]?.message?.content?.trim()
+    if (!text) {
+      return res.status(502).json({ error: 'AI review returned an empty response.' })
+    }
+
+    let parsed: unknown
+    try {
+      parsed = extractJsonObject(text)
+    } catch (e) {
+      console.error('Failed to parse AI review JSON:', text)
+      return res.status(502).json({ error: 'AI review returned invalid JSON.' })
+    }
+
+    const review: ProposalAIReviewResult = normalizeReviewResult({
+      raw: parsed,
+      body: proposalBody,
+      quarterlyMaxUsd,
+      budgetHintUsd,
+      model: AI_REVIEW_MODEL,
+    })
+
+    return res.status(200).json({
+      review,
+      quarterlyMaxUsd,
+    })
+  } catch (error: any) {
+    console.error('AI review error:', error)
+    return res.status(500).json({ error: error?.message || 'AI review failed.' })
+  }
+}
+
+export default withMiddleware(handler, rateLimit)

--- a/ui/scripts/.mocharc-cypress-unit.json
+++ b/ui/scripts/.mocharc-cypress-unit.json
@@ -15,6 +15,7 @@
     "cypress/integration/unit/audit-bug-regression.cy.tsx",
     "cypress/integration/unit/member-vote-tally.cy.tsx",
     "cypress/integration/unit/team-roles.cy.tsx",
+    "cypress/integration/unit/proposal-ai-review.cy.tsx",
     "cypress/integration/overview-delegate/leaderboard.cy.ts",
     "cypress/integration/overview-path-vote/tally.cy.ts"
   ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds an advisory AI review on the proposal editor so authors get immediate Senate-rubric feedback before (and after) submit.

## What's included
- `POST /api/proposals/ai-review` — Groq `openai/gpt-oss-120b`, JSON Object Mode, rate-limited
- `performGroqReview()` — the network call extracted into a pure, testable unit with an injectable fetch
- Rubric from the Senate review pack: 8 dimensions, hard flags, provisional vote labels
- Deterministic guards that override model optimism:
  - ask over `MAX_BUDGET_USD` → budget ≤2 + Request rewrite
  - missing Novelty & Prior Art → impact ≤3 + flag
  - any dimension ≤3 → hard flag; score clamping; hard-flag dedupe
- `ProposalAIReview` panel in the editor (Get / Re-run AI Review)
- Optional snapshot on the post-submit CTA when a review was run

## Verification
- 18 unit tests (`cypress/integration/unit/proposal-ai-review.cy.tsx`), full suite **254 passing**
- Covers helpers (novelty detection, JSON extraction, prompt building), all normalizer hard rules, and `performGroqReview` end-to-end with a **mocked Groq** for success + every failure branch (provider error → 502, empty/non-JSON content → 502, network throw → 500)
- New files type-check clean (`tsc --noEmit`); confirmed Groq supports `response_format: json_object` for `gpt-oss-120b`

## Notes
- Advisory only — does not block submit or replace Senate votes
- Requires existing `GROQ_API_KEY`
- Live end-to-end against Groq not run here (no key in CI env); the mocked tests exercise the full request→parse→normalize→response path

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4e19-9607-747b-9fc2-6c3a09276fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4e19-9607-747b-9fc2-6c3a09276fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

