### PR TITLE
perf(rpc): cache idempotent RPC reads to cut Infura credit usage

### DIFF
--- a/ui/lib/rpc/rpcCache.ts
+++ b/ui/lib/rpc/rpcCache.ts
@@ -1,0 +1,138 @@
+/**
+ * Tiny server-side cache for JSON-RPC results, backed by Upstash Redis with a
+ * bounded in-memory fallback (per-lambda).
+ *
+ * Motivation: the browser RPC proxy (`/api/rpc/[chainId]`) and the gas-price
+ * endpoint forward every read straight to Infura, so identical reads fired by
+ * many visitors (mission pages, dashboards, gas estimates) each burn credits.
+ * Caching idempotent reads for a couple of seconds collapses those duplicates
+ * across all clients without meaningfully staling the UI.
+ *
+ * Everything here fails open: if Redis is unavailable or slow the caller still
+ * gets a correct (uncached) response.
+ */
+import crypto from 'crypto'
+import { Redis } from '@upstash/redis'
+
+let redis: Redis | null | undefined
+
+function getRedis(): Redis | null {
+  if (redis !== undefined) return redis
+  const url = process.env.UPSTASH_REDIS_URL
+  const token = process.env.UPSTASH_REDIS_TOKEN
+  redis = url && token ? new Redis({ url, token }) : null
+  return redis
+}
+
+export const RPC_CACHE_DISABLED = process.env.RPC_CACHE_DISABLED === 'true'
+
+// Guard Redis round-trips so a slow/unreachable endpoint never delays a read.
+const REDIS_TIMEOUT_MS = 1500
+
+async function withTimeout<T>(p: Promise<T>, fallback: T): Promise<T> {
+  return Promise.race([
+    p.catch(() => fallback),
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), REDIS_TIMEOUT_MS)),
+  ])
+}
+
+// Per-lambda memory cache. Bounded so a long-lived instance can't grow forever.
+const MEM_MAX_ENTRIES = 5000
+const mem = new Map<string, { value: unknown; expiresAt: number }>()
+
+function memGet(key: string): unknown | undefined {
+  const hit = mem.get(key)
+  if (!hit) return undefined
+  if (hit.expiresAt <= Date.now()) {
+    mem.delete(key)
+    return undefined
+  }
+  return hit.value
+}
+
+function memSet(key: string, value: unknown, ttlMs: number): void {
+  if (mem.size >= MEM_MAX_ENTRIES) {
+    // Cheap eviction: drop the oldest inserted key.
+    const oldest = mem.keys().next().value
+    if (oldest !== undefined) mem.delete(oldest)
+  }
+  mem.set(key, { value, expiresAt: Date.now() + ttlMs })
+}
+
+/** Stable JSON stringify (sorted object keys) so equivalent params share a key. */
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj).sort()
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(',')}}`
+}
+
+export function hashKey(parts: string): string {
+  return crypto.createHash('sha1').update(parts).digest('hex')
+}
+
+/** Batch read. Returns an array aligned to `keys`; misses are `undefined`. */
+export async function cacheGetMany(keys: string[]): Promise<(unknown | undefined)[]> {
+  if (RPC_CACHE_DISABLED || keys.length === 0) return keys.map(() => undefined)
+
+  const results: (unknown | undefined)[] = keys.map((k) => memGet(k))
+  const missingIdx = results
+    .map((v, i) => (v === undefined ? i : -1))
+    .filter((i) => i >= 0)
+
+  if (missingIdx.length === 0) return results
+
+  const client = getRedis()
+  if (!client) return results
+
+  const missingKeys = missingIdx.map((i) => keys[i])
+  const fetched = await withTimeout<(unknown | null)[]>(
+    client.mget<(unknown | null)[]>(...missingKeys),
+    missingKeys.map(() => null)
+  )
+
+  missingIdx.forEach((origIdx, j) => {
+    const val = fetched[j]
+    if (val !== null && val !== undefined) results[origIdx] = val
+  })
+
+  return results
+}
+
+/** Fire-and-forget writes. Also populates the in-memory tier synchronously. */
+export async function cacheSetMany(
+  entries: { key: string; value: unknown; ttlMs: number }[]
+): Promise<void> {
+  if (RPC_CACHE_DISABLED || entries.length === 0) return
+
+  for (const { key, value, ttlMs } of entries) {
+    memSet(key, value, ttlMs)
+  }
+
+  const client = getRedis()
+  if (!client) return
+
+  try {
+    const pipeline = client.pipeline()
+    for (const { key, value, ttlMs } of entries) {
+      pipeline.set(key, value, { px: ttlMs })
+    }
+    await withTimeout(pipeline.exec(), undefined as unknown as unknown[])
+  } catch {
+    /* fail open — memory tier still serves subsequent reads */
+  }
+}
+
+export async function cacheGet(key: string): Promise<unknown | undefined> {
+  const [value] = await cacheGetMany([key])
+  return value
+}
+
+export async function cacheSet(key: string, value: unknown, ttlMs: number): Promise<void> {
+  await cacheSetMany([{ key, value, ttlMs }])
+}

--- a/ui/lib/rpc/serverJsonRpc.ts
+++ b/ui/lib/rpc/serverJsonRpc.ts
@@ -7,7 +7,21 @@
  * Server-only: public endpoints here are not subject to the browser CSP.
  */
 
+import {
+  cacheGetMany,
+  cacheSetMany,
+  hashKey,
+  stableStringify,
+} from './rpcCache'
+
 const infuraKey = process.env.NEXT_PUBLIC_INFURA_KEY
+
+// How long a "latest"/state read (eth_call, balances, code) may be reused.
+// A couple of seconds collapses duplicate reads fired by concurrent page loads
+// without staling balances/prices enough to matter for display or estimation.
+const SHORT_TTL_MS = Number(process.env.RPC_CACHE_TTL_MS) || 3000
+// Reads pinned to a specific block/hash (or chain identity) never change.
+const IMMUTABLE_TTL_MS = 5 * 60 * 1000
 
 function usableUrl(u: string): boolean {
   return typeof u === 'string' && u.length > 0 && !u.includes('undefined')
@@ -147,6 +161,98 @@ function isWellFormedJsonRpcResponse(request: unknown, body: unknown): boolean {
   return hasResultOrError(body)
 }
 
+type JsonRpcRequest = {
+  jsonrpc?: string
+  id?: unknown
+  method?: string
+  params?: unknown[]
+}
+
+// Reads whose result is a pure function of chain state at a given block. Anything
+// that mutates, depends on the mempool (pending), or must be fresh for correctness
+// (nonce, gas estimate, tx receipt) is intentionally absent so it never caches.
+const CACHEABLE_READ_METHODS = new Set([
+  'eth_call',
+  'eth_getBalance',
+  'eth_getCode',
+  'eth_getStorageAt',
+  'eth_getBlockByNumber',
+  'eth_getBlockByHash',
+  'eth_chainId',
+  'net_version',
+])
+
+// Block tag arg position per method (the tag decides short vs immutable TTL).
+const BLOCK_TAG_INDEX: Record<string, number> = {
+  eth_call: 1,
+  eth_getBalance: 1,
+  eth_getCode: 1,
+  eth_getStorageAt: 2,
+  eth_getBlockByNumber: 0,
+}
+
+/** null → do not cache; otherwise the TTL to use for this block tag. */
+function ttlForBlockTag(tag: unknown): number | null {
+  // Missing tag defaults to "latest".
+  if (tag === undefined || tag === null) return SHORT_TTL_MS
+  if (typeof tag === 'object') {
+    // EIP-1898 { blockNumber } / { blockHash } → pinned, immutable.
+    const obj = tag as Record<string, unknown>
+    if ('blockHash' in obj || 'blockNumber' in obj) return IMMUTABLE_TTL_MS
+    return null
+  }
+  if (typeof tag !== 'string') return null
+  const t = tag.toLowerCase()
+  if (t === 'pending') return null // mempool-dependent, never cache
+  if (t === 'latest' || t === 'safe' || t === 'finalized') return SHORT_TTL_MS
+  if (t === 'earliest') return IMMUTABLE_TTL_MS
+  // A concrete block number (0x...) is immutable once mined.
+  if (t.startsWith('0x')) return IMMUTABLE_TTL_MS
+  return null
+}
+
+/**
+ * Decide whether a single JSON-RPC request may be cached, and under what key /
+ * TTL. Returns null for anything that must always hit the node.
+ */
+function cachePolicyFor(
+  chainId: number,
+  req: JsonRpcRequest
+): { key: string; ttlMs: number } | null {
+  if (!req || typeof req !== 'object') return null
+  // Notifications (no id) can't be matched back into a response — skip.
+  if (req.id === undefined || req.id === null) return null
+  const method = req.method
+  if (!method || !CACHEABLE_READ_METHODS.has(method)) return null
+
+  const params = Array.isArray(req.params) ? req.params : []
+
+  let ttlMs: number
+  if (method === 'eth_chainId' || method === 'net_version') {
+    ttlMs = IMMUTABLE_TTL_MS
+  } else if (method === 'eth_getBlockByHash') {
+    ttlMs = IMMUTABLE_TTL_MS
+  } else {
+    const tagTtl = ttlForBlockTag(params[BLOCK_TAG_INDEX[method]])
+    if (tagTtl === null) return null
+    ttlMs = tagTtl
+  }
+
+  const key = `rpc:${chainId}:${hashKey(`${method}:${stableStringify(params)}`)}`
+  return { key, ttlMs }
+}
+
+/** Only cache successful results (never errors or empty payloads). */
+function isCacheableResponse(entry: unknown): boolean {
+  return (
+    !!entry &&
+    typeof entry === 'object' &&
+    'result' in (entry as object) &&
+    (entry as { result?: unknown }).result !== undefined &&
+    (entry as { result?: unknown }).result !== null
+  )
+}
+
 /**
  * Forward a raw JSON-RPC payload (single call or batch array) through the
  * chain's endpoint list. Used by `/api/rpc/[chainId]` so browser thirdweb
@@ -155,7 +261,7 @@ function isWellFormedJsonRpcResponse(request: unknown, body: unknown): boolean {
  * Returns the first HTTP 200 JSON body that looks like a JSON-RPC response.
  * Transport failures / 429s advance to the next URL.
  */
-export async function proxyJsonRpcRequest(
+async function sendUpstream(
   chainId: number,
   payload: unknown,
   { timeoutMs = 20_000 }: { timeoutMs?: number } = {}
@@ -226,4 +332,103 @@ export async function proxyJsonRpcRequest(
   }
 
   return { status: lastStatus, body: lastBody }
+}
+
+/**
+ * Cache-aware wrapper around {@link sendUpstream}. Serves idempotent reads
+ * (eth_call, balances, code, blocks, chain id) from the shared cache and only
+ * forwards genuine misses to the upstream node — the main lever for cutting
+ * Infura credit usage. Batches are split so cached and uncached sub-calls in
+ * the same request are handled independently, then re-merged in order. Falls
+ * back to a plain passthrough for anything that can't be cached.
+ */
+export async function proxyJsonRpcRequest(
+  chainId: number,
+  payload: unknown,
+  opts: { timeoutMs?: number } = {}
+): Promise<JsonRpcProxyResult> {
+  const isBatch = Array.isArray(payload)
+  const requests = (isBatch ? payload : [payload]) as JsonRpcRequest[]
+
+  // Map each sub-request to its cache policy (or null if uncacheable).
+  const policies = requests.map((req) => cachePolicyFor(chainId, req))
+  const cacheableIdx = policies
+    .map((p, i) => (p ? i : -1))
+    .filter((i) => i >= 0)
+
+  // Nothing is cacheable → straight passthrough (preserves prior behavior).
+  if (cacheableIdx.length === 0) {
+    return sendUpstream(chainId, payload, opts)
+  }
+
+  const cachedValues = await cacheGetMany(
+    cacheableIdx.map((i) => policies[i]!.key)
+  )
+
+  // Responses we already have, keyed by original index.
+  const responses: (unknown | undefined)[] = new Array(requests.length)
+  cacheableIdx.forEach((origIdx, j) => {
+    const value = cachedValues[j]
+    if (value !== undefined) {
+      responses[origIdx] = {
+        jsonrpc: '2.0',
+        id: requests[origIdx].id,
+        result: value,
+      }
+    }
+  })
+
+  // Everything without a cached response must be fetched upstream.
+  const missIdx = requests.map((_, i) => i).filter((i) => responses[i] === undefined)
+
+  if (missIdx.length > 0) {
+    const missPayload = isBatch
+      ? missIdx.map((i) => requests[i])
+      : requests[missIdx[0]]
+
+    const upstream = await sendUpstream(chainId, missPayload, opts)
+    if (upstream.status !== 200) {
+      // Can't partially serve a failed fetch — surface the upstream error.
+      return upstream
+    }
+
+    const upstreamBody = upstream.body
+    const upstreamArr = (
+      Array.isArray(upstreamBody) ? upstreamBody : [upstreamBody]
+    ) as JsonRpcRequest[]
+
+    // Match upstream entries back to requests by id (batch order isn't
+    // guaranteed), falling back to positional mapping.
+    const byId = new Map<unknown, unknown>()
+    for (const entry of upstreamArr) {
+      if (entry && typeof entry === 'object' && 'id' in entry) {
+        byId.set(entry.id, entry)
+      }
+    }
+
+    const toCache: { key: string; value: unknown; ttlMs: number }[] = []
+    missIdx.forEach((origIdx, position) => {
+      const req = requests[origIdx]
+      const entry =
+        (req.id !== undefined && byId.get(req.id)) || upstreamArr[position]
+      responses[origIdx] = entry
+
+      const policy = policies[origIdx]
+      if (policy && isCacheableResponse(entry)) {
+        toCache.push({
+          key: policy.key,
+          value: (entry as { result: unknown }).result,
+          ttlMs: policy.ttlMs,
+        })
+      }
+    })
+
+    if (toCache.length > 0) {
+      // Fire-and-forget; a cache write failure must not delay the response.
+      void cacheSetMany(toCache)
+    }
+  }
+
+  const body = isBatch ? responses : responses[0]
+  return { status: 200, body }
 }

--- a/ui/lib/rpc/useGasPrice.ts
+++ b/ui/lib/rpc/useGasPrice.ts
@@ -1,6 +1,41 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Chain } from '../rpc/chains'
 
+// Multiple components (contribute modal, onboarding, swap) can mount the hook at
+// once. Share a single in-flight fetch per chain and reuse the last result for a
+// few seconds so we don't fan out identical /api/rpc/gas-price requests.
+const GAS_PRICE_CLIENT_TTL_MS = 10_000
+type GasPricePayload = Record<string, any>
+const gasPriceInFlight = new Map<number, Promise<GasPricePayload>>()
+const gasPriceCache = new Map<number, { data: GasPricePayload; ts: number }>()
+
+async function fetchGasPriceData(chainId: number): Promise<GasPricePayload> {
+  const cached = gasPriceCache.get(chainId)
+  if (cached && Date.now() - cached.ts < GAS_PRICE_CLIENT_TTL_MS) {
+    return cached.data
+  }
+
+  const existing = gasPriceInFlight.get(chainId)
+  if (existing) return existing
+
+  const request = (async () => {
+    const response = await fetch(`/api/rpc/gas-price?chainId=${chainId}`)
+    if (!response.ok) {
+      throw new Error(`API request failed: ${response.status}`)
+    }
+    const data = await response.json()
+    if (data.error) throw new Error(data.error)
+    if (!data.gasPrice) throw new Error('No gas price returned from API')
+    gasPriceCache.set(chainId, { data, ts: Date.now() })
+    return data
+  })().finally(() => {
+    gasPriceInFlight.delete(chainId)
+  })
+
+  gasPriceInFlight.set(chainId, request)
+  return request
+}
+
 type UseGasPriceReturn = {
   gasPrice: bigint
   maxFeePerGas?: bigint // EIP-1559 max fee per gas
@@ -42,22 +77,9 @@ export function useGasPrice(
 
     try {
       // Always use API for consistent fee estimation (matches what wallets display)
-      // Wallet provider's getFeeData() may return inflated values that don't match
-      const response = await fetch(`/api/rpc/gas-price?chainId=${chain.id}`)
-
-      if (!response.ok) {
-        throw new Error(`API request failed: ${response.status}`)
-      }
-
-      const data = await response.json()
-
-      if (data.error) {
-        throw new Error(data.error)
-      }
-
-      if (!data.gasPrice) {
-        throw new Error('No gas price returned from API')
-      }
+      // Wallet provider's getFeeData() may return inflated values that don't match.
+      // Shared/deduped across concurrent hook mounts to avoid redundant requests.
+      const data = await fetchGasPriceData(chain.id)
 
       const baseGasPrice = BigInt(data.gasPrice)
       const gasPriceWithBuffer =

--- a/ui/pages/api/rpc/gas-price.ts
+++ b/ui/pages/api/rpc/gas-price.ts
@@ -1,10 +1,16 @@
 import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { cacheGet, cacheSet } from '@/lib/rpc/rpcCache'
 import {
   isSupportedRpcChain,
   jsonRpcWithFallback,
 } from '@/lib/rpc/serverJsonRpc'
+
+// Gas prices drift slowly relative to a page's lifetime; a short cache collapses
+// the 3 upstream calls (eth_gasPrice, eth_getBlockByNumber, eth_maxPriorityFeePerGas)
+// this endpoint makes down to one set per window across every visitor.
+const GAS_PRICE_CACHE_TTL_MS = 12_000
 
 type GasPriceResponse = {
   gasPrice: string // in wei (hex string)
@@ -53,6 +59,18 @@ export async function handler(
       chainId: chainIdNum,
       error: `Unsupported chain ID: ${chainId}`,
     })
+  }
+
+  // Let the CDN serve repeat hits without waking the function at all.
+  res.setHeader(
+    'Cache-Control',
+    's-maxage=12, stale-while-revalidate=30'
+  )
+
+  const cacheKey = `rpc:gasprice:${chainIdNum}`
+  const cached = (await cacheGet(cacheKey)) as GasPriceResponse | undefined
+  if (cached) {
+    return res.status(200).json(cached)
   }
 
   try {
@@ -125,6 +143,7 @@ export async function handler(
       response.baseFeePerGasGwei = (Number(baseFeePerGas) / 1e9).toFixed(2)
     }
 
+    void cacheSet(cacheKey, response, GAS_PRICE_CACHE_TTL_MS)
     return res.status(200).json(response)
   } catch (error) {
     console.error(


### PR DESCRIPTION
## Summary
Daily Infura usage is dominated by `eth_call` (+ batched reads), with `eth_getBlockByNumber`, `eth_gasPrice`, and `eth_maxPriorityFeePerGas` making up the rest. Today every browser read is proxied straight to Infura and the gas-price endpoint fires **three** uncached upstream calls on every request. This PR adds a shared, fail-open cache to collapse duplicate reads across all visitors.

- **New `lib/rpc/rpcCache.ts`** — Upstash Redis cache with a bounded in-memory fallback. Fully fails open (Redis slow/unavailable → correct uncached response); guarded with a 1.5s timeout on every Redis round-trip.
- **`/api/rpc/[chainId]` proxy** — now serves idempotent reads (`eth_call`, `eth_getBalance`/`Code`/`StorageAt`, `eth_getBlockByNumber`/`ByHash`, `eth_chainId`, `net_version`) from cache. Batches are split so cached and uncached sub-calls are handled independently and re-merged in order. `latest`/`safe`/`finalized` reads use a ~3s TTL; block-number/hash-pinned and chain-identity reads are treated as immutable (5 min). Anything mutating or mempool-dependent (`pending`, `eth_estimateGas`, `eth_getTransactionCount`, `eth_sendRawTransaction`, receipts, …) is never cached.
- **`/api/rpc/gas-price`** — caches its computed response (~12s) and sets `Cache-Control: s-maxage=12, stale-while-revalidate=30` so the CDN can serve repeats without waking the function. This collapses `eth_gasPrice` + `eth_getBlockByNumber` + `eth_maxPriorityFeePerGas` to ~one set per window across all users.
- **`useGasPrice`** — dedupes concurrent hook mounts client-side (shared in-flight promise + short client cache), so multiple components don't each hit the endpoint.

Tunable via `RPC_CACHE_TTL_MS`; fully disableable via `RPC_CACHE_DISABLED=true`.

## Test plan
- [ ] Dashboard / mission pages load correctly (balances, hats, fee hook reads) with cache enabled.
- [ ] Contribute / onboarding / swap flows still show correct gas estimates.
- [ ] Post-transaction balances refresh within the expected window (≤ ~3s stale).
- [ ] Confirm reduced Infura credit usage for `eth_call`, `eth_getBlockByNumber`, `eth_gasPrice`, `eth_maxPriorityFeePerGas`.
- [ ] Verify graceful behavior with Upstash unavailable (`RPC_CACHE_DISABLED=true` or bad creds) — reads still succeed.

Made with [Cursor](https://cursor.com)