### PR TITLE
fix(projects): unblock LunCoSim (MDP-238) and add project activation scripts

### DIFF
--- a/ui/const/whitelist.ts
+++ b/ui/const/whitelist.ts
@@ -14,7 +14,7 @@ export const BLOCKED_PROJECTS: any = new Set(
 )
 export const BLOCKED_MDPS: any = new Set(
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
-    ? [229, 238, 243, 246, 247]
+    ? [229, 243, 246, 247]
     : []
 )
 export const BLOCKED_PROPOSALS: any = new Set([221])

--- a/ui/scripts/activate-lunco.ts
+++ b/ui/scripts/activate-lunco.ts
@@ -1,0 +1,74 @@
+/**
+ * One-shot script: set LunCoSim (project id=120, MDP=238) to active=2.
+ *
+ * Uses the existing GCP HSM signer — requires GCP_SIGNER_SERVICE_ACCOUNT
+ * and GCP_PROJECT_ID to be set in .env.local (or the process environment).
+ *
+ * Run from ui/:
+ *   npx ts-node --project tsconfig.json -e "$(cat scripts/activate-lunco.ts)"
+ *   -- or --
+ *   npx ts-node scripts/activate-lunco.ts
+ */
+
+// dotenv MUST be loaded before any module that reads process.env at init time
+// (the GCP KMS client is a module-level singleton in hsm-signer.ts).
+import * as dotenv from 'dotenv'
+import * as path from 'path'
+dotenv.config({ path: path.resolve(__dirname, '..', '.env.local') })
+
+// Now safe to import the HSM signer (KMS client reads env at require time)
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getHSMSigner, isHSMAvailable } = require('../lib/google/hsm-signer')
+import { utils, providers } from 'ethers'
+
+const PROJECT_TABLE_ADDRESS = '0x83755AF34867a3513ddCE921E9cAd28f0828CDdB'
+const PROJECT_ID = 120
+const RPC_URL =
+  process.env.ARBITRUM_RPC_URL ||
+  process.env.RPC_URL ||
+  'https://arb1.arbitrum.io/rpc'
+
+const UPDATE_ABI = ['function updateTableCol(uint256 id, string col, string val)']
+
+async function main() {
+  if (!isHSMAvailable()) {
+    console.error('HSM not available — GCP_SIGNER_SERVICE_ACCOUNT must be set.')
+    process.exit(1)
+  }
+
+  const signer = getHSMSigner()
+  const address = await signer.getAddress()
+  console.log('HSM signer address:', address)
+  console.log(`Setting project id=${PROJECT_ID} → active=2 (PROJECT_ACTIVE)…`)
+
+  const provider = new providers.JsonRpcProvider(RPC_URL)
+  const iface = new utils.Interface(UPDATE_ABI)
+  const data = iface.encodeFunctionData('updateTableCol', [
+    PROJECT_ID,
+    'active',
+    '2',
+  ])
+
+  const tx = await signer.sendTransaction({
+    to: PROJECT_TABLE_ADDRESS,
+    data,
+    provider,
+  })
+
+  const hash = tx?.transactionHash || tx?.hash
+  console.log('Tx sent:', hash)
+
+  if (tx.wait) {
+    const receipt = await tx.wait()
+    console.log(
+      `Confirmed in block ${receipt.blockNumber}. LunCoSim (id=${PROJECT_ID}) is now PROJECT_ACTIVE.`
+    )
+  } else {
+    console.log('Transaction submitted. Check:', `https://arbiscan.io/tx/${hash}`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/ui/scripts/set-project-active.mjs
+++ b/ui/scripts/set-project-active.mjs
@@ -1,0 +1,95 @@
+// One-shot script to set a project's `active` column to 2 (PROJECT_ACTIVE)
+// in the on-chain Tableland ProjectTable.
+//
+// The ProjectTable owner is the GCP HSM EOA; this script accepts a plain
+// private key via OPERATOR_PK so it can be run locally when the HSM
+// environment is not available.
+//
+// Usage (from ui/):
+//   OPERATOR_PK=0x<owner-private-key> node scripts/set-project-active.mjs <projectId>
+//
+// Example — set LunCoSim (project id=120, MDP=238) to active:
+//   OPERATOR_PK=0x<key> node scripts/set-project-active.mjs 120
+
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import { ethers } from 'ethers'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const PROJECT_TABLE_ADDRESS = '0x83755AF34867a3513ddCE921E9cAd28f0828CDdB'
+const DEFAULT_RPC = 'https://arb1.arbitrum.io/rpc'
+
+const UPDATE_TABLE_COL_ABI = [
+  'function updateTableCol(uint256 id, string col, string val)',
+]
+
+function loadEnvLocal() {
+  try {
+    const envPath = join(__dirname, '..', '.env.local')
+    const text = readFileSync(envPath, 'utf8')
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const eq = trimmed.indexOf('=')
+      if (eq < 0) continue
+      const key = trimmed.slice(0, eq).trim()
+      let value = trimmed.slice(eq + 1).trim()
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      if (!(key in process.env)) process.env[key] = value
+    }
+  } catch {
+    // .env.local is optional
+  }
+}
+
+async function main() {
+  loadEnvLocal()
+
+  const projectId = process.argv[2]
+  if (!projectId || isNaN(Number(projectId))) {
+    console.error('Usage: OPERATOR_PK=0x<key> node scripts/set-project-active.mjs <projectId>')
+    console.error('Example: OPERATOR_PK=0x<key> node scripts/set-project-active.mjs 120')
+    process.exit(1)
+  }
+
+  const pk = process.env.OPERATOR_PK
+  if (!pk) {
+    console.log(`No OPERATOR_PK set — would call updateTableCol(${projectId}, 'active', '2') on:`)
+    console.log('  ProjectTable:', PROJECT_TABLE_ADDRESS)
+    console.log('\nRe-run with the ProjectTable owner key:')
+    console.log(`  OPERATOR_PK=0x<owner-key> node scripts/set-project-active.mjs ${projectId}`)
+    return
+  }
+
+  const rpcUrl = process.env.ARBITRUM_RPC_URL || process.env.RPC_URL || DEFAULT_RPC
+  const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
+  const wallet = new ethers.Wallet(pk, provider)
+
+  console.log('Signer:', wallet.address)
+  console.log('ProjectTable:', PROJECT_TABLE_ADDRESS)
+  console.log(`Setting project id=${projectId} active=2 …`)
+
+  const iface = new ethers.utils.Interface(UPDATE_TABLE_COL_ABI)
+  const data = iface.encodeFunctionData('updateTableCol', [projectId, 'active', '2'])
+
+  const tx = await wallet.sendTransaction({
+    to: PROJECT_TABLE_ADDRESS,
+    data,
+  })
+  console.log('Tx sent:', tx.hash)
+  console.log('Waiting for confirmation…')
+  const receipt = await tx.wait()
+  console.log(`Confirmed in block ${receipt.blockNumber}. Project ${projectId} is now active=2 (PROJECT_ACTIVE).`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- Removes MDP-238 from `BLOCKED_MDPS` in `ui/const/whitelist.ts` so that `moondao.com/project/238` (Lunar Colony Digital Simulator / LunCoSim) no longer 404s
- The on-chain `active` field for project id=120 was already set to 2 (PROJECT_ACTIVE) via a direct HSM-signed transaction prior to this PR
- Adds `scripts/activate-lunco.ts` — the one-shot script used to send that transaction
- Adds `scripts/set-project-active.mjs` — a reusable helper for future cases where a project needs its `active` column set manually

## Test plan
- [ ] Visit `https://moondao.com/project/238` — should resolve to LunCoSim project page (not 404)
- [ ] Project should appear in the active projects list on `/projects`
- [ ] Verify `active=2` in Tableland: `SELECT id,name,active FROM PROJECT_42161_122 WHERE id=120`

Made with [Cursor](https://cursor.com)