### PR TITLE
fix(bridge): use maxFeePerGas for ETH max-bridge reserve

### DIFF
--- a/ui/components/bridge/ArbitrumBridge.tsx
+++ b/ui/components/bridge/ArbitrumBridge.tsx
@@ -37,7 +37,7 @@ export default function ArbitrumBridge() {
   const [arbMooneyBalance, setArbMooneyBalance] = useState<any>()
   const [balance, setBalance] = useState(0)
   const [skipNetworkCheck, setSkipNetworkCheck] = useState(false)
-  const { effectiveGasPrice } = useGasPrice(ethereum)
+  const { effectiveGasPrice, maxFeePerGas } = useGasPrice(ethereum)
 
   async function approveMooney(signer: any, erc20Bridger: any) {
     const mooneyContract = getContract({
@@ -270,10 +270,15 @@ export default function ArbitrumBridge() {
   const numAmount = parseFloat(String(amount)) || 0
   // For ETH, reserve L1 gas so a (near-)full-balance entry doesn't revert the
   // deposit on fees. MOONEY gas is paid separately in ETH, so it needs no reserve.
+  //
+  // EIP-1559 wallets lock up maxFeePerGas * gasLimit upfront (not effectiveGasPrice),
+  // so we must use maxFeePerGas here. The Arbitrum deposit also runs ~300k gas, not
+  // 200k, so we use that larger estimate to avoid "insufficient funds" on MAX.
+  const gasPriceForReserve = maxFeePerGas && maxFeePerGas > BigInt(0) ? maxFeePerGas : effectiveGasPrice
   const gasReserveEth =
-    effectiveGasPrice > BigInt(0)
-      ? Number(effectiveGasPrice * BigInt(200000)) / 1e18
-      : 0.002
+    gasPriceForReserve > BigInt(0)
+      ? Number(gasPriceForReserve * BigInt(300000)) / 1e18
+      : 0.004
   const spendableBalance =
     inputToken === 'eth'
       ? Math.max(0, Number(balance) - gasReserveEth)


### PR DESCRIPTION
## Summary
- When a user clicks MAX to bridge ETH, the spendable balance is calculated as `balance - gasReserveEth`. The old code computed the reserve as `effectiveGasPrice * 200_000`, but EIP-1559 wallets lock up `maxFeePerGas * gasLimit` upfront — so the reserve was always understated, leaving the wallet short on funds and causing an \"insufficient ETH\" revert.
- Switched the reserve to use `maxFeePerGas` (falls back to `effectiveGasPrice` when unavailable).
- Raised the gas estimate from 200 k → 300 k to better match the actual Arbitrum L1 deposit gas usage.
- Raised the static fallback (used when no gas price data is available) from 0.002 → 0.004 ETH.

## Test plan
- [ ] Open the Bridge page with an ETH wallet that has a non-trivial balance (e.g. 0.05 ETH).
- [ ] Click MAX — confirm the filled amount is slightly below the full balance.
- [ ] Submit the bridge transaction and confirm it does **not** revert with \"insufficient funds\".
- [ ] Manually enter an amount a few wei below the MAX value and confirm it still goes through.
- [ ] Confirm MOONEY bridging is unaffected (reserve only applies to ETH token).

Made with [Cursor](https://cursor.com)