### PR TITLE
fix(proposals): block MDPs 252, 253, 257, 263 from frontend

### DIFF
--- a/ui/const/whitelist.ts
+++ b/ui/const/whitelist.ts
@@ -14,7 +14,7 @@ export const BLOCKED_PROJECTS: any = new Set(
 )
 export const BLOCKED_MDPS: any = new Set(
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
-    ? [229, 243, 246, 247]
+    ? [229, 243, 246, 247, 252, 253, 257, 263]
     : []
 )
 export const BLOCKED_PROPOSALS: any = new Set([221])


### PR DESCRIPTION
## Summary
- Add MDPs **252, 253, 257, 263** to `BLOCKED_MDPS` in `ui/const/whitelist.ts` (mainnet only).
- These are duplicate / withdrawn submissions that should no longer surface.
- `BLOCKED_MDPS` is applied server-side across every proposal surface, so a single-line change hides them from:
  - `/projects` listing (all tabs) — `pages/projects/index.tsx`
  - `/project/<mdp>` detail page (returns not-found) — `pages/project/[tokenId].tsx`
  - `/governance-proposals` — `pages/governance-proposals.tsx`
  - Signed-in dashboard feed — `components/home/SignedInDashboard.tsx`

## Notes
- Server-side only (build-time for ISR pages, request-time for SSR), so blocked proposals never reach the browser.
- `/projects` and `/governance-proposals` use ISR (`revalidate: 60`); trigger a redeploy/revalidation to flush the cache after merge.

## Test plan
- [ ] Deploy to mainnet and confirm MDP 252, 253, 257, 263 no longer appear in `/projects`.
- [ ] Confirm `/project/252` (and 253/257/263) no longer resolve to a proposal.
- [ ] Confirm they are absent from `/governance-proposals` and the dashboard feed.
- [ ] Confirm previously-blocked MDPs (229, 243, 246, 247) remain blocked.

Made with [Cursor](https://cursor.com)