### PR TITLE
feat(mission): gate contributions to citizens only

### DIFF
--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -292,6 +292,22 @@ export default function MissionContributeModal({
   const mockAddress = typeof window !== 'undefined' && (window as any).__CYPRESS_MOCK_ADDRESS__
   const address = account?.address || mockAddress
 
+  // Tracks whether the citizen check has had enough time to resolve so we
+  // don't flash the gate at citizens while the RPC call is in-flight.
+  const [citizenCheckDone, setCitizenCheckDone] = useState(false)
+  useEffect(() => {
+    if (!account) {
+      setCitizenCheckDone(false)
+      return
+    }
+    if (isCitizen) {
+      setCitizenCheckDone(true)
+      return
+    }
+    const timer = setTimeout(() => setCitizenCheckDone(true), 1500)
+    return () => clearTimeout(timer)
+  }, [account, isCitizen])
+
   const [input, setInput] = useState('')
   const [output, setOutput] = useState(0)
   const [message, setMessage] = useState(() => {
@@ -2164,6 +2180,39 @@ export default function MissionContributeModal({
               router={router}
               formatWithCommas={formatWithCommas}
             />
+          ) : account && !citizenCheckDone ? (
+            <div className="flex flex-col items-center justify-center py-12 px-6 space-y-4">
+              <div className="w-12 h-12 rounded-full border-2 border-blue-500/40 border-t-blue-400 animate-spin" />
+              <p className="text-gray-400 text-sm">Verifying citizenship…</p>
+            </div>
+          ) : account && citizenCheckDone && !isCitizen ? (
+            <div className="flex flex-col items-center justify-center py-10 px-6 space-y-6 text-center">
+              <div className="w-16 h-16 rounded-full bg-gradient-to-br from-yellow-500/20 to-amber-500/10 border border-yellow-500/30 flex items-center justify-center">
+                <span className="text-3xl">🌙</span>
+              </div>
+              <div className="space-y-2">
+                <h3 className="text-xl font-semibold text-white">Citizens Only</h3>
+                <p className="text-gray-400 text-sm max-w-sm leading-relaxed">
+                  Contributing to MoonDAO missions is reserved for Citizens of the Space
+                  Acceleration Network. Become a Citizen to participate.
+                </p>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-3 w-full max-w-xs">
+                <Link
+                  href="/citizen"
+                  className="flex-1 flex justify-center items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 text-white font-semibold rounded-xl transition-all duration-300 text-sm"
+                >
+                  Become a Citizen
+                </Link>
+                <button
+                  type="button"
+                  onClick={handleModalClose}
+                  className="flex-1 px-6 py-3 bg-slate-800/60 hover:bg-slate-700/60 border border-white/10 text-white font-medium rounded-xl transition-all duration-300 text-sm"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
           ) : (
             <>
               <MissionContributeStatusNotices

--- a/ui/pages/contributions.tsx
+++ b/ui/pages/contributions.tsx
@@ -1,11 +1,77 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import React, { useEffect, useState } from 'react'
+import { useActiveAccount } from 'thirdweb/react'
+import { DEFAULT_CHAIN_V5 } from 'const/config'
+import { useCitizen } from '@/lib/citizen/useCitizen'
 import type { Contribution } from './api/contributions/feed'
 import Container from '../components/layout/Container'
 import ContentLayout from '../components/layout/ContentLayout'
 import WebsiteHead from '../components/layout/Head'
 import { NoticeFooter } from '../components/layout/NoticeFooter'
 import { getIPFSGateway } from '@/lib/ipfs/gateway'
+
+const CONTRIBUTION_FORM_URL =
+  'https://docs.google.com/forms/d/e/1FAIpQLSdtHRzqDAAe1TOZ7Bp03TKVbxLFZzJeeKSUDQ-BpIZtDPxJWw/viewform'
+
+function CitizenSubmitButton() {
+  const account = useActiveAccount()
+  const isCitizen = useCitizen(DEFAULT_CHAIN_V5)
+  const [citizenCheckDone, setCitizenCheckDone] = useState(false)
+
+  useEffect(() => {
+    if (!account) {
+      setCitizenCheckDone(false)
+      return
+    }
+    if (isCitizen) {
+      setCitizenCheckDone(true)
+      return
+    }
+    const timer = setTimeout(() => setCitizenCheckDone(true), 1500)
+    return () => clearTimeout(timer)
+  }, [account, isCitizen])
+
+  const baseClass =
+    'flex-shrink-0 inline-flex items-center gap-2 px-6 py-3 font-semibold text-sm rounded-xl transition-all duration-200 whitespace-nowrap'
+
+  if (account && !citizenCheckDone) {
+    return (
+      <button disabled className={`${baseClass} bg-blue-500/50 text-white/60 cursor-not-allowed`}>
+        <span className="w-4 h-4 rounded-full border-2 border-white/30 border-t-white animate-spin" />
+        Checking…
+      </button>
+    )
+  }
+
+  if (account && citizenCheckDone && !isCitizen) {
+    return (
+      <Link
+        href="/citizen"
+        className={`${baseClass} bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 text-white`}
+      >
+        Become a Citizen to Submit
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" />
+        </svg>
+      </Link>
+    )
+  }
+
+  return (
+    <a
+      href={CONTRIBUTION_FORM_URL}
+      target="_blank"
+      rel="noreferrer"
+      className={`${baseClass} bg-blue-500 hover:bg-blue-400 text-white`}
+    >
+      Submit a Contribution
+      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" />
+      </svg>
+    </a>
+  )
+}
 
 function ContributionFeed() {
   const [contributions, setContributions] = useState<Contribution[]>([])
@@ -218,17 +284,7 @@ export default function ContributionsPage() {
                   <p className="text-white font-semibold text-sm mb-1">Ready to submit?</p>
                   <p className="text-gray-400 text-xs">The form takes about 5 minutes. Submissions are reviewed at the end of each quarter.</p>
                 </div>
-                <a
-                  href="https://docs.google.com/forms/d/e/1FAIpQLSdtHRzqDAAe1TOZ7Bp03TKVbxLFZzJeeKSUDQ-BpIZtDPxJWw/viewform"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="flex-shrink-0 inline-flex items-center gap-2 px-6 py-3 bg-blue-500 hover:bg-blue-400 text-white font-semibold text-sm rounded-xl transition-all duration-200 whitespace-nowrap"
-                >
-                  Submit a Contribution
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                    <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" />
-                  </svg>
-                </a>
+                <CitizenSubmitButton />
               </div>
 
               {/* Feed */}

--- a/ui/pages/contributions.tsx
+++ b/ui/pages/contributions.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import React, { useEffect, useState } from 'react'
+import { usePrivy } from '@privy-io/react-auth'
 import { useActiveAccount } from 'thirdweb/react'
 import { DEFAULT_CHAIN_V5 } from 'const/config'
 import { useCitizen } from '@/lib/citizen/useCitizen'
@@ -15,6 +16,7 @@ const CONTRIBUTION_FORM_URL =
   'https://docs.google.com/forms/d/e/1FAIpQLSdtHRzqDAAe1TOZ7Bp03TKVbxLFZzJeeKSUDQ-BpIZtDPxJWw/viewform'
 
 function CitizenSubmitButton() {
+  const { authenticated, login } = usePrivy()
   const account = useActiveAccount()
   const isCitizen = useCitizen(DEFAULT_CHAIN_V5)
   const [citizenCheckDone, setCitizenCheckDone] = useState(false)
@@ -35,7 +37,28 @@ function CitizenSubmitButton() {
   const baseClass =
     'flex-shrink-0 inline-flex items-center gap-2 px-6 py-3 font-semibold text-sm rounded-xl transition-all duration-200 whitespace-nowrap'
 
-  if (account && !citizenCheckDone) {
+  const arrowIcon = (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+      <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" />
+    </svg>
+  )
+
+  // Not signed in → prompt login
+  if (!authenticated) {
+    return (
+      <button
+        type="button"
+        onClick={login}
+        className={`${baseClass} bg-blue-500 hover:bg-blue-400 text-white`}
+      >
+        Sign In to Submit
+        {arrowIcon}
+      </button>
+    )
+  }
+
+  // Signed in but citizen check still in-flight
+  if (!citizenCheckDone) {
     return (
       <button disabled className={`${baseClass} bg-blue-500/50 text-white/60 cursor-not-allowed`}>
         <span className="w-4 h-4 rounded-full border-2 border-white/30 border-t-white animate-spin" />
@@ -44,20 +67,20 @@ function CitizenSubmitButton() {
     )
   }
 
-  if (account && citizenCheckDone && !isCitizen) {
+  // Signed in but not a citizen
+  if (!isCitizen) {
     return (
       <Link
         href="/citizen"
         className={`${baseClass} bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 text-white`}
       >
         Become a Citizen to Submit
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-          <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" />
-        </svg>
+        {arrowIcon}
       </Link>
     )
   }
 
+  // Citizen — open the form
   return (
     <a
       href={CONTRIBUTION_FORM_URL}
@@ -66,9 +89,7 @@ function CitizenSubmitButton() {
       className={`${baseClass} bg-blue-500 hover:bg-blue-400 text-white`}
     >
       Submit a Contribution
-      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-        <path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" />
-      </svg>
+      {arrowIcon}
     </a>
   )
 }


### PR DESCRIPTION
## Summary
- Non-citizen wallets that open the mission contribute modal now see a **Citizens Only** gate instead of the contribution form
- The gate shows a friendly message explaining that contributions are reserved for Citizens of the Space Acceleration Network, with a direct link to `/citizen` to become one
- A 1500 ms grace period prevents a false gate flash while the on-chain citizen check RPC call resolves for existing citizens

## Test plan
- [ ] Connect a wallet that holds a Citizen NFT → contribution form should appear normally
- [ ] Connect a wallet without a Citizen NFT → after ~1.5 s, "Citizens Only" gate appears with "Become a Citizen" and "Close" buttons
- [ ] Unauthenticated / no wallet connected → contribution form shows as before (PrivyWeb3Button prompts connect)
- [ ] "Become a Citizen" link routes to `/citizen`
- [ ] "Close" button dismisses the modal

Made with [Cursor](https://cursor.com)