### PR TITLE
fix(team): correct manager labeling + super manager role switching

### DIFF
--- a/ui/components/subscription/TeamManageMembers.tsx
+++ b/ui/components/subscription/TeamManageMembers.tsx
@@ -1,4 +1,4 @@
-import { TrashIcon, UserPlusIcon, ShieldCheckIcon, ExclamationTriangleIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { TrashIcon, UserPlusIcon, ShieldCheckIcon, ExclamationTriangleIcon, XMarkIcon, ArrowUpCircleIcon } from '@heroicons/react/24/outline'
 import { DEFAULT_CHAIN_V5, HATS_ADDRESS } from 'const/config'
 import { TEAM_CREATOR_V2_PASSTHROUGH_MODULE_PATCHED_ADDRESSES } from 'const/teams'
 import { ethers } from 'ethers'
@@ -10,8 +10,10 @@ import {
   buildAddRoleTx,
   buildRemoveRoleTx,
   getRoleLabel,
+  isManagerHat,
   isValidEthereumAddress,
   requiresSafeTx,
+  toHatIdHex,
 } from '@/lib/hats/teamRoles'
 import useHatNames from '@/lib/hats/useHatNames'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
@@ -33,6 +35,7 @@ type TeamManageMembersModalProps = {
   multisigAddress: string
   adminHatId: string
   managerHatId: any
+  isSuperManager?: boolean
 }
 
 type TeamManageMembersProps = {
@@ -45,6 +48,7 @@ type TeamManageMembersProps = {
   multisigAddress: string
   adminHatId: string
   managerHatId: any
+  isSuperManager?: boolean
 }
 
 function HatOption({ hat, managerHatId }: any) {
@@ -121,12 +125,53 @@ function TeamMembers({
   teamId,
   queueSafeTx,
   setHasDeletedMember,
+  setHasAddedMember,
   managerHatId,
   adminHatId,
 }: any) {
   const hatNames = useHatNames(hatsContract, wearer.hatIds)
   const chainSlug = getChainSlug(selectedChain)
   const [removingHat, setRemovingHat] = useState<string | null>(null)
+  const [promoting, setPromoting] = useState<boolean>(false)
+
+  // Whether this member already wears the manager hat (so we can offer to
+  // promote members who don't). Comparing against the team's manager hat id
+  // is deterministic and doesn't depend on IPFS metadata.
+  const isAlreadyManager = wearer.hatIds?.some((hatId: string) =>
+    isManagerHat(hatId, managerHatId)
+  )
+
+  async function promoteToManager() {
+    if (managerHatId == null) return toast.error('Manager role unavailable.')
+    setPromoting(true)
+    try {
+      const tx = buildAddRoleTx({
+        hatId: toHatIdHex(managerHatId),
+        memberAddress: wearer.address,
+        managerHatId,
+        adminHatId,
+        hatsAddress: HATS_ADDRESS,
+      })
+      const iface = new ethers.utils.Interface(HatsABI)
+      const txData = iface.encodeFunctionData(tx.functionName, tx.args)
+
+      // Granting the manager hat is always admin-gated, so it routes through
+      // the team Safe (queued for signers to execute).
+      if (tx.routing === 'safe') {
+        await queueSafeTx({ to: tx.to, data: txData, value: '0', safeTxGas: '1000000' })
+        setHasAddedMember?.(true)
+        toast.success('Promotion queued.')
+      } else {
+        await account?.sendTransaction({ to: tx.to, data: txData, value: '0', gas: 1000000 })
+        toast.success('Member promoted to Manager!')
+      }
+    } catch (err) {
+      console.log(err)
+      toast.error('Failed to promote member. Connect an authorized Safe signer.')
+    } finally {
+      setPromoting(false)
+    }
+  }
 
   return (
     <div className="flex items-start gap-3 p-4 rounded-xl bg-[#111827] border border-[#1e2a45] hover:bg-[#162035] transition-all duration-200">
@@ -217,6 +262,23 @@ function TeamMembers({
             })}
           </div>
         )}
+
+        {!isAlreadyManager && (
+          <button
+            type="button"
+            onClick={promoteToManager}
+            disabled={promoting}
+            className="mt-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-semibold bg-blue-900/40 border border-blue-500/30 text-blue-200 hover:bg-blue-900/60 transition-colors disabled:opacity-40"
+            title="Grant this member the Manager role"
+          >
+            {promoting ? (
+              <span className="block w-3 h-3 border border-current border-t-transparent rounded-full animate-spin" />
+            ) : (
+              <ArrowUpCircleIcon className="w-3.5 h-3.5" />
+            )}
+            Make Manager
+          </button>
+        )}
       </div>
     </div>
   )
@@ -232,6 +294,7 @@ function TeamManageMembersModal({
   multisigAddress,
   adminHatId,
   managerHatId,
+  isSuperManager,
   setEnabled,
 }: TeamManageMembersModalProps) {
   const reversedHats = hats.slice().reverse()
@@ -297,6 +360,17 @@ function TeamManageMembersModal({
           </button>
         </div>
 
+        {isSuperManager && (
+          <div className="mx-6 mt-4 flex items-start gap-2 p-3 rounded-lg bg-purple-900/20 border border-purple-500/30 text-purple-200 text-xs">
+            <ShieldCheckIcon className="w-4 h-4 flex-shrink-0 mt-0.5" />
+            <span>
+              You have super manager access. Manager role changes are queued to
+              the team Safe and must be signed by an authorized Safe signer to
+              finalize.
+            </span>
+          </div>
+        )}
+
         {/* Members list */}
         <div className="px-6 py-4">
           <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
@@ -315,6 +389,7 @@ function TeamManageMembersModal({
                   teamId={teamId}
                   queueSafeTx={queueSafeTx}
                   setHasDeletedMember={setHasDeletedMember}
+                  setHasAddedMember={setHasAddedMember}
                   managerHatId={managerHatId}
                   adminHatId={adminHatId}
                 />
@@ -473,6 +548,7 @@ export default function TeamManageMembers({
   multisigAddress,
   adminHatId,
   managerHatId,
+  isSuperManager,
 }: TeamManageMembersProps) {
   const [manageMembersModalEnabled, setManagerModalEnabled] = useState(false)
 
@@ -490,6 +566,7 @@ export default function TeamManageMembers({
           multisigAddress={multisigAddress}
           adminHatId={adminHatId}
           managerHatId={managerHatId}
+          isSuperManager={isSuperManager}
         />
       )}
       <StandardButton

--- a/ui/components/subscription/TeamMembers.tsx
+++ b/ui/components/subscription/TeamMembers.tsx
@@ -2,6 +2,7 @@ import { useContext, useMemo } from 'react'
 import Link from 'next/link'
 import { CITIZEN_TABLE_NAMES } from 'const/config'
 import { BLOCKED_CITIZENS } from 'const/whitelist'
+import { getRoleLabel } from '@/lib/hats/teamRoles'
 import useHatNames from '@/lib/hats/useHatNames'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
 import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
@@ -16,12 +17,14 @@ type TeamMemberProps = {
   hatIds: string[]
   hatsContract: any
   citizenNft?: any
+  managerHatId?: any
 }
 
 type TeamMembersProps = {
   hatsContract: any
   citizenContract: any
   hats: any[]
+  managerHatId?: any
 }
 
 type Wearer = {
@@ -54,15 +57,31 @@ function TeamMembersLoadingSkeleton({ count = 3 }: { count?: number }) {
   )
 }
 
-function TeamMember({ address, hatIds, hatsContract, citizenNft }: TeamMemberProps) {
+function TeamMember({
+  address,
+  hatIds,
+  hatsContract,
+  citizenNft,
+  managerHatId,
+}: TeamMemberProps) {
   const hatNames = useHatNames(hatsContract, hatIds)
 
   const metadata = citizenNft?.metadata
   const citizenName = metadata?.name || 'Anon'
   const citizenDescription =
     metadata?.description || 'This citizen has yet to add a profile'
+  // Label roles deterministically: the manager hat is always shown as "Manager"
+  // (via getRoleLabel) even if its IPFS metadata is missing/slow, so managers are
+  // never silently downgraded to a generic member label.
   const roles =
-    hatNames?.map((hatName: any) => hatName.name || '...').join(', ') || 'Team Member'
+    hatNames
+      ?.map((hatName: any) =>
+        getRoleLabel(hatName.hatId, {
+          managerHatId,
+          ipfsName: hatName.name,
+        })
+      )
+      .join(', ') || 'Team Member'
 
   const link = metadata?.name
     ? `/citizen/${generatePrettyLinkWithId(metadata.name, metadata?.id || citizenNft?.id)}`
@@ -103,6 +122,7 @@ export default function TeamMembers({
   hatsContract,
   citizenContract: _citizenContract,
   hats,
+  managerHatId,
 }: TeamMembersProps) {
   const { selectedChain } = useContext(ChainContextV5)
   const chainSlug = getChainSlug(selectedChain)
@@ -175,6 +195,7 @@ export default function TeamMembers({
           address={w.address}
           hatsContract={hatsContract}
           citizenNft={citizensByOwner.get(w.address.toLowerCase())}
+          managerHatId={managerHatId}
         />
       ))}
     </div>

--- a/ui/lib/hats/useHatNames.tsx
+++ b/ui/lib/hats/useHatNames.tsx
@@ -6,28 +6,33 @@ export default function useHatNames(hatsContract: any, hatIds: string[]) {
 
   useEffect(() => {
     async function getAllHatNames() {
-      try {
-        const hatNamesPromises = hatIds.map(async (hatId: string) => {
-          const hat: any = await readContract({
-            contract: hatsContract,
-            method: 'viewHat' as string,
-            params: [hatId],
-          })
-          const detailsIpfsHash = hat.details
-            ? hat.details.split('ipfs://')[1]
-            : hat[0].split('ipfs://')[1]
-          const hatDetailsRes = await fetch(
-            `https://ipfs.io/ipfs/${detailsIpfsHash}`
-          )
-          const { data: hatDetails } = await hatDetailsRes.json()
-          return { name: hatDetails.name, hatId }
+      // Resolve each hat independently so a single IPFS/RPC hiccup can't blank
+      // out every role. A failed lookup returns `name: null`, letting callers
+      // fall back to a deterministic label (e.g. via getRoleLabel) instead of
+      // mislabeling everyone as a generic member.
+      const names = await Promise.all(
+        hatIds.map(async (hatId: string) => {
+          try {
+            const hat: any = await readContract({
+              contract: hatsContract,
+              method: 'viewHat' as string,
+              params: [hatId],
+            })
+            const details = hat.details ?? hat[0]
+            const detailsIpfsHash = details?.split('ipfs://')[1]
+            if (!detailsIpfsHash) return { name: null, hatId }
+            const hatDetailsRes = await fetch(
+              `https://ipfs.io/ipfs/${detailsIpfsHash}`
+            )
+            const { data: hatDetails } = await hatDetailsRes.json()
+            return { name: hatDetails?.name ?? null, hatId }
+          } catch (err) {
+            console.error(`Failed to fetch hat name for ${hatId}:`, err)
+            return { name: null, hatId }
+          }
         })
-
-        const names = await Promise.all(hatNamesPromises)
-        setHatNames(names)
-      } catch (err) {
-        console.error('Failed to fetch hat names:', err)
-      }
+      )
+      setHatNames(names)
     }
     if (hatIds.length > 0 && hatsContract) {
       getAllHatNames()

--- a/ui/lib/team/useTeamData.tsx
+++ b/ui/lib/team/useTeamData.tsx
@@ -32,6 +32,7 @@ export function useTeamData(
   const [isDeleted, setIsDeleted] = useState<boolean>(false)
   const [isManager, setIsManager] = useState<boolean>(false)
   const [isTableOperator, setIsTableOperator] = useState<boolean>(false)
+  const [isSuperManager, setIsSuperManager] = useState<boolean>(false)
   const [subIsValid, setSubIsValid] = useState<boolean>(true)
   const [hatTreeId, setHatTreeId] = useState<any>()
   const [adminHatId, setAdminHatId] = useState<any>()
@@ -144,6 +145,9 @@ export function useTeamData(
           // (which would surface controls that call contracts they can't satisfy).
           if (SUPER_MANAGERS.includes(address.toLowerCase())) {
             setIsTableOperator(true)
+            setIsSuperManager(true)
+          } else {
+            setIsSuperManager(false)
           }
           const isAddressManager: any = await readContract({
             contract: teamContract,
@@ -153,6 +157,7 @@ export function useTeamData(
           setIsManager(isAddressManager || nft.owner === address)
         } else {
           setIsManager(false)
+          setIsSuperManager(false)
         }
       } catch (err) {
         console.log(err)
@@ -381,6 +386,7 @@ export function useTeamData(
     managerHatId,
     isManager,
     isTableOperator,
+    isSuperManager,
     isLoading,
     subIsValid,
     hasFullAccess,

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -181,6 +181,7 @@ function TeamDetailPageContent({
     managerHatId,
     isManager,
     isTableOperator,
+    isSuperManager,
     subIsValid,
     isLoading: isLoadingTeamData,
     hasFullAccess,
@@ -587,7 +588,7 @@ function TeamDetailPageContent({
                   />
                   <h2 className="font-GoodTimes text-2xl text-white">Meet the Team</h2>
                 </div>
-                {isManager && hats?.[0]?.id && (
+                {(isManager || isSuperManager) && hats?.[0]?.id && (
                   <TeamManageMembers
                     account={account}
                     hats={hats}
@@ -598,6 +599,7 @@ function TeamDetailPageContent({
                     multisigAddress={nft.owner}
                     adminHatId={adminHatId}
                     managerHatId={managerHatId}
+                    isSuperManager={isSuperManager}
                   />
                 )}
               </div>
@@ -606,6 +608,7 @@ function TeamDetailPageContent({
                   hats={hats}
                   hatsContract={hatsContract}
                   citizenContract={citizenContract}
+                  managerHatId={managerHatId}
                 />
               )}
             </div>


### PR DESCRIPTION
## Summary
- **Root cause of the lunarc "no manager" report:** the team member list derived role labels solely from IPFS hat metadata (`useHatNames`). That hook wrapped the whole batch in a single try/catch + `Promise.all`, so if *any one* hat's IPFS metadata failed to load, `hatNames` stayed `undefined` and every role fell back to the generic `"Team Member"` label — so a legitimate on-chain manager rendered as a plain member.
- Made `useHatNames` resilient: each hat now resolves independently (`name: null` on failure) instead of blanking the whole list.
- Labeled roles deterministically on the team page via `getRoleLabel(hatId, { managerHatId })`, so the manager hat is always shown as **Manager** regardless of IPFS availability (matches what the Manage Team modal already did).
- Exposed `isSuperManager` from `useTeamData` and gave super managers access to the **Manage Team** role controls on any team (previously gated strictly to on-chain `isManager`; super managers only had Tableland write access).
- Added a one-click **Make Manager** promotion per member in the modal. Granting the manager hat is admin-gated, so it is queued to the team Safe (existing pattern) with a super-manager notice explaining a Safe signer must finalize.

## Test plan
- [ ] Open a team where a member wears the on-chain manager hat but whose hat IPFS metadata is slow/broken — confirm they now show as **Manager**, not **Member**.
- [ ] As a `SUPER_MANAGER` wallet, open any team profile and confirm the **Manage Team** button now appears.
- [ ] In the modal, confirm a purple super-manager notice is shown and each non-manager member has a **Make Manager** button.
- [ ] Click **Make Manager**; confirm a Safe transaction is queued and the "Sign & execute in Safe" flow appears.
- [ ] Confirm existing managers/owners still see the full Manage Team controls and add/remove role flows are unchanged.
- [ ] `cypress/integration/unit/team-roles.cy.tsx` still passes (promotion reuses the tested `buildAddRoleTx` manager path).

Made with [Cursor](https://cursor.com)