### PR TITLE
feat(projects): close Q3 2026 Senate vote, open Member vote + Q2 2026 retroactives

### DIFF
--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -695,14 +695,14 @@ export const PROJECT_SYSTEM_CONFIG = {
 // Set IS_SENATE_VOTE to true during Senate Vote phase - shows proposals with "Temperature Check" status
 // Set IS_MEMBER_VOTE to true during Member Vote phase - shows proposals with "Voting" status (passed Senate vote)
 // Only one should be true at a time, or both false when no voting is active
-export const IS_SENATE_VOTE = true
-export const IS_MEMBER_VOTE = false
+export const IS_SENATE_VOTE = false
+export const IS_MEMBER_VOTE = true
 
 // When false, the Member Vote phase is still on (results panel, "Member
 // Vote" badge, etc. still render) but the actual submit/edit Distribution
 // UI on the proposals tab is hidden. Used to close member-vote submissions
 // while keeping the rest of the cycle UI intact.
-export const MEMBER_VOTE_SUBMISSIONS_OPEN = false
+export const MEMBER_VOTE_SUBMISSIONS_OPEN = true
 
 // Addresses (lowercase) whose Member Vote distribution should be dropped
 // from the *current* calendar quarter's tally — both the read-only
@@ -719,7 +719,7 @@ export const MEMBER_VOTE_EXCLUDED_ADDRESSES: string[] = []
 // Set IS_REWARDS_CYCLE to true during the retroactive rewards distribution
 // window. When true, the projects page treats the prior quarter as the active
 // retro cycle and surfaces the Citizen / Voting Member distribution UI.
-export const IS_REWARDS_CYCLE = false
+export const IS_REWARDS_CYCLE = true
 
 // Quarterly budget in USD (stablecoins)
 // 5% of liquid non-MOONEY assets, denominated in USD
@@ -766,7 +766,9 @@ export const RETRO_PAYOUT_TOKEN: 'ETH' | 'USDC' = 'USDC'
 export const RETRO_ETH_BUDGET = 2.215
 
 // Q2 2026 retroactives (current cycle, USDC-paid): $5,629.26 for projects.
-// The quarter's total USD budget is $23,409 (NEXT_QUARTER_BUDGET_USD).
+// The Q2 2026 quarterly USD budget was $23,409 (this is pinned to the
+// retro cohort's own quarter, NOT the live NEXT_QUARTER_BUDGET_USD, which
+// has since rolled forward to the Q3 2026 senate/member-vote budget).
 // 90% goes to projects ($21,068.10); $15,438.84 was committed upfront
 // to the 4 Member-Vote winners (MDP-240 $3,955 + MDP-235 $3,600 +
 // MDP-245 $3,233.84 + MDP-237 $4,650). The cycle approved 4 winners
@@ -783,11 +785,16 @@ export const RETRO_USD_BUDGET = 5629.26
 // receive upfront funding. Audit / results displays surface this value
 // alongside the project pool so every part of the cycle's spend is visible.
 //
-// USDC cycles: 10% of NEXT_QUARTER_BUDGET_USD (Q2 2026 = $2,340.90).
+// USDC cycles: 10% of the retro cohort's OWN quarterly budget. The
+// currently-voting retro cohort is Q2 2026, whose quarterly budget was
+// $23,409, so the community circle is $2,340.90. This is pinned to the
+// cohort quarter on purpose — it must NOT track NEXT_QUARTER_BUDGET_USD,
+// which has already rolled forward to the Q3 2026 senate/member-vote
+// budget ($24,310) and would otherwise mis-state this cycle's payout.
 // ETH cycles: must be hardcoded against the cycle's quarterly ETH total
 // (e.g. Q1 2026 was 1.16 ETH, set when RETRO_PAYOUT_TOKEN was 'ETH').
 // Past cycles are pinned in `HISTORICAL_RETRO_POOLS` (see
 // `lib/proposals/computeRetroactiveOutcome.ts`) so this constant only
 // needs to track the current cycle.
 export const RETRO_PRIMARY_COMMUNITY_CIRCLE: number =
-  RETRO_PAYOUT_TOKEN === 'USDC' ? NEXT_QUARTER_BUDGET_USD * 0.1 : 0
+  RETRO_PAYOUT_TOKEN === 'USDC' ? 2340.9 : 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Advances the Q3 2026 project cycle out of the **Senate Vote** phase and into the **Member Vote** phase, and opens the **retroactive rewards** distribution window for the completed prior-quarter (Q2 2026) cohort.

This replicates the core concept of the last time this transition was done — `82572b3f open retroactives and member vote` (Q2 2026). That PR also removed the operator KV override system (`/api/operator/set-*`, `lib/operator/senateVote.ts`, etc.) so that the phase is driven purely by `const/config.ts` flags. Those files are already gone on `main`, so this transition is now a focused config change.

## What changed (`ui/const/config.ts`)

| Flag | Before | After | Effect |
|------|--------|-------|--------|
| `IS_SENATE_VOTE` | `true` | `false` | Senate Vote phase closes; the "Temperature Check" proposal filter/badge stops rendering as active. |
| `IS_MEMBER_VOTE` | `false` | `true` | Member Vote phase opens; proposals that passed Senate (`tempCheckApproved`) surface with the Member Vote UI + badge + phase callout. |
| `MEMBER_VOTE_SUBMISSIONS_OPEN` | `false` | `true` | Re-opens the per-card distribute inputs and the "Submit Distribution" panel so members can actually cast their allocation (this flag defaults closed and is flipped off again at wrap-up). |
| `IS_REWARDS_CYCLE` | `false` | `true` | Opens the retroactive rewards window. The projects page treats the prior calendar quarter (Q2 2026) as the active retro cohort and surfaces the Citizen / Voting Member distribution UI + "Previous Cycle Results" repointing. |

### Retro community-circle correctness fix

`RETRO_PRIMARY_COMMUNITY_CIRCLE` was deriving from `NEXT_QUARTER_BUDGET_USD * 0.1`. That constant was already rolled forward to the **Q3 2026** senate/member-vote budget (`$24,310`) in `1d541a6c5 open Q3 2026 Senate vote`, so the live derivation would have reported the community circle as `$2,431` instead of the correct `$2,340.90` (10% of Q2 2026's `$23,409`). Since the retro cohort being opened is **Q2 2026**, this is pinned to the cohort's own quarter (`2340.9`) and the comments on `RETRO_USD_BUDGET` / `RETRO_PRIMARY_COMMUNITY_CIRCLE` were updated to explain the decoupling. `RETRO_USD_BUDGET` (`$5,629.26`) and `RETRO_PAYOUT_TOKEN` (`USDC`) were already staged correctly for the Q2 2026 retro pool.

## Out of scope (manual / on-chain steps for the EB)

These are not frontend config and must be handled separately, exactly as in prior cycles:

1. **On-chain Senate tally** — the contract owner must call `Proposals.tallyVotes(mdp)` for each Senate-approved MDP so the passed proposals flip to the Member Vote (`Voting`) state on chain.
2. **Mark completed Q2 2026 projects eligible + attach final reports** — done per project via the `/projects` Operator Panel ("Add Final Report & Mark Eligible"), which the retro tab reads to build the eligible cohort.

## Testing notes

This VM had no installed dependencies and no environment secrets, so a full `next build` / lint run wasn't possible here. The change is limited to boolean toggles and one numeric literal in `const/config.ts` (no new imports, no removed references — `NEXT_QUARTER_BUDGET_USD` is still consumed by `USD_BUDGET`, `MAX_BUDGET_USD`, proposal pages, and the member-vote tally), matching the exact shape of the merged reference PRs. Please confirm on the Vercel preview that:
- `/projects` shows the Member Vote phase active with the distribute/submit UI, and the Retroactive Rewards tab shows the Q2 2026 eligible cohort once projects are marked eligible.
- The retro results/audit panel reports the community circle as **$2,340.90**.

---

## Plan that was followed

1. Locate the source of truth for the phase (`const/config.ts` flags) and the last equivalent transition (`82572b3f`).
2. Confirm the operator KV override system was already removed on `main`, so a pure config flip is the intended mechanism.
3. Flip `IS_SENATE_VOTE`, `IS_MEMBER_VOTE`, `MEMBER_VOTE_SUBMISSIONS_OPEN`, `IS_REWARDS_CYCLE`.
4. Verify the retro cohort resolves to Q2 2026 via `getRelativeQuarter(-1)` and that `RETRO_*` budget constants describe that cohort; fix the stale `RETRO_PRIMARY_COMMUNITY_CIRCLE` derivation.
5. Document the out-of-scope on-chain/operator steps.

## Recommendations to simplify this in the future (button-click phase advance)

The mechanism used to be a one-click operator flow (there was a **"Close Senate & Open Member Vote"** button in `OperatorPanel.tsx` backed by Upstash KV flags). It was removed in `82572b3f` in favor of editing `config.ts` + redeploying. To get back to a single click without the drawbacks that led to its removal, I'd suggest one of:

- **Date-derived phases (no manual flip at all).** The cycle dates are deterministic (`isRewardsCycle`, `getSubmissionQuarter`, `getThirdThursdayOfQuarterTimestamp` already exist). Replace the three boolean flags with a single `getCurrentProjectPhase(now)` helper that returns `senate | member | retro | idle` from the calendar, and have the UI read that. The EB then only overrides for exceptions. This removes the recurring PR entirely for the common case.
- **Reinstate the one-click "advance phase" operator action, backed by a durable store** (Vercel KV/Edge Config or a single Tableland/contract row) rather than in-memory, with an audit trail (`setBy`, `setAt`). Layer it on top of the config default (config = fallback, override = live) so a deploy is never required to advance a phase. This is essentially the removed flow, hardened.
- **A tiny "cycle config" object + admin form.** Collapse the scattered flags/budgets into one `CYCLE_CONFIG` object (phase, quarter, budget, retro pool, community circle) and expose an EB-only settings form that writes it — so the whole quarterly roll-forward (budget, retro pool, community circle, phase) is one screen instead of hand-edited constants that can drift (like the `NEXT_QUARTER_BUDGET_USD` ↔ community-circle coupling this PR just fixed).
- **Regardless of approach: derive the retro community circle from the retro cohort's own quarter budget**, never from the live proposal budget, so rolling the proposal budget forward can't silently mis-state the retro payout.

The lowest-effort high-value step is the date-derived phase helper; the highest-safety step is consolidating the per-cycle numbers into one object so budget/pool/community-circle can't drift apart across quarters.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ea1e90c-93e8-474b-9895-7f2060daf029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ea1e90c-93e8-474b-9895-7f2060daf029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

