### PR TITLE
feat(citizen): move public/private visibility from join flow to edit danger zone

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -373,7 +373,7 @@ export default function CreateCitizen({
     email: '',
     description: '',
     location: '',
-    view: '',
+    view: 'public',
     discord: '',
     website: '',
     twitter: '',
@@ -2543,44 +2543,6 @@ export default function CreateCitizen({
                       </div>
                     </div>
 
-                    {/* Profile visibility */}
-                    <div className="flex flex-col gap-2">
-                      <span className="text-xs font-medium text-slate-400 uppercase tracking-wider">
-                        Profile Visibility
-                      </span>
-                      <div className="flex gap-3">
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setCitizenData((prev) => ({ ...prev, view: 'public' }))
-                          }
-                          className={`flex-1 py-2 rounded-xl border text-sm font-medium transition-all ${
-                            !citizenData.view || citizenData.view === 'public'
-                              ? 'border-indigo-500/60 bg-indigo-500/10 text-indigo-300'
-                              : 'border-white/[0.08] bg-white/[0.03] text-slate-400 hover:bg-white/[0.06]'
-                          }`}
-                        >
-                          Public
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setCitizenData((prev) => ({ ...prev, view: 'private' }))
-                          }
-                          className={`flex-1 py-2 rounded-xl border text-sm font-medium transition-all ${
-                            citizenData.view === 'private'
-                              ? 'border-indigo-500/60 bg-indigo-500/10 text-indigo-300'
-                              : 'border-white/[0.08] bg-white/[0.03] text-slate-400 hover:bg-white/[0.06]'
-                          }`}
-                        >
-                          Private
-                        </button>
-                      </div>
-                      <p className="text-xs text-slate-600">
-                        Public profiles are visible to other MoonDAO members. Private hides your
-                        details.
-                      </p>
-                    </div>
                   </div>
                 </div>
 

--- a/ui/components/subscription/CitizenMetadataModal.tsx
+++ b/ui/components/subscription/CitizenMetadataModal.tsx
@@ -196,7 +196,9 @@ export default function CitizenMetadataModal({ nft, selectedChain, setEnabled }:
         website: getAttribute(nft.metadata.attributes, 'website').value,
         instagram: getAttribute(nft.metadata.attributes, 'instagram').value,
         linkedin: getAttribute(nft.metadata.attributes, 'linkedin').value,
-        view: 'public',
+        view: (getAttribute(nft.metadata.attributes, 'view').value || 'public') as
+          | 'public'
+          | 'private',
       }
     })
   }, [nft?.metadata?.id])
@@ -468,6 +470,38 @@ export default function CitizenMetadataModal({ nft, selectedChain, setEnabled }:
           <h3 className="text-sm font-semibold text-red-400 uppercase tracking-wide mb-2">
             Danger Zone
           </h3>
+
+          {/* Profile visibility */}
+          <div className="mb-6">
+            <p className="text-gray-400 text-xs mb-3 leading-relaxed">
+              Control whether your profile is visible to other MoonDAO members.
+            </p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => setCitizenData((prev: any) => ({ ...prev, view: 'public' }))}
+                className={`flex-1 py-2 rounded-xl border text-sm font-medium transition-all ${
+                  citizenData?.view === 'public' || !citizenData?.view
+                    ? 'border-indigo-500/60 bg-indigo-500/10 text-indigo-300'
+                    : 'border-white/[0.08] bg-white/[0.03] text-slate-400 hover:bg-white/[0.06]'
+                }`}
+              >
+                Public
+              </button>
+              <button
+                type="button"
+                onClick={() => setCitizenData((prev: any) => ({ ...prev, view: 'private' }))}
+                className={`flex-1 py-2 rounded-xl border text-sm font-medium transition-all ${
+                  citizenData?.view === 'private'
+                    ? 'border-indigo-500/60 bg-indigo-500/10 text-indigo-300'
+                    : 'border-white/[0.08] bg-white/[0.03] text-slate-400 hover:bg-white/[0.06]'
+                }`}
+              >
+                Private
+              </button>
+            </div>
+          </div>
+
           <p className="text-gray-400 text-xs mb-4 leading-relaxed">
             Deleting your profile data is permanent and cannot be undone. All information —
             including your name, bio, image, and social links — will be erased from the blockchain.


### PR DESCRIPTION
## Summary
- Removed the Public/Private toggle from the citizen join wizard — all new citizens are now public by default
- The edit modal (`CitizenMetadataModal`) now reads the citizen's existing `view` attribute from their NFT instead of always resetting to `'public'` on every save
- Added a Public/Private visibility toggle to the **Danger Zone** section of the edit modal so existing citizens can change their visibility after joining

## Test plan
- [ ] Go through the citizen join flow — confirm there is no visibility toggle, and that the minted profile is public
- [ ] Open the edit modal for an existing citizen — confirm the visibility toggle appears in the Danger Zone
- [ ] Toggle to Private and save — confirm the on-chain `view` attribute is updated to `'private'`
- [ ] Toggle back to Public and save — confirm the on-chain `view` attribute is updated to `'public'`
- [ ] Verify an existing private citizen's `view` is preserved (not overwritten to `'public'`) when they save an edit without touching the toggle

Made with [Cursor](https://cursor.com)