### PR TITLE
fix(proposals): block MDP 256 (withdrawn)

### DIFF
--- a/ui/const/whitelist.ts
+++ b/ui/const/whitelist.ts
@@ -14,7 +14,7 @@ export const BLOCKED_PROJECTS: any = new Set(
 )
 export const BLOCKED_MDPS: any = new Set(
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
-    ? [229, 243, 246, 247, 252, 253, 257, 263]
+    ? [229, 243, 246, 247, 252, 253, 256, 257, 263]
     : []
 )
 export const BLOCKED_PROPOSALS: any = new Set([221])


### PR DESCRIPTION
## Summary
- Add MDP **256** to `BLOCKED_MDPS` in `ui/const/whitelist.ts` (mainnet).
- Author requested withdrawal.
- As a side note, this proposal was also mis-flagged `nonProjectProposal: true`, which was already causing it to be absent from `/projects` — blocking it makes the removal explicit and hides it from `/governance-proposals` and the dashboard feed as well.

## Test plan
- [ ] Confirm MDP 256 no longer appears in `/projects` pending list.
- [ ] Confirm MDP 256 no longer appears in `/governance-proposals`.
- [ ] Confirm `/project/256` no longer resolves.

Made with [Cursor](https://cursor.com)