### PR TITLE
fix(projects): stop one failed read from blanking every /projects tab

### DIFF
--- a/ui/pages/projects/index.tsx
+++ b/ui/pages/projects/index.tsx
@@ -9,9 +9,7 @@ import {
 } from 'const/config'
 import { BLOCKED_MDPS, BLOCKED_PROJECTS } from 'const/whitelist'
 import { useRouter } from 'next/router'
-import { getContract, readContract } from 'thirdweb'
-import { PROJECT_ACTIVE, PROJECT_ENDED, PROJECT_PENDING } from '@/lib/nance/types'
-import { getProposalStatus } from '@/lib/nance/useProposalStatus'
+import { PROJECT_ACTIVE, PROJECT_PENDING } from '@/lib/nance/types'
 import {
   getProjectDisplayName,
   isUntitledLike,
@@ -20,7 +18,6 @@ import {
 import { Project } from '@/lib/project/useProjectData'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
-import { serverClient } from '@/lib/thirdweb/serverClient'
 import { useChainDefault } from '@/lib/thirdweb/hooks/useChainDefault'
 import { getRelativeQuarter, isRewardsCycle } from '@/lib/utils/dates'
 import { ProjectRewards, ProjectRewardsProps } from '@/components/nance/ProjectRewards'
@@ -49,22 +46,36 @@ export default function Projects({
 }
 
 export async function getStaticProps() {
-  try {
-    const chain = DEFAULT_CHAIN_V5
-    const chainSlug = getChainSlug(chain)
+  const chain = DEFAULT_CHAIN_V5
+  const chainSlug = getChainSlug(chain)
 
+  const emptyProps = {
+    proposals: [] as Project[],
+    currentProjects: [] as Project[],
+    pastProjects: [] as Project[],
+    distributions: [] as any[],
+    proposalAllocations: [] as any[],
+  }
+
+  try {
     const { quarter, year } = getRelativeQuarter(
       isRewardsCycle(new Date(), IS_REWARDS_CYCLE) ? -1 : 0
     )
 
-    const projectStatement = `SELECT * FROM ${PROJECT_TABLE_NAMES[chainSlug]}`
-    const projects = (await queryTable(chain, projectStatement)) || []
-    const proposalContract = getContract({
-      client: serverClient,
-      address: PROPOSALS_ADDRESSES[chainSlug],
-      abi: ProposalsABI.abi as any,
-      chain: chain,
-    })
+    // The projects table is the one genuinely required read. If it fails
+    // there is nothing to render, so fall back to the empty state. Every
+    // *other* external dependency below is best-effort and must never be
+    // able to blank the whole page — a single flaky IPFS gateway response
+    // or a temp-check batch-read hiccup previously took down all four tabs
+    // at once because the entire function shared one try/catch.
+    let projects: Project[] = []
+    try {
+      const projectStatement = `SELECT * FROM ${PROJECT_TABLE_NAMES[chainSlug]}`
+      projects = (await queryTable(chain, projectStatement)) || []
+    } catch (error) {
+      console.error('[projects] Failed to load the project table:', error)
+      return { props: emptyProps, revalidate: 60 }
+    }
 
     // The proposals that should appear on /projects are the ones that belong
     // to the *current* calendar quarter — i.e. the cycle that's actively
@@ -77,54 +88,104 @@ export async function getStaticProps() {
     const proposals: Project[] = []
     const currentProjects: Project[] = []
     const pastProjects: Project[] = []
-    const { engineBatchRead } = await import('@/lib/thirdweb/engine')
-    const mdpArgs = projects.map((project: Project) => [project.MDP])
-    const [approveds, faileds] = await Promise.all([
-      engineBatchRead<string>(
-        PROPOSALS_ADDRESSES[chainSlug],
-        'tempCheckApproved',
-        mdpArgs,
-        ProposalsABI.abi,
-        chain.id
-      ),
-      engineBatchRead<string>(
-        PROPOSALS_ADDRESSES[chainSlug],
-        'tempCheckFailed',
-        mdpArgs,
-        ProposalsABI.abi,
-        chain.id
-      ),
-    ])
+
+    const isCurrentPending = (project: Project) =>
+      project.active == PROJECT_PENDING &&
+      project.quarter === activeProposalQuarter.quarter &&
+      project.year === activeProposalQuarter.year &&
+      !BLOCKED_PROJECTS.has(project.id) &&
+      !BLOCKED_MDPS.has(project.MDP)
+
+    // Temp-check (Senate) approval/failure flags are best-effort metadata that
+    // only pending, current-cycle proposals actually consume. Scope the batch
+    // read to just those MDPs instead of every project in the table: reading
+    // all ~N projects in a single multicall is both wasteful and the exact
+    // pattern that tips the Engine call over its size/time limit as the
+    // project count grows — which would otherwise take down the whole page.
+    // If the read fails we simply proceed without Senate flags.
+    const pendingMdps = Array.from(
+      new Set(projects.filter(isCurrentPending).map((p) => p.MDP))
+    )
+    const tempCheckByMdp = new Map<
+      any,
+      { approved?: string; failed?: string }
+    >()
+    if (pendingMdps.length > 0) {
+      try {
+        const { engineBatchRead } = await import('@/lib/thirdweb/engine')
+        const mdpArgs = pendingMdps.map((mdp) => [mdp])
+        const [approveds, faileds] = await Promise.all([
+          engineBatchRead<string>(
+            PROPOSALS_ADDRESSES[chainSlug],
+            'tempCheckApproved',
+            mdpArgs,
+            ProposalsABI.abi,
+            chain.id
+          ),
+          engineBatchRead<string>(
+            PROPOSALS_ADDRESSES[chainSlug],
+            'tempCheckFailed',
+            mdpArgs,
+            ProposalsABI.abi,
+            chain.id
+          ),
+        ])
+        pendingMdps.forEach((mdp, i) => {
+          tempCheckByMdp.set(mdp, {
+            approved: approveds[i],
+            failed: faileds[i],
+          })
+        })
+      } catch (error) {
+        console.error(
+          '[projects] Temp-check batch read failed; continuing without Senate flags:',
+          error
+        )
+      }
+    }
 
     await Promise.all(
-      projects.map(async (project: Project, index: number) => {
-        if (!BLOCKED_PROJECTS.has(project.id) && !BLOCKED_MDPS.has(project.MDP)) {
-          const activeStatus = project.active
-          if (activeStatus == PROJECT_PENDING
-            && project.quarter === activeProposalQuarter.quarter
-            && project.year === activeProposalQuarter.year
-          ) {
-            if (project.proposalIPFS) {
-              const proposalResponse = await fetch(project.proposalIPFS)
-              const proposalJSON = await proposalResponse.json()
-              if (!proposalJSON?.nonProjectProposal) {
-                // Enrich name from IPFS while we have the JSON in hand
-                if (isUntitledLike(project.name)) {
-                  const resolved = getProjectDisplayName(project, proposalJSON)
-                  if (resolved !== UNTITLED_FALLBACK) project.name = resolved
-                }
-                project.tempCheckApproved = approveds[index]
-                project.tempCheckFailed = faileds[index]
-                if (!faileds[index]) {
-                  proposals.push(project)
-                }
-              }
+      projects.map(async (project: Project) => {
+        if (BLOCKED_PROJECTS.has(project.id) || BLOCKED_MDPS.has(project.MDP)) {
+          return
+        }
+        const activeStatus = project.active
+        if (isCurrentPending(project)) {
+          if (!project.proposalIPFS) return
+          const { approved, failed } = tempCheckByMdp.get(project.MDP) ?? {}
+          try {
+            const proposalResponse = await fetch(project.proposalIPFS)
+            const proposalJSON = await proposalResponse.json()
+            if (proposalJSON?.nonProjectProposal) return
+            // Enrich name from IPFS while we have the JSON in hand
+            if (isUntitledLike(project.name)) {
+              const resolved = getProjectDisplayName(project, proposalJSON)
+              if (resolved !== UNTITLED_FALLBACK) project.name = resolved
             }
-          } else if (activeStatus == PROJECT_ACTIVE) {
-            currentProjects.push(project)
-          } else {
-            pastProjects.push(project)
+            project.tempCheckApproved = approved
+            project.tempCheckFailed = failed
+            if (!failed) {
+              proposals.push(project)
+            }
+          } catch (error) {
+            // A flaky IPFS gateway must not silently drop a live proposal (or,
+            // worse, blank the page). Include it as long as the temp-check
+            // didn't mark it failed; the client-side ProjectCard re-fetches the
+            // JSON for full display.
+            console.warn(
+              `[projects] proposal IPFS fetch failed for MDP ${project.MDP}; including with cached metadata:`,
+              error
+            )
+            project.tempCheckApproved = approved
+            project.tempCheckFailed = failed
+            if (!failed) {
+              proposals.push(project)
+            }
           }
+        } else if (activeStatus == PROJECT_ACTIVE) {
+          currentProjects.push(project)
+        } else {
+          pastProjects.push(project)
         }
       })
     )
@@ -156,8 +217,17 @@ export async function getStaticProps() {
       return a.eligible ? 1 : -1
     })
 
-    const distributionStatement = `SELECT * FROM ${DISTRIBUTION_TABLE_NAMES[chainSlug]} WHERE year = ${year} AND quarter = ${quarter}`
-    const distributions = (await queryTable(chain, distributionStatement)) || []
+    // Distributions + proposal allocations are supporting data for the
+    // retroactive / member-vote tabs. A failure here must not discard the
+    // proposals / projects we already assembled above, so each query gets
+    // its own guard and falls back to an empty array.
+    let distributions: any[] = []
+    try {
+      const distributionStatement = `SELECT * FROM ${DISTRIBUTION_TABLE_NAMES[chainSlug]} WHERE year = ${year} AND quarter = ${quarter}`
+      distributions = (await queryTable(chain, distributionStatement)) || []
+    } catch (error) {
+      console.error('[projects] Failed to load distributions:', error)
+    }
 
     // Proposal allocations (member-vote distributions) are keyed off of the
     // *current* proposal quarter — i.e. the quarter the proposals being
@@ -165,8 +235,13 @@ export async function getStaticProps() {
     // for retroactive payouts. Mixing the two surfaces an old member-vote
     // row from the prior quarter and incorrectly flips the UI into "Edit
     // Distribution" mode.
-    const proposalAllocationStatement = `SELECT * FROM ${PROPOSALS_TABLE_NAMES[chainSlug]} WHERE year = ${activeProposalQuarter.year} AND quarter = ${activeProposalQuarter.quarter}`
-    const proposalAllocations = (await queryTable(chain, proposalAllocationStatement)) || []
+    let proposalAllocations: any[] = []
+    try {
+      const proposalAllocationStatement = `SELECT * FROM ${PROPOSALS_TABLE_NAMES[chainSlug]} WHERE year = ${activeProposalQuarter.year} AND quarter = ${activeProposalQuarter.quarter}`
+      proposalAllocations = (await queryTable(chain, proposalAllocationStatement)) || []
+    } catch (error) {
+      console.error('[projects] Failed to load proposal allocations:', error)
+    }
 
     return {
       props: {
@@ -180,15 +255,6 @@ export async function getStaticProps() {
     }
   } catch (error) {
     console.error('Error fetching projects or distributions:', error)
-    return {
-      props: {
-        proposals: [],
-        currentProjects: [],
-        pastProjects: [],
-        distributions: [],
-        proposalAllocations: [],
-      },
-      revalidate: 60,
-    }
+    return { props: emptyProps, revalidate: 60 }
   }
 }


### PR DESCRIPTION
## Summary
- `/projects` was showing **0** in every tab (Proposals, Active, Retroactive, Past) even though the data is all still on-chain — the rewards figures still rendered because those come from config, not the table.
- Root cause: `getStaticProps` wrapped all of its work in a single `try/catch`, so any one failing dependency dumped the whole page into the empty fallback. The most likely trigger was the Engine multicall reading `tempCheckApproved`/`tempCheckFailed` for **every** project in the table (~149) on each revalidation — an oversized batch that grows with the project count — but a single flaky IPFS proposal fetch inside the `Promise.all` had the same all-or-nothing effect.
- Hardened `getStaticProps` so failures are isolated and the page degrades gracefully:
  - Each external read has its own guard; only a failed project-table query yields the empty state.
  - Scoped the Engine tempCheck batch read to just the current-cycle pending MDPs (keyed by MDP) instead of the entire table — removes the failure mode and is much cheaper.
  - Wrapped the per-proposal IPFS `fetch().json()` so one bad gateway response can't reject the whole batch (proposal still included; client cards re-fetch details).
  - Guarded the trailing distributions / proposal-allocation queries so a failure there can't discard already-assembled proposals and projects.
  - Removed now-dead imports and the unused `proposalContract`.

## Test plan
- [ ] After deploy / next ISR revalidation, `/projects` shows the pending Q3 2026 proposals, active projects, retroactive cohort, and past projects again.
- [ ] Temporarily force the Engine batch read to throw → page still renders proposals/projects (just without Senate approval flags), no blank tabs.
- [ ] Point a proposal at an unreachable IPFS CID → that proposal is still listed and the rest of the page is unaffected.
- [ ] Retroactive / member-vote tabs still load distributions and pre-populate an existing distribution for the connected wallet.

Made with [Cursor](https://cursor.com)