### PR TITLE
feat(marketplace): Arbitrum USDC onramp for USDC-priced listings

### DIFF
--- a/ui/components/coinbase/CBHeadlessOnramp.tsx
+++ b/ui/components/coinbase/CBHeadlessOnramp.tsx
@@ -3,20 +3,27 @@ import { usePrivy } from '@privy-io/react-auth'
 import Image from 'next/image'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import useOnrampVerification from '@/lib/coinbase/useOnrampVerification'
+import { OnrampAsset, onrampAssetIcon } from '@/lib/onramp/assets'
 import { LoadingSpinner } from '../layout/LoadingSpinner'
 import { PrivyWeb3Button } from '../privy/PrivyWeb3Button'
 
 interface CBHeadlessOnrampProps {
   address: string
   selectedChain: any
+  /**
+   * Crypto amount to purchase. Interpreted as the selected `asset` (ETH by
+   * default, or USDC when `asset="USDC"`).
+   */
   ethAmount: number
+  /** Crypto to purchase. Defaults to ETH. */
+  asset?: OnrampAsset
   onExit?: () => void
   isWaitingForGasEstimate?: boolean
   fullWidth?: boolean
   embedded?: boolean
   /** When true, shows a USD amount input the user fills in (e.g. generic
    *  wallet top-ups with no predetermined amount). The entered USD is
-   *  converted to ETH for the order. */
+   *  converted to the selected asset for the order. */
   allowAmountInput?: boolean
   /** Optional content rendered just beneath the "Fund" header. */
   headerSlot?: React.ReactNode
@@ -91,6 +98,7 @@ export function CBHeadlessOnramp({
   address,
   selectedChain,
   ethAmount,
+  asset = 'ETH',
   onExit,
   isWaitingForGasEstimate = false,
   fullWidth = false,
@@ -109,6 +117,7 @@ export function CBHeadlessOnramp({
   const { user } = usePrivy()
   const verification = useOnrampVerification()
   const [accountFlowLoading, setAccountFlowLoading] = useState(false)
+  const assetIcon = onrampAssetIcon(asset)
 
   const shellWidthClass = fullWidth ? 'w-full' : 'w-full max-w-md mx-auto'
   const shellChrome = embedded
@@ -123,12 +132,13 @@ export function CBHeadlessOnramp({
   const [quoteLoading, setQuoteLoading] = useState(false)
 
   // USD amount-input mode (e.g. generic wallet top-ups). The user types USD,
-  // which we convert to ETH using the spot price for the order.
+  // which we convert to the selected asset using the spot price for the order.
   const [usdInputString, setUsdInputString] = useState('')
   const [ethPrice, setEthPrice] = useState<number | null>(null)
 
   useEffect(() => {
-    if (!allowAmountInput) return
+    // USDC ≈ $1 — no spot-price fetch needed for the amount-input converter.
+    if (!allowAmountInput || asset === 'USDC') return
     let cancelled = false
     fetch('/api/coinbase/eth-price')
       .then((r) => (r.ok ? r.json() : null))
@@ -139,16 +149,18 @@ export function CBHeadlessOnramp({
     return () => {
       cancelled = true
     }
-  }, [allowAmountInput])
+  }, [allowAmountInput, asset])
 
-  // ETH the order will purchase: typed-USD ÷ spot when in input mode,
-  // otherwise the predetermined prop amount.
+  // Crypto the order will purchase: typed-USD ÷ spot when in input mode,
+  // otherwise the predetermined prop amount. For USDC, USD maps 1:1.
   const effectiveEthAmount = useMemo(() => {
     if (!allowAmountInput) return ethAmount
     const usd = parseFloat(usdInputString) || 0
-    if (!ethPrice || ethPrice <= 0 || usd <= 0) return 0
+    if (usd <= 0) return 0
+    if (asset === 'USDC') return usd
+    if (!ethPrice || ethPrice <= 0) return 0
     return usd / ethPrice
-  }, [allowAmountInput, ethAmount, usdInputString, ethPrice])
+  }, [allowAmountInput, ethAmount, usdInputString, ethPrice, asset])
 
   // Debounce the effective amount so we don't quote on every keystroke.
   const [debouncedEthAmount, setDebouncedEthAmount] = useState(ethAmount)
@@ -196,6 +208,22 @@ export function CBHeadlessOnramp({
       }
       setQuoteLoading(true)
       try {
+        // USDC ≈ $1. Avoid the ETH spot-price path and quote-API network gaps
+        // (Arbitrum isn't always supported by /buy/quote).
+        if (asset === 'USDC') {
+          const total = Math.max(2, debouncedEthAmount * 1.05)
+          if (!cancelled) {
+            setPaymentTotal(total)
+            onQuoteCalculated?.(
+              debouncedEthAmount,
+              debouncedEthAmount,
+              total,
+              total - debouncedEthAmount
+            )
+          }
+          return
+        }
+
         const priceRes = await fetch('/api/coinbase/eth-price')
         if (!priceRes.ok) throw new Error('price')
         const { price } = await priceRes.json()
@@ -237,7 +265,7 @@ export function CBHeadlessOnramp({
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address, debouncedEthAmount, isWaitingForGasEstimate])
+  }, [address, debouncedEthAmount, isWaitingForGasEstimate, asset])
 
   const handleExit = useCallback(() => {
     setFundingState('idle')
@@ -283,6 +311,8 @@ export function CBHeadlessOnramp({
             name: selectedChain?.name,
           },
           ethAmount: effectiveEthAmount,
+          cryptoAmount: effectiveEthAmount,
+          purchaseCurrency: asset,
           paymentMethod,
           email: verification.email,
           phoneNumber: verification.phoneNumber,
@@ -336,6 +366,7 @@ export function CBHeadlessOnramp({
   }, [
     address,
     agreed,
+    asset,
     effectiveEthAmount,
     paymentMethod,
     useGooglePay,
@@ -474,8 +505,8 @@ export function CBHeadlessOnramp({
             </div>
             <h2 className="text-lg font-semibold text-white">Payment complete</h2>
             <p className="text-gray-300 text-sm">
-              Your funds are on the way — this usually takes about a minute. The
-              contribute button will appear automatically as soon as they land.
+              Your funds are on the way — this usually takes about a minute. You
+              can continue as soon as they land.
             </p>
             <div className="flex items-center justify-center gap-2 text-gray-400 text-sm">
               <svg className="animate-spin h-4 w-4 text-blue-300" viewBox="0 0 24 24" fill="none">
@@ -526,7 +557,7 @@ export function CBHeadlessOnramp({
         <div className="flex items-center justify-between p-6 border-b border-white/10">
           <div className="flex items-center space-x-3">
             <div className="w-10 h-10 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
-              <Image src="/coins/ETH.svg" alt="ETH" width={20} height={20} className="w-6 h-6" />
+              <Image src={assetIcon} alt={asset} width={20} height={20} className="w-6 h-6" />
             </div>
             <div>
               <h2 className="text-lg font-semibold text-white">
@@ -612,7 +643,7 @@ export function CBHeadlessOnramp({
       <div className="flex items-center justify-between p-6 border-b border-white/10">
         <div className="flex items-center space-x-3">
           <div className="w-10 h-10 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
-            <Image src="/coins/ETH.svg" alt="ETH" width={20} height={20} className="w-6 h-6" />
+            <Image src={assetIcon} alt={asset} width={20} height={20} className="w-6 h-6" />
           </div>
           <div>
             <h2 className="text-lg font-semibold text-white">Fund</h2>
@@ -647,7 +678,11 @@ export function CBHeadlessOnramp({
             </div>
             {effectiveEthAmount > 0 && (
               <p className="text-gray-400 text-xs">
-                ≈ {effectiveEthAmount.toFixed(4)} ETH
+                ≈{' '}
+                {asset === 'USDC'
+                  ? effectiveEthAmount.toFixed(2)
+                  : effectiveEthAmount.toFixed(4)}{' '}
+                {asset}
               </p>
             )}
           </div>
@@ -669,7 +704,10 @@ export function CBHeadlessOnramp({
               {!allowAmountInput && ethAmount > 0 && (
                 <div className="flex items-center justify-between">
                   <span className="text-gray-400 text-sm">Amount:</span>
-                  <span className="text-white font-medium">{ethAmount.toFixed(4)} ETH</span>
+                  <span className="text-white font-medium">
+                    {asset === 'USDC' ? ethAmount.toFixed(2) : ethAmount.toFixed(4)}{' '}
+                    {asset}
+                  </span>
                 </div>
               )}
               {paymentTotal != null && (

--- a/ui/components/coinbase/CBOnramp.tsx
+++ b/ui/components/coinbase/CBOnramp.tsx
@@ -3,6 +3,7 @@ import { XMarkIcon } from '@heroicons/react/24/outline'
 import { DEPLOYED_ORIGIN } from 'const/config'
 import Image from 'next/image'
 import { useEffect, useState, useMemo, useCallback } from 'react'
+import { OnrampAsset, onrampAssetIcon } from '@/lib/onramp/assets'
 import { arbitrum } from '@/lib/rpc/chains'
 import { LoadingSpinner } from '../layout/LoadingSpinner'
 import { PrivyWeb3Button } from '../privy/PrivyWeb3Button'
@@ -16,7 +17,13 @@ import {
 interface CBOnrampProps {
   address: string
   selectedChain: any
+  /**
+   * Crypto amount to purchase. Interpreted as the selected `asset` (ETH by
+   * default, or USDC when `asset="USDC"`).
+   */
   ethAmount: number
+  /** Crypto to purchase. Defaults to ETH. */
+  asset?: OnrampAsset
   redirectUrl?: string
   onExit?: () => void
   onBeforeNavigate?: () => Promise<void>
@@ -54,6 +61,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
   address,
   selectedChain,
   ethAmount,
+  asset = 'ETH',
   redirectUrl,
   onExit,
   onBeforeNavigate,
@@ -68,6 +76,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
   onHeadlessSuccessInApp,
 }) => {
   const shellWidthClass = fullWidth ? 'w-full' : 'w-full max-w-md mx-auto'
+  const assetIcon = onrampAssetIcon(asset)
 
   // US users get the Headless (Apple Pay) onramp; everyone else keeps the
   // hosted Coinbase redirect. `null` = still detecting region. When a parent
@@ -195,6 +204,28 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
       setIsLoadingQuote(true)
 
       try {
+        // USDC ≈ $1 — skip the ETH spot-price / iterative quote loop. The
+        // Coinbase quote API also has limited network coverage (no Arbitrum),
+        // so a fiat estimate is more reliable for marketplace USDC purchases.
+        if (asset === 'USDC') {
+          const estimateUSD = Math.max(2, debouncedEthAmount * 1.05)
+          setQuoteData({
+            ethAmount: debouncedEthAmount,
+            purchaseAmount: estimateUSD,
+            totalAmount: estimateUSD,
+            fees: estimateUSD - debouncedEthAmount,
+            quoteId: null,
+          })
+          onQuoteCalculated?.(
+            debouncedEthAmount,
+            debouncedEthAmount,
+            estimateUSD,
+            estimateUSD - debouncedEthAmount
+          )
+          setIsLoadingQuote(false)
+          return
+        }
+
         // For Arbitrum, use Ethereum quotes to estimate fees
         const quoteNetwork = isArbitrum ? 'ethereum' : getQuoteNetworkName(selectedChain)
 
@@ -350,6 +381,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     address,
+    asset,
     debouncedEthAmount,
     selectedChain,
     isArbitrum,
@@ -446,7 +478,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
         body: JSON.stringify({
           address,
           blockchains: [networkName],
-          assets: ['ETH', 'USDC'],
+          assets: asset === 'USDC' ? ['USDC'] : ['ETH', 'USDC'],
         }),
       })
 
@@ -465,7 +497,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
     } catch (error: any) {
       throw error
     }
-  }, [address, selectedChain])
+  }, [address, selectedChain, asset])
 
   // Hosted Coinbase flow for US users who can't use Apple/Google Pay (e.g.
   // desktop, no iPhone to scan the QR). Supports signing into an existing
@@ -497,7 +529,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
       sessionToken: token,
       addresses: { [address]: [network] },
       defaultNetwork: network,
-      defaultAsset: 'ETH',
+      defaultAsset: asset,
       redirectUrl: redirectUrl || `${DEPLOYED_ORIGIN}/`,
     }
     if (ethAmount > 0) widgetParams.presetCryptoAmount = ethAmount
@@ -512,7 +544,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
       console.error('[CBOnramp] onBeforeNavigate (hosted fallback) failed:', error)
     }
     window.location.href = url
-  }, [address, ethAmount, redirectUrl, onBeforeNavigate, generateSessionToken, selectedChain])
+  }, [address, asset, ethAmount, redirectUrl, onBeforeNavigate, generateSessionToken, selectedChain])
 
   const handleOpenOnramp = async () => {
     if (!address) {
@@ -559,7 +591,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
           [address]: [getOnrampNetworkName(selectedChain)],
         },
         defaultNetwork: getOnrampNetworkName(selectedChain),
-        defaultAsset: 'ETH',
+        defaultAsset: asset,
         redirectUrl: redirectUrl || `${DEPLOYED_ORIGIN}/`,
       }
 
@@ -621,6 +653,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
         address={address}
         selectedChain={selectedChain}
         ethAmount={ethAmount}
+        asset={asset}
         allowAmountInput={allowAmountInput}
         onExit={onExit}
         isWaitingForGasEstimate={isWaitingForGasEstimate}
@@ -752,7 +785,7 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
       <div className="flex items-center justify-between p-6 border-b border-white/10">
         <div className="flex items-center space-x-3">
           <div className="w-10 h-10 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
-            <Image src="/coins/ETH.svg" alt="ETH" width={20} height={20} className="w-6 h-6" />
+            <Image src={assetIcon} alt={asset} width={20} height={20} className="w-6 h-6" />
           </div>
           <div>
             <h2 className="text-lg font-semibold text-white">Fund</h2>
@@ -773,7 +806,9 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
         {/* Amount Input (when allowAmountInput is true) */}
         {allowAmountInput && (
           <div className="space-y-2">
-            <label className="text-gray-300 text-sm font-medium">Amount (ETH)</label>
+            <label className="text-gray-300 text-sm font-medium">
+              Amount ({asset})
+            </label>
             <input
               data-testid="cbonramp-amount-input"
               type="text"
@@ -837,7 +872,12 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
                     data-testid="cbonramp-predetermined-amount"
                   >
                     <span className="text-gray-400 text-sm">Amount:</span>
-                    <span className="text-white font-medium">{ethAmount.toFixed(4)} ETH</span>
+                    <span className="text-white font-medium">
+                      {asset === 'USDC'
+                        ? ethAmount.toFixed(2)
+                        : ethAmount.toFixed(4)}{' '}
+                      {asset}
+                    </span>
                   </div>
                 )}
               </>
@@ -855,7 +895,12 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
                     data-testid="cbonramp-predetermined-amount"
                   >
                     <span className="text-gray-400 text-sm">Amount:</span>
-                    <span className="text-white font-medium">{ethAmount.toFixed(4)} ETH</span>
+                    <span className="text-white font-medium">
+                      {asset === 'USDC'
+                        ? ethAmount.toFixed(2)
+                        : ethAmount.toFixed(4)}{' '}
+                      {asset}
+                    </span>
                   </div>
                 )}
               </>
@@ -931,8 +976,12 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
               : isLoadingQuote
               ? 'Getting quote...'
               : quoteData?.purchaseAmount
-              ? `Buy ${quoteData.ethAmount.toFixed(4)} ETH with Coinbase`
-              : `Buy ETH with Coinbase`
+              ? `Buy ${
+                  asset === 'USDC'
+                    ? quoteData.ethAmount.toFixed(2)
+                    : quoteData.ethAmount.toFixed(4)
+                } ${asset} with Coinbase`
+              : `Buy ${asset} with Coinbase`
           }
           showSignInLabel={false}
           action={handleOpenOnramp}

--- a/ui/components/moonpay/MoonPayOnramp.tsx
+++ b/ui/components/moonpay/MoonPayOnramp.tsx
@@ -1,8 +1,13 @@
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import Image from 'next/image'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useMoonPay } from '@/lib/privy/hooks/useMoonPay'
+import {
+  estimateOnrampFiatUsd,
+  OnrampAsset,
+  onrampAssetIcon,
+} from '@/lib/onramp/assets'
 import { clearOnrampReturn, setOnrampReturn } from '@/lib/onramp/onrampReturn'
+import { useMoonPay } from '@/lib/privy/hooks/useMoonPay'
 import { LoadingSpinner } from '../layout/LoadingSpinner'
 import { PrivyWeb3Button } from '../privy/PrivyWeb3Button'
 
@@ -11,8 +16,13 @@ type FundingState = 'idle' | 'opening' | 'waiting' | 'sufficient'
 interface MoonPayOnrampProps {
   address: string
   selectedChain: any
-  /** Native token amount to pre-fill in the MoonPay widget */
+  /**
+   * Crypto amount to pre-fill. Interpreted as the selected `asset` (ETH by
+   * default, or USDC when `asset="USDC"`).
+   */
   ethAmount: number
+  /** Crypto to purchase. Defaults to ETH (native). */
+  asset?: OnrampAsset
   onExit?: () => void
   /** Called just before the MoonPay widget opens (e.g. cache form data) */
   onBeforeOpen?: () => Promise<void>
@@ -43,6 +53,7 @@ export function MoonPayOnramp({
   address,
   selectedChain,
   ethAmount,
+  asset = 'ETH',
   onExit,
   onBeforeOpen,
   onPurchaseSubmitted,
@@ -72,12 +83,16 @@ export function MoonPayOnramp({
   const [error, setError] = useState<string | null>(null)
   const [pollCount, setPollCount] = useState(0)
 
-  // Display the chain's native token symbol (all supported onramp chains are
-  // ETH-native, so this is "ETH" in practice).
-  const nativeSymbol: string = useMemo(
-    () => selectedChain?.nativeCurrency?.symbol ?? 'ETH',
-    [selectedChain]
+  // Symbol shown in copy / icons. USDC purchases use the stablecoin; otherwise
+  // fall back to the chain's native token (ETH on all supported onramp chains).
+  const assetSymbol: string = useMemo(
+    () =>
+      asset === 'USDC'
+        ? 'USDC'
+        : selectedChain?.nativeCurrency?.symbol ?? 'ETH',
+    [asset, selectedChain]
   )
+  const assetIcon = onrampAssetIcon(asset)
 
   const pollTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const pollStartRef = useRef<number | null>(null)
@@ -174,21 +189,22 @@ export function MoonPayOnramp({
       }
 
       // Privy's fiat onramp pre-fills a FIAT (USD) amount, not a token amount.
-      // Convert the native-token deficit to USD (with a small buffer for fees and
+      // Convert the crypto deficit to USD (with a small buffer for fees and
       // price drift) so the purchase covers the amount the user actually needs.
-      // All supported onramp chains are ETH-native, so the ETH spot price applies.
       let fiatAmount: number | undefined
       if (ethAmount > 0) {
-        try {
-          const res = await fetch('/api/coinbase/eth-price')
-          if (res.ok) {
-            const { price } = await res.json()
-            if (price > 0) {
-              fiatAmount = Math.ceil(ethAmount * price * 1.05)
+        if (asset === 'USDC') {
+          fiatAmount = estimateOnrampFiatUsd(ethAmount, 'USDC')
+        } else {
+          try {
+            const res = await fetch('/api/coinbase/eth-price')
+            if (res.ok) {
+              const { price } = await res.json()
+              fiatAmount = estimateOnrampFiatUsd(ethAmount, 'ETH', price)
             }
+          } catch {
+            // Price lookup failed — fall back to letting the user enter the amount.
           }
-        } catch {
-          // Price lookup failed — fall back to letting the user enter the amount.
         }
       }
 
@@ -202,7 +218,7 @@ export function MoonPayOnramp({
       // exits) the flow. It rejects if the user closes the modal before submitting.
       // Pass the known address directly — Privy's useWallets() list can be empty
       // right after load, which would otherwise throw "No wallet selected to fund".
-      const result = await fund(fiatAmount, selectedChain?.id, address)
+      const result = await fund(fiatAmount, selectedChain?.id, address, asset)
 
       // Resolved in-context (no redirect happened) — the breadcrumb isn't needed.
       clearOnrampReturn()
@@ -231,6 +247,7 @@ export function MoonPayOnramp({
   }, [
     address,
     ethAmount,
+    asset,
     selectedChain,
     onBeforeOpen,
     onPurchaseSubmitted,
@@ -284,11 +301,11 @@ export function MoonPayOnramp({
         <div className="flex items-center justify-between p-6 border-b border-white/10">
           <div className="flex items-center space-x-3">
             <div className="w-10 h-10 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
-              <Image src="/coins/ETH.svg" alt={nativeSymbol} width={20} height={20} className="w-6 h-6" />
+              <Image src={assetIcon} alt={assetSymbol} width={20} height={20} className="w-6 h-6" />
             </div>
             <div>
               <h2 className="text-lg font-semibold text-white">MoonPay Processing</h2>
-              <p className="text-gray-400 text-xs">Waiting for {nativeSymbol} to arrive</p>
+              <p className="text-gray-400 text-xs">Waiting for {assetSymbol} to arrive</p>
             </div>
           </div>
           <button onClick={handleExit} className="p-2 hover:bg-white/10 rounded-full transition-colors duration-200">
@@ -307,7 +324,7 @@ export function MoonPayOnramp({
                   Your purchase is being processed
                 </p>
                 <p className="text-blue-100/80 text-xs leading-relaxed">
-                  MoonPay typically delivers {nativeSymbol} within <strong>5–30 minutes</strong>. Once your funds arrive, your transaction will proceed automatically.
+                  MoonPay typically delivers {assetSymbol} within <strong>5–30 minutes</strong>. Once your funds arrive, your transaction will proceed automatically.
                 </p>
                 {checkBalanceSufficient && (
                   <p className="text-blue-100/60 text-xs mt-2">
@@ -348,7 +365,7 @@ export function MoonPayOnramp({
       <div className="flex items-center justify-between p-6 border-b border-white/10">
         <div className="flex items-center space-x-3">
           <div className="w-10 h-10 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
-            <Image src="/coins/ETH.svg" alt={nativeSymbol} width={20} height={20} className="w-6 h-6" />
+            <Image src={assetIcon} alt={assetSymbol} width={20} height={20} className="w-6 h-6" />
           </div>
           <div>
             <h2 className="text-lg font-semibold text-white">Fund Wallet</h2>
@@ -381,7 +398,12 @@ export function MoonPayOnramp({
               {ethAmount > 0 && (
                 <div className="flex items-center justify-between">
                   <span className="text-gray-400 text-sm">Amount needed:</span>
-                  <span className="text-white font-medium">{ethAmount.toFixed(4)} {nativeSymbol}</span>
+                  <span className="text-white font-medium">
+                    {asset === 'USDC'
+                      ? ethAmount.toFixed(2)
+                      : ethAmount.toFixed(4)}{' '}
+                    {assetSymbol}
+                  </span>
                 </div>
               )}
             </>
@@ -413,8 +435,10 @@ export function MoonPayOnramp({
             fundingState === 'opening'
               ? 'Opening MoonPay…'
               : ethAmount > 0
-              ? `Buy ${ethAmount.toFixed(4)} ${nativeSymbol} with MoonPay`
-              : `Buy ${nativeSymbol} with MoonPay`
+              ? `Buy ${
+                  asset === 'USDC' ? ethAmount.toFixed(2) : ethAmount.toFixed(4)
+                } ${assetSymbol} with MoonPay`
+              : `Buy ${assetSymbol} with MoonPay`
           }
           showSignInLabel={false}
           action={handleFund}

--- a/ui/components/onramp/FundOnramp.tsx
+++ b/ui/components/onramp/FundOnramp.tsx
@@ -1,13 +1,22 @@
 import { useEffect, useRef, useState } from 'react'
+import { OnrampAsset } from '@/lib/onramp/assets'
 import { CBOnramp } from '../coinbase/CBOnramp'
 import { MoonPayOnramp } from '../moonpay/MoonPayOnramp'
 
 export type OnrampProvider = 'moonpay' | 'coinbase'
+export type { OnrampAsset }
 
 interface FundOnrampProps {
   address: string
   selectedChain: any
+  /**
+   * Crypto amount to purchase. Interpreted as the selected `asset` (ETH by
+   * default, or USDC when `asset="USDC"`). Kept as `ethAmount` for backward
+   * compatibility with existing callers.
+   */
   ethAmount: number
+  /** Crypto to purchase. Defaults to ETH (native). Pass 'USDC' for marketplace. */
+  asset?: OnrampAsset
   fullWidth?: boolean
   isWaitingForGasEstimate?: boolean
   onExit?: () => void
@@ -48,6 +57,7 @@ export function FundOnramp({
   address,
   selectedChain,
   ethAmount,
+  asset = 'ETH',
   fullWidth = false,
   isWaitingForGasEstimate = false,
   onExit,
@@ -201,6 +211,7 @@ export function FundOnramp({
           address={address}
           selectedChain={selectedChain}
           ethAmount={ethAmount}
+          asset={asset}
           isWaitingForGasEstimate={isWaitingForGasEstimate}
           onExit={onExit}
           onBeforeOpen={onMoonPayBeforeOpen}
@@ -220,6 +231,7 @@ export function FundOnramp({
           address={address}
           selectedChain={selectedChain}
           ethAmount={ethAmount}
+          asset={asset}
           isWaitingForGasEstimate={isWaitingForGasEstimate}
           onExit={onExit}
           allowAmountInput={allowAmountInput}

--- a/ui/components/onramp/FundOnrampModal.tsx
+++ b/ui/components/onramp/FundOnrampModal.tsx
@@ -2,6 +2,7 @@ import { DEPLOYED_ORIGIN } from 'const/config'
 import { useRouter } from 'next/router'
 import React, { useCallback, useMemo } from 'react'
 import useOnrampJWT from '@/lib/coinbase/useOnrampJWT'
+import { OnrampAsset } from '@/lib/onramp/assets'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import Modal from '../layout/Modal'
 import { FundOnramp, OnrampProvider } from './FundOnramp'
@@ -12,6 +13,8 @@ interface FundOnrampModalProps {
   address: string
   selectedChain: any
   ethAmount: number
+  /** Crypto to purchase. Defaults to ETH (native). */
+  asset?: OnrampAsset
   onExit?: () => void
   isWaitingForGasEstimate?: boolean
   defaultProvider?: OnrampProvider
@@ -46,6 +49,7 @@ export const FundOnrampModal: React.FC<FundOnrampModalProps> = ({
   address,
   selectedChain,
   ethAmount,
+  asset = 'ETH',
   onExit,
   isWaitingForGasEstimate = false,
   defaultProvider,
@@ -134,6 +138,7 @@ export const FundOnrampModal: React.FC<FundOnrampModalProps> = ({
         address={address}
         selectedChain={selectedChain}
         ethAmount={ethAmount}
+        asset={asset}
         isWaitingForGasEstimate={isWaitingForGasEstimate}
         onExit={handleExit}
         defaultProvider={defaultProvider}

--- a/ui/components/subscription/BuyTeamListingModal.tsx
+++ b/ui/components/subscription/BuyTeamListingModal.tsx
@@ -12,17 +12,19 @@ import {
   DEFAULT_CHAIN_V5,
   DEPLOYED_ORIGIN,
 } from 'const/config'
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import { prepareContractCall, readContract, sendAndConfirmTransaction, toUnits } from 'thirdweb'
 import { getNFT } from 'thirdweb/extensions/erc721'
-import { useActiveAccount } from 'thirdweb/react'
+import { useActiveAccount, useWalletBalance } from 'thirdweb/react'
 import CitizenContext from '@/lib/citizen/citizen-context'
 import useCitizenEmail from '@/lib/citizen/useCitizenEmail'
 import { generatePrettyLink } from '@/lib/subscription/pretty-links'
 import { getChainSlug } from '@/lib/thirdweb/chain'
+import client from '@/lib/thirdweb/client'
 import useContract from '@/lib/thirdweb/hooks/useContract'
 import { truncateTokenValue } from '@/lib/utils/numbers'
+import { FundOnramp } from '@/components/onramp/FundOnramp'
 import { TeamListing } from '@/components/subscription/TeamListing'
 import IPFSRenderer from '../layout/IPFSRenderer'
 import Input from '../layout/Input'
@@ -97,6 +99,73 @@ export default function BuyTeamListingModal({
     chain: selectedChain,
   })
 
+  const numericPrice = useMemo(
+    () => parseFloat(String(listing.price).replace(/,/g, '')),
+    [listing.price]
+  )
+
+  // Final USDC/ETH/etc amount the buyer will pay (includes non-citizen markup).
+  const purchasePrice = useMemo(() => {
+    if (isGift || citizen) return numericPrice
+    return numericPrice * 1.1
+  }, [isGift, citizen, numericPrice])
+
+  // USDC onramp: when a listing is priced in USDC and the wallet doesn't hold
+  // enough on Arbitrum, surface the shared FundOnramp flow for the deficit.
+  const isUsdcListing = listing.currency === 'USDC'
+  const usdcAddress = USDC_ADDRESSES[chainSlug] as `0x${string}` | undefined
+  const {
+    data: usdcBalanceData,
+    refetch: refetchUsdcBalance,
+    isLoading: isUsdcBalanceLoading,
+  } = useWalletBalance({
+    client,
+    address: account?.address,
+    chain: selectedChain,
+    tokenAddress: isUsdcListing ? usdcAddress : undefined,
+  })
+
+  const usdcBalance = useMemo(() => {
+    if (!isUsdcListing) return null
+    if (!usdcBalanceData?.displayValue) return null
+    const n = Number(usdcBalanceData.displayValue)
+    return Number.isFinite(n) ? n : null
+  }, [isUsdcListing, usdcBalanceData])
+
+  const hasEnoughUsdc = useMemo(() => {
+    if (!isUsdcListing) return true
+    // Treat unresolved balance as insufficient so we show the onramp rather
+    // than a Buy button that will fail. Mirrors the mission fund-UI pattern.
+    if (usdcBalance == null) return false
+    return usdcBalance >= purchasePrice
+  }, [isUsdcListing, usdcBalance, purchasePrice])
+
+  const usdcDeficit = useMemo(() => {
+    if (!isUsdcListing) return 0
+    if (usdcBalance == null) return purchasePrice
+    return Math.max(0, purchasePrice - usdcBalance)
+  }, [isUsdcListing, usdcBalance, purchasePrice])
+
+  const [awaitingUsdcOnramp, setAwaitingUsdcOnramp] = useState(false)
+
+  // Poll USDC after an in-app onramp so the Buy button appears once funds land.
+  useEffect(() => {
+    if (!awaitingUsdcOnramp || !isUsdcListing) return
+    if (hasEnoughUsdc) {
+      setAwaitingUsdcOnramp(false)
+      return
+    }
+    const id = setInterval(() => {
+      refetchUsdcBalance()
+    }, 10_000)
+    return () => clearInterval(id)
+  }, [
+    awaitingUsdcOnramp,
+    isUsdcListing,
+    hasEnoughUsdc,
+    refetchUsdcBalance,
+  ])
+
   useEffect(() => {
     async function getTeamNFT() {
       const nft = await getNFT({
@@ -135,14 +204,8 @@ export default function BuyTeamListingModal({
   async function buyListing() {
     if (!account || !resolvedRecipient) return
 
-    const numericPrice = parseFloat(listing.price.replace(/,/g, ''))
-    let price
-    if (isGift || citizen) {
-      // Gifted citizenship is always the flat citizen price (no markup).
-      price = numericPrice
-    } else {
-      price = numericPrice * 1.1 // 10% upcharge for non-citizens
-    }
+    // Gifted citizenship is always the flat citizen price (no markup).
+    const price = purchasePrice
 
     setIsLoading(true)
     let transactionHash
@@ -348,9 +411,7 @@ export default function BuyTeamListingModal({
             </p>
             <div className="mt-auto flex flex-wrap items-center gap-2">
               <p id="listing-price" className="font-GoodTimes text-lg text-white">{`${
-                isGift || citizen
-                  ? truncateTokenValue(listing.price, listing.currency)
-                  : truncateTokenValue(parseFloat(listing.price.replace(/,/g, '')) * 1.1, listing.currency)
+                truncateTokenValue(purchasePrice, listing.currency)
               } ${listing.currency}`}</p>
               {!citizen && !isGift && (
                 <span className="rounded-full bg-white/5 px-2 py-0.5 text-[10px] text-white/50">
@@ -445,38 +506,105 @@ export default function BuyTeamListingModal({
             </div>
           </div>
         )}
-        <PrivyWeb3Button
-          v5
-          requiredChain={DEFAULT_CHAIN_V5}
-          label={
-            isLoading
-              ? 'Processing...'
-              : resolvedRecipient
-              ? 'Buy'
-              : 'Loading vendor...'
-          }
-          action={async () => {
-            if (!resolvedRecipient)
-              return toast.error(
-                'Still loading the vendor details. Please try again in a moment.'
-              )
-            if (!email || email.trim() === '' || !email.includes('@'))
-              return toast.error('Please enter a valid email.')
-            if (listing.shipping === 'true') {
-              if (
-                shippingInfo.streetAddress.trim() === '' ||
-                shippingInfo.city.trim() === '' ||
-                shippingInfo.state.trim() === '' ||
-                shippingInfo.postalCode.trim() === '' ||
-                shippingInfo.country.trim() === ''
-              )
-                return toast.error('Please fill out all fields.')
+        {isUsdcListing && account?.address && !hasEnoughUsdc && (
+          <div
+            data-testid="marketplace-usdc-onramp"
+            className="w-full flex flex-col gap-3"
+          >
+            <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3">
+              <p className="text-amber-100 text-sm font-medium">
+                You need USDC on Arbitrum to buy this listing
+              </p>
+              <p className="text-amber-100/70 text-xs mt-1 leading-relaxed">
+                {isUsdcBalanceLoading || usdcBalance == null
+                  ? `Add ${truncateTokenValue(
+                      purchasePrice,
+                      'USDC'
+                    )} USDC to your wallet to continue.`
+                  : `Your wallet has ${truncateTokenValue(
+                      usdcBalance,
+                      'USDC'
+                    )} USDC. Add ${truncateTokenValue(
+                      usdcDeficit,
+                      'USDC'
+                    )} more to cover this purchase.`}
+              </p>
+              {awaitingUsdcOnramp && (
+                <p className="text-amber-100/60 text-xs mt-2">
+                  Waiting for USDC to arrive…
+                </p>
+              )}
+            </div>
+            {usdcDeficit > 0 && (
+              <FundOnramp
+                fullWidth
+                address={account.address}
+                selectedChain={DEFAULT_CHAIN_V5}
+                ethAmount={usdcDeficit}
+                asset="USDC"
+                coinbaseRedirectUrl={`${DEPLOYED_ORIGIN}/marketplace?onrampSuccess=true`}
+                checkBalanceSufficient={async () => {
+                  const result = await refetchUsdcBalance()
+                  const next = result?.data?.displayValue
+                  if (next == null) return false
+                  const n = Number(next)
+                  return Number.isFinite(n) && n >= purchasePrice
+                }}
+                refetchBalance={async () => {
+                  await refetchUsdcBalance()
+                }}
+                onBalanceSufficient={() => {
+                  setAwaitingUsdcOnramp(false)
+                }}
+                onCoinbaseSuccessInApp={() => {
+                  setAwaitingUsdcOnramp(true)
+                }}
+                onMoonPayPurchaseSubmitted={() => {
+                  setAwaitingUsdcOnramp(true)
+                }}
+              />
+            )}
+          </div>
+        )}
+        {(!isUsdcListing || !account?.address || hasEnoughUsdc) && (
+          <PrivyWeb3Button
+            v5
+            requiredChain={DEFAULT_CHAIN_V5}
+            label={
+              isLoading
+                ? 'Processing...'
+                : resolvedRecipient
+                ? 'Buy'
+                : 'Loading vendor...'
             }
-            await buyListing()
-          }}
-          className="w-full gradient-2 rounded-[5vmax]"
-          isDisabled={isLoading || !resolvedRecipient}
-        />
+            action={async () => {
+              if (!resolvedRecipient)
+                return toast.error(
+                  'Still loading the vendor details. Please try again in a moment.'
+                )
+              if (!email || email.trim() === '' || !email.includes('@'))
+                return toast.error('Please enter a valid email.')
+              if (listing.shipping === 'true') {
+                if (
+                  shippingInfo.streetAddress.trim() === '' ||
+                  shippingInfo.city.trim() === '' ||
+                  shippingInfo.state.trim() === '' ||
+                  shippingInfo.postalCode.trim() === '' ||
+                  shippingInfo.country.trim() === ''
+                )
+                  return toast.error('Please fill out all fields.')
+              }
+              if (isUsdcListing && !hasEnoughUsdc) {
+                return toast.error(
+                  'You need more USDC on Arbitrum before purchasing.'
+                )
+              }
+              await buyListing()
+            }}
+            className="w-full gradient-2 rounded-[5vmax]"
+            isDisabled={isLoading || !resolvedRecipient}
+          />
+        )}
         {!resolvedRecipient && !isLoading && (
           <p className="w-full text-center text-sm opacity-60">Loading vendor details...</p>
         )}

--- a/ui/components/subscription/BuyTeamListingModal.tsx
+++ b/ui/components/subscription/BuyTeamListingModal.tsx
@@ -19,6 +19,12 @@ import { getNFT } from 'thirdweb/extensions/erc721'
 import { useActiveAccount, useWalletBalance } from 'thirdweb/react'
 import CitizenContext from '@/lib/citizen/citizen-context'
 import useCitizenEmail from '@/lib/citizen/useCitizenEmail'
+import {
+  computePurchasePrice,
+  evaluateUsdcPurchase,
+  parseListingPrice,
+  parseUsdcBalance,
+} from '@/lib/marketplace/usdcListingPurchase'
 import { generatePrettyLink } from '@/lib/subscription/pretty-links'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import client from '@/lib/thirdweb/client'
@@ -100,15 +106,20 @@ export default function BuyTeamListingModal({
   })
 
   const numericPrice = useMemo(
-    () => parseFloat(String(listing.price).replace(/,/g, '')),
+    () => parseListingPrice(listing.price),
     [listing.price]
   )
 
   // Final USDC/ETH/etc amount the buyer will pay (includes non-citizen markup).
-  const purchasePrice = useMemo(() => {
-    if (isGift || citizen) return numericPrice
-    return numericPrice * 1.1
-  }, [isGift, citizen, numericPrice])
+  const purchasePrice = useMemo(
+    () =>
+      computePurchasePrice({
+        price: listing.price,
+        isGift,
+        isCitizen: !!citizen,
+      }),
+    [listing.price, isGift, citizen]
+  )
 
   // USDC onramp: when a listing is priced in USDC and the wallet doesn't hold
   // enough on Arbitrum, surface the shared FundOnramp flow for the deficit.
@@ -125,26 +136,21 @@ export default function BuyTeamListingModal({
     tokenAddress: isUsdcListing ? usdcAddress : undefined,
   })
 
-  const usdcBalance = useMemo(() => {
-    if (!isUsdcListing) return null
-    if (!usdcBalanceData?.displayValue) return null
-    const n = Number(usdcBalanceData.displayValue)
-    return Number.isFinite(n) ? n : null
-  }, [isUsdcListing, usdcBalanceData])
+  const usdcBalance = useMemo(
+    () =>
+      isUsdcListing ? parseUsdcBalance(usdcBalanceData?.displayValue) : null,
+    [isUsdcListing, usdcBalanceData]
+  )
 
-  const hasEnoughUsdc = useMemo(() => {
-    if (!isUsdcListing) return true
-    // Treat unresolved balance as insufficient so we show the onramp rather
-    // than a Buy button that will fail. Mirrors the mission fund-UI pattern.
-    if (usdcBalance == null) return false
-    return usdcBalance >= purchasePrice
-  }, [isUsdcListing, usdcBalance, purchasePrice])
-
-  const usdcDeficit = useMemo(() => {
-    if (!isUsdcListing) return 0
-    if (usdcBalance == null) return purchasePrice
-    return Math.max(0, purchasePrice - usdcBalance)
-  }, [isUsdcListing, usdcBalance, purchasePrice])
+  const { hasEnoughUsdc, usdcDeficit } = useMemo(
+    () =>
+      evaluateUsdcPurchase({
+        isUsdcListing,
+        usdcBalance,
+        purchasePrice,
+      }),
+    [isUsdcListing, usdcBalance, purchasePrice]
+  )
 
   const [awaitingUsdcOnramp, setAwaitingUsdcOnramp] = useState(false)
 

--- a/ui/cypress/integration/unit/marketplace-usdc-onramp.cy.tsx
+++ b/ui/cypress/integration/unit/marketplace-usdc-onramp.cy.tsx
@@ -1,0 +1,209 @@
+import { USDC_ADDRESSES } from '../../../const/config'
+import {
+  computePurchasePrice,
+  evaluateUsdcPurchase,
+  NON_CITIZEN_MARKUP,
+  parseListingPrice,
+  parseUsdcBalance,
+} from '../../../lib/marketplace/usdcListingPurchase'
+import {
+  destinationAssetFor,
+  estimateOnrampFiatUsd,
+  formatOnrampPurchaseAmount,
+  isOnrampAsset,
+  onrampAssetIcon,
+  USDC_BY_CHAIN_ID,
+} from '../../../lib/onramp/assets'
+
+describe('Marketplace USDC onramp', () => {
+  describe('onramp asset helpers', () => {
+    it('isOnrampAsset accepts only ETH and USDC', () => {
+      expect(isOnrampAsset('ETH')).to.equal(true)
+      expect(isOnrampAsset('USDC')).to.equal(true)
+      expect(isOnrampAsset('DAI')).to.equal(false)
+      expect(isOnrampAsset('usdc')).to.equal(false)
+      expect(isOnrampAsset(undefined)).to.equal(false)
+      expect(isOnrampAsset(null)).to.equal(false)
+    })
+
+    it('onrampAssetIcon maps to the right coin icon', () => {
+      expect(onrampAssetIcon('ETH')).to.equal('/coins/ETH.svg')
+      expect(onrampAssetIcon('USDC')).to.equal('/coins/USDC.svg')
+    })
+
+    it('formatOnrampPurchaseAmount uses 6 decimals for USDC, 8 for ETH', () => {
+      expect(formatOnrampPurchaseAmount(12.3456789, 'USDC')).to.equal(
+        '12.345679'
+      )
+      expect(formatOnrampPurchaseAmount(0.123456789, 'ETH')).to.equal(
+        '0.12345679'
+      )
+      // Coinbase Order API expects a plain decimal string, never exponent form.
+      expect(formatOnrampPurchaseAmount(1e-7, 'ETH')).to.equal('0.00000010')
+    })
+
+    it('estimateOnrampFiatUsd treats USDC as ~$1 with a 5% buffer', () => {
+      expect(estimateOnrampFiatUsd(100, 'USDC')).to.equal(105)
+      expect(estimateOnrampFiatUsd(1, 'USDC')).to.equal(2) // ceil(1.05)
+    })
+
+    it('estimateOnrampFiatUsd converts ETH via spot price with buffer', () => {
+      expect(estimateOnrampFiatUsd(0.5, 'ETH', 2000)).to.equal(1050)
+    })
+
+    it('estimateOnrampFiatUsd is undefined without an ETH spot price or valid amount', () => {
+      expect(estimateOnrampFiatUsd(0.5, 'ETH')).to.equal(undefined)
+      expect(estimateOnrampFiatUsd(0, 'USDC')).to.equal(undefined)
+      expect(estimateOnrampFiatUsd(-3, 'USDC')).to.equal(undefined)
+    })
+  })
+
+  describe('destinationAssetFor (Privy/MoonPay)', () => {
+    it("returns the 'eth' shorthand for native ETH on any chain", () => {
+      expect(destinationAssetFor(1, 'ETH')).to.equal('eth')
+      expect(destinationAssetFor(42161, 'ETH')).to.equal('eth')
+    })
+
+    it('returns the native USDC contract for configured chains', () => {
+      expect(destinationAssetFor(42161, 'USDC')).to.equal(
+        USDC_ADDRESSES.arbitrum
+      )
+      expect(destinationAssetFor(1, 'USDC')).to.equal(USDC_ADDRESSES.ethereum)
+      expect(destinationAssetFor(8453, 'USDC')).to.equal(USDC_ADDRESSES.base)
+    })
+
+    it('USDC chain map matches const/config addresses', () => {
+      expect(USDC_BY_CHAIN_ID[42161]).to.equal(USDC_ADDRESSES.arbitrum)
+      expect(USDC_BY_CHAIN_ID[11155111]).to.equal(USDC_ADDRESSES.sepolia)
+      expect(USDC_BY_CHAIN_ID[84532]).to.equal(
+        USDC_ADDRESSES['base-sepolia-testnet']
+      )
+    })
+
+    it('throws for chains without a configured USDC contract', () => {
+      expect(() => destinationAssetFor(137, 'USDC')).to.throw(
+        'USDC is not configured for chain 137'
+      )
+    })
+  })
+
+  describe('parseListingPrice', () => {
+    it('parses plain and comma-separated prices', () => {
+      expect(parseListingPrice('100')).to.equal(100)
+      expect(parseListingPrice('1,250.50')).to.equal(1250.5)
+      expect(parseListingPrice(42)).to.equal(42)
+    })
+  })
+
+  describe('computePurchasePrice', () => {
+    it('citizens pay the flat listing price', () => {
+      expect(
+        computePurchasePrice({ price: '100', isGift: false, isCitizen: true })
+      ).to.equal(100)
+    })
+
+    it('gift listings are always flat-priced', () => {
+      expect(
+        computePurchasePrice({ price: '100', isGift: true, isCitizen: false })
+      ).to.equal(100)
+    })
+
+    it('non-citizens pay a 10% markup', () => {
+      expect(
+        computePurchasePrice({ price: '100', isGift: false, isCitizen: false })
+      ).to.equal(100 * NON_CITIZEN_MARKUP)
+    })
+  })
+
+  describe('parseUsdcBalance', () => {
+    it('parses a resolved balance', () => {
+      expect(parseUsdcBalance('12.5')).to.equal(12.5)
+      expect(parseUsdcBalance('0')).to.equal(0)
+    })
+
+    it('returns null when unresolved or invalid', () => {
+      expect(parseUsdcBalance(undefined)).to.equal(null)
+      expect(parseUsdcBalance(null)).to.equal(null)
+      expect(parseUsdcBalance('')).to.equal(null)
+      expect(parseUsdcBalance('NaN')).to.equal(null)
+    })
+  })
+
+  describe('evaluateUsdcPurchase', () => {
+    it('non-USDC listings always pass with no deficit', () => {
+      const gate = evaluateUsdcPurchase({
+        isUsdcListing: false,
+        usdcBalance: null,
+        purchasePrice: 100,
+      })
+      expect(gate.hasEnoughUsdc).to.equal(true)
+      expect(gate.usdcDeficit).to.equal(0)
+    })
+
+    it('unresolved balance is treated as insufficient for the full price', () => {
+      const gate = evaluateUsdcPurchase({
+        isUsdcListing: true,
+        usdcBalance: null,
+        purchasePrice: 110,
+      })
+      expect(gate.hasEnoughUsdc).to.equal(false)
+      expect(gate.usdcDeficit).to.equal(110)
+    })
+
+    it('sufficient balance passes with zero deficit', () => {
+      const gate = evaluateUsdcPurchase({
+        isUsdcListing: true,
+        usdcBalance: 150,
+        purchasePrice: 110,
+      })
+      expect(gate.hasEnoughUsdc).to.equal(true)
+      expect(gate.usdcDeficit).to.equal(0)
+    })
+
+    it('exact balance passes', () => {
+      const gate = evaluateUsdcPurchase({
+        isUsdcListing: true,
+        usdcBalance: 110,
+        purchasePrice: 110,
+      })
+      expect(gate.hasEnoughUsdc).to.equal(true)
+      expect(gate.usdcDeficit).to.equal(0)
+    })
+
+    it('partial balance reports the exact deficit', () => {
+      const gate = evaluateUsdcPurchase({
+        isUsdcListing: true,
+        usdcBalance: 40,
+        purchasePrice: 110,
+      })
+      expect(gate.hasEnoughUsdc).to.equal(false)
+      expect(gate.usdcDeficit).to.equal(70)
+    })
+
+    it('zero balance owes the full purchase price', () => {
+      const gate = evaluateUsdcPurchase({
+        isUsdcListing: true,
+        usdcBalance: 0,
+        purchasePrice: 110,
+      })
+      expect(gate.hasEnoughUsdc).to.equal(false)
+      expect(gate.usdcDeficit).to.equal(110)
+    })
+
+    it('non-citizen markup flows through to the deficit', () => {
+      const purchasePrice = computePurchasePrice({
+        price: '100',
+        isGift: false,
+        isCitizen: false,
+      })
+      const gate = evaluateUsdcPurchase({
+        isUsdcListing: true,
+        usdcBalance: 100,
+        purchasePrice,
+      })
+      // Non-citizen owes $110 total; $100 in wallet leaves ~$10 to onramp.
+      expect(gate.hasEnoughUsdc).to.equal(false)
+      expect(gate.usdcDeficit).to.be.closeTo(10, 1e-9)
+    })
+  })
+})

--- a/ui/lib/marketplace/usdcListingPurchase.ts
+++ b/ui/lib/marketplace/usdcListingPurchase.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure helpers for the marketplace USDC onramp flow in BuyTeamListingModal.
+ * Extracted so the purchase-gating rules (markup, unresolved-balance handling,
+ * deficit computation) are unit-testable without React.
+ */
+
+export const NON_CITIZEN_MARKUP = 1.1
+
+/** Numeric listing price, tolerant of thousands separators ("1,000"). */
+export function parseListingPrice(price: string | number): number {
+  return parseFloat(String(price).replace(/,/g, ''))
+}
+
+/**
+ * Final amount the buyer pays. Gifted citizenship and citizen buyers pay the
+ * flat listing price; non-citizens pay a 10% markup.
+ */
+export function computePurchasePrice(params: {
+  price: string | number
+  isGift: boolean
+  isCitizen: boolean
+}): number {
+  const numericPrice = parseListingPrice(params.price)
+  if (params.isGift || params.isCitizen) return numericPrice
+  return numericPrice * NON_CITIZEN_MARKUP
+}
+
+/** Parse a wallet balance display value; null when unresolved/invalid. */
+export function parseUsdcBalance(
+  displayValue: string | undefined | null
+): number | null {
+  if (!displayValue) return null
+  const n = Number(displayValue)
+  return Number.isFinite(n) ? n : null
+}
+
+export type UsdcPurchaseGate = {
+  /** True when the Buy button may be shown. */
+  hasEnoughUsdc: boolean
+  /** USDC still needed to cover the purchase (0 when sufficient). */
+  usdcDeficit: number
+}
+
+/**
+ * Decide whether the buyer can purchase a USDC-priced listing or must onramp
+ * first. An unresolved balance (null) is treated as insufficient so we show
+ * the onramp instead of a Buy button that would fail — mirrors the mission
+ * fund-UI pattern. Non-USDC listings always pass.
+ */
+export function evaluateUsdcPurchase(params: {
+  isUsdcListing: boolean
+  usdcBalance: number | null
+  purchasePrice: number
+}): UsdcPurchaseGate {
+  if (!params.isUsdcListing) {
+    return { hasEnoughUsdc: true, usdcDeficit: 0 }
+  }
+  if (params.usdcBalance == null) {
+    return { hasEnoughUsdc: false, usdcDeficit: params.purchasePrice }
+  }
+  return {
+    hasEnoughUsdc: params.usdcBalance >= params.purchasePrice,
+    usdcDeficit: Math.max(0, params.purchasePrice - params.usdcBalance),
+  }
+}

--- a/ui/lib/onramp/assets.ts
+++ b/ui/lib/onramp/assets.ts
@@ -1,9 +1,40 @@
+import { USDC_ADDRESSES } from 'const/config'
+
 /**
  * Assets the shared FundOnramp / Coinbase / MoonPay stack can purchase.
  * ETH is the default (missions, citizen/team creation, wallet top-ups).
  * USDC is used for marketplace listings priced in USDC on Arbitrum.
  */
 export type OnrampAsset = 'ETH' | 'USDC'
+
+/** Native USDC contract per chain ID (matches `USDC_ADDRESSES` in config). */
+export const USDC_BY_CHAIN_ID: Record<number, string> = {
+  1: USDC_ADDRESSES.ethereum,
+  11155111: USDC_ADDRESSES.sepolia,
+  42161: USDC_ADDRESSES.arbitrum,
+  8453: USDC_ADDRESSES.base,
+  84532: USDC_ADDRESSES['base-sepolia-testnet'],
+}
+
+/**
+ * Resolve the Privy/MoonPay destination asset for a given chain + onramp
+ * asset: the 'eth' symbol shorthand for native ETH, or the chain's native
+ * USDC contract address.
+ */
+export function destinationAssetFor(
+  chainId: number,
+  asset: OnrampAsset
+): string {
+  if (asset === 'ETH') {
+    // Keep the existing symbol shorthand used across the app for native ETH.
+    return 'eth'
+  }
+  const usdc = USDC_BY_CHAIN_ID[chainId]
+  if (!usdc) {
+    throw new Error(`USDC is not configured for chain ${chainId}`)
+  }
+  return usdc
+}
 
 export function isOnrampAsset(value: unknown): value is OnrampAsset {
   return value === 'ETH' || value === 'USDC'

--- a/ui/lib/onramp/assets.ts
+++ b/ui/lib/onramp/assets.ts
@@ -1,0 +1,41 @@
+/**
+ * Assets the shared FundOnramp / Coinbase / MoonPay stack can purchase.
+ * ETH is the default (missions, citizen/team creation, wallet top-ups).
+ * USDC is used for marketplace listings priced in USDC on Arbitrum.
+ */
+export type OnrampAsset = 'ETH' | 'USDC'
+
+export function isOnrampAsset(value: unknown): value is OnrampAsset {
+  return value === 'ETH' || value === 'USDC'
+}
+
+export function onrampAssetIcon(asset: OnrampAsset): string {
+  return asset === 'USDC' ? '/coins/USDC.svg' : '/coins/ETH.svg'
+}
+
+/** Format a crypto purchase amount for the Coinbase Order API. */
+export function formatOnrampPurchaseAmount(
+  amount: number,
+  asset: OnrampAsset
+): string {
+  return asset === 'USDC' ? amount.toFixed(6) : amount.toFixed(8)
+}
+
+/**
+ * Rough fiat (USD) to pre-fill in MoonPay / Privy. USDC ≈ $1; ETH needs a
+ * spot price. Includes a ~5% buffer for provider fees and price drift.
+ */
+export function estimateOnrampFiatUsd(
+  cryptoAmount: number,
+  asset: OnrampAsset,
+  ethSpotPrice?: number
+): number | undefined {
+  if (!cryptoAmount || cryptoAmount <= 0) return undefined
+  if (asset === 'USDC') {
+    return Math.ceil(cryptoAmount * 1.05)
+  }
+  if (ethSpotPrice && ethSpotPrice > 0) {
+    return Math.ceil(cryptoAmount * ethSpotPrice * 1.05)
+  }
+  return undefined
+}

--- a/ui/lib/privy/hooks/useMoonPay.tsx
+++ b/ui/lib/privy/hooks/useMoonPay.tsx
@@ -1,7 +1,6 @@
 import { useFiatOnramp, useWallets } from '@privy-io/react-auth'
-import { USDC_ADDRESSES } from 'const/config'
 import { useContext } from 'react'
-import { OnrampAsset } from '@/lib/onramp/assets'
+import { destinationAssetFor, OnrampAsset } from '@/lib/onramp/assets'
 import PrivyWalletContext from '../privy-wallet-context'
 
 /**
@@ -17,28 +16,6 @@ export const SUPPORTED_MOONPAY_CHAIN_IDS = new Set([
   8453, // Base
   84532, // Base Sepolia
 ])
-
-/** Native USDC contract per chain ID (matches `USDC_ADDRESSES` in config). */
-const USDC_BY_CHAIN_ID: Record<number, string> = {
-  1: USDC_ADDRESSES.ethereum,
-  11155111: USDC_ADDRESSES.sepolia,
-  42161: USDC_ADDRESSES.arbitrum,
-  8453: USDC_ADDRESSES.base,
-  84532: USDC_ADDRESSES['base-sepolia-testnet'],
-}
-
-/** Resolve the Privy destination.asset for a given chain + onramp asset. */
-function destinationAssetFor(chainId: number, asset: OnrampAsset): string {
-  if (asset === 'ETH') {
-    // Keep the existing symbol shorthand used across the app for native ETH.
-    return 'eth'
-  }
-  const usdc = USDC_BY_CHAIN_ID[chainId]
-  if (!usdc) {
-    throw new Error(`USDC is not configured for chain ${chainId}`)
-  }
-  return usdc
-}
 
 export function useMoonPay() {
   const { fund } = useFiatOnramp()

--- a/ui/lib/privy/hooks/useMoonPay.tsx
+++ b/ui/lib/privy/hooks/useMoonPay.tsx
@@ -1,11 +1,13 @@
 import { useFiatOnramp, useWallets } from '@privy-io/react-auth'
+import { USDC_ADDRESSES } from 'const/config'
 import { useContext } from 'react'
+import { OnrampAsset } from '@/lib/onramp/assets'
 import PrivyWalletContext from '../privy-wallet-context'
 
 /**
- * Chain IDs where Privy's in-app fiat onramp can deliver the chain's native
- * token (ETH) directly. These are all ETH-native networks, so the destination
- * asset is always "eth".
+ * Chain IDs where Privy's in-app fiat onramp can deliver funds. ETH (native)
+ * is available on all of these; USDC is delivered via the chain's native USDC
+ * contract address when requested.
  */
 export const SUPPORTED_MOONPAY_CHAIN_IDS = new Set([
   1, // Ethereum Mainnet
@@ -16,13 +18,35 @@ export const SUPPORTED_MOONPAY_CHAIN_IDS = new Set([
   84532, // Base Sepolia
 ])
 
+/** Native USDC contract per chain ID (matches `USDC_ADDRESSES` in config). */
+const USDC_BY_CHAIN_ID: Record<number, string> = {
+  1: USDC_ADDRESSES.ethereum,
+  11155111: USDC_ADDRESSES.sepolia,
+  42161: USDC_ADDRESSES.arbitrum,
+  8453: USDC_ADDRESSES.base,
+  84532: USDC_ADDRESSES['base-sepolia-testnet'],
+}
+
+/** Resolve the Privy destination.asset for a given chain + onramp asset. */
+function destinationAssetFor(chainId: number, asset: OnrampAsset): string {
+  if (asset === 'ETH') {
+    // Keep the existing symbol shorthand used across the app for native ETH.
+    return 'eth'
+  }
+  const usdc = USDC_BY_CHAIN_ID[chainId]
+  if (!usdc) {
+    throw new Error(`USDC is not configured for chain ${chainId}`)
+  }
+  return usdc
+}
+
 export function useMoonPay() {
   const { fund } = useFiatOnramp()
   const { wallets } = useWallets()
   const { selectedWallet } = useContext(PrivyWalletContext)
 
   /**
-   * Opens Privy's in-app fiat onramp modal to buy the chain's native token.
+   * Opens Privy's in-app fiat onramp modal to buy ETH (native) or USDC.
    * The entire purchase flow (provider selection, KYC, payment) renders inside
    * the Privy modal — there is no redirect to an external page. Privy routes the
    * purchase through an available provider (MoonPay, Coinbase, or Meld) based on
@@ -34,11 +58,14 @@ export function useMoonPay() {
    * @param address - destination wallet address. When provided, it's used directly
    *   (the caller already knows the active wallet); otherwise we fall back to the
    *   Privy `useWallets()` list, which can be empty/lagging right after load.
+   * @param asset - crypto to purchase. Defaults to ETH (native). Pass 'USDC' for
+   *   marketplace listings priced in USDC.
    */
   async function fundWallet(
     fiatAmount?: number,
     chainId?: number,
-    address?: string
+    address?: string,
+    asset: OnrampAsset = 'ETH'
   ) {
     const destinationAddress = address || wallets[selectedWallet]?.address
     if (!destinationAddress) {
@@ -52,7 +79,7 @@ export function useMoonPay() {
       // Default the fiat picker to USD but allow the user's local currency too.
       source: { defaultAsset: 'usd' },
       destination: {
-        asset: 'eth',
+        asset: destinationAssetFor(chainId, asset),
         chain: `eip155:${chainId}`,
         address: destinationAddress,
       },

--- a/ui/pages/api/coinbase/create-onramp-order.ts
+++ b/ui/pages/api/coinbase/create-onramp-order.ts
@@ -107,6 +107,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       selectedChain,
       destinationNetwork: providedNetwork,
       ethAmount,
+      // Alias for ethAmount — used when purchaseCurrency is not ETH (e.g. USDC).
+      cryptoAmount,
+      purchaseCurrency: providedPurchaseCurrency,
       paymentMethod,
       email,
       phoneNumber,
@@ -136,9 +139,16 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (!partnerUserRef) {
       return res.status(400).json({ error: 'partnerUserRef is required' })
     }
-    if (!ethAmount || Number(ethAmount) <= 0) {
-      return res.status(400).json({ error: 'A valid ethAmount is required' })
+    const purchaseAmountValue = Number(
+      cryptoAmount != null ? cryptoAmount : ethAmount
+    )
+    if (!purchaseAmountValue || purchaseAmountValue <= 0) {
+      return res
+        .status(400)
+        .json({ error: 'A valid crypto purchase amount is required' })
     }
+    const purchaseCurrency =
+      providedPurchaseCurrency === 'USDC' ? 'USDC' : 'ETH'
 
     const method: OnrampOrderPaymentMethod = VALID_PAYMENT_METHODS.includes(
       paymentMethod
@@ -195,11 +205,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
     const clientIp = getClientIp(req)
 
+    // USDC uses up to 6 decimals; ETH keeps the existing 8-decimal precision.
+    const purchaseAmount =
+      purchaseCurrency === 'USDC'
+        ? purchaseAmountValue.toFixed(6)
+        : purchaseAmountValue.toFixed(8)
+
     const orderBody: CreateOnrampOrderRequest & { clientIp?: string } = {
       destinationAddress,
       destinationNetwork,
-      purchaseAmount: Number(ethAmount).toFixed(8),
-      purchaseCurrency: 'ETH',
+      purchaseAmount,
+      purchaseCurrency,
       paymentCurrency: 'USD',
       paymentMethod: method,
       email,

--- a/ui/pages/api/coinbase/create-onramp-order.ts
+++ b/ui/pages/api/coinbase/create-onramp-order.ts
@@ -16,6 +16,7 @@ import {
   getCountryFromHeaders,
   getClientIp,
 } from '../../../lib/geo'
+import { formatOnrampPurchaseAmount } from '../../../lib/onramp/assets'
 
 const redis = new Redis({
   url: process.env.UPSTASH_REDIS_URL!,
@@ -206,10 +207,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const clientIp = getClientIp(req)
 
     // USDC uses up to 6 decimals; ETH keeps the existing 8-decimal precision.
-    const purchaseAmount =
-      purchaseCurrency === 'USDC'
-        ? purchaseAmountValue.toFixed(6)
-        : purchaseAmountValue.toFixed(8)
+    const purchaseAmount = formatOnrampPurchaseAmount(
+      purchaseAmountValue,
+      purchaseCurrency
+    )
 
     const orderBody: CreateOnrampOrderRequest & { clientIp?: string } = {
       destinationAddress,

--- a/ui/scripts/.mocharc-cypress-unit.json
+++ b/ui/scripts/.mocharc-cypress-unit.json
@@ -15,6 +15,7 @@
     "cypress/integration/unit/audit-bug-regression.cy.tsx",
     "cypress/integration/unit/member-vote-tally.cy.tsx",
     "cypress/integration/unit/team-roles.cy.tsx",
+    "cypress/integration/unit/marketplace-usdc-onramp.cy.tsx",
     "cypress/integration/overview-delegate/leaderboard.cy.ts",
     "cypress/integration/overview-path-vote/tally.cy.ts"
   ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a USDC onramp on Arbitrum when someone tries to buy a marketplace listing priced in USDC but doesn’t have enough USDC yet.

## Changes
- Extend the shared `FundOnramp` / Coinbase / MoonPay stack with an optional `asset` (`ETH` | `USDC`). Existing ETH callers are unchanged.
- Coinbase headless orders and hosted widget can purchase `USDC` on the selected chain (marketplace uses Arbitrum).
- Privy/MoonPay destination uses the native USDC contract address for the chain.
- `BuyTeamListingModal` checks the buyer’s Arbitrum USDC balance; if short, shows the onramp for the deficit and reveals **Buy** once funds arrive.

## How to verify
1. Open a marketplace listing priced in USDC with a wallet that has little/no USDC on Arbitrum.
2. Confirm the “need USDC on Arbitrum” notice and Fund UI appear instead of Buy.
3. Complete (or mock) an onramp; after balance updates, Buy should appear and complete the transfer.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5209-cfa2-798b-b1b3-0cc152085525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5209-cfa2-798b-b1b3-0cc152085525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

