### PR TITLE
Open Q3 2026 Senate vote

### DIFF
--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -678,12 +678,12 @@ export const OVERVIEW_FLIGHT_TERMS_AND_CONDITIONS_DOCS_URL =
 
 // Project System Configuration
 export const PROJECT_SYSTEM_CONFIG = {
-  // Q1 2026 deadline - second Thursday of the quarter
-  submissionDeadline: 'January 15, 2026',
+  // Q3 2026 deadline - second Thursday of the quarter
+  submissionDeadline: 'July 9, 2026',
   // Approval timeline details
   senateReviewDays: 1, // Senate reviews the day after submission
-  editingDeadline: 'January 22, 2026', // 48 hours before third Thursday
-  votingDate: 'January 22, 2026', // Third Thursday of quarter
+  editingDeadline: 'July 14, 2026', // 48 hours before third Thursday
+  votingDate: 'July 16, 2026', // Third Thursday of quarter
   // Submission link
   submissionUrl: 'https://moondao.com/propose',
   // Documentation link
@@ -695,7 +695,7 @@ export const PROJECT_SYSTEM_CONFIG = {
 // Set IS_SENATE_VOTE to true during Senate Vote phase - shows proposals with "Temperature Check" status
 // Set IS_MEMBER_VOTE to true during Member Vote phase - shows proposals with "Voting" status (passed Senate vote)
 // Only one should be true at a time, or both false when no voting is active
-export const IS_SENATE_VOTE = false
+export const IS_SENATE_VOTE = true
 export const IS_MEMBER_VOTE = false
 
 // When false, the Member Vote phase is still on (results panel, "Member
@@ -713,11 +713,8 @@ export const MEMBER_VOTE_SUBMISSIONS_OPEN = false
 // row stays in the proposals table for the audit trail, it just
 // doesn't count toward the outcome.
 //
-// Q2 2026:
-//   - 0x47cc...be05 (e-Cat) excluded by EB decision.
-export const MEMBER_VOTE_EXCLUDED_ADDRESSES: string[] = [
-  '0x47cc4c7fef42187f9f7901838f316b033e92be05',
-]
+// Q3 2026: no disqualifications yet.
+export const MEMBER_VOTE_EXCLUDED_ADDRESSES: string[] = []
 
 // Set IS_REWARDS_CYCLE to true during the retroactive rewards distribution
 // window. When true, the projects page treats the prior quarter as the active
@@ -727,7 +724,8 @@ export const IS_REWARDS_CYCLE = false
 // Quarterly budget in USD (stablecoins)
 // 5% of liquid non-MOONEY assets, denominated in USD
 // See: https://docs.moondao.com/Projects/Project-System#quarterly-rewards
-export const NEXT_QUARTER_BUDGET_USD = 23409
+// Q3 2026: $24,310 → per-proposal max $4,862 (posted in the Senate review pack).
+export const NEXT_QUARTER_BUDGET_USD = 24310
 
 // Alias used by the retroactive rewards system (ProjectRewards.tsx / getPayouts).
 // The 10% community-circle carve-out is handled inside runQuadraticVoting


### PR DESCRIPTION
## Summary
Opens the **Senate vote** for the Q3 2026 project cycle. Senators can now cast temperature-check (👍/👎) votes on the active proposals at `/projects`.

All changes are in `ui/const/config.ts`:

- **`IS_SENATE_VOTE`** → `true` (enables the Senate Vote UI; `IS_MEMBER_VOTE` and `IS_REWARDS_CYCLE` stay `false`).
- **`PROJECT_SYSTEM_CONFIG`** dates rolled to Q3 2026:
  - Submission deadline: **July 9, 2026** (2nd Thursday)
  - Editing deadline: **July 14, 2026** (48h before 3rd Thursday)
  - Member vote / voting date: **July 16, 2026** (3rd Thursday)
- **`NEXT_QUARTER_BUDGET_USD`** → **$24,310**, giving a per-proposal max of **$4,862** (matches the posted Senate review pack).
- **`MEMBER_VOTE_EXCLUDED_ADDRESSES`** reset to `[]` for the new cycle.

## How proposals are selected
There is no hard-coded proposal list. Active proposals surface dynamically in `pages/projects/index.tsx` from the current calendar quarter's Tableland rows where `active == PROJECT_PENDING`, minus anything in `BLOCKED_PROJECTS` / `BLOCKED_MDPS`.

## Please confirm before merge
- [ ] Q3 2026 cycle dates (Jul 9 / Jul 14 / Jul 16) are correct.
- [ ] Quarterly budget of **$24,310** (max $4,862) is the intended figure.
- [ ] No current-cycle MDPs need adding to `BLOCKED_MDPS` in `const/whitelist.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy-time config gates who sees Senate voting UI and the published budget caps; wrong dates or budget would mislead senators and members, but there is no auth or payout logic change in this diff.
> 
> **Overview**
> Flips **`IS_SENATE_VOTE`** to `true` so `/projects` enters the Senate temperature-check phase (👍/👎 on pending proposals). **`IS_MEMBER_VOTE`** and **`IS_REWARDS_CYCLE`** stay off.
> 
> **`PROJECT_SYSTEM_CONFIG`** is rolled forward to **Q3 2026**: submission **July 9**, editing **July 14**, member vote **July 16**. **`NEXT_QUARTER_BUDGET_USD`** moves from **$23,409** to **$24,310** (per-proposal cap via **`MAX_BUDGET_USD`** becomes **$4,862**). **`MEMBER_VOTE_EXCLUDED_ADDRESSES`** is cleared for the new quarter (removes the prior Q2 e-Cat disqualification).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d541a6c5010a436546cbf301fe7d03f4194b199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->