### PR TITLE
fix(projects): show 2026 past projects in Past Projects tab

### DIFF
--- a/ui/components/project/PastProjects.tsx
+++ b/ui/components/project/PastProjects.tsx
@@ -41,10 +41,6 @@ function buildYearIndex(projects: Project[]): YearGroup[] {
 }
 
 export default function PastProjects({ projects }: PastProjectProps) {
-  const finalReportProjects = useMemo(
-    () => projects.filter(hasFinalReport),
-    [projects]
-  )
   const { selectedChain } = useContext(ChainContextV5)
   const chainSlug = getChainSlug(selectedChain)
 
@@ -63,8 +59,8 @@ export default function PastProjects({ projects }: PastProjectProps) {
   const [input, setInput] = useState('')
 
   const yearGroups = useMemo(
-    () => buildYearIndex(finalReportProjects),
-    [finalReportProjects]
+    () => buildYearIndex(projects),
+    [projects]
   )
 
   const [selectedYear, setSelectedYear] = useState<number | null>(null)
@@ -137,7 +133,7 @@ export default function PastProjects({ projects }: PastProjectProps) {
             Past Projects
           </h1>
           <span className="text-[11px] sm:text-xs font-RobotoMono uppercase tracking-wider text-gray-500">
-            {finalReportProjects.length} total
+            {projects.length} total
           </span>
         </div>
         <div className="relative w-full sm:max-w-xs">


### PR DESCRIPTION
## Summary
- The Past Projects section was capped at Q4 2025 because `PastProjects.tsx` applied a `hasFinalReport` filter before building the year/quarter index
- Any 2026 past project without a `finalReportIPFS` or `finalReportLink` was silently dropped, so the 2026 year tab never appeared
- Removed the pre-filter so all past projects (regardless of final-report status) are indexed and displayed
- The `hasFinalReport` helper export is preserved — other parts of the codebase still reference it

## Test plan
- [ ] Navigate to `/projects` and open the **Past Projects** tab
- [ ] Confirm a **2026** year button now appears alongside 2025, 2024, etc.
- [ ] Confirm Q1/Q2/Q3 quarter buttons for 2026 show the correct project counts
- [ ] Confirm existing 2025 and earlier projects still display correctly
- [ ] Confirm the "total" count in the header reflects all past projects

Made with [Cursor](https://cursor.com)