### PR TITLE
fix(final-reports): query last quarter so projects can submit final reports

### DIFF
--- a/ui/components/nance/FinalReportEditor.tsx
+++ b/ui/components/nance/FinalReportEditor.tsx
@@ -382,7 +382,7 @@ export default function FinalReportEditor({ projectsFromLastQuarter }: FinalRepo
                     : 'Submit Final Report'
                 }
                 action={handleFormSubmit}
-                isDisabled={buttonsDisabled || isUploadingImage}
+                actionDisabled={buttonsDisabled || isUploadingImage}
               />
               {(buttonsDisabled || isUploadingImage) && getButtonDisabledReason() && (
                 <p className="text-sm text-yellow-400 font-medium">{getButtonDisabledReason()}</p>

--- a/ui/pages/final-reports.tsx
+++ b/ui/pages/final-reports.tsx
@@ -105,9 +105,7 @@ export async function getStaticProps() {
       method: 'getTableName',
     })
 
-    // FIXME use last quarter
-    //const { quarter, year } = getRelativeQuarter(-1)
-    const { quarter, year } = getRelativeQuarter(0)
+    const { quarter, year } = getRelativeQuarter(-1)
 
     const statement = `SELECT * FROM ${projectTableName} WHERE quarter = ${quarter} AND year = ${year}`
     const projectsFromLastQuarter = await queryTable(chain, statement)


### PR DESCRIPTION
## Summary
- Users could not submit final reports because `getStaticProps` in `ui/pages/final-reports.tsx` queried the **current** quarter (`getRelativeQuarter(0)`) instead of the **previous** one. Completed projects live under last quarter's `quarter`/`year`, so the project dropdown was empty and there was nothing to select or submit. This was a known `// FIXME use last quarter` — now fixed to use `getRelativeQuarter(-1)`.
- Switched the submit button in `ui/components/nance/FinalReportEditor.tsx` from `isDisabled` to `actionDisabled` on `PrivyWeb3Button`. `isDisabled` also greys out the "Switch Network" state, trapping wrong-network users before they select a project; `actionDisabled` only gates the action state so they can still connect / switch network.

## Test plan
- [ ] Visit `/final-reports` and confirm the project dropdown lists last quarter's projects
- [ ] As a project manager, select a project and submit a final report; confirm IPFS upload + on-chain `updateFinalReportIPFS` succeed
- [ ] Connect a wallet on the wrong network with no project selected and confirm the "Switch Network" button is still clickable
- [ ] Confirm the disabled-reason messaging still shows when not a manager / no project selected

Made with [Cursor](https://cursor.com)