### PR TITLE
feat(treasury): show citizen names for multisig signers

### DIFF
--- a/ui/components/subscription/TeamTreasury.tsx
+++ b/ui/components/subscription/TeamTreasury.tsx
@@ -5,6 +5,7 @@ import { useActiveAccount } from 'thirdweb/react'
 import { useSafeBalances } from '@/lib/nance/SafeHooks'
 import { PROJECT_PENDING } from '@/lib/nance/types'
 import { useENS } from '@/lib/utils/hooks/useENS'
+import { useCitizenNameByAddress } from '@/lib/citizen/useCitizenNameByAddress'
 import StandardButton from '../layout/StandardButton'
 import SafeBalances from '../safe/SafeBalances'
 import SafeModal from '../safe/SafeModal'
@@ -71,6 +72,9 @@ function MultisigAddressPill({ address }: { address: string }) {
 
 function SignerAddress({ address }: { address: string }) {
   const { data: ens } = useENS(address)
+  const citizenName = useCitizenNameByAddress(address)
+  const displayName =
+    citizenName || ens?.name || `${address.slice(0, 6)}...${address.slice(-4)}`
   return (
     <a
       href={`https://etherscan.io/address/${address}`}
@@ -79,8 +83,8 @@ function SignerAddress({ address }: { address: string }) {
       className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 transition-colors"
     >
       <div className="w-6 h-6 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex-shrink-0" />
-      <span className="text-xs sm:text-sm text-gray-300 font-mono truncate">
-        {ens?.name || `${address.slice(0, 6)}...${address.slice(-4)}`}
+      <span className={`text-xs sm:text-sm truncate ${citizenName ? 'text-white font-medium' : 'text-gray-300 font-mono'}`}>
+        {displayName}
       </span>
     </a>
   )

--- a/ui/lib/citizen/useCitizenNameByAddress.tsx
+++ b/ui/lib/citizen/useCitizenNameByAddress.tsx
@@ -1,0 +1,43 @@
+import { TABLELAND_ENDPOINT, CITIZEN_TABLE_NAMES } from 'const/config'
+import { useEffect, useState } from 'react'
+
+const chainSlug =
+  process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? 'arbitrum' : 'sepolia'
+
+/**
+ * Look up a MoonDAO citizen name for a given wallet address.
+ * Queries the Tableland citizen table via its public REST API.
+ * Returns the citizen name string if found, or null if the address
+ * is not a citizen (or the lookup is still in flight).
+ */
+export function useCitizenNameByAddress(address: string | undefined): string | null {
+  const [citizenName, setCitizenName] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!address) return
+
+    let cancelled = false
+    const tableName = CITIZEN_TABLE_NAMES[chainSlug]
+    if (!tableName) return
+
+    const stmt = `SELECT name FROM ${tableName} WHERE LOWER(owner) = '${address.toLowerCase()}' LIMIT 1`
+    const url = `${TABLELAND_ENDPOINT}?statement=${encodeURIComponent(stmt)}`
+
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: any) => {
+        if (!cancelled && Array.isArray(data) && data.length > 0 && data[0]?.name) {
+          setCitizenName(data[0].name)
+        }
+      })
+      .catch(() => {
+        // silently fall back — non-citizen addresses are expected
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [address])
+
+  return citizenName
+}


### PR DESCRIPTION
## Summary

- Adds `useCitizenNameByAddress` hook that queries the Tableland citizen table (public REST API) to resolve a wallet address to a MoonDAO citizen name
- Updates the `SignerAddress` component in `TeamTreasury` so the multisig Signers list shows **citizen name → ENS → truncated 0x address** in that priority order
- Citizen names render in `text-white font-medium` (non-monospace) to visually distinguish them from raw addresses

## Test plan

- [ ] Navigate to a team page with a funded multisig that has citizen signers
- [ ] Confirm citizen names appear in the Signers section instead of 0x addresses
- [ ] Confirm non-citizen signers still fall back to ENS or truncated address
- [ ] Confirm the Etherscan link on each signer chip still points to the correct address

Requested by HSP.

Made with [Cursor](https://cursor.com)