### PR TITLE
fix(proposals): harden budget body parser for N-column tables and mixed content

### DIFF
--- a/ui/cypress/integration/unit/budget-overrides.cy.tsx
+++ b/ui/cypress/integration/unit/budget-overrides.cy.tsx
@@ -20,7 +20,10 @@ import {
   BUDGET_OVERRIDES_USD,
   getBudgetOverrideUSD,
 } from '../../../lib/proposals/budgetOverrides'
-import { extractUsdBudget } from '../../../lib/proposals/extractUsdBudget'
+import {
+  extractUsdBudget,
+  parseUsdBudgetFromBody,
+} from '../../../lib/proposals/extractUsdBudget'
 
 describe('budget overrides', () => {
   describe('getBudgetOverrideUSD', () => {
@@ -132,6 +135,118 @@ describe('budget overrides', () => {
         body: 'no budget anywhere here',
       }
       expect(extractUsdBudget(proposal, { MDP: 999999 })).to.equal(0)
+    })
+  })
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Parser regression tests — one test per Q3 2026 failure shape so each
+  // bug is caught if the body-parsing logic regresses.
+  // ─────────────────────────────────────────────────────────────────────────
+  describe('parseUsdBudgetFromBody — regression suite', () => {
+    // MDP-266 shape: 3-column table (desc | quantity | cost), plural "Totals"
+    // row, and an invisible U+200E mark embedded in the amount cell.
+    it('reads the last (cost) column of a 3-column table, plural Totals row (MDP-266 shape)', () => {
+      const body = [
+        '# Budget',
+        '',
+        '| Description | Man-days | Cost |',
+        '| --- | --- | --- |',
+        '| Main modules / Airlocks | 1 | US$ 500 |',
+        '| Central Hub / Counter-rotation | 1 | US$ 500 |',
+        '| Environment Control | 1.5 | US$ 750 |',
+        // U+200E embedded before the dollar sign, as in the real proposal
+        '| Totals | 8 | US\u200E$ 4,000 |',
+        '',
+      ].join('\n')
+      expect(parseUsdBudgetFromBody(body)).to.equal(4000)
+    })
+
+    // MDP-259 shape: Totals row cell contains a mixed-currency string
+    // "$2430 USD 1.30 ETH". The old isUsdValue() rejected the whole cell
+    // because "ETH" appeared in it, even though a $ USD amount was present.
+    it('extracts USD amount from a mixed-currency total cell "$X USD N.N ETH" (MDP-259 shape)', () => {
+      const body = [
+        '# Budget',
+        '',
+        '| Description | Amount | Justification |',
+        '| --- | --- | --- |',
+        '| Kits | $1560 | 150 kits |',
+        '| Transport | $280 | logistics |',
+        '| Total | $2430 USD 1.30 ETH | |',
+        '',
+      ].join('\n')
+      expect(parseUsdBudgetFromBody(body)).to.equal(2430)
+    })
+
+    // MDP-250 shape: budget written as prose with an arithmetic expression.
+    // "Total costs: (820 + 88 + 3200) $= $4108" — the inline parser must
+    // find the LAST / largest $ amount on the trigger line, not the first
+    // number inside the parentheses.
+    it('parses inline "Total costs: (items) $= $total" prose (MDP-250 shape)', () => {
+      const body =
+        'Software costs:\nNvivo $820\nGoogle Workspace $88\n\nResearcher Compensation $3200\n\nTotal costs: (820 + 88 + 3200) $= $4108'
+      expect(parseUsdBudgetFromBody(body)).to.equal(4108)
+    })
+
+    // MDP-255 shape: proposal has a # Budget section whose table carries
+    // no dollar amounts (only category labels), AND the body contains a
+    // large Revenue Potential table. The parser must NOT fall through to
+    // the whole-body scan and accidentally sum the revenue figures.
+    it('does not sum a Revenue table when a Budget section heading exists but has no parseable total (MDP-255 shape)', () => {
+      const body = [
+        '# Solution',
+        'Some description.',
+        '',
+        '# Revenue Potential',
+        '',
+        '| Channel | Revenue |',
+        '| --- | --- |',
+        '| Online courses | $60,000 |',
+        '| Premium paths | $62,500 |',
+        '| Total | $122,500 |',
+        '',
+        '# Budget (Table C)#',
+        '',
+        '| Budget Category |',
+        '| --- |',
+        '| Platform Completion |',
+        '| Marketing |',
+        '',
+      ].join('\n')
+      // Should return 0 (no parseable total in the budget section) rather
+      // than $122,500 from the Revenue table.
+      expect(parseUsdBudgetFromBody(body)).to.equal(0)
+    })
+
+    // Regression: standard 2-column budget table still works after the
+    // extractTableRowPairs refactor.
+    it('still reads a standard 2-column budget table correctly', () => {
+      const body = [
+        '## Budget',
+        '',
+        '| Item | Cost |',
+        '| --- | --- |',
+        '| Dev work | $3,000 |',
+        '| Marketing | $1,000 |',
+        '| Total | $4,000 |',
+      ].join('\n')
+      expect(parseUsdBudgetFromBody(body)).to.equal(4000)
+    })
+
+    // Regression: 3-column desc|amount|justification table (MDP-251 style).
+    // The amount is in the middle column, not the last.
+    it('picks the middle USD column when last column is non-numeric justification text (MDP-251 style)', () => {
+      const body = [
+        '## Budget',
+        '',
+        '| Description | Amount | Justification |',
+        '| --- | --- | --- |',
+        '| Crew registration fee | $3,500 | Published MDRS rate |',
+        '| Security deposit | $250 | Refundable |',
+        '| Travel | $700 | Round-trip |',
+        '| Total | $5,500 USD | Sent in ETH or MOONEY |',
+      ].join('\n')
+      expect(parseUsdBudgetFromBody(body)).to.equal(5500)
     })
   })
 })

--- a/ui/lib/proposals/extractUsdBudget.ts
+++ b/ui/lib/proposals/extractUsdBudget.ts
@@ -33,10 +33,23 @@ const NON_USD_TOKENS = /\b(ETH|MOONEY|BTC|MATIC|ARB|OP|SOL)\b/i
 // pathological single-line paragraph can't feed the regex below.
 const MAX_FREEFORM_LINE_LENGTH = 500
 
+/**
+ * Strip invisible Unicode directional / zero-width marks that can embed in
+ * copy-pasted text (e.g. U+200E left-to-right mark in "US$‎ 4,000").
+ * Must be called before any regex-based parsing.
+ */
+function sanitizeText(text: string): string {
+  return text.replace(/[\u200B-\u200F\uFEFF\u2060]/g, '')
+}
+
 function isUsdValue(rawCell: string): boolean {
-  if (NON_USD_TOKENS.test(rawCell)) return false
+  // A leading $ or an explicit stablecoin keyword confirms USD even when the
+  // cell also mentions non-USD tokens (e.g. "$2,430 USD  1.30 ETH").
+  // The old code checked NON_USD_TOKENS first, which caused the whole cell
+  // to be rejected whenever ETH/MOONEY appeared alongside a USD amount.
   if (/\$/.test(rawCell)) return true
-  return /\b(USDC|USDT|DAI|USD)\b/i.test(rawCell)
+  if (/\b(USDC|USDT|DAI|USD)\b/i.test(rawCell)) return true
+  return false
 }
 
 function parseAmount(cell: string): number {
@@ -48,44 +61,54 @@ function parseAmount(cell: string): number {
 type TableRowPair = { desc: string; value: string }
 
 /**
- * Extract `| description | numeric value |` cell pairs from markdown table
- * rows, scanning line by line and splitting on pipes.
+ * Extract `{ desc, value }` pairs from markdown table rows, scanning line
+ * by line and splitting on pipes.
  *
- * This used to be a single global regex with nested lazy quantifiers run over
- * the whole body. On large bodies it backtracked catastrophically — a 333KB
- * proposal (MDP 259) pinned the browser main thread for ~40s PER PASS, which
- * is what froze /dashboard and /projects with "Page Unresponsive". Splitting
- * into lines and cells first keeps the work linear in body size.
+ * For each row:
+ *   - `desc`  = the first non-empty interior cell.
+ *   - `value` = the first cell (after `desc`) that contains an explicit
+ *               USD marker ($ or stablecoin keyword).  If no USD cell is
+ *               found, falls back to the last numeric cell.
+ *
+ * This handles both:
+ *   desc | $amount | justification text   → picks $amount  (MDP-251 style)
+ *   desc | quantity | $cost               → picks $cost    (MDP-266 style)
+ *
+ * Previously this was a single global regex with nested lazy quantifiers.
+ * On large bodies it backtracked catastrophically — a 333 KB proposal
+ * pinned the browser main thread for ~40 s per pass. Splitting into lines
+ * and cells first keeps the work O(n) in body size.
  */
 function extractTableRowPairs(text: string): TableRowPair[] {
   const pairs: TableRowPair[] = []
   for (const line of text.split('\n')) {
     if (line.indexOf('|') === -1) continue
-    if (/---/.test(line)) continue // markdown table separator row
-    const cells = line.split('|')
-    // cells[0] is the text before the first pipe and cells[length-1] the text
-    // after the last pipe; only interior cells are table columns.
-    const lastInterior = cells.length - 2
-    let i = 1
-    while (i < lastInterior) {
-      const desc = cells[i].trim()
-      const value = cells[i + 1].trim()
-      if (desc && /\d/.test(value)) {
-        pairs.push({ desc, value })
-        // The old regex consumed the value cell's closing pipe, so matched
-        // pairs advanced two cells at a time.
-        i += 2
-      } else {
-        i += 1
-      }
+    if (/---/.test(line)) continue
+    const interior = line
+      .split('|')
+      .slice(1, -1)
+      .map((c) => c.trim())
+      .filter(Boolean)
+    if (interior.length < 2) continue
+    const desc = interior[0]
+
+    // Scan forward from the second cell; prefer the first cell that carries
+    // an explicit USD marker, but remember the last numeric cell as a fallback.
+    let value = ''
+    for (let i = 1; i < interior.length; i++) {
+      const cell = interior[i]
+      if (!/\d/.test(cell)) continue
+      value = cell
+      if (isUsdValue(cell)) break // stop on the first explicit USD cell
     }
+    if (value) pairs.push({ desc, value })
   }
   return pairs
 }
 
 function findGrandTotal(text: string): number {
   for (const { desc, value } of extractTableRowPairs(text)) {
-    if (/\bgrand\s+total\b/i.test(desc) && isUsdValue(value)) {
+    if (/\bgrand\s+totals?\b/i.test(desc) && isUsdValue(value)) {
       return parseAmount(value)
     }
   }
@@ -96,7 +119,8 @@ function sumUsdTotals(text: string): number {
   let sum = 0
   let count = 0
   for (const { desc, value } of extractTableRowPairs(text)) {
-    if (!/\b[Tt]otal\b/i.test(desc)) continue
+    // Match both "Total" and "Totals" (plural used by some budget templates).
+    if (!/\btotals?\b/i.test(desc)) continue
     if (!isUsdValue(value)) continue
     sum += parseAmount(value)
     count++
@@ -142,37 +166,72 @@ function parseBudgetFromSection(text: string): number {
   return sumFreeformBudgetLines(text)
 }
 
+/**
+ * Scan each line for a budget trigger phrase and return the largest dollar
+ * amount found on that same line. Taking the maximum handles patterns like:
+ *
+ *   "Total Budget: $5,000 (includes $500 contingency)"  → 5000
+ *   "Total costs: (820 + 88 + 3200) $= $4108"           → 4108
+ *   "Total Requested from MoonDAO: $2430 USD"            → 2430
+ *
+ * If no `$X` pattern exists but a bare "N USD/USDC" pattern is present,
+ * that value is returned instead.
+ */
 function parseInlineUsdBudget(body: string): number {
-  const inline = body.match(
-    /(?:estimated|total|project)\s+budget\s*:?\s*\(?\s*\$\s*([\d,]+(?:\.\d+)?)/i
-  )
-  if (inline) return parseFloat(inline[1].replace(/,/g, '')) || 0
+  const TRIGGER =
+    /(?:total|estimated|project)\s+(?:budget|costs?|funding|requested?(?:\s+from\s+\w+)?|ask)/i
+  for (const line of body.split('\n')) {
+    if (!TRIGGER.test(line)) continue
+    const dollars = Array.from(line.matchAll(/\$\s*([\d,]+(?:\.\d+)?)/g))
+      .map((m) => parseFloat(m[1].replace(/,/g, '')) || 0)
+      .filter((v) => v > 0)
+    if (dollars.length > 0) return Math.max(...dollars)
+    // No $ sign — try bare "N USD/USDC/DAI" on this line.
+    const bare = line.match(/\b([\d,]+(?:\.\d+)?)\s*(?:USD|USDC|USDT|DAI)\b/i)
+    if (bare) {
+      const v = parseFloat(bare[1].replace(/,/g, '')) || 0
+      if (v > 0) return v
+    }
+  }
   return 0
 }
 
 export function parseUsdBudgetFromBody(body: string | undefined | null): number {
   if (!body || typeof body !== 'string') return 0
 
-  const inline = parseInlineUsdBudget(body)
+  // Strip invisible Unicode control/directional marks before any parsing so
+  // characters like U+200E ("US$‎ 4,000") don't silently break $ detection.
+  const sanitized = sanitizeText(body)
+
+  const inline = parseInlineUsdBudget(sanitized)
   if (inline > 0) return inline
 
-  const budgetHeading = body.match(
-    /^#{1,3}\s+Budget(?:\s+(?:Allocation|Breakdown|Overview|Summary))?\s*(?:\(.*?\))?\s*$/im
+  // Budget heading — handle optional Table label and trailing # markers that
+  // some editors emit (e.g. "# Budget (Table C)#").
+  const budgetHeading = sanitized.match(
+    /^#{1,3}\s+Budget(?:\s+[^\n#]*?)?\s*#*\s*$/im
   )
   if (budgetHeading && budgetHeading.index !== undefined) {
     const sectionStart = budgetHeading.index + budgetHeading[0].length
-    const nextHeading = body.slice(sectionStart).search(/^#{1,2}\s+(?!#)/m)
+    const nextHeading = sanitized.slice(sectionStart).search(/^#{1,2}\s+(?!#)/m)
     const section =
       nextHeading !== -1
-        ? body.slice(sectionStart, sectionStart + nextHeading)
-        : body.slice(sectionStart)
+        ? sanitized.slice(sectionStart, sectionStart + nextHeading)
+        : sanitized.slice(sectionStart)
     const result = parseBudgetFromSection(section)
     if (result > 0) return result
+    // The budget heading was found but its section contains no parseable
+    // total. Stop here rather than falling through to the whole-body scan —
+    // that risks summing Revenue / Projection tables elsewhere in the body
+    // and producing a wildly inflated number (e.g. MDP-255 read $219,500).
+    return 0
   }
 
-  const grand = findGrandTotal(body)
+  // No budget section heading found — whole-body fallback is safe because
+  // there is no Revenue table to accidentally absorb.
+  const grand = findGrandTotal(sanitized)
   if (grand > 0) return grand
-  const totals = sumUsdTotals(body)
+  const totals = sumUsdTotals(sanitized)
   if (totals > 0) return totals
 
   return 0


### PR DESCRIPTION
## Summary

Fixes four distinct bugs in `extractUsdBudget.ts` that caused Q3 2026 proposals to display `$0` or wildly wrong budget amounts. These are the root-cause fixes — the overrides added in #1478 are now belt-and-suspenders rather than the only safeguard.

- **Bug 1 — plural "Totals" row skipped** (`/\b[Tt]otal\b/` → `/\btotals?\b/i`): proposals that write `| Totals | ... | $4,000 |` had their summary row silently skipped (MDP-266 shape)
- **Bug 2 — wrong column in N-column tables**: `extractTableRowPairs` advanced two cells at a time, so a 3-column row `desc | quantity | cost` yielded `value = quantity`, never `cost`. Now scans forward and breaks on the first cell with an explicit USD marker, falling back to the last numeric cell. Handles both `desc|amount|justification` (MDP-251) and `desc|quantity|cost` (MDP-266) correctly.
- **Bug 3 — mixed-currency cells rejected**: `isUsdValue()` checked for ETH/MOONEY *before* checking for `$`, so `"$2430 USD 1.30 ETH"` was discarded entirely. Now the `$` / USD keyword check takes precedence (MDP-259 shape)
- **Bug 4 — Revenue tables summed as the funding ask**: when a `# Budget` section was found but had no parseable amounts, the parser fell through to a whole-body scan and summed Revenue Potential tables, producing inflated numbers like `$219,500`. Now returns `0` immediately when the Budget section yields no total (MDP-255 shape)

**Additional hardening:**
- `sanitizeText()` strips invisible Unicode directional marks (U+200E etc.) before parsing — fixes `US$‎ 4,000` in MDP-266
- Budget heading regex broadened to match trailing `#` markers: `# Budget (Table C)#` now matches
- `parseInlineUsdBudget()` scans line-by-line and returns the *largest* `$` amount on the trigger line, correctly handling `"Total costs: (820+88+3200) $= $4108"`

## Test plan
- [ ] Six new regression tests in `budget-overrides.cy.tsx` cover each failure shape — run `yarn cypress run --spec 'cypress/integration/unit/budget-overrides.cy.tsx'`
- [ ] Visit `/project/250`, `/project/255`, `/project/259`, `/project/266` — without overrides these should now read the correct budget directly from the body
- [ ] Visit `/project/251` — still shows `$4,000` (from override #1478)
- [ ] Visit proposals with standard 2-column budget tables — confirm no regression

Made with [Cursor](https://cursor.com)