### PR TITLE
fix(safe): show correct token amount instead of 0.0 ETH on pending transactions

### DIFF
--- a/ui/components/safe/SafeTransactions.tsx
+++ b/ui/components/safe/SafeTransactions.tsx
@@ -1,5 +1,4 @@
 import { useWallets } from '@privy-io/react-auth'
-import { ethers } from 'ethers'
 import { useContext, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
@@ -7,6 +6,7 @@ import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
 import {
   deriveTransactionActions,
   getRecipientAddress,
+  getTransactionDisplayValue,
   getTransactionMethod,
   groupHasRejection,
   groupTransactionsByNonce,
@@ -147,6 +147,7 @@ export default function SafeTransactions({
 
                     const method = getTransactionMethod(tx)
                     const recipientAddress = getRecipientAddress(tx)
+                    const displayValue = getTransactionDisplayValue(tx)
 
                     const isTransfer = isEthTransfer(tx) || isTokenTransfer(tx)
                     const methodBadgeClass = isTransfer
@@ -186,17 +187,19 @@ export default function SafeTransactions({
                               {recipientAddress}
                             </span>
                           </div>
-                          <div className="flex items-center justify-between gap-4 text-sm">
-                            <span className="text-slate-500 shrink-0">
-                              Value
-                            </span>
-                            <span
-                              data-testid={`transaction-value-${tx.safeTxHash}`}
-                              className="text-slate-200"
-                            >
-                              {ethers.utils.formatEther(tx.value)} ETH
-                            </span>
-                          </div>
+                          {displayValue && (
+                            <div className="flex items-center justify-between gap-4 text-sm">
+                              <span className="text-slate-500 shrink-0">
+                                Value
+                              </span>
+                              <span
+                                data-testid={`transaction-value-${tx.safeTxHash}`}
+                                className="text-slate-200"
+                              >
+                                {displayValue.amount} {displayValue.symbol}
+                              </span>
+                            </div>
+                          )}
                         </div>
 
                         <div

--- a/ui/lib/safe/safeTransactionActions.ts
+++ b/ui/lib/safe/safeTransactionActions.ts
@@ -57,6 +57,46 @@ export function isTokenTransfer(tx: SafeTxLike): boolean {
   )
 }
 
+/**
+ * Returns the human-readable value to display on a transaction card.
+ *
+ * - ETH transfers: format tx.value from wei → "1.5 ETH"
+ * - ERC-20 transfers: decode the token amount from dataDecoded parameters
+ *   (assumes 18 decimals — correct for MOONEY and most standard tokens).
+ *   Returns null when the value is zero and there is no decoded token amount,
+ *   so callers can hide the row entirely for contract calls with no value.
+ */
+export function getTransactionDisplayValue(
+  tx: SafeTxLike
+): { amount: string; symbol: string } | null {
+  if (isEthTransfer(tx)) {
+    return { amount: ethers.utils.formatEther(tx.value ?? '0'), symbol: 'ETH' }
+  }
+
+  if (isTokenTransfer(tx)) {
+    const params = tx.dataDecoded?.parameters ?? []
+    // transfer(address to, uint256 value)  → params[1]
+    // transferFrom(address from, address to, uint256 value) → params[2]
+    const amountParam =
+      tx.dataDecoded?.method === 'transferFrom' ? params[2] : params[1]
+    const raw: string = amountParam?.value ?? '0'
+    return {
+      amount: ethers.utils.formatEther(
+        ethers.BigNumber.from(raw).toString()
+      ),
+      symbol: 'tokens',
+    }
+  }
+
+  // Generic contract call — show ETH value only when non-zero.
+  const valueBN = valueAsBN(tx.value)
+  if (valueBN.gt(0)) {
+    return { amount: ethers.utils.formatEther(tx.value ?? '0'), symbol: 'ETH' }
+  }
+
+  return null
+}
+
 /** Human-friendly method label shown on the card. */
 export function getTransactionMethod(tx: SafeTxLike): string {
   if (isEthTransfer(tx)) return 'Transfer ETH'


### PR DESCRIPTION
## Summary
- ERC-20 token transfers showed **0.0 ETH** because the Value row always read `tx.value` (ETH attached to the call), which is `0` for token transfers
- The actual token amount is encoded in `tx.dataDecoded.parameters[1].value` (or `[2]` for `transferFrom`)
- Added `getTransactionDisplayValue` helper in `safeTransactionActions.ts` that:
  - **ETH transfers** → formats `tx.value` from wei with "ETH" symbol
  - **ERC-20 transfers** → decodes the token amount from `dataDecoded.parameters` with "tokens" symbol (assumes 18 decimals, correct for MOONEY and standard tokens)
  - **Generic contract calls with ETH** → shows the ETH value
  - **Generic contract calls with no ETH** → hides the Value row entirely (returns `null`)
- Removed the now-unused `ethers` import from `SafeTransactions.tsx`

## Test plan
- [ ] Queue a MOONEY transfer in a Safe — Value row should show the token amount (e.g. `1000.0 tokens`) instead of `0.0 ETH`
- [ ] Queue a plain ETH transfer — Value row should still show the ETH amount correctly
- [ ] Queue a generic contract interaction (no ETH value) — Value row should be hidden
- [ ] Reject transaction nonce-bump tx — Value row should be hidden

Made with [Cursor](https://cursor.com)