### PR TITLE
feat(network): extend citizen search to bio and location fields

### DIFF
--- a/ui/lib/network/useNetworkData.ts
+++ b/ui/lib/network/useNetworkData.ts
@@ -23,6 +23,7 @@ import client from '@/lib/thirdweb/client'
 import { NetworkNFT, NetworkDataResult, UseNetworkDataOptions } from './types'
 import {
   buildSearchClause,
+  buildCitizenSearchClause,
   buildPaginationClause,
   calculateMaxPage,
   buildExcludeIdsCondition,
@@ -115,7 +116,7 @@ export function useCitizensCount(
   enabled: boolean = true
 ): { count: number; isLoading: boolean } {
   const { citizenTableName } = useTableNames()
-  const searchClause = buildSearchClause(search)
+  const searchClause = buildCitizenSearchClause(search)
   const excludeCondition = buildExcludeIdsCondition(BLOCKED_CITIZENS)
   const whereClause = appendToWhereClause(
     appendToWhereClause(searchClause, excludeCondition),
@@ -195,7 +196,7 @@ export function useCitizens(options: UseNetworkDataOptions = {}): NetworkDataRes
   const { citizenTableName } = useTableNames()
   const { count, isLoading: countLoading } = useCitizensCount(search, enabled)
 
-  const searchClause = buildSearchClause(search)
+  const searchClause = buildCitizenSearchClause(search)
   const excludeCondition = buildExcludeIdsCondition(BLOCKED_CITIZENS)
   const whereClause = appendToWhereClause(
     appendToWhereClause(searchClause, excludeCondition),

--- a/ui/lib/network/utils.ts
+++ b/ui/lib/network/utils.ts
@@ -48,6 +48,20 @@ export function buildSearchClauseForCount(search: string, column: string = 'name
   return buildSearchClause(search, column)
 }
 
+/**
+ * Builds a WHERE clause that searches across citizen name, bio (description),
+ * and location so that queries like "engineer", "Brazil", or "satellite" return
+ * relevant results from the full citizen profile, not just the name field.
+ */
+export function buildCitizenSearchClause(search: string): string {
+  if (!search || search.trim() === '') {
+    return ''
+  }
+  const sanitized = search.trim().replace(/'/g, "''")
+  const term = `'%${sanitized}%'`
+  return `WHERE (LOWER(name) LIKE LOWER(${term}) OR LOWER(description) LIKE LOWER(${term}) OR LOWER(location) LIKE LOWER(${term}))`
+}
+
 export function buildPaginationClause(page: number, pageSize: number): string {
   const offset = (page - 1) * pageSize
   return `LIMIT ${pageSize} OFFSET ${offset}`

--- a/ui/pages/api/citizens/search.ts
+++ b/ui/pages/api/citizens/search.ts
@@ -47,11 +47,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         ? `id NOT IN (${OVERVIEW_BLOCKED_CITIZEN_IDS.join(',')})`
         : '1=1'
 
+    const term = `'%${sanitized}%'`
+    const textMatch = `LOWER(name) LIKE LOWER(${term}) OR LOWER(description) LIKE LOWER(${term}) OR LOWER(location) LIKE LOWER(${term})`
     let searchClause: string
     if (isNumeric) {
-      searchClause = `LOWER(name) LIKE LOWER('%${sanitized}%') OR id = ${parseInt(sanitized, 10)}`
+      searchClause = `${textMatch} OR id = ${parseInt(sanitized, 10)}`
     } else {
-      searchClause = `LOWER(name) LIKE LOWER('%${sanitized}%')`
+      searchClause = textMatch
     }
 
     const statement = `SELECT id, name, owner, image FROM ${tableName} WHERE (${searchClause}) AND ${excludeIds} ORDER BY name ASC LIMIT 20`


### PR DESCRIPTION
## Summary
- Citizen directory search previously only matched on the `name` column, making it impossible to find members by profession, expertise, or country
- Added `buildCitizenSearchClause()` in `lib/network/utils.ts` that generates a case-insensitive `WHERE (LOWER(name) LIKE … OR LOWER(description) LIKE … OR LOWER(location) LIKE …)` clause
- Swapped the name-only `buildSearchClause()` call for `buildCitizenSearchClause()` in both `useCitizensCount()` and `useCitizens()` in `useNetworkData.ts` — teams search is unchanged
- Extended the same three-column match in `pages/api/citizens/search.ts` (the autocomplete endpoint used by referral/delegate flows), preserving numeric token-ID lookup

## Test plan
- [ ] Search "engineer" on /network citizens tab — should return citizens whose bio contains "engineer" even if their name doesn't
- [ ] Search "Brazil" — should return citizens with "Brazil" in their location field
- [ ] Search "satellite" — should return citizens with matching bio/description
- [ ] Plain name search still works as before (existing behaviour unchanged)
- [ ] Numeric search (token ID) still works in the autocomplete endpoint
- [ ] Empty / short (< 3 char) search still returns no results / 400 from the API
- [ ] Blocked citizens are still excluded from all results

Made with [Cursor](https://cursor.com)