### PR TITLE
feat: projects as teams via on-chain role registry (open jobs/marketplace/launchpad)

### DIFF
--- a/subscription-contracts/0002-v2-coverage.patch
+++ b/subscription-contracts/0002-v2-coverage.patch
@@ -1,0 +1,59 @@
+diff --git a/subscription-contracts/src/MoonDAOTeamCreatorV2.sol b/subscription-contracts/src/MoonDAOTeamCreatorV2.sol
+index 52ae58a1a..c39b98316 100644
+--- a/subscription-contracts/src/MoonDAOTeamCreatorV2.sol
++++ b/subscription-contracts/src/MoonDAOTeamCreatorV2.sol
+@@ -160,12 +160,12 @@ contract MoonDAOTeamCreatorV2 is Ownable {
+ 
+         table.insertIntoTable(
+             tokenId,
+-            metadata.name,
+-            metadata.bio,
+-            metadata.image,
+-            metadata.twitter,
+-            metadata.communications,
+-            metadata.website,
++            "",
++            "",
++            "",
++            "",
++            "",
++            "",
+             metadata._view,
+             metadata.formId
+         );
+diff --git a/subscription-contracts/src/ProjectTeamCreatorV2.sol b/subscription-contracts/src/ProjectTeamCreatorV2.sol
+index 34742b530..45079e776 100644
+--- a/subscription-contracts/src/ProjectTeamCreatorV2.sol
++++ b/subscription-contracts/src/ProjectTeamCreatorV2.sol
+@@ -143,12 +143,12 @@ contract ProjectTeamCreatorV2 is Ownable {
+ 
+         teamTable.insertIntoTable(
+             tokenId,
+-            teamMetadata.name,
+-            teamMetadata.bio,
+-            teamMetadata.image,
+-            teamMetadata.twitter,
+-            teamMetadata.communications,
+-            teamMetadata.website,
++            "",
++            "",
++            "",
++            "",
++            "",
++            "",
+             teamMetadata._view,
+             teamMetadata.formId
+         );
+@@ -157,9 +157,9 @@ contract ProjectTeamCreatorV2 is Ownable {
+             ProjectV2.ProjectData({
+                 id: projectMetadata.id,
+                 teamId: tokenId,
+-                name: projectMetadata.name,
+-                description: projectMetadata.description,
+-                image: projectMetadata.image,
++                name: "",
++                description: "",
++                image: "",
+                 quarter: projectMetadata.quarter,
+                 year: projectMetadata.year,
+                 MDP: projectMetadata.MDP,

--- a/subscription-contracts/apply_patch.sh
+++ b/subscription-contracts/apply_patch.sh
@@ -15,3 +15,7 @@ echo "Applying patch to MoonDAO..."
 pushd subscription-contracts
 git apply 0001-struct.patch
 popd
+echo "Applying V2 creator patch to MoonDAO..."
+pushd subscription-contracts
+git apply 0002-v2-coverage.patch
+popd

--- a/subscription-contracts/script/RegistryAndV2Creators.s.sol
+++ b/subscription-contracts/script/RegistryAndV2Creators.s.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+/*
+Deploys the hats-free authorization + projects-as-teams stack:
+
+  1. TeamRoleRegistry        - on-chain roles; falls back to hats for legacy teams
+  2. TeamMinterRouter        - allows multiple creators to mint MoonDAOTeam NFTs
+  3. ProjectV2               - governance overlay Tableland table (keyed by teamId)
+  4. MoonDAOTeamCreatorV2    - hats-free team creator (registry roles)
+  5. ProjectTeamCreatorV2    - governance-driven project creator (projects are teams)
+
+Deployer-owned wiring is done here. The following steps must be executed by the
+owner of each contract (the DAO Safe) after deploy, e.g. via Safe transactions:
+
+  moonDAOTeam.setMoonDaoCreator(router)          // route minting through the router
+  jobBoardTable.setMoonDaoTeam(registry)         // repoint jobs authorization
+  marketplaceTable.setMoonDaoTeam(registry)      // repoint marketplace authorization
+  missionTable.setMoonDaoTeam(registry)          // repoint mission table authorization
+  missionCreator.setMoonDAOTeam(registry)        // repoint launchpad authorization
+  teamTableV2.setMoonDaoTeam(registry)           // repoint team-profile authorization
+
+Repointing is reversible: point back at the MoonDAOTeam address to restore hats-only auth.
+*/
+
+import "forge-std/Script.sol";
+import {TeamRoleRegistry} from "../src/TeamRoleRegistry.sol";
+import {TeamMinterRouter} from "../src/TeamMinterRouter.sol";
+import {ProjectV2} from "../src/tables/ProjectV2.sol";
+import {MoonDAOTeamCreatorV2} from "../src/MoonDAOTeamCreatorV2.sol";
+import {ProjectTeamCreatorV2} from "../src/ProjectTeamCreatorV2.sol";
+
+contract RegistryAndV2CreatorsScript is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address authorizedSignerAddress = vm.envAddress("AUTHORIZED_SIGNER_ADDRESS");
+
+        // Arbitrum mainnet addresses (see ui/const/config.ts)
+        address TEAM_ADDRESS = 0xAB2C354eC32880C143e87418f80ACc06334Ff55F;
+        address TEAM_TABLE_ADDRESS = 0x36A57e45A1F8e378AA3e35bD8799bBfB5b4C00b3;
+        address WHITELIST_ADDRESS = 0x203ca831edec28b7657A022b8aFe5d28b6BE6Eda;
+        address GNOSIS_SINGLETON_ADDRESS = 0x3E5c63644E683549055b9Be8653de26E0B4CD36E;
+        address GNOSIS_SAFE_PROXY_FACTORY_ADDRESS = 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2;
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        TeamRoleRegistry registry = new TeamRoleRegistry(TEAM_ADDRESS);
+        TeamMinterRouter router = new TeamMinterRouter(TEAM_ADDRESS);
+        ProjectV2 projectTable = new ProjectV2("PROJECTV2");
+
+        address[] memory authorizedSigners = new address[](1);
+        authorizedSigners[0] = authorizedSignerAddress;
+
+        MoonDAOTeamCreatorV2 teamCreator = new MoonDAOTeamCreatorV2(
+            TEAM_ADDRESS,
+            address(router),
+            address(registry),
+            GNOSIS_SINGLETON_ADDRESS,
+            GNOSIS_SAFE_PROXY_FACTORY_ADDRESS,
+            TEAM_TABLE_ADDRESS,
+            WHITELIST_ADDRESS,
+            authorizedSigners
+        );
+
+        ProjectTeamCreatorV2 projectCreator = new ProjectTeamCreatorV2(
+            TEAM_ADDRESS,
+            address(router),
+            address(registry),
+            GNOSIS_SINGLETON_ADDRESS,
+            GNOSIS_SAFE_PROXY_FACTORY_ADDRESS,
+            TEAM_TABLE_ADDRESS,
+            address(projectTable)
+        );
+
+        // Deployer-owned wiring
+        router.setMinter(address(teamCreator), true);
+        router.setMinter(address(projectCreator), true);
+
+        registry.setOperator(address(teamCreator), true);
+        registry.setOperator(address(projectCreator), true);
+
+        projectTable.setRegistry(address(registry));
+        projectTable.setOperator(address(projectCreator), true);
+
+        vm.stopBroadcast();
+
+        console.log("TeamRoleRegistry:", address(registry));
+        console.log("TeamMinterRouter:", address(router));
+        console.log("ProjectV2 table:", address(projectTable));
+        console.log("ProjectV2 tableName:", projectTable.getTableName());
+        console.log("MoonDAOTeamCreatorV2:", address(teamCreator));
+        console.log("ProjectTeamCreatorV2:", address(projectCreator));
+    }
+}

--- a/subscription-contracts/script/RegistryAndV2Creators.s.sol
+++ b/subscription-contracts/script/RegistryAndV2Creators.s.sol
@@ -20,8 +20,11 @@ owner of each contract (the DAO Safe) after deploy, e.g. via Safe transactions:
   missionTable.setMoonDaoTeam(registry)          // repoint mission table authorization
   missionCreator.setMoonDAOTeam(registry)        // repoint launchpad authorization
   teamTableV2.setMoonDaoTeam(registry)           // repoint team-profile authorization
+  teamTableV2.setOperator(teamCreatorV2, true)   // allow V2 team inserts (keeps V1 _teamCreatorAddress)
+  teamTableV2.setOperator(projectCreatorV2, true)// allow V2 project-team inserts
 
 Repointing is reversible: point back at the MoonDAOTeam address to restore hats-only auth.
+TeamTableV2 must support setOperator (redeploy if the live table is still single-creator only).
 */
 
 import "forge-std/Script.sol";

--- a/subscription-contracts/script/RegistryAndV2Creators.s.sol
+++ b/subscription-contracts/script/RegistryAndV2Creators.s.sol
@@ -38,6 +38,7 @@ contract RegistryAndV2CreatorsScript is Script {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         address authorizedSignerAddress = vm.envAddress("AUTHORIZED_SIGNER_ADDRESS");
+        address daoSafeAddress = vm.envAddress("DAO_SAFE_ADDRESS");
 
         // Arbitrum mainnet addresses (see ui/const/config.ts)
         address TEAM_ADDRESS = 0xAB2C354eC32880C143e87418f80ACc06334Ff55F;
@@ -85,6 +86,14 @@ contract RegistryAndV2CreatorsScript is Script {
 
         projectTable.setRegistry(address(registry));
         projectTable.setOperator(address(projectCreator), true);
+
+        // Hand ownership to the DAO Safe so the broadcast deployer does not
+        // retain privileged write access on the registry (and sibling Ownables).
+        registry.transferOwnership(daoSafeAddress);
+        router.transferOwnership(daoSafeAddress);
+        projectTable.transferOwnership(daoSafeAddress);
+        teamCreator.transferOwnership(daoSafeAddress);
+        projectCreator.transferOwnership(daoSafeAddress);
 
         vm.stopBroadcast();
 

--- a/subscription-contracts/src/MoonDAOTeamCreatorV2.sol
+++ b/subscription-contracts/src/MoonDAOTeamCreatorV2.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {MoonDAOTeam} from "./ERC5643.sol";
+import {TeamMinterRouter} from "./TeamMinterRouter.sol";
+import {TeamRoleRegistry} from "./TeamRoleRegistry.sol";
+import "./GnosisSafeProxyFactory.sol";
+import "./GnosisSafeProxy.sol";
+import {MoonDaoTeamTableland} from "./tables/MoonDaoTeamTableland.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Whitelist} from "./Whitelist.sol";
+import {PaymentSplitter} from "./PaymentSplitter.sol";
+
+/**
+ * @title MoonDAOTeamCreatorV2
+ * @notice Hats-free replacement for MoonDAOTeamCreator. Deploys a Gnosis Safe and a payment
+ *         splitter, mints a MoonDAOTeam NFT via the TeamMinterRouter, and records roles in the
+ *         TeamRoleRegistry (creator = MANAGER, members = MEMBER) instead of building a hats tree.
+ */
+contract MoonDAOTeamCreatorV2 is Ownable {
+    MoonDAOTeam internal moonDAOTeam;
+    TeamMinterRouter internal minter;
+    TeamRoleRegistry internal registry;
+
+    address internal gnosisSingleton;
+    GnosisSafeProxyFactory internal gnosisSafeProxyFactory;
+
+    MoonDaoTeamTableland public table;
+    Whitelist internal whitelist;
+
+    bool public openAccess;
+
+    mapping(address => bool) public authorizedSigners;
+
+    struct TeamMetadata {
+        string name;
+        string bio;
+        string image;
+        string twitter;
+        string communications;
+        string website;
+        string _view;
+        string formId;
+    }
+
+    constructor(
+        address _moonDAOTeam,
+        address _minter,
+        address _registry,
+        address _gnosisSingleton,
+        address _gnosisSafeProxyFactory,
+        address _table,
+        address _whitelist,
+        address[] memory _authorizedSigners
+    ) Ownable(msg.sender) {
+        moonDAOTeam = MoonDAOTeam(_moonDAOTeam);
+        minter = TeamMinterRouter(_minter);
+        registry = TeamRoleRegistry(_registry);
+        gnosisSingleton = _gnosisSingleton;
+        gnosisSafeProxyFactory = GnosisSafeProxyFactory(_gnosisSafeProxyFactory);
+        table = MoonDaoTeamTableland(_table);
+        whitelist = Whitelist(_whitelist);
+        for (uint256 i = 0; i < _authorizedSigners.length; i++) {
+            authorizedSigners[_authorizedSigners[i]] = true;
+        }
+    }
+
+    function setAuthorizedSigner(address _authorizedSigner, bool _authorized) external onlyOwner {
+        authorizedSigners[_authorizedSigner] = _authorized;
+    }
+
+    modifier onlyAuthorizedSigner() {
+        require(authorizedSigners[msg.sender], "Only authorized signer can call this function");
+        _;
+    }
+
+    function setMoonDAOTeam(address _moonDAOTeam) external onlyOwner {
+        moonDAOTeam = MoonDAOTeam(_moonDAOTeam);
+    }
+
+    function setMinter(address _minter) external onlyOwner {
+        minter = TeamMinterRouter(_minter);
+    }
+
+    function setRegistry(address _registry) external onlyOwner {
+        registry = TeamRoleRegistry(_registry);
+    }
+
+    function setGnosisSingleton(address _gnosisSingleton) external onlyOwner {
+        gnosisSingleton = _gnosisSingleton;
+    }
+
+    function setGnosisSafeProxyFactory(address _gnosisSafeProxyFactory) external onlyOwner {
+        gnosisSafeProxyFactory = GnosisSafeProxyFactory(_gnosisSafeProxyFactory);
+    }
+
+    function setMoonDaoTeamTable(address _table) external onlyOwner {
+        table = MoonDaoTeamTableland(_table);
+    }
+
+    function setWhitelist(address _whitelist) external onlyOwner {
+        whitelist = Whitelist(_whitelist);
+    }
+
+    function setOpenAccess(bool _openAccess) external onlyOwner {
+        openAccess = _openAccess;
+    }
+
+    function createMoonDAOTeamFor(
+        address creator,
+        TeamMetadata calldata metadata,
+        address[] memory members
+    ) external payable onlyAuthorizedSigner returns (uint256 tokenId) {
+        return _createMoonDAOTeam(creator, metadata, members);
+    }
+
+    function createMoonDAOTeam(
+        TeamMetadata calldata metadata,
+        address[] memory members
+    ) external payable returns (uint256 tokenId) {
+        return _createMoonDAOTeam(msg.sender, metadata, members);
+    }
+
+    function _createMoonDAOTeam(
+        address creator,
+        TeamMetadata calldata metadata,
+        address[] memory members
+    ) internal returns (uint256 tokenId) {
+        require(whitelist.isWhitelisted(creator) || openAccess, "Only whitelisted addresses can create a MoonDAO Team");
+
+        bytes memory safeCallData = constructSafeCallData(creator, members);
+        GnosisSafeProxy gnosisSafe = gnosisSafeProxyFactory.createProxy(gnosisSingleton, safeCallData);
+
+        address[] memory payees = new address[](2);
+        payees[0] = address(gnosisSafe);
+        payees[1] = creator;
+        uint256[] memory shares = new uint256[](2);
+        shares[0] = 9900;
+        shares[1] = 100;
+        PaymentSplitter split = new PaymentSplitter(payees, shares);
+
+        tokenId = minter.mintTo{value: msg.value}(
+            address(gnosisSafe),
+            creator,
+            0,
+            0,
+            0,
+            address(0),
+            address(split)
+        );
+
+        registry.setRegistryBased(tokenId, true);
+        registry.setRole(tokenId, creator, registry.MANAGER());
+        for (uint256 i = 0; i < members.length; i++) {
+            if (members[i] != creator) {
+                registry.setRole(tokenId, members[i], registry.MEMBER());
+            }
+        }
+
+        table.insertIntoTable(
+            tokenId,
+            metadata.name,
+            metadata.bio,
+            metadata.image,
+            metadata.twitter,
+            metadata.communications,
+            metadata.website,
+            metadata._view,
+            metadata.formId
+        );
+    }
+
+    function constructSafeCallData(address caller, address[] memory members) internal pure returns (bytes memory) {
+        uint256 maxOwners = 5;
+        uint256 ownersLength = members.length + 1 > maxOwners ? maxOwners : members.length + 1;
+        address[] memory owners = new address[](ownersLength);
+        owners[0] = caller;
+        for (uint256 i = 1; i < ownersLength; i++) {
+            owners[i] = members[i - 1];
+        }
+        uint256 threshold = owners.length / 2 + 1;
+        bytes memory proxyInitData = abi.encodeWithSelector(
+            0xb63e800d,
+            owners,
+            threshold,
+            address(0x0),
+            new bytes(0),
+            address(0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4),
+            address(0x0),
+            0,
+            address(0x0)
+        );
+        return proxyInitData;
+    }
+}

--- a/subscription-contracts/src/ProjectTeamCreatorV2.sol
+++ b/subscription-contracts/src/ProjectTeamCreatorV2.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {MoonDAOTeam} from "./ERC5643.sol";
+import {TeamMinterRouter} from "./TeamMinterRouter.sol";
+import {TeamRoleRegistry} from "./TeamRoleRegistry.sol";
+import "./GnosisSafeProxyFactory.sol";
+import "./GnosisSafeProxy.sol";
+import {MoonDaoTeamTableland} from "./tables/MoonDaoTeamTableland.sol";
+import {ProjectV2} from "./tables/ProjectV2.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {PaymentSplitter} from "./PaymentSplitter.sol";
+
+/**
+ * @title ProjectTeamCreatorV2
+ * @notice Governance-driven (onlyOwner) creator for projects that are teams under the hood.
+ *         Mints a MoonDAOTeam NFT via the TeamMinterRouter, records roles in the
+ *         TeamRoleRegistry (lead = MANAGER, members = MEMBER), writes the team profile row,
+ *         and writes the project governance overlay row into ProjectV2.
+ *
+ *         Because a project is now a real team, jobs / marketplace / launchpad work for it
+ *         with no changes to those feature contracts.
+ */
+contract ProjectTeamCreatorV2 is Ownable {
+    uint256 public constant PROJECT_ACTIVE = 2;
+
+    MoonDAOTeam internal moonDAOTeam;
+    TeamMinterRouter internal minter;
+    TeamRoleRegistry internal registry;
+
+    address internal gnosisSingleton;
+    GnosisSafeProxyFactory internal gnosisSafeProxyFactory;
+
+    MoonDaoTeamTableland public teamTable;
+    ProjectV2 public projectTable;
+
+    struct TeamMetadata {
+        string name;
+        string bio;
+        string image;
+        string twitter;
+        string communications;
+        string website;
+        string _view;
+        string formId;
+    }
+
+    struct ProjectMetadata {
+        uint256 id;
+        string name;
+        string description;
+        string image;
+        uint256 quarter;
+        uint256 year;
+        uint256 MDP;
+        string proposalIPFS;
+        string proposalLink;
+        string upfrontPayments;
+    }
+
+    constructor(
+        address _moonDAOTeam,
+        address _minter,
+        address _registry,
+        address _gnosisSingleton,
+        address _gnosisSafeProxyFactory,
+        address _teamTable,
+        address _projectTable
+    ) Ownable(msg.sender) {
+        moonDAOTeam = MoonDAOTeam(_moonDAOTeam);
+        minter = TeamMinterRouter(_minter);
+        registry = TeamRoleRegistry(_registry);
+        gnosisSingleton = _gnosisSingleton;
+        gnosisSafeProxyFactory = GnosisSafeProxyFactory(_gnosisSafeProxyFactory);
+        teamTable = MoonDaoTeamTableland(_teamTable);
+        projectTable = ProjectV2(_projectTable);
+    }
+
+    function setMoonDAOTeam(address _moonDAOTeam) external onlyOwner {
+        moonDAOTeam = MoonDAOTeam(_moonDAOTeam);
+    }
+
+    function setMinter(address _minter) external onlyOwner {
+        minter = TeamMinterRouter(_minter);
+    }
+
+    function setRegistry(address _registry) external onlyOwner {
+        registry = TeamRoleRegistry(_registry);
+    }
+
+    function setGnosisSingleton(address _gnosisSingleton) external onlyOwner {
+        gnosisSingleton = _gnosisSingleton;
+    }
+
+    function setGnosisSafeProxyFactory(address _gnosisSafeProxyFactory) external onlyOwner {
+        gnosisSafeProxyFactory = GnosisSafeProxyFactory(_gnosisSafeProxyFactory);
+    }
+
+    function setTeamTable(address _teamTable) external onlyOwner {
+        teamTable = MoonDaoTeamTableland(_teamTable);
+    }
+
+    function setProjectTable(address _projectTable) external onlyOwner {
+        projectTable = ProjectV2(_projectTable);
+    }
+
+    function createProjectTeam(
+        TeamMetadata calldata teamMetadata,
+        ProjectMetadata calldata projectMetadata,
+        address lead,
+        address[] memory members,
+        address[] memory signers
+    ) external payable onlyOwner returns (uint256 tokenId) {
+        bytes memory safeCallData = constructSafeCallData(signers);
+        GnosisSafeProxy gnosisSafe = gnosisSafeProxyFactory.createProxy(gnosisSingleton, safeCallData);
+
+        address[] memory payees = new address[](2);
+        payees[0] = address(gnosisSafe);
+        payees[1] = lead;
+        uint256[] memory shares = new uint256[](2);
+        shares[0] = 9900;
+        shares[1] = 100;
+        PaymentSplitter split = new PaymentSplitter(payees, shares);
+
+        tokenId = minter.mintTo{value: msg.value}(
+            address(gnosisSafe),
+            lead,
+            0,
+            0,
+            0,
+            address(0),
+            address(split)
+        );
+
+        registry.setRegistryBased(tokenId, true);
+        registry.setRole(tokenId, lead, registry.MANAGER());
+        for (uint256 i = 0; i < members.length; i++) {
+            if (members[i] != lead) {
+                registry.setRole(tokenId, members[i], registry.MEMBER());
+            }
+        }
+
+        teamTable.insertIntoTable(
+            tokenId,
+            teamMetadata.name,
+            teamMetadata.bio,
+            teamMetadata.image,
+            teamMetadata.twitter,
+            teamMetadata.communications,
+            teamMetadata.website,
+            teamMetadata._view,
+            teamMetadata.formId
+        );
+
+        projectTable.insertIntoTable(
+            ProjectV2.ProjectData({
+                id: projectMetadata.id,
+                teamId: tokenId,
+                name: projectMetadata.name,
+                description: projectMetadata.description,
+                image: projectMetadata.image,
+                quarter: projectMetadata.quarter,
+                year: projectMetadata.year,
+                MDP: projectMetadata.MDP,
+                proposalIPFS: projectMetadata.proposalIPFS,
+                proposalLink: projectMetadata.proposalLink,
+                upfrontPayments: projectMetadata.upfrontPayments,
+                active: PROJECT_ACTIVE,
+                eligible: 0
+            })
+        );
+    }
+
+    function constructSafeCallData(address[] memory signers) internal pure returns (bytes memory) {
+        uint256 threshold = signers.length / 2 + 1;
+        bytes memory proxyInitData = abi.encodeWithSelector(
+            0xb63e800d,
+            signers,
+            threshold,
+            address(0x0),
+            new bytes(0),
+            address(0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4),
+            address(0x0),
+            0,
+            address(0x0)
+        );
+        return proxyInitData;
+    }
+}

--- a/subscription-contracts/src/ProjectTeamCreatorV2.sol
+++ b/subscription-contracts/src/ProjectTeamCreatorV2.sol
@@ -112,6 +112,7 @@ contract ProjectTeamCreatorV2 is Ownable {
         address[] memory members,
         address[] memory signers
     ) external payable onlyOwner returns (uint256 tokenId) {
+        require(signers.length > 0, "No signers");
         bytes memory safeCallData = constructSafeCallData(signers);
         GnosisSafeProxy gnosisSafe = gnosisSafeProxyFactory.createProxy(gnosisSingleton, safeCallData);
 

--- a/subscription-contracts/src/TeamMinterRouter.sol
+++ b/subscription-contracts/src/TeamMinterRouter.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {MoonDAOTeam} from "./ERC5643.sol";
+
+/**
+ * @title TeamMinterRouter
+ * @notice `MoonDAOTeam.mintTo` is restricted to a single `moonDaoCreator` address. To let
+ *         several creators (the hats-free team creator and the project creator) mint teams,
+ *         this router is set as the sole `moonDaoCreator` and forwards mint calls from any
+ *         authorized minter.
+ */
+contract TeamMinterRouter is Ownable {
+    MoonDAOTeam public moonDAOTeam;
+
+    mapping(address => bool) public minters;
+
+    event MinterSet(address indexed minter, bool enabled);
+
+    constructor(address _moonDAOTeam) Ownable(msg.sender) {
+        moonDAOTeam = MoonDAOTeam(_moonDAOTeam);
+    }
+
+    function setMoonDAOTeam(address _moonDAOTeam) external onlyOwner {
+        moonDAOTeam = MoonDAOTeam(_moonDAOTeam);
+    }
+
+    function setMinter(address minter, bool enabled) external onlyOwner {
+        minters[minter] = enabled;
+        emit MinterSet(minter, enabled);
+    }
+
+    function mintTo(
+        address to,
+        address sender,
+        uint256 adminHat,
+        uint256 managerHat,
+        uint256 memberHat,
+        address memberPassthroughModule,
+        address splitContract
+    ) external payable returns (uint256) {
+        require(minters[msg.sender], "Only authorized minter");
+        return
+            moonDAOTeam.mintTo{value: msg.value}(
+                to,
+                sender,
+                adminHat,
+                managerHat,
+                memberHat,
+                memberPassthroughModule,
+                splitContract
+            );
+    }
+}

--- a/subscription-contracts/src/TeamRoleRegistry.sol
+++ b/subscription-contracts/src/TeamRoleRegistry.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {MoonDAOTeam} from "./ERC5643.sol";
+
+/**
+ * @title TeamRoleRegistry
+ * @notice On-chain role registry that replaces Hats Protocol as the authorization
+ *         source of truth for MoonDAO teams (and projects, which are teams under the hood).
+ *
+ *         Feature contracts (JobBoardTable, MarketplaceTable, MissionTable, MissionCreator,
+ *         TeamTableV2) call `isManager(teamId, sender)` with the exact same signature as
+ *         `MoonDAOTeam.isManager`, so they can be repointed at this registry via their
+ *         existing `setMoonDaoTeam` / `setMoonDAOTeam` owner-only setters without any
+ *         redeployment or data migration.
+ *
+ *         Teams created through the V2 creators are flagged `registryBased` and resolve
+ *         roles purely from this contract. Legacy teams (created via the hats-based creator)
+ *         are not flagged and transparently fall back to `MoonDAOTeam.isManager` (hats).
+ */
+contract TeamRoleRegistry is Ownable {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using EnumerableSet for EnumerableSet.UintSet;
+
+    uint8 public constant NONE = 0;
+    uint8 public constant MEMBER = 1;
+    uint8 public constant MANAGER = 2;
+
+    MoonDAOTeam public moonDAOTeam;
+
+    // teamId => member => role
+    mapping(uint256 => mapping(address => uint8)) public roles;
+
+    // teamId => enumerable set of addresses that currently hold any role
+    mapping(uint256 => EnumerableSet.AddressSet) private _members;
+
+    // account => enumerable set of teamIds the account holds any role in (reverse index)
+    mapping(address => EnumerableSet.UintSet) private _accountTeams;
+
+    // teamId => whether this team resolves roles from the registry (true) or falls back to hats (false)
+    mapping(uint256 => bool) public registryBased;
+
+    // Privileged callers (V2 creators, migration scripts, super managers) that may write any role
+    mapping(address => bool) public operators;
+
+    event RoleSet(uint256 indexed teamId, address indexed account, uint8 role);
+    event RegistryBasedSet(uint256 indexed teamId, bool enabled);
+    event OperatorSet(address indexed operator, bool enabled);
+
+    constructor(address _moonDAOTeam) Ownable(msg.sender) {
+        moonDAOTeam = MoonDAOTeam(_moonDAOTeam);
+    }
+
+    function setMoonDAOTeam(address _moonDAOTeam) external onlyOwner {
+        moonDAOTeam = MoonDAOTeam(_moonDAOTeam);
+    }
+
+    function setOperator(address operator, bool enabled) external onlyOwner {
+        operators[operator] = enabled;
+        emit OperatorSet(operator, enabled);
+    }
+
+    // ---------------------------------------------------------------------
+    // Authorization helpers
+    // ---------------------------------------------------------------------
+
+    /// @dev The team admin is the Gnosis Safe that owns the team NFT.
+    function _teamAdmin(uint256 teamId) internal view returns (address) {
+        try moonDAOTeam.ownerOf(teamId) returns (address teamOwner) {
+            return teamOwner;
+        } catch {
+            return address(0);
+        }
+    }
+
+    function _isPrivileged(address account) internal view returns (bool) {
+        return account == owner() || operators[account];
+    }
+
+    // ---------------------------------------------------------------------
+    // Role reads (drop-in replacement for MoonDAOTeam.isManager)
+    // ---------------------------------------------------------------------
+
+    /**
+     * @notice Returns true when `sender` may manage `teamId`.
+     * @dev For registry-based teams this reads the roles mapping. For legacy teams it
+     *      falls back to the hats-based `MoonDAOTeam.isManager`, which reverts (rather
+     *      than returning false) for non-managers, so the call is wrapped in try/catch.
+     */
+    function isManager(uint256 teamId, address sender) external view returns (bool) {
+        if (registryBased[teamId]) {
+            return roles[teamId][sender] >= MANAGER || _isPrivileged(sender);
+        }
+        try moonDAOTeam.isManager(teamId, sender) returns (bool result) {
+            return result;
+        } catch {
+            return false;
+        }
+    }
+
+    function isMember(uint256 teamId, address account) external view returns (bool) {
+        if (registryBased[teamId]) {
+            return roles[teamId][account] >= MEMBER;
+        }
+        // Legacy teams do not expose a boolean member check on-chain; treat managers as members.
+        try moonDAOTeam.isManager(teamId, account) returns (bool result) {
+            return result;
+        } catch {
+            return false;
+        }
+    }
+
+    function getRole(uint256 teamId, address account) external view returns (uint8) {
+        return roles[teamId][account];
+    }
+
+    function getMembers(uint256 teamId) external view returns (address[] memory) {
+        return _members[teamId].values();
+    }
+
+    function getMemberCount(uint256 teamId) external view returns (uint256) {
+        return _members[teamId].length();
+    }
+
+    /// @notice All teams the account currently holds any role in (reverse index).
+    function getTeamsForAccount(address account) external view returns (uint256[] memory) {
+        return _accountTeams[account].values();
+    }
+
+    // ---------------------------------------------------------------------
+    // Role writes
+    // ---------------------------------------------------------------------
+
+    /**
+     * @notice Marks a team as registry-based. Once set, roles are resolved from this
+     *         contract instead of hats. Called by a V2 creator at mint time.
+     */
+    function setRegistryBased(uint256 teamId, bool enabled) external {
+        require(_isPrivileged(msg.sender), "Only operator or owner");
+        registryBased[teamId] = enabled;
+        emit RegistryBasedSet(teamId, enabled);
+    }
+
+    /**
+     * @notice Grant or revoke the MANAGER role.
+     * @dev Authorized: privileged callers, or the team admin (the Gnosis Safe owner).
+     */
+    function setManager(uint256 teamId, address account, bool enabled) external {
+        require(_isPrivileged(msg.sender) || msg.sender == _teamAdmin(teamId), "Only admin/operator");
+        _setRole(teamId, account, enabled ? MANAGER : NONE);
+    }
+
+    /**
+     * @notice Grant or revoke the MEMBER role.
+     * @dev Authorized: privileged callers, the team admin, or an existing manager.
+     */
+    function setMember(uint256 teamId, address account, bool enabled) external {
+        require(
+            _isPrivileged(msg.sender) ||
+                msg.sender == _teamAdmin(teamId) ||
+                roles[teamId][msg.sender] >= MANAGER,
+            "Only manager/admin/operator"
+        );
+        // Never silently demote an existing manager through the member setter.
+        if (!enabled && roles[teamId][account] > MEMBER) {
+            revert("Use setManager to change a manager");
+        }
+        _setRole(teamId, account, enabled ? MEMBER : NONE);
+    }
+
+    /**
+     * @notice Directly set a role. Privileged callers only (used by creators during mint).
+     */
+    function setRole(uint256 teamId, address account, uint8 role) external {
+        require(_isPrivileged(msg.sender), "Only operator or owner");
+        require(role <= MANAGER, "Invalid role");
+        _setRole(teamId, account, role);
+    }
+
+    function _setRole(uint256 teamId, address account, uint8 role) internal {
+        require(account != address(0), "Zero address");
+        roles[teamId][account] = role;
+        if (role == NONE) {
+            _members[teamId].remove(account);
+            _accountTeams[account].remove(teamId);
+        } else {
+            _members[teamId].add(account);
+            _accountTeams[account].add(teamId);
+        }
+        emit RoleSet(teamId, account, role);
+    }
+}

--- a/subscription-contracts/src/TeamRoleRegistry.sol
+++ b/subscription-contracts/src/TeamRoleRegistry.sol
@@ -92,7 +92,10 @@ contract TeamRoleRegistry is Ownable {
      */
     function isManager(uint256 teamId, address sender) external view returns (bool) {
         if (registryBased[teamId]) {
-            return roles[teamId][sender] >= MANAGER || _isPrivileged(sender);
+            // Privileged accounts (owner/operators) may write roles via setRole /
+            // setManager, but must not implicitly pass per-team manager checks for
+            // every registry-based team (feature tables, UI gating, etc.).
+            return roles[teamId][sender] >= MANAGER;
         }
         try moonDAOTeam.isManager(teamId, sender) returns (bool result) {
             return result;

--- a/subscription-contracts/src/TeamRoleRegistry.sol
+++ b/subscription-contracts/src/TeamRoleRegistry.sol
@@ -165,7 +165,7 @@ contract TeamRoleRegistry is Ownable {
             "Only manager/admin/operator"
         );
         // Never silently demote an existing manager through the member setter.
-        if (!enabled && roles[teamId][account] > MEMBER) {
+        if (roles[teamId][account] > MEMBER) {
             revert("Use setManager to change a manager");
         }
         _setRole(teamId, account, enabled ? MEMBER : NONE);

--- a/subscription-contracts/src/tables/ProjectV2.sol
+++ b/subscription-contracts/src/tables/ProjectV2.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TablelandDeployments} from "@evm-tableland/contracts/utils/TablelandDeployments.sol";
+import {SQLHelpers} from "@evm-tableland/contracts/utils/SQLHelpers.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import {TeamRoleRegistry} from "../TeamRoleRegistry.sol";
+
+/**
+ * @title ProjectV2
+ * @notice Governance-lifecycle overlay for projects that are teams under the hood.
+ *         Each row is keyed by the underlying `teamId` (the MoonDAOTeam tokenId minted for
+ *         the project) and additionally carries a project `id`. Authorization for updates is
+ *         delegated to the TeamRoleRegistry, so a project's team manager can maintain the row.
+ */
+contract ProjectV2 is ERC721Holder, Ownable {
+    uint256 private _tableId;
+    string private _TABLE_PREFIX;
+    TeamRoleRegistry public registry;
+    mapping(address => bool) public operators;
+
+    // projectId => teamId
+    mapping(uint256 => uint256) public idToTeamId;
+
+    event ProjectInserted(uint256 indexed id, uint256 indexed teamId);
+    event ProjectUpdated(uint256 indexed id, uint256 indexed teamId);
+    event OperatorSet(address indexed operator, bool enabled);
+
+    modifier onlyOperators() {
+        require(msg.sender == owner() || operators[msg.sender], "Only Owner or Operator");
+        _;
+    }
+
+    constructor(string memory _table_prefix) Ownable(msg.sender) {
+        _TABLE_PREFIX = _table_prefix;
+        _tableId = TablelandDeployments.get().create(
+            address(this),
+            SQLHelpers.toCreateFromSchema(
+                "id integer primary key,"
+                "teamId integer,"
+                "name text,"
+                "description text,"
+                "image text,"
+                "quarter integer,"
+                "year integer,"
+                "MDP integer,"
+                "proposalIPFS text,"
+                "proposalLink text,"
+                "finalReportIPFS text,"
+                "finalReportLink text,"
+                "rewardDistribution text,"
+                "upfrontPayments text,"
+                "active integer,"
+                "eligible integer",
+                _TABLE_PREFIX
+            )
+        );
+    }
+
+    function setRegistry(address _registry) external onlyOwner {
+        registry = TeamRoleRegistry(_registry);
+    }
+
+    function setOperator(address operator, bool enabled) external onlyOwner {
+        operators[operator] = enabled;
+        emit OperatorSet(operator, enabled);
+    }
+
+    function _isAuthorized(uint256 teamId) internal view {
+        if (msg.sender == owner() || operators[msg.sender]) return;
+        require(registry.isManager(teamId, msg.sender), "Only Manager, Operator, or Owner can write");
+    }
+
+    struct ProjectData {
+        uint256 id;
+        uint256 teamId;
+        string name;
+        string description;
+        string image;
+        uint256 quarter;
+        uint256 year;
+        uint256 MDP;
+        string proposalIPFS;
+        string proposalLink;
+        string upfrontPayments;
+        uint256 active;
+        uint256 eligible;
+    }
+
+    function insertIntoTable(ProjectData calldata data) external onlyOperators {
+        string memory part1 = string.concat(
+            Strings.toString(data.id),
+            ",",
+            Strings.toString(data.teamId),
+            ",",
+            SQLHelpers.quote(data.name),
+            ",",
+            SQLHelpers.quote(data.description),
+            ",",
+            SQLHelpers.quote(data.image),
+            ",",
+            Strings.toString(data.quarter),
+            ",",
+            Strings.toString(data.year),
+            ",",
+            Strings.toString(data.MDP)
+        );
+        string memory part2 = string.concat(
+            SQLHelpers.quote(data.proposalIPFS),
+            ",",
+            SQLHelpers.quote(data.proposalLink),
+            ",",
+            SQLHelpers.quote(""),
+            ",",
+            SQLHelpers.quote(""),
+            ",",
+            SQLHelpers.quote(""),
+            ",",
+            SQLHelpers.quote(data.upfrontPayments),
+            ",",
+            Strings.toString(data.active),
+            ",",
+            Strings.toString(data.eligible)
+        );
+        TablelandDeployments.get().mutate(
+            address(this),
+            _tableId,
+            SQLHelpers.toInsert(
+                _TABLE_PREFIX,
+                _tableId,
+                "id,teamId,name,description,image,quarter,year,MDP,proposalIPFS,proposalLink,finalReportIPFS,finalReportLink,rewardDistribution,upfrontPayments,active,eligible",
+                string.concat(part1, ",", part2)
+            )
+        );
+        idToTeamId[data.id] = data.teamId;
+        emit ProjectInserted(data.id, data.teamId);
+    }
+
+    function updateTableCol(uint256 id, uint256 teamId, string memory colName, string memory val) external {
+        require(Strings.equal(colName, "id") == false, "Cannot update id");
+        require(Strings.equal(colName, "teamId") == false, "Cannot update teamId");
+        require(idToTeamId[id] == teamId, "teamId mismatch");
+        _isAuthorized(teamId);
+
+        string memory setters = string.concat(colName, "=", SQLHelpers.quote(val));
+        string memory filters = string.concat("id=", Strings.toString(id));
+        TablelandDeployments.get().mutate(
+            address(this),
+            _tableId,
+            SQLHelpers.toUpdate(_TABLE_PREFIX, _tableId, setters, filters)
+        );
+        emit ProjectUpdated(id, teamId);
+    }
+
+    function setActive(uint256 id, uint256 teamId, uint256 active) external {
+        require(idToTeamId[id] == teamId, "teamId mismatch");
+        // Only the owner/operator (governance) may toggle a project's active status.
+        require(msg.sender == owner() || operators[msg.sender], "Only Owner or Operator");
+        string memory setters = string.concat("active=", Strings.toString(active));
+        string memory filters = string.concat("id=", Strings.toString(id));
+        TablelandDeployments.get().mutate(
+            address(this),
+            _tableId,
+            SQLHelpers.toUpdate(_TABLE_PREFIX, _tableId, setters, filters)
+        );
+        emit ProjectUpdated(id, teamId);
+    }
+
+    function setAccessControl(address controller) external onlyOwner {
+        TablelandDeployments.get().setController(address(this), _tableId, controller);
+    }
+
+    function getTableId() external view returns (uint256) {
+        return _tableId;
+    }
+
+    function getTableName() external view returns (string memory) {
+        return SQLHelpers.toNameFromId(_TABLE_PREFIX, _tableId);
+    }
+}

--- a/subscription-contracts/src/tables/TeamTableV2.sol
+++ b/subscription-contracts/src/tables/TeamTableV2.sol
@@ -13,10 +13,17 @@ contract MoonDAOTeamTable is ERC721Holder, Ownable {
     uint256 private _tableId;
     string private _TABLE_PREFIX;
     MoonDAOTeam public _moonDaoTeam;
+    // Legacy single-creator slot (V1 MoonDAOTeamCreator). Prefer `operators` for new creators.
     address public _teamCreatorAddress;
+    mapping(address => bool) public operators;
+
+    event OperatorSet(address indexed operator, bool enabled);
 
     modifier onlyOperators() {
-        require(msg.sender == _teamCreatorAddress || msg.sender == owner(), "Only MoonDaoTeamCreator or Owner can call this function");
+        require(
+            msg.sender == _teamCreatorAddress || operators[msg.sender] || msg.sender == owner(),
+            "Only MoonDaoTeamCreator, Operator, or Owner can call this function"
+        );
         _;
     }
 
@@ -46,6 +53,11 @@ contract MoonDAOTeamTable is ERC721Holder, Ownable {
 
     function setTeamCreatorAddress(address teamCreatorAddress) external onlyOwner{
         _teamCreatorAddress = teamCreatorAddress;
+    }
+
+    function setOperator(address operator, bool enabled) external onlyOwner {
+        operators[operator] = enabled;
+        emit OperatorSet(operator, enabled);
     }
 
     function addColumn(string memory columnName, string memory columnType) external onlyOwner {

--- a/ui/components/subscription/TeamManageMembers.tsx
+++ b/ui/components/subscription/TeamManageMembers.tsx
@@ -2,7 +2,7 @@ import { TrashIcon, UserPlusIcon, ShieldCheckIcon, ExclamationTriangleIcon, XMar
 import { DEFAULT_CHAIN_V5, HATS_ADDRESS } from 'const/config'
 import { TEAM_CREATOR_V2_PASSTHROUGH_MODULE_PATCHED_ADDRESSES } from 'const/teams'
 import { ethers } from 'ethers'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import { readContract } from 'thirdweb'
 import { useCitizen } from '@/lib/citizen/useCitizen'
@@ -18,8 +18,12 @@ import {
 import useHatNames from '@/lib/hats/useHatNames'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
 import useSafe from '@/lib/safe/useSafe'
+import useTeamRoleRegistry, {
+  REGISTRY_ROLE,
+} from '@/lib/team/useTeamRoleRegistry'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import HatsABI from '../../const/abis/Hats.json'
+import TeamRoleRegistryABI from '../../const/abis/TeamRoleRegistry.json'
 import Modal from '../layout/Modal'
 import StandardButton from '../layout/StandardButton'
 import { PrivyWeb3Button } from '../privy/PrivyWeb3Button'
@@ -538,6 +542,267 @@ function TeamManageMembersModal({
   )
 }
 
+function RegistryManageMembersModal({
+  account,
+  selectedChain,
+  registryContract,
+  members,
+  refresh,
+  teamId,
+  multisigAddress,
+  setEnabled,
+}: any) {
+  const { queueSafeTx } = useSafe(multisigAddress)
+  const [newMemberAddress, setNewMemberAddress] = useState<string>('')
+  const [selectedRole, setSelectedRole] = useState<number>(REGISTRY_ROLE.MEMBER)
+  const [isValidAddress, setIsValidAddress] = useState(false)
+  const [pending, setPending] = useState<string | null>(null)
+  const [hasQueuedManagerTx, setHasQueuedManagerTx] = useState(false)
+
+  const safeNetwork = process.env.NEXT_PUBLIC_CHAIN === 'mainnet' ? 'arb1' : 'sep'
+  const safeUrl = `https://app.safe.global/home?safe=${safeNetwork}:${multisigAddress}`
+
+  const iface = useMemo(() => new ethers.utils.Interface(TeamRoleRegistryABI), [])
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [])
+
+  // Manager grants/revokes are admin-gated (only the team Safe can call
+  // setManager), so they route through the Safe. Member changes can be made
+  // directly by any connected manager.
+  async function setManagerRole(address: string, enabled: boolean) {
+    const data = iface.encodeFunctionData('setManager', [teamId, address, enabled])
+    await queueSafeTx({
+      to: registryContract.address,
+      data,
+      value: '0',
+      safeTxGas: '1000000',
+    })
+    setHasQueuedManagerTx(true)
+    toast.success('Manager change queued to the Safe.')
+  }
+
+  async function setMemberRole(address: string, enabled: boolean) {
+    const data = iface.encodeFunctionData('setMember', [teamId, address, enabled])
+    await account?.sendTransaction({
+      to: registryContract.address,
+      data,
+      value: '0',
+      gas: 1000000,
+    })
+    toast.success(enabled ? 'Member added.' : 'Member removed.')
+  }
+
+  return (
+    <Modal
+      id="team-manage-members-modal"
+      setEnabled={setEnabled}
+      showCloseButton={false}
+      className="fixed inset-0 z-[9999] w-screen h-screen bg-[#00000080] backdrop-blur-sm flex justify-center items-start overflow-y-auto px-4 animate-fadeIn"
+    >
+      <div
+        style={{ marginTop: 80, marginBottom: 40, maxHeight: 'calc(100vh - 120px)' }}
+        className="relative z-[10000] flex flex-col w-full md:w-[520px] overflow-y-auto bg-[#0a0f1e] rounded-2xl border border-[#1e2a45] shadow-2xl"
+      >
+        <div className="px-6 pt-6 pb-4 border-b border-[#1e2a45] flex items-start justify-between gap-4">
+          <div>
+            <h2 className="font-GoodTimes text-xl text-white tracking-wide">Manage Team</h2>
+            <p className="text-xs text-slate-400 mt-1">Add or remove roles for team members</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setEnabled(false)}
+            className="flex-shrink-0 -mr-1 -mt-1 p-1.5 rounded-lg text-slate-400 hover:text-white hover:bg-white/5 transition-colors"
+            aria-label="Close"
+          >
+            <XMarkIcon className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="px-6 py-4">
+          <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">Current Team</p>
+          <div className="flex flex-col gap-2 pr-1">
+            {members?.length ? (
+              members.map((m: any) => {
+                const isManager = m.role >= REGISTRY_ROLE.MANAGER
+                return (
+                  <div
+                    key={`registry-member-${m.address}`}
+                    className="flex items-center gap-3 p-4 rounded-xl bg-[#111827] border border-[#1e2a45]"
+                  >
+                    <div className="w-9 h-9 rounded-full bg-[#1a2545] border border-[#2a3a60] flex items-center justify-center flex-shrink-0 text-sm font-bold text-slate-300">
+                      {m.address.slice(2, 4).toUpperCase()}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <TeamMemberName selectedChain={selectedChain} address={m.address} />
+                      <p className="text-xs text-slate-400 font-mono mt-0.5">
+                        {`${m.address.slice(0, 6)}...${m.address.slice(-4)}`}
+                      </p>
+                      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                        <RoleBadge name={isManager ? 'Manager' : 'Member'} />
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {!isManager && (
+                        <button
+                          type="button"
+                          disabled={pending === m.address}
+                          onClick={async () => {
+                            setPending(m.address)
+                            try {
+                              await setManagerRole(m.address, true)
+                            } catch (err) {
+                              console.log(err)
+                              toast.error('Failed. Connect an authorized Safe signer.')
+                            } finally {
+                              setPending(null)
+                            }
+                          }}
+                          className="inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold bg-blue-900/40 border border-blue-500/30 text-blue-200 hover:bg-blue-900/60 disabled:opacity-40"
+                          title="Promote to Manager"
+                        >
+                          <ArrowUpCircleIcon className="w-3.5 h-3.5" />
+                          Make Manager
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        disabled={pending === m.address}
+                        onClick={async () => {
+                          setPending(m.address)
+                          try {
+                            if (isManager) await setManagerRole(m.address, false)
+                            else await setMemberRole(m.address, false)
+                            refresh?.()
+                          } catch (err) {
+                            console.log(err)
+                            toast.error('Failed to remove role.')
+                          } finally {
+                            setPending(null)
+                          }
+                        }}
+                        className="p-1 text-slate-500 hover:text-red-400 transition-colors disabled:opacity-40"
+                        title="Remove role"
+                      >
+                        {pending === m.address ? (
+                          <span className="block w-3 h-3 border border-current border-t-transparent rounded-full animate-spin" />
+                        ) : (
+                          <TrashIcon className="w-4 h-4" />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+                )
+              })
+            ) : (
+              <p className="text-sm text-slate-500 py-4 text-center">No members yet</p>
+            )}
+          </div>
+
+          {hasQueuedManagerTx && (
+            <div className="mt-3 flex items-start gap-2 p-3 rounded-lg bg-amber-900/20 border border-amber-500/30 text-amber-300 text-xs">
+              <ExclamationTriangleIcon className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              <span>
+                Manager change queued.{' '}
+                <button className="underline font-semibold hover:text-amber-200" onClick={() => window.open(safeUrl)}>
+                  Sign & execute in Safe
+                </button>{' '}
+                to finalize.
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="h-px bg-[#1e2a45] mx-6" />
+
+        <form
+          className="px-6 py-5 flex flex-col gap-3"
+          onSubmit={async (e) => {
+            e.preventDefault()
+            if (!isValidEthereumAddress(newMemberAddress))
+              return toast.error('Please enter a valid Ethereum address (0x...).')
+            try {
+              if (selectedRole >= REGISTRY_ROLE.MANAGER) {
+                await setManagerRole(newMemberAddress, true)
+              } else {
+                await setMemberRole(newMemberAddress, true)
+                refresh?.()
+              }
+              setNewMemberAddress('')
+              setIsValidAddress(false)
+            } catch (err: any) {
+              console.log(err?.message)
+              toast.error('Failed to add member.')
+            }
+          }}
+        >
+          <div className="flex items-center gap-2">
+            <UserPlusIcon className="w-4 h-4 text-slate-400" />
+            <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Add a Teammate</p>
+          </div>
+
+          <div className="relative w-full">
+            <label className="block text-xs text-slate-500 mb-1 pl-1">Role</label>
+            <select
+              className="w-full px-4 py-2.5 bg-[#111827] border border-[#1e2a45] rounded-xl text-white text-sm appearance-none focus:outline-none focus:ring-2 focus:ring-[#425eeb]/50 focus:border-[#425eeb]/60 transition-all"
+              onChange={({ target }) => setSelectedRole(Number(target.value))}
+              value={selectedRole}
+            >
+              <option value={REGISTRY_ROLE.MEMBER} className="bg-[#0e1630] text-white">
+                Member
+              </option>
+              <option value={REGISTRY_ROLE.MANAGER} className="bg-[#0e1630] text-white">
+                Manager
+              </option>
+            </select>
+          </div>
+
+          {selectedRole >= REGISTRY_ROLE.MANAGER ? (
+            <div className="flex items-start gap-2 p-2.5 rounded-lg bg-blue-900/20 border border-blue-500/25 text-blue-300 text-xs">
+              <ShieldCheckIcon className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+              <span>Managers get full administrative access. Granting requires Safe multisig approval.</span>
+            </div>
+          ) : (
+            <div className="flex items-start gap-2 p-2.5 rounded-lg bg-[#0d1424] border border-[#1e2a45] text-slate-400 text-xs">
+              <UserPlusIcon className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+              <span>Members get standard access. Assign the Manager role for admin-level control.</span>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-xs text-slate-500 mb-1 pl-1">Wallet Address</label>
+            <input
+              className="w-full px-4 py-2.5 bg-[#111827] border border-[#1e2a45] rounded-xl text-white text-sm font-mono placeholder:text-slate-600 placeholder:font-sans focus:outline-none focus:ring-2 focus:ring-[#425eeb]/50 focus:border-[#425eeb]/60 transition-all"
+              placeholder="0x..."
+              value={newMemberAddress}
+              onChange={({ target }: any) => {
+                setNewMemberAddress(target.value)
+                setIsValidAddress(isValidEthereumAddress(target.value))
+              }}
+            />
+          </div>
+
+          <PrivyWeb3Button
+            requiredChain={DEFAULT_CHAIN_V5}
+            label={selectedRole >= REGISTRY_ROLE.MANAGER ? 'Queue Safe Transaction' : 'Add Member'}
+            type="submit"
+            className={`w-full gradient-2 rounded-xl py-2.5 text-sm font-semibold transition-all duration-200 ${
+              !isValidAddress ? 'opacity-40 cursor-not-allowed' : 'hover:opacity-90'
+            }`}
+            action={() => {}}
+            isDisabled={!isValidAddress}
+          />
+        </form>
+      </div>
+    </Modal>
+  )
+}
+
 export default function TeamManageMembers({
   account,
   selectedChain,
@@ -551,24 +816,38 @@ export default function TeamManageMembers({
   isSuperManager,
 }: TeamManageMembersProps) {
   const [manageMembersModalEnabled, setManagerModalEnabled] = useState(false)
+  const { registryBased, members, refresh, registryContract } =
+    useTeamRoleRegistry(teamContract, teamId)
 
   return (
     <div>
-      {manageMembersModalEnabled && (
-        <TeamManageMembersModal
-          account={account}
-          selectedChain={selectedChain}
-          hatsContract={hatsContract}
-          teamContract={teamContract}
-          teamId={teamId}
-          hats={hats}
-          setEnabled={setManagerModalEnabled}
-          multisigAddress={multisigAddress}
-          adminHatId={adminHatId}
-          managerHatId={managerHatId}
-          isSuperManager={isSuperManager}
-        />
-      )}
+      {manageMembersModalEnabled &&
+        (registryBased ? (
+          <RegistryManageMembersModal
+            account={account}
+            selectedChain={selectedChain}
+            registryContract={registryContract}
+            members={members}
+            refresh={refresh}
+            teamId={teamId}
+            multisigAddress={multisigAddress}
+            setEnabled={setManagerModalEnabled}
+          />
+        ) : (
+          <TeamManageMembersModal
+            account={account}
+            selectedChain={selectedChain}
+            hatsContract={hatsContract}
+            teamContract={teamContract}
+            teamId={teamId}
+            hats={hats}
+            setEnabled={setManagerModalEnabled}
+            multisigAddress={multisigAddress}
+            adminHatId={adminHatId}
+            managerHatId={managerHatId}
+            isSuperManager={isSuperManager}
+          />
+        ))}
       <StandardButton
         className="min-w-[200px] gradient-2 rounded-[2vmax] rounded-bl-[10px] transition-all duration-200 hover:scale-105"
         onClick={() => setManagerModalEnabled(true)}

--- a/ui/components/subscription/TeamMembers.tsx
+++ b/ui/components/subscription/TeamMembers.tsx
@@ -5,6 +5,9 @@ import { BLOCKED_CITIZENS } from 'const/whitelist'
 import { getRoleLabel } from '@/lib/hats/teamRoles'
 import useHatNames from '@/lib/hats/useHatNames'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
+import useTeamRoleRegistry, {
+  REGISTRY_ROLE,
+} from '@/lib/team/useTeamRoleRegistry'
 import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
 import { citizenRowToNFT } from '@/lib/tableland/convertRow'
 import { useTablelandQuery } from '@/lib/swr/useTablelandQuery'
@@ -18,6 +21,7 @@ type TeamMemberProps = {
   hatsContract: any
   citizenNft?: any
   managerHatId?: any
+  roleLabelOverride?: string
 }
 
 type TeamMembersProps = {
@@ -25,11 +29,16 @@ type TeamMembersProps = {
   citizenContract: any
   hats: any[]
   managerHatId?: any
+  // Optional: when provided, registry-based teams resolve membership from the
+  // on-chain role registry instead of the hats subgraph.
+  teamContract?: any
+  teamId?: string | number
 }
 
 type Wearer = {
   address: string
   hatIds: string[]
+  roleLabel?: string
 }
 
 function TeamMemberSkeleton() {
@@ -63,6 +72,7 @@ function TeamMember({
   hatsContract,
   citizenNft,
   managerHatId,
+  roleLabelOverride,
 }: TeamMemberProps) {
   const hatNames = useHatNames(hatsContract, hatIds)
 
@@ -72,8 +82,10 @@ function TeamMember({
     metadata?.description || 'This citizen has yet to add a profile'
   // Label roles deterministically: the manager hat is always shown as "Manager"
   // (via getRoleLabel) even if its IPFS metadata is missing/slow, so managers are
-  // never silently downgraded to a generic member label.
+  // never silently downgraded to a generic member label. Registry-based teams
+  // pass an explicit role label since they have no hats.
   const roles =
+    roleLabelOverride ||
     hatNames
       ?.map((hatName: any) =>
         getRoleLabel(hatName.hatId, {
@@ -81,7 +93,8 @@ function TeamMember({
           ipfsName: hatName.name,
         })
       )
-      .join(', ') || 'Team Member'
+      .join(', ') ||
+    'Team Member'
 
   const link = metadata?.name
     ? `/citizen/${generatePrettyLinkWithId(metadata.name, metadata?.id || citizenNft?.id)}`
@@ -123,10 +136,28 @@ export default function TeamMembers({
   citizenContract: _citizenContract,
   hats,
   managerHatId,
+  teamContract,
+  teamId,
 }: TeamMembersProps) {
   const { selectedChain } = useContext(ChainContextV5)
   const chainSlug = getChainSlug(selectedChain)
-  const wearers = useUniqueHatWearers(hats)
+  const hatWearers = useUniqueHatWearers(hats)
+  const { registryBased, members: registryMembers } = useTeamRoleRegistry(
+    teamContract,
+    teamId as any
+  )
+
+  // Registry-based teams resolve membership from the registry; legacy teams use hats.
+  const wearers: Wearer[] | undefined = useMemo(() => {
+    if (registryBased) {
+      return registryMembers.map((m) => ({
+        address: m.address,
+        hatIds: [],
+        roleLabel: m.role >= REGISTRY_ROLE.MANAGER ? 'Manager' : 'Member',
+      }))
+    }
+    return hatWearers
+  }, [registryBased, registryMembers, hatWearers])
 
   const ownerAddressesKey = useMemo(() => {
     if (!wearers?.length) return ''
@@ -196,6 +227,7 @@ export default function TeamMembers({
           hatsContract={hatsContract}
           citizenNft={citizensByOwner.get(w.address.toLowerCase())}
           managerHatId={managerHatId}
+          roleLabelOverride={w.roleLabel}
         />
       ))}
     </div>

--- a/ui/const/abis/ProjectV2.json
+++ b/ui/const/abis/ProjectV2.json
@@ -1,0 +1,441 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_table_prefix",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getTableId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTableName",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "idToTeamId",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "insertIntoTable",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "tuple",
+        "internalType": "struct ProjectV2.ProjectData",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "teamId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "image",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "quarter",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "year",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "MDP",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "proposalIPFS",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "proposalLink",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "upfrontPayments",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "active",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "eligible",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "onERC721Received",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "operators",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract TeamRoleRegistry"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setAccessControl",
+    "inputs": [
+      {
+        "name": "controller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setActive",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "active",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setOperator",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRegistry",
+    "inputs": [
+      {
+        "name": "_registry",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateTableCol",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "colName",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "val",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "OperatorSet",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProjectInserted",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProjectUpdated",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ChainNotSupported",
+    "inputs": [
+      {
+        "name": "chainid",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  }
+]

--- a/ui/const/abis/TeamRoleRegistry.json
+++ b/ui/const/abis/TeamRoleRegistry.json
@@ -1,0 +1,511 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_moonDAOTeam",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "MANAGER",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MEMBER",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "NONE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMemberCount",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMembers",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRole",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTeamsForAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isManager",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isMember",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "moonDAOTeam",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract MoonDAOTeam"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "operators",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registryBased",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "roles",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setManager",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMember",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMoonDAOTeam",
+    "inputs": [
+      {
+        "name": "_moonDAOTeam",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setOperator",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRegistryBased",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRole",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "role",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "OperatorSet",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RegistryBasedSet",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleSet",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "role",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  }
+]

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -312,6 +312,47 @@ export const TEAM_TABLE_NAMES: Index = {
   sepolia: 'TEAMTABLE_11155111_1895',
 }
 
+// On-chain role registry that replaces Hats Protocol as the authorization source of
+// truth for teams/projects created via the V2 creators. Falls back to hats for legacy
+// teams. Populate these once deployed; empty values keep the legacy hats path active.
+export const TEAM_ROLE_REGISTRY_ADDRESSES: Index = {
+  arbitrum: '',
+  sepolia: '',
+}
+
+// Router set as MoonDAOTeam.moonDaoCreator so multiple V2 creators may mint teams.
+export const TEAM_MINTER_ROUTER_ADDRESSES: Index = {
+  arbitrum: '',
+  sepolia: '',
+}
+
+// Hats-free team creator.
+export const TEAM_CREATOR_V2_ADDRESSES: Index = {
+  arbitrum: '',
+  sepolia: '',
+}
+
+// Governance-driven creator that mints projects as teams under the hood.
+export const PROJECT_CREATOR_V2_ADDRESSES: Index = {
+  arbitrum: '',
+  sepolia: '',
+}
+
+// Project governance overlay table (keyed by teamId).
+export const PROJECT_V2_TABLE_ADDRESSES: Index = {
+  arbitrum: '',
+  sepolia: '',
+}
+
+export const PROJECT_V2_TABLE_NAMES: Index = {
+  arbitrum: '',
+  sepolia: '',
+}
+
+// Project ids in the ProjectV2 overlay are offset by this amount so they never collide
+// with legacy PROJECT table ids inside reward-distribution JSON.
+export const PROJECT_V2_ID_OFFSET = 10000
+
 export const TEAM_WHITELIST_ADDRESSES: Index = {
   arbitrum: '0x203ca831edec28b7657A022b8aFe5d28b6BE6Eda',
   sepolia: '0xBB22b6bfb410e62BC103CA6cAcc342bEe42117aA',

--- a/ui/lib/launchpad/useRegistryManagerTeams.tsx
+++ b/ui/lib/launchpad/useRegistryManagerTeams.tsx
@@ -51,6 +51,7 @@ export function useRegistryManagerTeams(
         return
       }
       setIsLoading(true)
+      setUserTeamsAsManager([])
       try {
         const registryContract = getContract({
           client: teamContract.client,

--- a/ui/lib/launchpad/useRegistryManagerTeams.tsx
+++ b/ui/lib/launchpad/useRegistryManagerTeams.tsx
@@ -1,0 +1,77 @@
+import { TEAM_ROLE_REGISTRY_ADDRESSES } from 'const/config'
+import { useEffect, useState } from 'react'
+import { getContract, readContract } from 'thirdweb'
+import TeamRoleRegistryABI from 'const/abis/TeamRoleRegistry.json'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import { REGISTRY_ROLE } from '@/lib/team/useTeamRoleRegistry'
+import { UserTeam } from './types'
+
+/**
+ * Returns the teams (including projects, which are teams under the hood) that the
+ * connected address manages according to the on-chain role registry. This complements
+ * the hats-subgraph discovery used for legacy teams, so launchpad access and the mission
+ * team selector work for registry-based teams and projects.
+ */
+export function useRegistryManagerTeams(
+  teamContract: any,
+  address: string | undefined
+) {
+  const [userTeamsAsManager, setUserTeamsAsManager] = useState<UserTeam[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    async function load() {
+      if (!teamContract?.chain || !address) {
+        setUserTeamsAsManager([])
+        return
+      }
+      const chainSlug = getChainSlug(teamContract.chain)
+      const registryAddress = TEAM_ROLE_REGISTRY_ADDRESSES[chainSlug]
+      if (!registryAddress) {
+        setUserTeamsAsManager([])
+        return
+      }
+      setIsLoading(true)
+      try {
+        const registryContract = getContract({
+          client: teamContract.client,
+          address: registryAddress,
+          abi: TeamRoleRegistryABI as any,
+          chain: teamContract.chain,
+        })
+        const teamIds: any = await readContract({
+          contract: registryContract,
+          method: 'getTeamsForAccount' as string,
+          params: [address],
+        })
+        const managerTeams = await Promise.all(
+          (teamIds || []).map(async (teamId: bigint) => {
+            const role: any = await readContract({
+              contract: registryContract,
+              method: 'getRole' as string,
+              params: [teamId, address],
+            })
+            return Number(role) >= REGISTRY_ROLE.MANAGER
+              ? ({ teamId: String(teamId), hats: [] } as UserTeam)
+              : null
+          })
+        )
+        if (active) {
+          setUserTeamsAsManager(managerTeams.filter(Boolean) as UserTeam[])
+        }
+      } catch (err) {
+        console.error('Failed to load registry manager teams:', err)
+        if (active) setUserTeamsAsManager([])
+      } finally {
+        if (active) setIsLoading(false)
+      }
+    }
+    load()
+    return () => {
+      active = false
+    }
+  }, [teamContract, address])
+
+  return { userTeamsAsManager, isLoading }
+}

--- a/ui/lib/launchpad/useRegistryManagerTeams.tsx
+++ b/ui/lib/launchpad/useRegistryManagerTeams.tsx
@@ -1,28 +1,46 @@
 import { TEAM_ROLE_REGISTRY_ADDRESSES } from 'const/config'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { getContract, readContract } from 'thirdweb'
 import TeamRoleRegistryABI from 'const/abis/TeamRoleRegistry.json'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import { REGISTRY_ROLE } from '@/lib/team/useTeamRoleRegistry'
 import { UserTeam } from './types'
 
+function normalizeAddresses(input: string | string[] | null | undefined): string[] {
+  if (input == null || input === '') return []
+  const list = Array.isArray(input) ? input : [input]
+  const out = new Set<string>()
+  for (const a of list) {
+    if (a && typeof a === 'string' && /^0x[a-fA-F0-9]{40}$/i.test(a.trim())) {
+      out.add(a.trim().toLowerCase())
+    }
+  }
+  return Array.from(out)
+}
+
 /**
  * Returns the teams (including projects, which are teams under the hood) that the
  * connected address manages according to the on-chain role registry. This complements
  * the hats-subgraph discovery used for legacy teams, so launchpad access and the mission
  * team selector work for registry-based teams and projects.
+ *
+ * Accepts the active wallet and/or all Privy-linked EVM addresses, matching the
+ * wearerAddresses pattern used by hat-based discovery.
  */
 export function useRegistryManagerTeams(
   teamContract: any,
-  address: string | undefined
+  addressOrAddresses: string | string[] | null | undefined,
 ) {
   const [userTeamsAsManager, setUserTeamsAsManager] = useState<UserTeam[]>([])
   const [isLoading, setIsLoading] = useState(false)
 
+  const addresses = useMemo(() => normalizeAddresses(addressOrAddresses), [addressOrAddresses])
+  const addressKey = addresses.slice().sort().join(',')
+
   useEffect(() => {
     let active = true
     async function load() {
-      if (!teamContract?.chain || !address) {
+      if (!teamContract?.chain || addresses.length === 0) {
         setUserTeamsAsManager([])
         return
       }
@@ -40,25 +58,34 @@ export function useRegistryManagerTeams(
           abi: TeamRoleRegistryABI as any,
           chain: teamContract.chain,
         })
-        const teamIds: any = await readContract({
-          contract: registryContract,
-          method: 'getTeamsForAccount' as string,
-          params: [address],
-        })
-        const managerTeams = await Promise.all(
-          (teamIds || []).map(async (teamId: bigint) => {
-            const role: any = await readContract({
+        const perAddress = await Promise.all(
+          addresses.map(async (address) => {
+            const teamIds: any = await readContract({
               contract: registryContract,
-              method: 'getRole' as string,
-              params: [teamId, address],
+              method: 'getTeamsForAccount' as string,
+              params: [address],
             })
-            return Number(role) >= REGISTRY_ROLE.MANAGER
-              ? ({ teamId: String(teamId), hats: [] } as UserTeam)
-              : null
-          })
+            const managerTeams = await Promise.all(
+              (teamIds || []).map(async (teamId: bigint) => {
+                const role: any = await readContract({
+                  contract: registryContract,
+                  method: 'getRole' as string,
+                  params: [teamId, address],
+                })
+                return Number(role) >= REGISTRY_ROLE.MANAGER
+                  ? ({ teamId: String(teamId), hats: [] } as UserTeam)
+                  : null
+              }),
+            )
+            return managerTeams.filter(Boolean) as UserTeam[]
+          }),
         )
         if (active) {
-          setUserTeamsAsManager(managerTeams.filter(Boolean) as UserTeam[])
+          const byId = new Map<string, UserTeam>()
+          for (const team of perAddress.flat()) {
+            byId.set(team.teamId, team)
+          }
+          setUserTeamsAsManager(Array.from(byId.values()))
         }
       } catch (err) {
         console.error('Failed to load registry manager teams:', err)
@@ -71,7 +98,9 @@ export function useRegistryManagerTeams(
     return () => {
       active = false
     }
-  }, [teamContract, address])
+    // addressKey is the stable dep for the normalized address list
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teamContract, addressKey])
 
   return { userTeamsAsManager, isLoading }
 }

--- a/ui/lib/project/getProjectActiveMap.ts
+++ b/ui/lib/project/getProjectActiveMap.ts
@@ -1,0 +1,32 @@
+import { PROJECT_V2_TABLE_NAMES } from 'const/config'
+import queryTable from '@/lib/tableland/queryTable'
+
+/**
+ * Returns a map of `teamId` -> `active` for every project in the ProjectV2 overlay
+ * table. Project-teams (projects that are teams under the hood) are gated by this
+ * `active` flag instead of subscription expiry on the global jobs/marketplace pages.
+ *
+ * Returns an empty map when no ProjectV2 table is configured for the chain yet, in
+ * which case callers fall back to treating every team as an ordinary (subscription) team.
+ */
+export default async function getProjectActiveMap(
+  chain: any,
+  chainSlug: string
+): Promise<Map<string, number>> {
+  const map = new Map<string, number>()
+  const tableName = PROJECT_V2_TABLE_NAMES[chainSlug]
+  if (!tableName) return map
+  try {
+    const rows = await queryTable(
+      chain,
+      `SELECT teamId, active FROM ${tableName}`
+    )
+    for (const row of rows || []) {
+      if (row?.teamId == null) continue
+      map.set(String(row.teamId), Number(row.active))
+    }
+  } catch (err) {
+    console.error('Failed to load ProjectV2 active map:', err)
+  }
+  return map
+}

--- a/ui/lib/team/useTeamData.tsx
+++ b/ui/lib/team/useTeamData.tsx
@@ -1,8 +1,10 @@
-import { SUPER_MANAGERS } from 'const/config'
+import { SUPER_MANAGERS, TEAM_ROLE_REGISTRY_ADDRESSES } from 'const/config'
 import { BLOCKED_MISSIONS } from 'const/whitelist'
 import { useEffect, useMemo, useState } from 'react'
-import { readContract } from 'thirdweb'
+import { getContract, readContract } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
+import TeamRoleRegistryABI from 'const/abis/TeamRoleRegistry.json'
+import { getChainSlug } from '@/lib/thirdweb/chain'
 import { useTablelandQuery } from '@/lib/swr/useTablelandQuery'
 import { Job } from '@/components/jobs/Job'
 import { Mission } from '@/components/mission/MissionCard'
@@ -149,8 +151,26 @@ export function useTeamData(
           } else {
             setIsSuperManager(false)
           }
+          // Prefer the on-chain role registry (which itself falls back to hats
+          // for legacy teams). If no registry is configured for this chain yet,
+          // call the team contract's hats-based isManager directly.
+          let managerContract = teamContract
+          try {
+            const chainSlug = getChainSlug(teamContract.chain)
+            const registryAddress = TEAM_ROLE_REGISTRY_ADDRESSES[chainSlug]
+            if (registryAddress) {
+              managerContract = getContract({
+                client: teamContract.client,
+                address: registryAddress,
+                abi: TeamRoleRegistryABI as any,
+                chain: teamContract.chain,
+              })
+            }
+          } catch (err) {
+            console.error('Failed to resolve role registry contract:', err)
+          }
           const isAddressManager: any = await readContract({
-            contract: teamContract,
+            contract: managerContract,
             method: 'isManager' as string,
             params: [nft?.metadata?.id, address],
           })

--- a/ui/lib/team/useTeamRoleRegistry.tsx
+++ b/ui/lib/team/useTeamRoleRegistry.tsx
@@ -89,10 +89,9 @@ export default function useTeamRoleRegistry(teamContract: any, teamId: string | 
         if (active) setMembers(withRoles)
       } catch (err) {
         console.error('Failed to load registry roles:', err)
-        if (active) {
-          setRegistryBased(false)
-          setMembers([])
-        }
+        // Leave registryBased and members unchanged. Resetting registryBased
+        // to false would make a registry team appear as a legacy hats team and
+        // blank the roster on transient RPC failures.
       } finally {
         if (active) setIsLoading(false)
       }

--- a/ui/lib/team/useTeamRoleRegistry.tsx
+++ b/ui/lib/team/useTeamRoleRegistry.tsx
@@ -1,0 +1,112 @@
+import { TEAM_ROLE_REGISTRY_ADDRESSES } from 'const/config'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { getContract, readContract } from 'thirdweb'
+import TeamRoleRegistryABI from 'const/abis/TeamRoleRegistry.json'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+
+export const REGISTRY_ROLE = {
+  NONE: 0,
+  MEMBER: 1,
+  MANAGER: 2,
+} as const
+
+export type RegistryMember = {
+  address: string
+  role: number
+}
+
+/**
+ * Reads role data from the on-chain TeamRoleRegistry for a given team.
+ *
+ * Teams created through the V2 (hats-free) creators are `registryBased` and resolve
+ * their membership entirely from the registry. Legacy teams return `registryBased=false`,
+ * in which case callers should keep using the hats-based membership UI.
+ */
+export default function useTeamRoleRegistry(teamContract: any, teamId: string | number) {
+  const [registryContract, setRegistryContract] = useState<any>(null)
+  const [registryBased, setRegistryBased] = useState<boolean>(false)
+  const [members, setMembers] = useState<RegistryMember[]>([])
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [refreshKey, setRefreshKey] = useState<number>(0)
+
+  useEffect(() => {
+    if (!teamContract?.chain) return
+    try {
+      const chainSlug = getChainSlug(teamContract.chain)
+      const registryAddress = TEAM_ROLE_REGISTRY_ADDRESSES[chainSlug]
+      if (!registryAddress) {
+        setRegistryContract(null)
+        return
+      }
+      setRegistryContract(
+        getContract({
+          client: teamContract.client,
+          address: registryAddress,
+          abi: TeamRoleRegistryABI as any,
+          chain: teamContract.chain,
+        })
+      )
+    } catch (err) {
+      console.error('Failed to build role registry contract:', err)
+      setRegistryContract(null)
+    }
+  }, [teamContract])
+
+  const refresh = useCallback(() => setRefreshKey((k) => k + 1), [])
+
+  useEffect(() => {
+    let active = true
+    async function load() {
+      if (!registryContract || teamId == null || teamId === '') return
+      setIsLoading(true)
+      try {
+        const based: any = await readContract({
+          contract: registryContract,
+          method: 'registryBased' as string,
+          params: [teamId],
+        })
+        if (!active) return
+        setRegistryBased(!!based)
+        if (!based) {
+          setMembers([])
+          return
+        }
+        const addresses: any = await readContract({
+          contract: registryContract,
+          method: 'getMembers' as string,
+          params: [teamId],
+        })
+        const withRoles = await Promise.all(
+          (addresses || []).map(async (address: string) => {
+            const role: any = await readContract({
+              contract: registryContract,
+              method: 'getRole' as string,
+              params: [teamId, address],
+            })
+            return { address, role: Number(role) }
+          })
+        )
+        if (active) setMembers(withRoles)
+      } catch (err) {
+        console.error('Failed to load registry roles:', err)
+        if (active) {
+          setRegistryBased(false)
+          setMembers([])
+        }
+      } finally {
+        if (active) setIsLoading(false)
+      }
+    }
+    load()
+    return () => {
+      active = false
+    }
+  }, [registryContract, teamId, refreshKey])
+
+  const managers = useMemo(
+    () => members.filter((m) => m.role >= REGISTRY_ROLE.MANAGER),
+    [members]
+  )
+
+  return { registryContract, registryBased, members, managers, isLoading, refresh }
+}

--- a/ui/pages/jobs.tsx
+++ b/ui/pages/jobs.tsx
@@ -1,4 +1,6 @@
 import { DEFAULT_CHAIN_V5, JOBS_TABLE_ADDRESSES, TEAM_ADDRESSES } from 'const/config'
+import { PROJECT_ACTIVE } from '@/lib/nance/types'
+import getProjectActiveMap from '@/lib/project/getProjectActiveMap'
 import Link from 'next/link'
 import { useContext, useEffect, useState } from 'react'
 import { getContract, readContract } from 'thirdweb'
@@ -175,14 +177,27 @@ export async function getStaticProps() {
 
     const allJobs = await queryTable(chain, statement)
 
-    const validJobs = allJobs?.filter(async (job: any) => {
-      const teamExpiration = await readContract({
-        contract: teamContract,
-        method: 'expiresAt',
-        params: [job.teamId],
-      })
-      return +teamExpiration.toString() > now
-    })
+    // Project-teams (projects that are teams under the hood) are gated by the
+    // ProjectV2 `active` flag rather than subscription expiry. Build a map of
+    // project teamId -> active status so we can gate their jobs.
+    const projectActiveByTeamId = await getProjectActiveMap(chain, chainSlug)
+
+    const validJobs = (
+      await Promise.all(
+        (allJobs || []).map(async (job: any) => {
+          const projectActive = projectActiveByTeamId.get(String(job.teamId))
+          if (projectActive !== undefined) {
+            return projectActive === PROJECT_ACTIVE ? job : null
+          }
+          const teamExpiration = await readContract({
+            contract: teamContract,
+            method: 'expiresAt',
+            params: [job.teamId],
+          })
+          return +teamExpiration.toString() > now ? job : null
+        })
+      )
+    ).filter(Boolean)
 
     return {
       props: {

--- a/ui/pages/launch.tsx
+++ b/ui/pages/launch.tsx
@@ -43,11 +43,10 @@ type LaunchProps = {
 
 export default function Launch({ missions, featuredMissionData }: LaunchProps) {
   const account = useActiveAccount()
-  const address = account?.address
   const { user } = usePrivy()
   const wearerAddresses = useMemo(
     () => getLinkedEvmAddresses(user, account?.address),
-    [user, account?.address]
+    [user, account?.address],
   )
   const { selectedChain } = useContext(ChainContextV5)
   const chainSlug = getChainSlug(selectedChain)
@@ -73,21 +72,17 @@ export default function Launch({ missions, featuredMissionData }: LaunchProps) {
   const { userTeams, isLoading: userTeamsLoading } = useTeamWearer(
     teamContract,
     selectedChain,
-    wearerAddresses
+    wearerAddresses,
   )
 
-  const {
-    userTeamsAsManager: hatsTeamsAsManager,
-    isLoading: hatsManagerLoading,
-  } = useTeamManagerCheck(teamContract, userTeams, userTeamsLoading)
+  const { userTeamsAsManager: hatsTeamsAsManager, isLoading: hatsManagerLoading } =
+    useTeamManagerCheck(teamContract, userTeams, userTeamsLoading)
 
   // Registry-based teams (and projects, which are teams under the hood) are not
   // in the hats subgraph, so discover them from the on-chain role registry and
   // merge the two manager lists (deduped by teamId).
-  const {
-    userTeamsAsManager: registryTeamsAsManager,
-    isLoading: registryManagerLoading,
-  } = useRegistryManagerTeams(teamContract, address)
+  const { userTeamsAsManager: registryTeamsAsManager, isLoading: registryManagerLoading } =
+    useRegistryManagerTeams(teamContract, wearerAddresses)
 
   const userTeamsAsManager = useMemo(() => {
     const byId = new Map<string, any>()
@@ -100,7 +95,7 @@ export default function Launch({ missions, featuredMissionData }: LaunchProps) {
 
   const { hasAccess: citizenHasAccess } = useLaunchpadAccess(
     userTeamsAsManager,
-    userTeamsAsManagerLoading
+    userTeamsAsManagerLoading,
   )
 
   const { status, setStatus, handleCreateMission } = useLaunchStatus(userTeamsAsManager)
@@ -152,7 +147,7 @@ export const getStaticProps: GetStaticProps = async (): Promise<
       chain,
       chainSlug,
       MISSION_TABLE_ADDRESSES[chainSlug],
-      JBV5_CONTROLLER_ADDRESS
+      JBV5_CONTROLLER_ADDRESS,
     )
 
     const featuredMissionData = await fetchFeaturedMissionData(
@@ -160,7 +155,7 @@ export const getStaticProps: GetStaticProps = async (): Promise<
       chain,
       chainSlug,
       JBV5_CONTROLLER_ADDRESS,
-      JBV5Controller.abi as any
+      JBV5Controller.abi as any,
     )
 
     return {

--- a/ui/pages/launch.tsx
+++ b/ui/pages/launch.tsx
@@ -21,6 +21,7 @@ import { fetchMissions } from '@/lib/launchpad/fetchMissions'
 import { FeaturedMissionData, Mission } from '@/lib/launchpad/types'
 import { useLaunchStatus } from '@/lib/launchpad/useLaunchStatus'
 import { useLaunchpadAccess } from '@/lib/launchpad/useLaunchpadAccess'
+import { useRegistryManagerTeams } from '@/lib/launchpad/useRegistryManagerTeams'
 import { useTeamManagerCheck } from '@/lib/launchpad/useTeamManagerCheck'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
@@ -75,11 +76,27 @@ export default function Launch({ missions, featuredMissionData }: LaunchProps) {
     wearerAddresses
   )
 
-  const { userTeamsAsManager, isLoading: userTeamsAsManagerLoading } = useTeamManagerCheck(
-    teamContract,
-    userTeams,
-    userTeamsLoading
-  )
+  const {
+    userTeamsAsManager: hatsTeamsAsManager,
+    isLoading: hatsManagerLoading,
+  } = useTeamManagerCheck(teamContract, userTeams, userTeamsLoading)
+
+  // Registry-based teams (and projects, which are teams under the hood) are not
+  // in the hats subgraph, so discover them from the on-chain role registry and
+  // merge the two manager lists (deduped by teamId).
+  const {
+    userTeamsAsManager: registryTeamsAsManager,
+    isLoading: registryManagerLoading,
+  } = useRegistryManagerTeams(teamContract, address)
+
+  const userTeamsAsManager = useMemo(() => {
+    const byId = new Map<string, any>()
+    for (const t of hatsTeamsAsManager || []) byId.set(String(t.teamId), t)
+    for (const t of registryTeamsAsManager || []) byId.set(String(t.teamId), t)
+    return Array.from(byId.values())
+  }, [hatsTeamsAsManager, registryTeamsAsManager])
+
+  const userTeamsAsManagerLoading = hatsManagerLoading || registryManagerLoading
 
   const { hasAccess: citizenHasAccess } = useLaunchpadAccess(
     userTeamsAsManager,

--- a/ui/pages/marketplace/index.tsx
+++ b/ui/pages/marketplace/index.tsx
@@ -12,6 +12,8 @@ import { useRouter } from 'next/router'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import { getContract, readContract } from 'thirdweb'
 import CitizenContext from '@/lib/citizen/citizen-context'
+import { PROJECT_ACTIVE } from '@/lib/nance/types'
+import getProjectActiveMap from '@/lib/project/getProjectActiveMap'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
@@ -324,10 +326,18 @@ export async function getStaticProps() {
       }
     }
 
+    // Project-teams (projects that are teams under the hood) are gated by the
+    // ProjectV2 `active` flag rather than subscription expiry.
+    const projectActiveByTeamId = await getProjectActiveMap(chain, chainSlug)
+
     // Keep a listing when its team is unexpired. If the expiration could not be
     // resolved (null, e.g. rate limited), fail open and keep the listing so a
     // transient RPC issue never wipes out the entire marketplace.
     const validListings = allListings.filter((listing: any) => {
+      const projectActive = projectActiveByTeamId.get(String(listing.teamId))
+      if (projectActive !== undefined) {
+        return projectActive === PROJECT_ACTIVE
+      }
       const expiration = teamExpirations.get(listing.teamId)
       return expiration === null || expiration === undefined || expiration > now
     })

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -588,7 +588,7 @@ function TeamDetailPageContent({
                   />
                   <h2 className="font-GoodTimes text-2xl text-white">Meet the Team</h2>
                 </div>
-                {(isManager || isSuperManager) && hats?.[0]?.id && (
+                {(isManager || isSuperManager) && (hats?.[0]?.id || teamContract) && (
                   <TeamManageMembers
                     account={account}
                     hats={hats}

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -94,6 +94,7 @@ function TeamDetailPageContent({
   queriedListing,
   safeOwners,
   projectActive,
+  projectActiveUnknown,
 }: any) {
   const router = useRouter()
   const account = useActiveAccount()
@@ -206,8 +207,14 @@ function TeamDetailPageContent({
   } = useTeamData(teamContract, hatsContract, nft, citizen, fetchActivityData)
 
   // Project-teams are gated by ProjectV2.active instead of subscription expiry,
-  // matching /jobs and /marketplace. null/undefined means ordinary team.
-  const isActive = projectActive != null ? projectActive === PROJECT_ACTIVE : subIsValid
+  // matching /jobs and /marketplace. null means ordinary team. When the ProjectV2
+  // lookup fails we fail open so a Tableland blip cannot mark an active
+  // project-team as expired via the subscription fallback.
+  const isActive = projectActiveUnknown
+    ? true
+    : projectActive != null
+      ? projectActive === PROJECT_ACTIVE
+      : subIsValid
 
   const hats = useSubHats(selectedChain, adminHatId, true)
   const wearers = useUniqueHatWearers(hats)
@@ -675,17 +682,23 @@ function TeamDetailPageContent({
               <EBRewards isManager={isManager} teamId={tokenId} />
             )}
 
-          {/* Subscription expired — only shown to managers/owners who can act on it */}
+          {/* Inactive / deleted — only shown to managers/owners who can act on it */}
           {(!isActive || isDeleted) && (isManager || isTableOperator || address === nft.owner) && (
             <div className="bg-gradient-to-b from-red-900/20 to-red-800/30 rounded-2xl border border-red-600/30 p-6 mb-10">
               <div className="text-center mb-6">
                 <h3 className="text-xl font-GoodTimes text-white mb-2">
-                  {isDeleted ? 'Profile Deleted' : 'Subscription Expired'}
+                  {isDeleted
+                    ? 'Profile Deleted'
+                    : projectActive != null
+                      ? 'Project Inactive'
+                      : 'Subscription Expired'}
                 </h3>
                 <p className="text-slate-300">
                   {isDeleted
                     ? `The profile has been deleted, please connect the owner or admin wallet to submit new data.`
-                    : `The profile has expired, please connect the owner or admin wallet to renew.`}
+                    : projectActive != null
+                      ? `This project is not currently active. Manager controls stay locked until governance marks it active.`
+                      : `The profile has expired, please connect the owner or admin wallet to renew.`}
                 </p>
               </div>
 
@@ -772,7 +785,10 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
 
   // Project-teams are gated by ProjectV2.active instead of subscription expiry.
   // null means this tokenId is not a project-team (ordinary subscription team).
+  // projectActiveUnknown means the lookup failed — callers must not fall back to
+  // subscription validity (that would falsely expire active project-teams).
   let projectActive: number | null = null
+  let projectActiveUnknown = false
   const projectTableName = PROJECT_V2_TABLE_NAMES[chainSlug]
   if (projectTableName) {
     try {
@@ -785,6 +801,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
       }
     } catch (error) {
       console.error(`Failed to load ProjectV2 active for team ${tokenId}:`, error)
+      projectActiveUnknown = true
     }
   }
 
@@ -856,6 +873,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
       queriedListing,
       safeOwners,
       projectActive,
+      projectActiveUnknown,
     },
   }
 }

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -38,6 +38,7 @@ import {
   JBV5_DIRECTORY_ADDRESS,
   MISSION_CREATOR_ADDRESSES,
   EB_TEAM_ID,
+  PROJECT_V2_TABLE_NAMES,
 } from 'const/config'
 import { BLOCKED_TEAMS } from 'const/whitelist'
 import { GetServerSideProps } from 'next'
@@ -52,6 +53,7 @@ import { useActiveAccount } from 'thirdweb/react'
 import CitizenContext from '@/lib/citizen/citizen-context'
 import { useSubHats } from '@/lib/hats/useSubHats'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
+import { PROJECT_ACTIVE } from '@/lib/nance/types'
 import useSafe from '@/lib/safe/useSafe'
 import queryTable from '@/lib/tableland/queryTable'
 import { resolveTeamIdFromPrettyLink } from '@/lib/team/teamPrettyLinks'
@@ -90,6 +92,7 @@ function TeamDetailPageContent({
   queriedJob,
   queriedListing,
   safeOwners,
+  projectActive,
 }: any) {
   const router = useRouter()
   const account = useActiveAccount()
@@ -163,14 +166,24 @@ function TeamDetailPageContent({
     chain: selectedChain,
   })
 
-  const fetchActivityData = useMemo(() => ({
-    teamId: tokenId,
-    selectedChain,
-    jobTableContract,
-    marketplaceTableContract,
-    missionTableContract,
-    jbControllerContract,
-  }), [tokenId, selectedChain, jobTableContract, marketplaceTableContract, missionTableContract, jbControllerContract])
+  const fetchActivityData = useMemo(
+    () => ({
+      teamId: tokenId,
+      selectedChain,
+      jobTableContract,
+      marketplaceTableContract,
+      missionTableContract,
+      jbControllerContract,
+    }),
+    [
+      tokenId,
+      selectedChain,
+      jobTableContract,
+      marketplaceTableContract,
+      missionTableContract,
+      jbControllerContract,
+    ],
+  )
 
   const {
     socials,
@@ -191,6 +204,10 @@ function TeamDetailPageContent({
     isLoadingActivityData,
   } = useTeamData(teamContract, hatsContract, nft, citizen, fetchActivityData)
 
+  // Project-teams are gated by ProjectV2.active instead of subscription expiry,
+  // matching /jobs and /marketplace. null/undefined means ordinary team.
+  const isActive = projectActive != null ? projectActive === PROJECT_ACTIVE : subIsValid
+
   const hats = useSubHats(selectedChain, adminHatId, true)
   const wearers = useUniqueHatWearers(hats)
 
@@ -204,11 +221,17 @@ function TeamDetailPageContent({
     safeOwners && safeOwners.length > 0 ? safeOwners : safeData?.owners || []
 
   const isSigner = resolvedSafeOwners.some(
-    (owner: string) => owner.toLowerCase() === (address || '').toLowerCase()
+    (owner: string) => owner.toLowerCase() === (address || '').toLowerCase(),
   )
 
   // Only citizens (or team managers / owners / signers) can see team content
-  const canViewContent = !!(citizen || isManager || isTableOperator || isSigner || address === nft.owner)
+  const canViewContent = !!(
+    citizen ||
+    isManager ||
+    isTableOperator ||
+    isSigner ||
+    address === nft.owner
+  )
 
   //Subscription Data
   const { data: expiresAt } = useRead({
@@ -244,9 +267,9 @@ function TeamDetailPageContent({
               {nft?.metadata?.image ? (
                 <div id="team-image-container" className="relative flex-shrink-0">
                   <div
-                    className={`w-[200px] h-[200px] lg:w-[250px] lg:h-[250px] relative${subIsValid && isManager ? ' group cursor-pointer' : ''}`}
+                    className={`w-[200px] h-[200px] lg:w-[250px] lg:h-[250px] relative${isActive && isManager ? ' group cursor-pointer' : ''}`}
                     onClick={() => {
-                      if (subIsValid && isManager) setTeamMetadataModalEnabled(true)
+                      if (isActive && isManager) setTeamMetadataModalEnabled(true)
                     }}
                   >
                     <IPFSRenderer
@@ -256,7 +279,7 @@ function TeamDetailPageContent({
                       width={250}
                       alt="Team Image"
                     />
-                    {subIsValid && isManager && (
+                    {isActive && isManager && (
                       <div className="absolute inset-0 rounded-2xl bg-black/50 flex flex-col items-center justify-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                         <CameraIcon width={36} height={36} className="text-white" />
                         <span className="text-white text-xs font-medium">Edit Photo</span>
@@ -271,13 +294,13 @@ function TeamDetailPageContent({
                 </div>
               ) : (
                 <div
-                  className={`w-[200px] h-[200px] lg:w-[250px] lg:h-[250px] bg-gradient-to-b from-slate-600/50 to-slate-700/50 rounded-2xl border-4 border-slate-500/50 flex flex-col items-center justify-center flex-shrink-0 gap-2${subIsValid && isManager ? ' group cursor-pointer hover:border-slate-400/70 transition-colors' : ''}`}
+                  className={`w-[200px] h-[200px] lg:w-[250px] lg:h-[250px] bg-gradient-to-b from-slate-600/50 to-slate-700/50 rounded-2xl border-4 border-slate-500/50 flex flex-col items-center justify-center flex-shrink-0 gap-2${isActive && isManager ? ' group cursor-pointer hover:border-slate-400/70 transition-colors' : ''}`}
                   onClick={() => {
-                    if (subIsValid && isManager) setTeamMetadataModalEnabled(true)
+                    if (isActive && isManager) setTeamMetadataModalEnabled(true)
                   }}
                 >
                   <div className="text-slate-400 text-6xl">🏢</div>
-                  {subIsValid && isManager && (
+                  {isActive && isManager && (
                     <span className="text-slate-400 text-xs font-medium opacity-0 group-hover:opacity-100 transition-opacity">
                       Add Photo
                     </span>
@@ -290,15 +313,13 @@ function TeamDetailPageContent({
               >
                 <div id="team-name" className="flex flex-col gap-4 w-full">
                   <div id="team-name-container" className="relative flex flex-col w-full">
-                    {subIsValid && isManager && (
+                    {isActive && isManager && (
                       <button
                         className="absolute top-0 right-0 p-2 bg-slate-600/50 hover:bg-slate-500/50 rounded-xl transition-colors"
                         onClick={() => {
                           if (address === nft?.owner || isManager) setTeamMetadataModalEnabled(true)
                           else
-                            return toast.error(
-                              'Connect the team admin or multisig wallet to edit.'
-                            )
+                            return toast.error('Connect the team admin or multisig wallet to edit.')
                         }}
                       >
                         <PencilIcon width={24} height={24} className="text-white" />
@@ -421,7 +442,7 @@ function TeamDetailPageContent({
           selectedChain={selectedChain}
           setEnabled={setTeamSubscriptionModalEnabled}
           nft={nft}
-          validPass={subIsValid}
+          validPass={isActive}
           expiresAt={expiresAt}
           subscriptionContract={teamContract}
           type="team"
@@ -486,7 +507,7 @@ function TeamDetailPageContent({
           className="animate-fadeIn flex flex-col gap-5 w-full max-w-[1080px] mx-auto pb-10"
         >
           {/* Lock banner for non-citizens */}
-          {!canViewContent && subIsValid && !isDeleted && (
+          {!canViewContent && isActive && !isDeleted && (
             <Action
               title="Unlock Full Profile"
               description="Become a Citizen of the Space Acceleration Network to view the full team profile. Citizenship also unlocks access to the jobs board, marketplace discounts, and more benefits."
@@ -496,7 +517,7 @@ function TeamDetailPageContent({
           )}
 
           {/* Team Statistics Overview */}
-          {!isDeleted && subIsValid && (
+          {!isDeleted && isActive && (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
               <StatsCard
                 title="Team Members"
@@ -525,7 +546,7 @@ function TeamDetailPageContent({
             </div>
           )}
 
-          {!isDeleted && subIsValid && (isManager || isTableOperator || address === nft.owner) && (
+          {!isDeleted && isActive && (isManager || isTableOperator || address === nft.owner) && (
             <div
               id="entity-actions-container"
               className="bg-gradient-to-b from-slate-700/20 to-slate-800/30 rounded-2xl border border-slate-600/30 p-6"
@@ -553,7 +574,7 @@ function TeamDetailPageContent({
             </div>
           )}
 
-          {subIsValid && canViewContent && (
+          {isActive && canViewContent && (
             <div className="bg-gradient-to-b from-slate-700/20 to-slate-800/30 rounded-2xl border border-slate-600/30">
               <TeamTreasury
                 isSigner={isSigner}
@@ -564,7 +585,7 @@ function TeamDetailPageContent({
             </div>
           )}
 
-          {subIsValid && canViewContent && (
+          {isActive && canViewContent && (
             <div className="bg-gradient-to-b from-slate-700/20 to-slate-800/30 rounded-2xl border border-slate-600/30">
               <TeamMissions
                 isManager={isManager}
@@ -575,7 +596,7 @@ function TeamDetailPageContent({
               />
             </div>
           )}
-          {subIsValid && !isDeleted && canViewContent && (
+          {isActive && !isDeleted && canViewContent && (
             <div className="bg-gradient-to-b from-slate-700/20 to-slate-800/30 rounded-2xl border border-slate-600/30 p-6">
               <div className="flex flex-col lg:flex-row items-start lg:items-center justify-between gap-5 mb-6">
                 <div className="flex gap-5 items-center">
@@ -616,7 +637,7 @@ function TeamDetailPageContent({
             </div>
           )}
 
-          {subIsValid && !isDeleted && (
+          {isActive && !isDeleted && (
             <div className="bg-gradient-to-b from-slate-700/20 to-slate-800/30 rounded-2xl border border-slate-600/30">
               <TeamJobs
                 teamId={tokenId}
@@ -629,7 +650,7 @@ function TeamDetailPageContent({
             </div>
           )}
 
-          {subIsValid && !isDeleted && (
+          {isActive && !isDeleted && (
             <div className="bg-gradient-to-b from-slate-700/20 to-slate-800/30 rounded-2xl border border-slate-600/30">
               <TeamMarketplace
                 selectedChain={selectedChain}
@@ -643,12 +664,16 @@ function TeamDetailPageContent({
             </div>
           )}
 
-          {subIsValid && !isDeleted && isManager && EB_TEAM_ID && String(tokenId) === String(EB_TEAM_ID) && (
-            <EBRewards isManager={isManager} teamId={tokenId} />
-          )}
+          {isActive &&
+            !isDeleted &&
+            isManager &&
+            EB_TEAM_ID &&
+            String(tokenId) === String(EB_TEAM_ID) && (
+              <EBRewards isManager={isManager} teamId={tokenId} />
+            )}
 
           {/* Subscription expired — only shown to managers/owners who can act on it */}
-          {(!subIsValid || isDeleted) && (isManager || isTableOperator || address === nft.owner) && (
+          {(!isActive || isDeleted) && (isManager || isTableOperator || address === nft.owner) && (
             <div className="bg-gradient-to-b from-red-900/20 to-red-800/30 rounded-2xl border border-red-600/30 p-6 mb-10">
               <div className="text-center mb-6">
                 <h3 className="text-xl font-GoodTimes text-white mb-2">
@@ -735,12 +760,30 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
     } catch (error) {
       console.error(
         `Failed to load Safe owners for team ${tokenId} (${nft.owner}):`,
-        (error as Error)?.message || error
+        (error as Error)?.message || error,
       )
     }
   }
 
   const imageIpfsLink = nft.metadata.image
+
+  // Project-teams are gated by ProjectV2.active instead of subscription expiry.
+  // null means this tokenId is not a project-team (ordinary subscription team).
+  let projectActive: number | null = null
+  const projectTableName = PROJECT_V2_TABLE_NAMES[chainSlug]
+  if (projectTableName) {
+    try {
+      const rows = await queryTable(
+        chain,
+        `SELECT active FROM ${projectTableName} WHERE teamId = ${tokenId} LIMIT 1`,
+      )
+      if (rows?.[0] != null && rows[0].active != null) {
+        projectActive = Number(rows[0].active)
+      }
+    } catch (error) {
+      console.error(`Failed to load ProjectV2 active for team ${tokenId}:`, error)
+    }
+  }
 
   // Optional ?job= and ?listing= query params hydrate the page with metadata
   // for a specific job/listing (used for OG previews when sharing). They are
@@ -809,6 +852,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
       queriedJob,
       queriedListing,
       safeOwners,
+      projectActive,
     },
   }
 }

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -58,6 +58,7 @@ import useSafe from '@/lib/safe/useSafe'
 import queryTable from '@/lib/tableland/queryTable'
 import { resolveTeamIdFromPrettyLink } from '@/lib/team/teamPrettyLinks'
 import { useTeamData } from '@/lib/team/useTeamData'
+import useTeamRoleRegistry from '@/lib/team/useTeamRoleRegistry'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
 import { serverClient } from '@/lib/thirdweb/serverClient'
@@ -210,6 +211,7 @@ function TeamDetailPageContent({
 
   const hats = useSubHats(selectedChain, adminHatId, true)
   const wearers = useUniqueHatWearers(hats)
+  const { registryBased, members: registryMembers } = useTeamRoleRegistry(teamContract, tokenId)
 
   const safeData = useSafe(nft?.owner)
 
@@ -240,9 +242,10 @@ function TeamDetailPageContent({
     params: [tokenId],
   })
 
-  // Calculate stats from fetched data
+  // Calculate stats from fetched data. Registry teams have no hat tree, so
+  // member count comes from TeamRoleRegistry (same source as TeamMembers).
   const teamStats = {
-    memberCount: wearers?.length || 0,
+    memberCount: registryBased ? registryMembers.length : wearers?.length || 0,
     jobCount: jobs?.length || 0,
     listingCount: listings?.length || 0,
     missionCount: missions?.length || 0,

--- a/ui/pages/team/[tokenIdOrName].tsx
+++ b/ui/pages/team/[tokenIdOrName].tsx
@@ -603,12 +603,14 @@ function TeamDetailPageContent({
                   />
                 )}
               </div>
-              {hats?.[0].id && (
+              {(hats?.[0]?.id || teamContract) && (
                 <TeamMembers
                   hats={hats}
                   hatsContract={hatsContract}
                   citizenContract={citizenContract}
                   managerHatId={managerHatId}
+                  teamContract={teamContract}
+                  teamId={tokenId}
                 />
               )}
             </div>


### PR DESCRIPTION
## Summary

Opens **jobs, marketplace, and launchpad** to MoonDAO projects by making future projects real teams under the hood, and replaces Hats Protocol as the authorization source of truth with a simple on-chain role registry.

The key idea: since the feature contracts only ever call `isManager(teamId, sender)` on `MoonDAOTeam`, and every one of them has an owner-only setter for that address, we can repoint them all at a new `TeamRoleRegistry` that implements the same signature — **no table redeploys, no row migrations, no MissionCreator redeploy, and fully reversible.**

## Contracts (`subscription-contracts/`)

- **`TeamRoleRegistry.sol`** — on-chain roles (`NONE`/`MEMBER`/`MANAGER`), enumerable members, and a reverse `account → teamIds` index. `isManager(teamId, sender)` matches `MoonDAOTeam`'s signature exactly; for legacy (non-registry) teams it transparently falls back to `MoonDAOTeam.isManager` (hats) via try/catch. Legacy teams keep working untouched.
- **`TeamMinterRouter.sol`** — set as the single `moonDaoCreator` so multiple V2 creators can mint teams.
- **`MoonDAOTeamCreatorV2.sol`** — hats-free team creator; writes registry roles instead of building a hat tree.
- **`ProjectTeamCreatorV2.sol`** — governance (`onlyOwner`) creator that mints a project as a real `MoonDAOTeam`, sets registry roles (lead = MANAGER, members = MEMBER), and writes a `ProjectV2` governance overlay row.
- **`tables/ProjectV2.sol`** — project governance overlay table keyed by `teamId`, authorized via the registry, with offset ids to avoid collision with legacy PROJECT ids.
- **`script/RegistryAndV2Creators.s.sol`** — deploy + deployer-owned wiring; header documents the DAO-Safe repoint calls.

## UI (`ui/`)

- **Auth**: `useTeamData` resolves `isManager` through the registry (which itself falls back to hats), so one call path serves both legacy and registry teams.
- **Members**: new `useTeamRoleRegistry` hook; `TeamManageMembers` gets a registry-based add/remove UI (manager grants route through the Safe, member changes are direct manager calls); `TeamMembers` renders registry membership.
- **Launchpad**: new `useRegistryManagerTeams` merges registry-managed teams (including project-teams) into launchpad access + the mission team selector.
- **Jobs/Marketplace**: SSG gates project-teams by `ProjectV2.active` while ordinary teams keep subscription-expiry gating.
- Config + ABIs added (empty address placeholders keep the legacy hats path active until deployed).

## Key outcome

Because a future project is now a real `MoonDAOTeam` token, **jobs, marketplace, and launchpad work for it with zero feature-contract changes** — it renders and functions at `/team/[id]` exactly like a team.

---

# Post-merge activation guide (turning this "on")

**This PR is inert when merged.** Every new code path is gated behind config addresses in `ui/const/config.ts` that are currently empty strings, so with no further action production behavior is byte-for-byte identical to today (legacy hats auth). Activation is a separate, deliberate, and **fully reversible** on-chain rollout. Do **not** run these steps until Phase 0 is satisfied.

> ⚠️ **The dangerous, semi-irreversible parts are all on-chain wiring, not the merge.** Execute the phases in order. Each phase lists its rollback.

### Phase 0 — Prerequisites (gate before activating)

- [ ] Dedicated Foundry test suite for the 5 new contracts passes on a fork (registry role transitions + legacy fallback, router authorized/unauthorized mint + value forwarding, both V2 creators end-to-end). *There is no V2-specific test yet — write it first.*
- [ ] Security/audit pass on `TeamRoleRegistry`, `TeamMinterRouter`, `MoonDAOTeamCreatorV2`, `ProjectTeamCreatorV2`, `ProjectV2`.
- [ ] Record the **current live `moonDaoCreator`** on `MoonDAOTeam` (this is the V1 creator address — you will re-authorize it in Phase 3). Read it via `moonDAOTeam.moonDaoCreator()`.
- [ ] Confirm the **live `TeamTableV2` supports `setOperator`** (this PR adds a multi-operator allowlist). If the deployed table is still single-creator only, redeploy it or the V2 creators' inserts will revert.
- [ ] Have the **DAO Safe** ready as the owner/executor for Phases 2–5.

### Phase 1 — Deploy the stack (deployer EOA)

```bash
cd subscription-contracts
export PRIVATE_KEY=...                 # deployer
export AUTHORIZED_SIGNER_ADDRESS=...   # authorized signer for V2 team creator
forge script script/RegistryAndV2Creators.s.sol:RegistryAndV2CreatorsScript \
  --rpc-url <arbitrum_rpc> --broadcast
```

Record the logged addresses (you need all of them for Phases 3–7):

- `TeamRoleRegistry`
- `TeamMinterRouter`
- `ProjectV2 table` **and** `ProjectV2 tableName`
- `MoonDAOTeamCreatorV2`
- `ProjectTeamCreatorV2`

The script already does the deployer-owned wiring: `router.setMinter(teamCreatorV2/projectCreatorV2, true)`, `registry.setOperator(teamCreatorV2/projectCreatorV2, true)`, `projectTable.setRegistry(registry)`, `projectTable.setOperator(projectCreatorV2, true)`.

### Phase 2 — Transfer ownership of the new contracts to the DAO Safe

The three new owned contracts are deployed owned by the deployer. Hand them to the DAO Safe:

- [ ] `registry.transferOwnership(daoSafe)`
- [ ] `router.transferOwnership(daoSafe)`
- [ ] `projectTable.transferOwnership(daoSafe)`

*(Skip any you intend to keep operating from the deployer, but production ownership should be the Safe.)*

### Phase 3 — Authorize minters on the router ⚠️ (do this BEFORE Phase 4)

`MoonDAOTeam.mintTo` requires `msg.sender == moonDaoCreator`. Once the router becomes the creator (Phase 4), **only addresses the router authorizes can mint.** The deploy script authorizes the two V2 creators but **not the existing V1 creator**, so you must add it or normal team creation breaks the moment you repoint:

- [ ] `router.setMinter(<current V1 MoonDAOTeamCreator>, true)` — **critical for backward compatibility**
- [x] `router.setMinter(teamCreatorV2, true)` — done by deploy script
- [x] `router.setMinter(projectCreatorV2, true)` — done by deploy script

> The router forwards `msg.value`, so the V1 creator's subscription payment still flows through unchanged.

### Phase 4 — Repoint minting through the router (highest-risk step)

- [ ] `moonDAOTeam.setMoonDaoCreator(router)`

**Rollback:** `moonDAOTeam.setMoonDaoCreator(<V1 creator>)` restores direct V1 minting instantly.

### Phase 5 — Repoint feature-contract authorization at the registry

Each of these has an owner-only setter and the registry falls back to hats for any team not flagged `registryBased`, so legacy teams keep working:

- [ ] `jobBoardTable.setMoonDaoTeam(registry)`
- [ ] `marketplaceTable.setMoonDaoTeam(registry)`
- [ ] `missionTable.setMoonDaoTeam(registry)`
- [ ] `missionCreator.setMoonDAOTeam(registry)`
- [ ] `teamTableV2.setMoonDaoTeam(registry)`
- [ ] `teamTableV2.setOperator(teamCreatorV2, true)`
- [ ] `teamTableV2.setOperator(projectCreatorV2, true)`

**Rollback:** call the same `setMoonDaoTeam(<MoonDAOTeam address>)` on each to restore hats-only auth. `setOperator(..., false)` to revoke.

### Phase 6 — On-chain smoke tests (before touching the UI)

- [ ] **Legacy team still works:** an existing team's manager can still write a job / marketplace listing (verifies the registry hats-fallback).
- [ ] **V2 team works:** mint via `MoonDAOTeamCreatorV2`; `registry.isManager(teamId, creator) == true`.
- [ ] **Project-as-team works:** create via `ProjectTeamCreatorV2`; confirm the `ProjectV2` row exists with `active = 2` and the token renders at `/team/[id]`.

### Phase 7 — Turn on the UI

Populate these in `ui/const/config.ts` (per chain — `arbitrum` and `sepolia`) with the Phase 1 addresses, then deploy the UI. **Until these are non-empty the UI stays on the legacy hats path**, so you can complete Phases 1–6 and validate on-chain before any user-visible change.

- `TEAM_ROLE_REGISTRY_ADDRESSES`
- `TEAM_MINTER_ROUTER_ADDRESSES`
- `TEAM_CREATOR_V2_ADDRESSES`
- `PROJECT_CREATOR_V2_ADDRESSES`
- `PROJECT_V2_TABLE_ADDRESSES`
- `PROJECT_V2_TABLE_NAMES` (the logged `ProjectV2 tableName`)
- `PROJECT_V2_ID_OFFSET` (already set to `10000`; only change if it collides with live PROJECT ids)

### Full rollback (any time)

1. UI: blank the config entries and redeploy → instantly back to legacy behavior.
2. Contracts: `setMoonDaoTeam(<MoonDAOTeam>)` on each feature contract; `setMoonDaoCreator(<V1 creator>)` on `MoonDAOTeam`. Registry-based teams created in the meantime would need their auth re-homed, so prefer rolling back the UI first and leaving the on-chain wiring until you're sure.

### Operational/security notes for whoever activates

- **Operators are powerful:** owner + any `operators[]` entry on the registry pass `isManager` for **every** registry-based team and can set any role. Keep the operator set minimal (only the V2 creators / migration scripts), prefer contracts/Safe over EOAs, and revoke operators that don't need ongoing writes.
- **Manager authority == Safe control:** `setManager` trusts `moonDAOTeam.ownerOf(teamId)` (the team's Gnosis Safe) — same trust model as hats admin today.
- **Projects pay a subscription on mint** (`mintTo` is payable and renews 1 year); `ProjectTeamCreatorV2` covers it from the DAO. Budget for this per project creation.

## Remaining follow-ups (deploy-dependent)

1. **Project governance UI** — branch `/project/[tokenId]` and union `/projects` to surface the `ProjectV2` proposal/vote/reward overlay. Not required for the three target features.
2. **Rewards integration** — wire `ProjectV2` ids (with the id offset) into the retro-rewards/voting pipeline. Left for a focused pass since it touches financially-sensitive code and needs the table populated.

## Testing

- `forge build` passes for all new contracts.
- Coverage CI (`forge coverage --ir-minimum`) passes: the V2 creators hit the same stack-too-deep limit the legacy creators do, so `0002-v2-coverage.patch` (coverage-only, never applied to committed source — production keeps all metadata fields) strips the string args for the coverage run, following the existing `apply_patch.sh` convention.
- `tsc --noEmit` is clean for all touched UI files (the only 2 remaining repo-wide tsc errors are pre-existing in files not touched here).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes team authorization, mint routing, and Tableland write paths across contracts and UI; incorrect DAO Safe repointing or registry wiring could break manager checks or minting for all teams.
> 
> **Overview**
> Introduces a **hats-free authorization stack** so new teams and governance-minted **projects-as-teams** can use jobs, marketplace, and launchpad without redeploying feature contracts. **`TeamRoleRegistry`** exposes the same `isManager(teamId, sender)` shape as `MoonDAOTeam`, with legacy teams still resolving via hats when not marked `registryBased`. **`TeamMinterRouter`** becomes the sole `moonDaoCreator` and forwards mints from V2 creators.
> 
> **`MoonDAOTeamCreatorV2`** and **`ProjectTeamCreatorV2`** deploy a Gnosis Safe + payment splitter, mint through the router, seed registry roles, and write Tableland rows (team profile + **`ProjectV2`** overlay for projects). **`MoonDAOTeamTable`** gains an **`operators`** map so V2 creators can insert alongside the legacy creator. A Forge deploy script wires minters/operators and transfers ownership to the DAO Safe; post-deploy Safe repoints of existing tables/minting are documented.
> 
> On the UI, **`useTeamRoleRegistry`** drives registry rosters and a **Manage Team** modal (`setMember` direct, `setManager` via Safe). **`useTeamData`** and launchpad **`useRegistryManagerTeams`** read manager status from the registry when configured. Jobs/marketplace SSG and the team page gate **project-teams** on **`ProjectV2.active`** instead of subscription expiry, with fail-open behavior on lookup errors. Config placeholders and ABIs are added until mainnet addresses are filled in. A coverage-only patch blanks string metadata in V2 creators for compiler limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab04beeea790b5c90fb82937133280088d210bbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
