### PR TITLE
feat(projects): one-click cycle-phase advance + PROJECT_CYCLE config object

### DIFF
--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -15,14 +15,13 @@ import {
   POLYGON_ASSETS_URL,
   BASE_ASSETS_URL,
   USD_BUDGET,
-  IS_SENATE_VOTE,
-  IS_MEMBER_VOTE,
   MEMBER_VOTE_SUBMISSIONS_OPEN,
-  IS_REWARDS_CYCLE,
   RETRO_PAYOUT_TOKEN,
   RETRO_ETH_BUDGET,
   RETRO_USD_BUDGET,
+  PROJECT_CYCLE,
 } from 'const/config'
+import type { ProjectCyclePhase } from 'const/config'
 import useStakedEth from 'lib/utils/hooks/useStakedEth'
 import lodashIsEqual from 'lodash/isEqual'
 import lodashSum from 'lodash/sum'
@@ -87,6 +86,10 @@ export type ProjectRewardsProps = {
   distributions: Distribution[]
   proposalAllocations?: Distribution[]
   refreshRewards: () => void
+  // Live cycle phase resolved server-side (getStaticProps) so the initial
+  // render matches the operator's live phase override. Falls back to the
+  // PROJECT_CYCLE.phase default when not provided.
+  initialLivePhase?: ProjectCyclePhase
 }
 
 // The `distribution` column on both Tableland tables is stored via
@@ -278,6 +281,7 @@ export function ProjectRewards({
   distributions,
   proposalAllocations,
   refreshRewards,
+  initialLivePhase,
 }: ProjectRewardsProps) {
   const router = useRouter()
 
@@ -287,14 +291,44 @@ export function ProjectRewards({
   const account = useActiveAccount()
   const userAddress = account?.address
 
-  const [rewardVotingActive, setRewardVotingActive] = useState(IS_REWARDS_CYCLE)
+  // Live cycle phase. Seeded from the value resolved server-side in
+  // getStaticProps (so the pre-rendered HTML matches), then polled from
+  // /api/operator/phase-status so an operator "Advance Phase" click
+  // propagates to every visitor without a redeploy. Retroactive rewards run
+  // concurrently with the Member Vote, so `member` drives both.
+  const [livePhase, setLivePhase] = useState<ProjectCyclePhase>(
+    initialLivePhase ?? PROJECT_CYCLE.phase
+  )
+  const isSenateVote = livePhase === 'senate'
+  const isMemberVote = livePhase === 'member'
+  const [rewardVotingActive, setRewardVotingActive] = useState(
+    livePhase === 'member'
+  )
   const [approvalVotingActive, setApprovalVotingActive] = useState(false)
-  const isSenateVote = IS_SENATE_VOTE
-  const isMemberVote = IS_MEMBER_VOTE
   // Member-vote submissions are gated separately so we can keep the rest
   // of the Member Vote UI (badge, results panel, phase callout) live while
   // closing off new distribution submits/edits at the end of the window.
   const memberVoteSubmissionsOpen = isMemberVote && MEMBER_VOTE_SUBMISSIONS_OPEN
+
+  // Poll the live phase so operator phase advances propagate without a reload.
+  useEffect(() => {
+    let cancelled = false
+    const fetchPhase = () => {
+      fetch('/api/operator/phase-status')
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (cancelled || !data?.livePhase) return
+          setLivePhase(data.livePhase as ProjectCyclePhase)
+        })
+        .catch(() => {})
+    }
+    fetchPhase()
+    const id = setInterval(fetchPhase, 60000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
   const { quarter, year } = getRelativeQuarter(rewardVotingActive ? -1 : 0)
   const { quarter: currentQuarter, year: currentYear } = getRelativeQuarter(0)
   // The proposals being voted on right now belong to the current calendar
@@ -350,11 +384,11 @@ export function ProjectRewards({
   const validProposalIds = useMemo(() => {
     if (!proposals?.length) return new Set<string>()
     let visible = proposals
-    if (IS_SENATE_VOTE) {
+    if (isSenateVote) {
       visible = proposals.filter(
         (p: any) => !p.tempCheckApproved && !p.tempCheckFailed
       )
-    } else if (IS_MEMBER_VOTE) {
+    } else if (isMemberVote) {
       visible = proposals.filter(
         (p: any) => p.tempCheckApproved && !p.tempCheckFailed
       )
@@ -362,7 +396,7 @@ export function ProjectRewards({
       visible = proposals.filter((p: any) => !p.tempCheckFailed)
     }
     return new Set(visible.map((p: any) => String(p.id)))
-  }, [proposals])
+  }, [proposals, isSenateVote, isMemberVote])
 
   const validEligibleIds = useMemo(() => {
     if (!currentProjects?.length) return new Set<string>()
@@ -405,14 +439,14 @@ export function ProjectRewards({
     return () => clearInterval(interval)
   }, [])
 
-  //Check if its the rewards cycle. `IS_REWARDS_CYCLE` (config) acts as a
+  //Check if its the rewards cycle. The live `member` phase acts as a
   // force-on switch; otherwise we fall through to the date-based default.
   useEffect(() => {
     let cancelled = false
 
     const update = () => {
       if (cancelled) return
-      setRewardVotingActive(isRewardsCycle(new Date(), IS_REWARDS_CYCLE))
+      setRewardVotingActive(isRewardsCycle(new Date(), livePhase === 'member'))
     }
 
     update()
@@ -421,7 +455,7 @@ export function ProjectRewards({
       cancelled = true
       clearInterval(updateInterval)
     }
-  }, [])
+  }, [livePhase])
 
   // Check if the user already has a distribution for the current quarter.
   // We prune the loaded distribution to the set of project IDs that are

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -310,7 +310,13 @@ export function ProjectRewards({
   // closing off new distribution submits/edits at the end of the window.
   const memberVoteSubmissionsOpen = isMemberVote && MEMBER_VOTE_SUBMISSIONS_OPEN
 
-  // Poll the live phase so operator phase advances propagate without a reload.
+  // Poll the live phase so operator phase advances propagate without a redeploy.
+  // When the phase actually changes, reload the page so getStaticProps data
+  // (Senate temp-check flags, retro distributions, cohort quarter) refreshes
+  // for every visitor — same path the operator panel already takes via
+  // onAfterChange → refreshRewards.
+  const livePhaseRef = useRef(livePhase)
+  livePhaseRef.current = livePhase
   useEffect(() => {
     let cancelled = false
     const fetchPhase = () => {
@@ -318,7 +324,11 @@ export function ProjectRewards({
         .then((r) => (r.ok ? r.json() : null))
         .then((data) => {
           if (cancelled || !data?.livePhase) return
-          setLivePhase(data.livePhase as ProjectCyclePhase)
+          const next = data.livePhase as ProjectCyclePhase
+          if (next === livePhaseRef.current) return
+          livePhaseRef.current = next
+          setLivePhase(next)
+          router.reload()
         })
         .catch(() => {})
     }
@@ -328,8 +338,12 @@ export function ProjectRewards({
       cancelled = true
       clearInterval(id)
     }
-  }, [])
-  const { quarter, year } = getRelativeQuarter(rewardVotingActive ? -1 : 0)
+  }, [router])
+  // Derive the retro cohort from livePhase synchronously so we don't lag a
+  // render behind the rewardVotingActive effect when the poll flips to member.
+  const { quarter, year } = getRelativeQuarter(
+    isRewardsCycle(new Date(), livePhase === 'member') ? -1 : 0
+  )
   const { quarter: currentQuarter, year: currentYear } = getRelativeQuarter(0)
   // The proposals being voted on right now belong to the current calendar
   // quarter — that's the key the page already filters by in
@@ -2117,7 +2131,9 @@ export function ProjectRewards({
                     audit page (`/projects/retro-audit`). */}
                 {(() => {
                   const prev = getRelativeQuarter(
-                    rewardVotingActive ? -2 : -1
+                    isRewardsCycle(new Date(), livePhase === 'member')
+                      ? -2
+                      : -1
                   )
                   return (
                     <div className="mt-6 sm:mt-8 pt-4 sm:pt-6 border-t border-white/10">

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -15,7 +15,6 @@ import {
   POLYGON_ASSETS_URL,
   BASE_ASSETS_URL,
   USD_BUDGET,
-  MEMBER_VOTE_SUBMISSIONS_OPEN,
   RETRO_PAYOUT_TOKEN,
   RETRO_ETH_BUDGET,
   RETRO_USD_BUDGET,
@@ -90,6 +89,9 @@ export type ProjectRewardsProps = {
   // render matches the operator's live phase override. Falls back to the
   // PROJECT_CYCLE.phase default when not provided.
   initialLivePhase?: ProjectCyclePhase
+  // Whether Member Vote distribute/submit UI is open (live KV override when
+  // set by Advance Phase, else PROJECT_CYCLE.memberVoteSubmissionsOpen).
+  initialMemberVoteSubmissionsOpen?: boolean
 }
 
 // The `distribution` column on both Tableland tables is stored via
@@ -282,6 +284,7 @@ export function ProjectRewards({
   proposalAllocations,
   refreshRewards,
   initialLivePhase,
+  initialMemberVoteSubmissionsOpen,
 }: ProjectRewardsProps) {
   const router = useRouter()
 
@@ -308,7 +311,13 @@ export function ProjectRewards({
   // Member-vote submissions are gated separately so we can keep the rest
   // of the Member Vote UI (badge, results panel, phase callout) live while
   // closing off new distribution submits/edits at the end of the window.
-  const memberVoteSubmissionsOpen = isMemberVote && MEMBER_VOTE_SUBMISSIONS_OPEN
+  // Seeded from SSR (which honors the live KV override set by Advance Phase).
+  const [memberVoteSubmissionsOpen, setMemberVoteSubmissionsOpen] = useState(
+    () =>
+      initialMemberVoteSubmissionsOpen ??
+      ((initialLivePhase ?? PROJECT_CYCLE.phase) === 'member' &&
+        PROJECT_CYCLE.memberVoteSubmissionsOpen)
+  )
 
   // Poll the live phase so operator phase advances propagate without a redeploy.
   // When the phase actually changes, reload the page so getStaticProps data
@@ -325,6 +334,9 @@ export function ProjectRewards({
         .then((data) => {
           if (cancelled || !data?.livePhase) return
           const next = data.livePhase as ProjectCyclePhase
+          if (typeof data.memberVoteSubmissionsOpen === 'boolean') {
+            setMemberVoteSubmissionsOpen(data.memberVoteSubmissionsOpen)
+          }
           if (next === livePhaseRef.current) return
           livePhaseRef.current = next
           setLivePhase(next)
@@ -345,14 +357,10 @@ export function ProjectRewards({
     isRewardsCycle(new Date(), livePhase === 'member') ? -1 : 0
   )
   const { quarter: currentQuarter, year: currentYear } = getRelativeQuarter(0)
-  // The proposals being voted on right now belong to the current calendar
-  // quarter — that's the key the page already filters by in
-  // `getStaticProps`. We deliberately do NOT use `getSubmissionQuarter()`
-  // here: past its ~3-week submission cutoff it advances to the *next*
-  // quarter (because new submissions then target the next cycle), which
-  // would orphan member-vote rows from the in-flight Q{n} proposals.
-  const proposalQuarter = currentQuarter
-  const proposalYear = currentYear
+  // Proposal cohort matches PROJECT_CYCLE (and advance-phase / getStaticProps),
+  // not the calendar quarter — keeps distribute keys aligned with listed MDPs.
+  const proposalQuarter = PROJECT_CYCLE.quarter
+  const proposalYear = PROJECT_CYCLE.year
 
   const [edit, setEdit] = useState(false)
   const [distribution, setDistribution] = useState<{ [key: string]: number }>({})

--- a/ui/components/nance/Proposal.tsx
+++ b/ui/components/nance/Proposal.tsx
@@ -1,5 +1,4 @@
 import { ChevronRightIcon } from '@heroicons/react/24/outline'
-import { IS_MEMBER_VOTE, IS_SENATE_VOTE } from 'const/config'
 import { useRouter } from 'next/router'
 import useProposalJSON from '@/lib/nance/useProposalJSON'
 import {
@@ -9,6 +8,7 @@ import {
   type StatusIndicatorStyle,
   ProposalStatus,
 } from '@/lib/nance/useProposalStatus'
+import { useLivePhase } from '@/lib/operator/useLivePhase'
 import ProposalInfo from './ProposalInfo'
 import RequestingTokensOfProposal from './RequestingTokensOfProposal'
 
@@ -44,15 +44,19 @@ function StatusDot({
 
 /**
  * Resolve the user-facing voting-phase context for a proposal based on the
- * current cycle flags in `const/config.ts` (IS_SENATE_VOTE / IS_MEMBER_VOTE).
+ * live cycle phase (KV override when set, else PROJECT_CYCLE.phase defaults).
  *
  * - Member Vote: proposals in `Voting` status need vMOONEY holders to allocate
  *   their voting power on /projects. Treat this as an active call to action.
  * - Senate Vote: proposals in `Temperature Check` status are awaiting Senate
  *   approval. Surface this so members understand the proposal isn't stale.
  */
-function getVotingPhaseContext(status: ProposalStatus | undefined) {
-  if (IS_MEMBER_VOTE && status === 'Voting') {
+function getVotingPhaseContext(
+  status: ProposalStatus | undefined,
+  isMemberVote: boolean,
+  isSenateVote: boolean
+) {
+  if (isMemberVote && status === 'Voting') {
     return {
       label: 'Member Vote',
       cta: 'Vote Now',
@@ -61,7 +65,7 @@ function getVotingPhaseContext(status: ProposalStatus | undefined) {
       pulse: true,
     }
   }
-  if (IS_SENATE_VOTE && status === 'Temperature Check') {
+  if (isSenateVote && status === 'Temperature Check') {
     return {
       label: 'Senate Vote In Progress',
       cta: null,
@@ -81,6 +85,7 @@ function getDescriptionPreview(body: string | undefined, maxLength = 120): strin
 }
 
 export default function Proposal({ project, feedStyle = false, linkDisabled = false }: ProposalProps) {
+  const { isMemberVote, isSenateVote } = useLivePhase()
   const proposalStatus = (useProposalStatus(project) || project?.status) as ProposalStatus
   const proposalJSON = useProposalJSON(project) || project?.proposalJSON
   const config = getStatusIndicatorConfig(proposalStatus)
@@ -93,7 +98,11 @@ export default function Proposal({ project, feedStyle = false, linkDisabled = fa
   const descriptionPreview = getDescriptionPreview(
     proposalJSON?.body || project?.description
   )
-  const phase = getVotingPhaseContext(proposalStatus)
+  const phase = getVotingPhaseContext(
+    proposalStatus,
+    isMemberVote,
+    isSenateVote
+  )
 
   if (feedStyle) {
     return (

--- a/ui/components/operator/OperatorPanel.tsx
+++ b/ui/components/operator/OperatorPanel.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
+import type { ProjectCyclePhase } from 'const/config'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import { useIsExecutive } from '@/lib/operator/useIsExecutive'
 import { Project } from '@/lib/project/useProjectData'
@@ -18,12 +19,54 @@ type ClearProgress = {
   failed: Array<{ projectId: number; error: string }>
 }
 
+type PhaseInfo = {
+  configPhase: ProjectCyclePhase
+  livePhase: ProjectCyclePhase
+  nextPhase: ProjectCyclePhase | null
+  quarter: number
+  year: number
+  override?: {
+    phase: ProjectCyclePhase | null
+    setBy?: string
+    setAt?: string
+    note?: string
+  }
+}
+
+type SenateTallyRow = {
+  mdp: number
+  projectId: number | string
+  name?: string
+  status: string
+  voteCount?: number
+  approvalCount?: number
+  quorum?: number
+  txHash?: string
+  error?: string
+}
+
+function phaseLabel(phase: ProjectCyclePhase | null | undefined): string {
+  switch (phase) {
+    case 'senate':
+      return 'Senate Vote'
+    case 'member':
+      return 'Member Vote + Retroactive Rewards'
+    case 'idle':
+      return 'Idle (between cycles)'
+    default:
+      return 'Unknown'
+  }
+}
+
 // EB-only operator panel. Renders nothing for non-EB members.
 //
-// Phase flags (`IS_SENATE_VOTE`, `IS_MEMBER_VOTE`, `IS_REWARDS_CYCLE`) live in
-// `const/config.ts` and are flipped by editing the file + redeploying. The
-// only thing this panel does today is let an operator attach a final report
-// and mark a project eligible for retroactive rewards.
+// The per-cycle defaults live in `PROJECT_CYCLE` (`const/config.ts`). This
+// panel lets an operator advance the LIVE cycle phase (Senate → Member →
+// wrap-up) without a redeploy — the "Cycle Phase" card runs the required
+// on-chain calls (Senate `tallyVotes`, Member Vote tally) and flips a phase
+// override stored in Upstash KV (see `lib/operator/cyclePhase.ts`). It also
+// lets an operator attach a final report and mark projects eligible for
+// retroactive rewards.
 export default function OperatorPanel({
   proposals,
   currentProjects,
@@ -35,6 +78,124 @@ export default function OperatorPanel({
   const [modalProject, setModalProject] = useState<Project | null>(null)
   const [clearProgress, setClearProgress] = useState<ClearProgress | null>(null)
   const [isClearing, setIsClearing] = useState(false)
+
+  // Cycle phase advance
+  const [phaseInfo, setPhaseInfo] = useState<PhaseInfo | null>(null)
+  const [advancing, setAdvancing] = useState(false)
+  const [tallying, setTallying] = useState(false)
+  const [advanceResult, setAdvanceResult] = useState<any | null>(null)
+
+  const loadPhase = () => {
+    fetch('/api/operator/phase-status')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data) setPhaseInfo(data as PhaseInfo)
+      })
+      .catch((err) => console.warn('phase-status fetch failed:', err))
+  }
+
+  useEffect(() => {
+    if (!isExecutive) return
+    loadPhase()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isExecutive])
+
+  const previewAdvance = async () => {
+    setAdvancing(true)
+    setAdvanceResult(null)
+    try {
+      const res = await fetch('/api/operator/advance-phase', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dryRun: true }),
+      })
+      const json = await res.json()
+      setAdvanceResult(json)
+      if (!res.ok) throw new Error(json?.error || 'Preview failed')
+      toast.success('Preview ready — review below before advancing.', {
+        style: toastStyle,
+      })
+    } catch (err: any) {
+      toast.error(err?.message || 'Preview failed.', { style: toastStyle })
+    } finally {
+      setAdvancing(false)
+    }
+  }
+
+  const doAdvance = async (force = false) => {
+    const phase = phaseInfo?.livePhase
+    const confirmMsg =
+      phase === 'senate'
+        ? 'Close the Senate Vote ON-CHAIN (tally every pending proposal), then open the Member Vote + Retroactive rewards?'
+        : phase === 'member'
+        ? 'Wrap up the cycle (close the Member Vote UI)? Make sure the Member Vote on-chain tally has already been run.'
+        : 'Advance the cycle phase?'
+    if (!window.confirm(confirmMsg + (force ? '\n\nFORCING past blockers.' : '')))
+      return
+    setAdvancing(true)
+    try {
+      const res = await fetch('/api/operator/advance-phase', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force }),
+      })
+      const json = await res.json()
+      setAdvanceResult(json)
+      if (!res.ok) {
+        if (res.status === 409) {
+          toast.error(
+            'Blocked: some proposals are not closed. Review below, then Force if intended.',
+            { style: toastStyle }
+          )
+          return
+        }
+        throw new Error(json?.error || 'Advance failed')
+      }
+      toast.success(`Phase advanced to ${phaseLabel(json.newPhase)}.`, {
+        style: toastStyle,
+        duration: 5000,
+      })
+      loadPhase()
+      onAfterChange?.()
+    } catch (err: any) {
+      toast.error(err?.message || 'Advance failed.', { style: toastStyle })
+    } finally {
+      setAdvancing(false)
+    }
+  }
+
+  const runMemberTally = async () => {
+    if (
+      !window.confirm(
+        'Run the Member Vote on-chain tally now? This flips winning projects to active on-chain.'
+      )
+    )
+      return
+    setTallying(true)
+    try {
+      const res = await fetch('/api/proposals/vote', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(json?.error || 'Tally failed')
+      toast.success('Member Vote tallied on-chain.', {
+        style: toastStyle,
+        duration: 5000,
+      })
+      onAfterChange?.()
+    } catch (err: any) {
+      toast.error(err?.message || 'Member Vote tally failed.', {
+        style: toastStyle,
+      })
+    } finally {
+      setTallying(false)
+    }
+  }
 
   const allProjects = useMemo(
     () => [...currentProjects, ...pastProjects, ...proposals],
@@ -153,14 +314,163 @@ export default function OperatorPanel({
             Operator Panel
           </h3>
           <p className="text-xs text-gray-400 mt-1">
-            Visible only to Executive Branch members. Phase flags are managed
-            in <code>const/config.ts</code>; this panel handles project-level
-            actions signed by the GCP HSM owner wallet.
+            Visible only to Executive Branch members. Advance the cycle phase
+            and run project-level actions — all on-chain calls are signed by
+            the GCP HSM owner wallet.
           </p>
         </div>
       </div>
 
       <div className="mt-4 grid grid-cols-1 gap-3">
+        {/* Cycle phase advance — one-click Senate → Member → wrap-up */}
+        <div className="min-w-0 bg-black/30 rounded-lg p-3 border border-emerald-400/20 flex flex-col gap-2">
+          <h4 className="text-xs uppercase tracking-wider text-emerald-200 font-RobotoMono">
+            Cycle Phase
+          </h4>
+          {!phaseInfo ? (
+            <p className="text-[11px] text-gray-500 italic">Loading phase…</p>
+          ) : (
+            <>
+              <p className="text-xs text-gray-300">
+                Live phase:{' '}
+                <span className="font-semibold text-white">
+                  {phaseLabel(phaseInfo.livePhase)}
+                </span>{' '}
+                <span className="text-gray-500">
+                  (Q{phaseInfo.quarter} {phaseInfo.year})
+                </span>
+              </p>
+              {phaseInfo.livePhase !== phaseInfo.configPhase && (
+                <p className="text-[11px] text-amber-300">
+                  Runtime override active — config default is{' '}
+                  {phaseLabel(phaseInfo.configPhase)}.
+                  {phaseInfo.override?.setBy
+                    ? ` Set by ${phaseInfo.override.setBy.slice(0, 6)}…`
+                    : ''}
+                </p>
+              )}
+
+              {phaseInfo.livePhase === 'senate' && (
+                <>
+                  <p className="text-xs text-gray-400">
+                    Closes the Senate Vote on-chain (signs{' '}
+                    <code>tallyVotes(mdp)</code> for every pending proposal in
+                    Q{phaseInfo.quarter} {phaseInfo.year}), then opens the
+                    Member Vote + Retroactive rewards.
+                  </p>
+                  <div className="flex flex-wrap gap-2 mt-1">
+                    <button
+                      type="button"
+                      onClick={previewAdvance}
+                      disabled={advancing}
+                      className="px-3 py-2 rounded-lg bg-white/10 hover:bg-white/15 text-gray-200 text-xs font-RobotoMono shadow disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {advancing ? 'Working…' : 'Preview (dry run)'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => doAdvance(false)}
+                      disabled={advancing}
+                      className="px-3 py-2 rounded-lg bg-gradient-to-r from-emerald-500 to-teal-600 hover:from-emerald-600 hover:to-teal-700 text-white text-xs font-RobotoMono shadow disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {advancing
+                        ? 'Advancing…'
+                        : 'Close Senate & Open Member Vote'}
+                    </button>
+                  </div>
+                </>
+              )}
+
+              {phaseInfo.livePhase === 'member' && (
+                <>
+                  <p className="text-xs text-gray-400">
+                    Run the Member Vote on-chain tally first (flips winners to
+                    active), then wrap up the cycle UI.
+                  </p>
+                  <div className="flex flex-wrap gap-2 mt-1">
+                    <button
+                      type="button"
+                      onClick={runMemberTally}
+                      disabled={tallying}
+                      className="px-3 py-2 rounded-lg bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white text-xs font-RobotoMono shadow disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {tallying ? 'Tallying…' : 'Run Member Vote Tally'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => doAdvance(false)}
+                      disabled={advancing}
+                      className="px-3 py-2 rounded-lg bg-gradient-to-r from-amber-500 to-rose-600 hover:from-amber-600 hover:to-rose-700 text-white text-xs font-RobotoMono shadow disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {advancing ? 'Wrapping…' : 'Wrap Up Cycle'}
+                    </button>
+                  </div>
+                </>
+              )}
+
+              {phaseInfo.livePhase === 'idle' && (
+                <p className="text-xs text-gray-400">
+                  Cycle is idle. Start the next cycle by editing{' '}
+                  <code>PROJECT_CYCLE</code> in <code>const/config.ts</code>{' '}
+                  (new quarter, budget, retro pool) and deploying.
+                </p>
+              )}
+
+              {advanceResult?.blockers?.length > 0 && (
+                <div className="mt-1">
+                  <p className="text-[11px] text-rose-300">
+                    {advanceResult.blockers.length} proposal(s) block the
+                    advance (below quorum or errored):
+                  </p>
+                  <ul className="mt-1 ml-4 list-disc text-[11px] text-rose-200 space-y-0.5">
+                    {(advanceResult.blockers as SenateTallyRow[]).map((b) => (
+                      <li key={b.mdp}>
+                        MDP-{b.mdp} {b.name ? `“${b.name}” ` : ''}— {b.status}
+                        {b.status === 'below-quorum' &&
+                        b.voteCount != null &&
+                        b.quorum != null
+                          ? ` (${b.voteCount}/${b.quorum})`
+                          : ''}
+                        {b.error ? `: ${b.error}` : ''}
+                      </li>
+                    ))}
+                  </ul>
+                  {phaseInfo.livePhase === 'senate' && (
+                    <button
+                      type="button"
+                      onClick={() => doAdvance(true)}
+                      disabled={advancing}
+                      className="mt-2 px-3 py-2 rounded-lg bg-rose-600/80 hover:bg-rose-600 text-white text-xs font-RobotoMono shadow disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      Force advance past blockers
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {advanceResult?.senateTally?.length > 0 && (
+                <details className="mt-1 text-[11px] text-gray-300">
+                  <summary className="cursor-pointer text-gray-400 hover:text-gray-200">
+                    Senate tally detail ({advanceResult.senateTally.length})
+                    {advanceResult.dryRun ? ' — preview' : ''}
+                  </summary>
+                  <ul className="mt-1 ml-4 list-disc space-y-0.5">
+                    {(advanceResult.senateTally as SenateTallyRow[]).map((r) => (
+                      <li key={r.mdp}>
+                        MDP-{r.mdp}: {r.status}
+                        {r.approvalCount != null && r.voteCount != null
+                          ? ` (${r.approvalCount}/${r.voteCount})`
+                          : ''}
+                        {r.txHash ? ' ✓' : ''}
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              )}
+            </>
+          )}
+        </div>
+
         {/* Add final report + add to retroactives */}
         <div className="min-w-0 bg-black/30 rounded-lg p-3 border border-white/10 flex flex-col gap-2">
           <h4 className="text-xs uppercase tracking-wider text-gray-300 font-RobotoMono">

--- a/ui/components/project/ProjectCard.tsx
+++ b/ui/components/project/ProjectCard.tsx
@@ -5,7 +5,6 @@ import CitizenABI from 'const/abis/Citizen.json'
 import {
   CITIZEN_ADDRESSES,
   DEFAULT_CHAIN_V5,
-  IS_SENATE_VOTE,
 } from 'const/config'
 import { getProposalVideoUrl } from 'const/proposalVideos'
 import Link from 'next/link'
@@ -17,6 +16,7 @@ import { useSubHats } from '@/lib/hats/useSubHats'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
 import { PROJECT_ACTIVE, PROJECT_PENDING } from '@/lib/nance/types'
 import useProposalJSON from '@/lib/nance/useProposalJSON'
+import { useLivePhase } from '@/lib/operator/useLivePhase'
 import { getProjectDisplayName } from '@/lib/project/getProjectDisplayName'
 import useProjectData, { Project } from '@/lib/project/useProjectData'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -145,9 +145,8 @@ type ProjectCardProps = {
   userHasVotingPower?: any
   isVotingPeriod?: boolean
   active?: boolean
-  // Optional override for the senate-vote phase. Defaults to the
-  // `IS_SENATE_VOTE` config constant. Operators can flip this off via the
-  // operator panel without redeploying.
+  // Optional override for the senate-vote phase. Defaults to the live
+  // phase from `/api/operator/phase-status` (KV override when set).
   isSenateVote?: boolean
   // Hide the inline status pill ("Active" / "Inactive" / budget) in the
   // card header. Useful when the surrounding tab already provides the
@@ -174,7 +173,7 @@ const ProjectCardContent = memo(
     isExpanded,
     onToggleExpand,
     citizenContract,
-    isSenateVote = IS_SENATE_VOTE,
+    isSenateVote,
     hideStatusBadge = false,
     loadHeavy = true,
   }: any) => {
@@ -462,7 +461,8 @@ export default function ProjectCard({
   hideStatusBadge,
   linkToProjectPage,
 }: ProjectCardProps) {
-  const isSenateVote = isSenateVoteProp ?? IS_SENATE_VOTE
+  const { isSenateVote: liveIsSenateVote } = useLivePhase()
+  const isSenateVote = isSenateVoteProp ?? liveIsSenateVote
   const router = useRouter()
   const account = useActiveAccount()
   const address = account?.address

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -676,56 +676,130 @@ export const CITIZENSHIP_GIFT_TAG = 'citizenship-gift'
 export const OVERVIEW_FLIGHT_TERMS_AND_CONDITIONS_DOCS_URL =
   'https://docs.moondao.com/Legal/Overview-Flight/Overview-Flight-Terms-and-Conditions'
 
-// Project System Configuration
-export const PROJECT_SYSTEM_CONFIG = {
-  // Q3 2026 deadline - second Thursday of the quarter
-  submissionDeadline: 'July 9, 2026',
-  // Approval timeline details
-  senateReviewDays: 1, // Senate reviews the day after submission
-  editingDeadline: 'July 14, 2026', // 48 hours before third Thursday
-  votingDate: 'July 16, 2026', // Third Thursday of quarter
-  // Submission link
-  submissionUrl: 'https://moondao.com/propose',
-  // Documentation link
-  docsUrl: 'https://docs.moondao.com/Projects/Project-System',
-  // Total quarterly budget is displayed dynamically on the page
+// ---------------------------------------------------------------------------
+// PROJECT CYCLE — single source of truth for the quarterly project system.
+// ---------------------------------------------------------------------------
+// This is the ONE object the Executive Branch edits when rolling the project
+// system forward to a new cycle. Everything below (phase flags, budgets,
+// deadlines, retro pool) is derived from it so the per-cycle numbers can never
+// drift apart across quarters.
+//
+// Rolling to the NEXT cycle (once, by editing this object):
+//   1. Bump `quarter` / `year` and the three deadline strings.
+//   2. Set `budgetUSD` to the new quarterly budget.
+//   3. Set `phase` to 'senate' (Senate Vote opens first).
+//   4. Update `retro` for the cohort being paid out this cycle (the prior
+//      quarter's completed projects) — see the field comments below.
+//   5. Reset `memberVoteExcludedAddresses` to [].
+//
+// Advancing WITHIN a cycle (Senate -> Member -> idle) no longer requires a
+// redeploy: an operator clicks "Advance Phase" on /projects, which runs the
+// required on-chain calls and flips a live phase override stored in Upstash
+// KV (see `lib/operator/cyclePhase.ts`). `phase` here is the deploy-time
+// DEFAULT / fallback the live override layers on top of.
+export type ProjectCyclePhase = 'senate' | 'member' | 'idle'
+
+export interface ProjectCycleConfig {
+  // Deploy-time default phase. 'senate' = Senate Vote, 'member' = Member Vote
+  // + Retroactive rewards (they run concurrently), 'idle' = nothing active
+  // (between cycles / wrapped up). The operator "Advance Phase" button moves
+  // the LIVE phase forward without a redeploy.
+  phase: ProjectCyclePhase
+  // Calendar quarter/year the current proposals belong to (the Senate/Member
+  // vote cohort). The retro cohort is always the PRIOR quarter.
+  quarter: number
+  year: number
+  // When false, the Member Vote phase is still on (results panel, badge, etc.
+  // still render) but the submit/edit Distribution UI is hidden — used to
+  // close member-vote submissions while keeping the rest of the cycle intact.
+  memberVoteSubmissionsOpen: boolean
+  // Addresses (lowercase) whose Member Vote distribution is dropped from THIS
+  // cycle's tally (both the read-only display and the on-chain close). Past
+  // quarters are unaffected so historical audits stay reproducible. Use for
+  // one-off disqualifications; the row stays in the table for the audit trail.
+  memberVoteExcludedAddresses: string[]
+  // Deadlines shown on /projects and the project banner.
+  submissionDeadline: string // second Thursday of the quarter
+  editingDeadline: string // 48 hours before the third Thursday
+  votingDate: string // third Thursday of the quarter
+  // Quarterly project budget in USD (stablecoins): 5% of liquid non-MOONEY
+  // assets. Per-proposal max is 1/5 of this. See docs Projects/Project-System.
+  budgetUSD: number
+  // Retroactive rewards pool for the cohort being paid THIS cycle — i.e. the
+  // PRIOR quarter's completed projects. These are pinned to the retro cohort's
+  // own quarter and must NOT be derived from `budgetUSD` (which describes the
+  // current Senate/Member-vote cohort, a different quarter).
+  retro: {
+    // Primary payout asset. 'USDC' uses `usdBudget`; 'ETH' uses `ethBudget`.
+    payoutToken: 'ETH' | 'USDC'
+    // USDC pool for projects (post-upfront remainder) when payoutToken='USDC'.
+    usdBudget: number
+    // ETH pool for projects (post-upfront remainder) when payoutToken='ETH'.
+    ethBudget: number
+    // Community circle's slice of the primary asset = 10% of the retro
+    // cohort's OWN quarterly budget (before upfront funding). Parallel cohort,
+    // not a carve-out of the project pool. ETH cycles: set to the ETH amount.
+    communityCirclePrimary: number
+  }
 }
 
-// Voting Phase Flags
-// Set IS_SENATE_VOTE to true during Senate Vote phase - shows proposals with "Temperature Check" status
-// Set IS_MEMBER_VOTE to true during Member Vote phase - shows proposals with "Voting" status (passed Senate vote)
-// Only one should be true at a time, or both false when no voting is active
-export const IS_SENATE_VOTE = true
-export const IS_MEMBER_VOTE = false
+export const PROJECT_CYCLE: ProjectCycleConfig = {
+  phase: 'senate',
+  quarter: 3,
+  year: 2026,
+  memberVoteSubmissionsOpen: false,
+  memberVoteExcludedAddresses: [],
+  // Q3 2026 deadlines.
+  submissionDeadline: 'July 9, 2026',
+  editingDeadline: 'July 14, 2026',
+  votingDate: 'July 16, 2026',
+  // Q3 2026: $24,310 → per-proposal max $4,862 (posted in the Senate review pack).
+  budgetUSD: 24310,
+  retro: {
+    // Q2 2026 retroactives (the cohort paid out this cycle), USDC-paid:
+    //   - $5,629.26 for projects = ($23,409 * 0.9) - $15,438.84 upfront to the
+    //     4 Member-Vote winners (MDP-240 $3,955 + MDP-235 $3,600 +
+    //     MDP-245 $3,233.84 + MDP-237 $4,650).
+    //   - $2,340.90 community circle = 10% of Q2's $23,409 budget (pinned to
+    //     the cohort's own quarter, NOT the current $24,310 budget).
+    // The prior ETH cycle (Q1 2026) kept 2.215 ETH here for reference.
+    payoutToken: 'USDC',
+    usdBudget: 5629.26,
+    ethBudget: 2.215,
+    communityCirclePrimary: 2340.9,
+  },
+}
 
-// When false, the Member Vote phase is still on (results panel, "Member
-// Vote" badge, etc. still render) but the actual submit/edit Distribution
-// UI on the proposals tab is hidden. Used to close member-vote submissions
-// while keeping the rest of the cycle UI intact.
-export const MEMBER_VOTE_SUBMISSIONS_OPEN = false
+// Project System Configuration (deadlines/links surfaced on /projects + banner).
+// Derived from PROJECT_CYCLE so the deadlines live in exactly one place.
+export const PROJECT_SYSTEM_CONFIG = {
+  submissionDeadline: PROJECT_CYCLE.submissionDeadline,
+  // Approval timeline details
+  senateReviewDays: 1, // Senate reviews the day after submission
+  editingDeadline: PROJECT_CYCLE.editingDeadline,
+  votingDate: PROJECT_CYCLE.votingDate,
+  submissionUrl: 'https://moondao.com/propose',
+  docsUrl: 'https://docs.moondao.com/Projects/Project-System',
+}
 
-// Addresses (lowercase) whose Member Vote distribution should be dropped
-// from the *current* calendar quarter's tally — both the read-only
-// display in `computeMemberVoteOutcome` and the on-chain close in
-// `/api/proposals/vote`. Past-quarter audits/tallies are unaffected, so
-// historical results stay reproducible. Use this for one-off
-// disqualifications (e.g. a vote ruled invalid post-hoc); the wallet's
-// row stays in the proposals table for the audit trail, it just
-// doesn't count toward the outcome.
-//
-// Q3 2026: no disqualifications yet.
-export const MEMBER_VOTE_EXCLUDED_ADDRESSES: string[] = []
+// Voting Phase Flags — derived from PROJECT_CYCLE.phase. These are the
+// DEPLOY-TIME defaults; the operator "Advance Phase" button can override the
+// live phase at runtime (see `lib/operator/cyclePhase.ts` +
+// `getPhaseFlags`). Member Vote and the Retroactive rewards window run
+// concurrently, so both derive from the 'member' phase.
+export const IS_SENATE_VOTE = PROJECT_CYCLE.phase === 'senate'
+export const IS_MEMBER_VOTE = PROJECT_CYCLE.phase === 'member'
+export const IS_REWARDS_CYCLE = PROJECT_CYCLE.phase === 'member'
 
-// Set IS_REWARDS_CYCLE to true during the retroactive rewards distribution
-// window. When true, the projects page treats the prior quarter as the active
-// retro cycle and surfaces the Citizen / Voting Member distribution UI.
-export const IS_REWARDS_CYCLE = false
+// See PROJECT_CYCLE.memberVoteSubmissionsOpen.
+export const MEMBER_VOTE_SUBMISSIONS_OPEN = PROJECT_CYCLE.memberVoteSubmissionsOpen
 
-// Quarterly budget in USD (stablecoins)
-// 5% of liquid non-MOONEY assets, denominated in USD
-// See: https://docs.moondao.com/Projects/Project-System#quarterly-rewards
-// Q3 2026: $24,310 → per-proposal max $4,862 (posted in the Senate review pack).
-export const NEXT_QUARTER_BUDGET_USD = 24310
+// See PROJECT_CYCLE.memberVoteExcludedAddresses.
+export const MEMBER_VOTE_EXCLUDED_ADDRESSES: string[] =
+  PROJECT_CYCLE.memberVoteExcludedAddresses
+
+// Quarterly budget in USD (stablecoins). See PROJECT_CYCLE.budgetUSD.
+export const NEXT_QUARTER_BUDGET_USD = PROJECT_CYCLE.budgetUSD
 
 // Alias used by the retroactive rewards system (ProjectRewards.tsx / getPayouts).
 // The 10% community-circle carve-out is handled inside runQuadraticVoting
@@ -753,41 +827,23 @@ export const OPERATORS: string[] = [
   '0xaf6f2a7643a97b849bd9cf6d3f57e142c5bbb0da', // miguel
 ]
 
-// Retroactive rewards payout token for the *currently-voting* cycle.
-// Switch to 'ETH' (and use RETRO_ETH_BUDGET) when the cycle pays in ETH;
-// 'USDC' (and RETRO_USD_BUDGET) is the default for stablecoin retros.
-export const RETRO_PAYOUT_TOKEN: 'ETH' | 'USDC' = 'USDC'
+// Retroactive rewards pool for the *currently-voting* cycle — all derived
+// from PROJECT_CYCLE.retro so the pool, payout token, and community circle
+// stay pinned together to the retro cohort's own quarter (never the live
+// project budget). Past cycles are pinned in `HISTORICAL_RETRO_POOLS`
+// (see `lib/proposals/computeRetroactiveOutcome.ts`) so these constants only
+// need to track the current cycle.
+export const RETRO_PAYOUT_TOKEN: 'ETH' | 'USDC' = PROJECT_CYCLE.retro.payoutToken
 
-// Q1 2026 retroactives (last cycle, ETH-paid): 2.215 ETH for projects.
-// The quarter's total ETH budget was 11.6, of which 90% goes to projects
-// (10.44 ETH). 8.225 ETH was paid out upfront to funded projects, so the
-// remainder for retroactive distribution is (11.6 * 0.9) - 8.225 = 2.215 ETH.
-// The community circle slice for that cycle was 1.16 ETH (10% of 11.6).
-export const RETRO_ETH_BUDGET = 2.215
+export const RETRO_ETH_BUDGET = PROJECT_CYCLE.retro.ethBudget
 
-// Q2 2026 retroactives (current cycle, USDC-paid): $5,629.26 for projects.
-// The quarter's total USD budget is $23,409 (NEXT_QUARTER_BUDGET_USD).
-// 90% goes to projects ($21,068.10); $15,438.84 was committed upfront
-// to the 4 Member-Vote winners (MDP-240 $3,955 + MDP-235 $3,600 +
-// MDP-245 $3,233.84 + MDP-237 $4,650). The cycle approved 4 winners
-// (not 5) because rank-5 MDP-248 ($3,000) would have pushed cumulative
-// upfront past the 3/4 cap of $17,556.75.
-// Retroactive remainder = ($23,409 * 0.9) - $15,438.84 = $5,629.26.
-export const RETRO_USD_BUDGET = 5629.26
+export const RETRO_USD_BUDGET = PROJECT_CYCLE.retro.usdBudget
 
-// Community circle's slice of the primary asset for the *currently-voting*
-// cycle. The community circle is reserved as 10% of the original quarterly
-// budget (before any upfront project funding), in the same asset paid out
-// to projects via `RETRO_PAYOUT_TOKEN`. This is a parallel cohort, NOT a
-// carve-out of the retro project pool: it does NOT scale down when projects
-// receive upfront funding. Audit / results displays surface this value
-// alongside the project pool so every part of the cycle's spend is visible.
-//
-// USDC cycles: 10% of NEXT_QUARTER_BUDGET_USD (Q2 2026 = $2,340.90).
-// ETH cycles: must be hardcoded against the cycle's quarterly ETH total
-// (e.g. Q1 2026 was 1.16 ETH, set when RETRO_PAYOUT_TOKEN was 'ETH').
-// Past cycles are pinned in `HISTORICAL_RETRO_POOLS` (see
-// `lib/proposals/computeRetroactiveOutcome.ts`) so this constant only
-// needs to track the current cycle.
+// Community circle's slice of the primary asset for the currently-voting
+// cycle. A parallel cohort (10% of the retro cohort's original quarterly
+// budget, before upfront funding) — NOT a carve-out of the project pool, so
+// it does not scale down when projects get funded upfront. Surfaced alongside
+// the project pool so every part of the cycle's spend is visible. Zero when
+// the cycle pays in ETH but no ETH community circle is configured.
 export const RETRO_PRIMARY_COMMUNITY_CIRCLE: number =
-  RETRO_PAYOUT_TOKEN === 'USDC' ? NEXT_QUARTER_BUDGET_USD * 0.1 : 0
+  PROJECT_CYCLE.retro.communityCirclePrimary

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -783,10 +783,12 @@ export const PROJECT_SYSTEM_CONFIG = {
 }
 
 // Voting Phase Flags — derived from PROJECT_CYCLE.phase. These are the
-// DEPLOY-TIME defaults; the operator "Advance Phase" button can override the
-// live phase at runtime (see `lib/operator/cyclePhase.ts` +
-// `getPhaseFlags`). Member Vote and the Retroactive rewards window run
-// concurrently, so both derive from the 'member' phase.
+// DEPLOY-TIME defaults only. After an operator "Advance Phase", the live
+// phase may differ (see `lib/operator/cyclePhase.ts` + `useLivePhase`).
+// Client UI that gates on the current vote window should use `useLivePhase`
+// (or a server-resolved live phase prop), not these constants.
+// Member Vote and the Retroactive rewards window run concurrently, so both
+// derive from the 'member' phase.
 export const IS_SENATE_VOTE = PROJECT_CYCLE.phase === 'senate'
 export const IS_MEMBER_VOTE = PROJECT_CYCLE.phase === 'member'
 export const IS_REWARDS_CYCLE = PROJECT_CYCLE.phase === 'member'

--- a/ui/docs/PROJECT_CYCLE_OPERATOR_RUNBOOK.md
+++ b/ui/docs/PROJECT_CYCLE_OPERATOR_RUNBOOK.md
@@ -1,0 +1,181 @@
+# Project Cycle Operator Runbook
+
+Step-by-step guide for Executive Branch operators to move MoonDAO’s project
+system between phases. Use this every quarter.
+
+**Who can do this:** wallets in `OPERATORS` in `ui/const/config.ts` (currently
+pmoncada, ryand2d, miguel). Sign in on [moondao.com/projects](https://moondao.com/projects)
+with that wallet; the purple **Operator Panel** appears at the top of the page.
+
+**Who signs on-chain txs:** the GCP HSM wallet
+(`GCP_HSM_SIGNER_ADDRESS` / `0xb206…f5d32`), which owns the `Proposals` and
+`ProjectTable` contracts. Your click hits a server API; the HSM signs. Your EOA
+does **not** need contract ownership.
+
+---
+
+## Phase overview
+
+| Phase | What’s live | How you get there |
+|---|---|---|
+| **Senate Vote** | Pending proposals; senators vote Yes/No | Edit `PROJECT_CYCLE` + deploy (start of quarter) |
+| **Member Vote + Retro** | Member Vote distribute UI; retroactive rewards for prior quarter | One click: **Close Senate & Open Member Vote** |
+| **Idle** | Neither voting UI is active | One click: **Wrap Up Cycle** (after member tally) |
+
+Member Vote and Retroactive Rewards run **at the same time**. Advancing into
+the *next* quarter’s Senate Vote is a config edit (new budget/deadlines/retro
+pool), not a runtime button.
+
+---
+
+## 0. Start of a new quarter (roll forward)
+
+Do this once when opening a new cycle. Requires a PR + deploy.
+
+1. Open `ui/const/config.ts` and edit **`PROJECT_CYCLE` only**:
+   - `quarter` / `year` → the new proposal quarter
+   - `phase` → `'senate'`
+   - `submissionDeadline` / `editingDeadline` / `votingDate`
+   - `budgetUSD` → new quarterly budget
+   - `memberVoteSubmissionsOpen` → `false` until Member Vote opens (or leave false; Advance will open the phase, and you can set this `true` in the same PR if you want submissions ready when Member Vote starts)
+   - `memberVoteExcludedAddresses` → `[]`
+   - `retro` → pool for the **prior** quarter’s completed projects:
+     - `payoutToken` (`USDC` or `ETH`)
+     - `usdBudget` or `ethBudget` (post-upfront remainder for projects)
+     - `communityCirclePrimary` = **10% of the prior quarter’s own budget** (not the new `budgetUSD`)
+2. Open a PR, merge, wait for production deploy.
+3. Confirm `/projects` shows Senate Vote (Temperature Check proposals).
+
+---
+
+## 1. During Senate Vote
+
+Senators vote on each proposal page. Operators can close a single proposal via
+the per-proposal **Close Senate Vote** control, or wait and batch-close in step 2.
+
+Optional prep while senators vote:
+
+- Collect final reports for completed prior-quarter projects.
+- Use **Add Final Report & Mark Eligible** in the Operator Panel so the retro
+  tab has a cohort ready when Member Vote opens.
+
+---
+
+## 2. Close Senate → open Member Vote + Retro
+
+When senators have voted (quorum met on the proposals you intend to advance):
+
+1. Go to `/projects` → **Operator Panel** → **Cycle Phase**.
+2. Click **Preview (dry run)**. Review the per-MDP list:
+   - `passed` / `failed` — would tally
+   - `below-quorum` — still needs senators (or Force later)
+   - `already-closed` / `passed`/`failed` from prior close — already done
+3. Click **Close Senate & Open Member Vote**. Confirm the dialog.
+4. The server will:
+   - Sign `Proposals.tallyVotes(mdp)` for every pending current-cycle MDP
+     (idempotent; skips closed / below-quorum)
+   - Flip the live phase to **Member Vote + Retro** (stored in Upstash; no redeploy)
+5. Within about a minute, `/projects` should show:
+   - Member Vote UI for Senate-passed proposals
+   - Retroactive Rewards tab for the prior-quarter cohort
+
+**If some proposals are below quorum:** either wait for more senator votes and
+retry, or use **Force advance past blockers** only if you intentionally want to
+leave those proposals untallied and still open Member Vote.
+
+**If a tx fails:** the panel lists the MDP + error. Fix (RPC / HSM / ownership)
+and click Advance again — already-closed MDPs are skipped.
+
+---
+
+## 3. During Member Vote + Retro
+
+### Member Vote
+
+- Citizens / voting members submit distributions on the proposals tab.
+- To freeze new submissions but keep results visible: set
+  `PROJECT_CYCLE.memberVoteSubmissionsOpen = false` in a PR (or keep it open
+  until wrap-up).
+
+### Retroactive rewards
+
+1. For each completed prior-quarter project: **Add Final Report & Mark Eligible**.
+2. Citizens / members allocate on the Retroactive tab.
+3. After the retro window, run **Clear Retro Cohort** so `eligible` is reset
+   before the next cycle marks new projects.
+
+---
+
+## 4. Close Member Vote (on-chain tally)
+
+When the Member Vote window should end (typically ~5 days after the third
+Thursday):
+
+1. In **Cycle Phase**, click **Run Member Vote Tally**.
+2. This calls `POST /api/proposals/vote`, which:
+   - Tallies √vMOONEY-weighted distributions
+   - Flips winners to `active` / losers to vote-failed on `ProjectTable` (HSM)
+   - Logs a vMOONEY + distributions snapshot to the server console
+3. **Paste that snapshot** into `ui/lib/proposals/vMooneySnapshots.ts` under
+   `MEMBER_VOTE_VMOONEY_SNAPSHOTS` and open a follow-up PR so the public audit
+   stays frozen.
+4. Optionally upgrade the snapshot later with  
+   `yarn --prefix ui snapshot:vmooney -- --kind=member --quarter=Q --year=Y`.
+
+If the API returns “Voting period has not ended,” wait until the window is over
+(mainnet enforces this).
+
+---
+
+## 5. Wrap up the cycle (UI)
+
+After the member tally (and after retro is settled):
+
+1. Click **Wrap Up Cycle** in the Operator Panel.
+2. Live phase → **idle**. Senate / Member / Retro UIs stop highlighting as active.
+3. Run **Clear Retro Cohort** if you haven’t already.
+4. Pin the completed retro pool into `HISTORICAL_RETRO_POOLS` in
+   `computeRetroactiveOutcome.ts` when you roll config to the next cycle.
+
+---
+
+## 6. Next quarter
+
+Return to **§0**. Edit `PROJECT_CYCLE` (new quarter, budget, retro for the
+cohort you just closed, `phase: 'senate'`), PR, deploy.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Operator Panel missing | Wallet not in `OPERATORS` / not signed in | Sign in with an allowlisted wallet |
+| Advance fails: HSM not available | Missing `GCP_SIGNER_*` env on Vercel | Restore HSM env; do not transfer ownership to a personal EOA |
+| `OwnableUnauthorizedAccount` | HSM is not contract owner | Transfer ownership back to `GCP_HSM_SIGNER_ADDRESS` |
+| Advance 409 with blockers | Quorum not met on some MDPs | Wait for votes, or Force if intentional |
+| UI still on Senate after Advance | Stale ISR / cache | Wait ~60s or hard-refresh; panel polls `/api/operator/phase-status` |
+| Phase stuck / wrong after deploy | Live KV override still set | Expected — override wins over `PROJECT_CYCLE.phase`. Wrap up or advance, or clear the Redis key `moondao:operator:cycle_phase` |
+
+---
+
+## Mental model (short)
+
+```
+[Edit PROJECT_CYCLE + deploy]
+        ↓
+   Senate Vote  ──(Advance: tallyVotes + flip)──►  Member Vote + Retro
+                                                         │
+                                              (Run Member Vote Tally)
+                                                         │
+                                              (Wrap Up Cycle)
+                                                         ↓
+                                                       Idle
+                                                         │
+                                              [Edit PROJECT_CYCLE + deploy]
+                                                         ↓
+                                                  next Senate Vote
+```
+
+Runtime advances (Senate → Member → Idle) = button + HSM txs + Redis phase.
+Starting a new quarter = edit `PROJECT_CYCLE` + deploy.

--- a/ui/lib/operator/cyclePhase.ts
+++ b/ui/lib/operator/cyclePhase.ts
@@ -1,0 +1,144 @@
+import { Redis } from '@upstash/redis'
+import { PROJECT_CYCLE } from 'const/config'
+import type { ProjectCyclePhase } from 'const/config'
+
+/**
+ * Live project-cycle phase override.
+ *
+ * The deploy-time default phase lives in `PROJECT_CYCLE.phase` (const/config).
+ * This module layers a runtime override on top of it — backed by the same
+ * Upstash Redis store the rate-limiter / geo cache use — so the Executive
+ * Branch can advance the cycle (Senate → Member → idle) from the operator
+ * panel WITHOUT a redeploy. If the override is missing, expired, or KV is
+ * unreachable, callers fall back to the config default, so the site always
+ * has a safe, deterministic phase.
+ *
+ * Only the phase flag is stored here. Per-cycle numbers (budget, retro pool,
+ * deadlines) are NOT runtime-overridable — those are deliberate, reviewed
+ * edits to `PROJECT_CYCLE` that roll the whole cycle forward at once.
+ */
+
+export type { ProjectCyclePhase }
+
+// Ordered phase progression within a single cycle. Advancing past 'idle'
+// (into the next cycle's Senate Vote) is intentionally NOT automatic: it
+// requires editing PROJECT_CYCLE (new quarter, budget, retro pool), which is
+// a reviewed config change rather than a one-click runtime flip.
+export const PHASE_ORDER: ProjectCyclePhase[] = ['senate', 'member', 'idle']
+
+export type PhaseFlags = {
+  isSenateVote: boolean
+  isMemberVote: boolean
+  // Retroactive rewards run concurrently with the Member Vote.
+  isRewardsCycle: boolean
+}
+
+// Single mapping from a phase to the three boolean flags the rest of the app
+// reads. Mirrors the derived constants in const/config.ts so the live phase
+// and the deploy-time default resolve flags identically.
+export function getPhaseFlags(phase: ProjectCyclePhase): PhaseFlags {
+  return {
+    isSenateVote: phase === 'senate',
+    isMemberVote: phase === 'member',
+    isRewardsCycle: phase === 'member',
+  }
+}
+
+// The phase the operator "Advance Phase" button moves to next, or null when
+// there's nothing left to advance to within this cycle (i.e. already idle).
+export function getNextPhase(
+  phase: ProjectCyclePhase
+): ProjectCyclePhase | null {
+  const idx = PHASE_ORDER.indexOf(phase)
+  if (idx === -1 || idx >= PHASE_ORDER.length - 1) return null
+  return PHASE_ORDER[idx + 1]
+}
+
+export type LivePhaseOverride = {
+  // null → follow the PROJECT_CYCLE.phase default.
+  phase: ProjectCyclePhase | null
+  setBy?: string
+  note?: string
+  setAt?: string // ISO timestamp
+}
+
+const LIVE_PHASE_KEY = 'moondao:operator:cycle_phase'
+
+let cachedRedis: Redis | null | undefined
+function getRedis(): Redis | null {
+  if (cachedRedis !== undefined) return cachedRedis
+  const url = process.env.UPSTASH_REDIS_URL
+  const token = process.env.UPSTASH_REDIS_TOKEN
+  cachedRedis = url && token ? new Redis({ url, token }) : null
+  return cachedRedis
+}
+
+function isProjectCyclePhase(value: unknown): value is ProjectCyclePhase {
+  return value === 'senate' || value === 'member' || value === 'idle'
+}
+
+/**
+ * Read the live phase override. Returns `{ phase: null }` when unset, malformed,
+ * or when KV is unreachable — callers must treat null as "use config default".
+ */
+export async function getLivePhaseOverride(): Promise<LivePhaseOverride> {
+  const redis = getRedis()
+  if (!redis) return { phase: null }
+  try {
+    const value = await redis.get<LivePhaseOverride | string | null>(
+      LIVE_PHASE_KEY
+    )
+    if (value == null) return { phase: null }
+    const record: any =
+      typeof value === 'string' ? JSON.parse(value) : value
+    return {
+      phase: isProjectCyclePhase(record?.phase) ? record.phase : null,
+      setBy: typeof record?.setBy === 'string' ? record.setBy : undefined,
+      note: typeof record?.note === 'string' ? record.note : undefined,
+      setAt: typeof record?.setAt === 'string' ? record.setAt : undefined,
+    }
+  } catch (err) {
+    console.error('[cyclePhase] getLivePhaseOverride failed:', err)
+    return { phase: null }
+  }
+}
+
+/**
+ * Persist a live phase override. Pass `phase: null` to clear it (revert to the
+ * config default). Throws if KV is not configured so the operator endpoint can
+ * surface a clear error instead of silently no-opping.
+ */
+export async function setLivePhaseOverride(params: {
+  phase: ProjectCyclePhase | null
+  setBy?: string
+  note?: string
+}): Promise<LivePhaseOverride> {
+  const redis = getRedis()
+  if (!redis) {
+    throw new Error(
+      'Live phase store is not configured (UPSTASH_REDIS_URL / UPSTASH_REDIS_TOKEN).'
+    )
+  }
+  if (params.phase === null) {
+    await redis.del(LIVE_PHASE_KEY)
+    return { phase: null }
+  }
+  const record: LivePhaseOverride = {
+    phase: params.phase,
+    setBy: params.setBy,
+    note: params.note,
+    setAt: new Date().toISOString(),
+  }
+  await redis.set(LIVE_PHASE_KEY, record)
+  return record
+}
+
+/**
+ * Effective phase = live override (if set) else the PROJECT_CYCLE default.
+ * This is the single resolver every read path should use.
+ */
+export function resolveLivePhase(
+  override: LivePhaseOverride | null | undefined
+): ProjectCyclePhase {
+  return override?.phase ?? PROJECT_CYCLE.phase
+}

--- a/ui/lib/operator/cyclePhase.ts
+++ b/ui/lib/operator/cyclePhase.ts
@@ -13,9 +13,10 @@ import type { ProjectCyclePhase } from 'const/config'
  * unreachable, callers fall back to the config default, so the site always
  * has a safe, deterministic phase.
  *
- * Only the phase flag is stored here. Per-cycle numbers (budget, retro pool,
- * deadlines) are NOT runtime-overridable — those are deliberate, reviewed
- * edits to `PROJECT_CYCLE` that roll the whole cycle forward at once.
+ * Phase and Member Vote submissions-open are stored here. Per-cycle numbers
+ * (budget, retro pool, deadlines) are NOT runtime-overridable — those are
+ * deliberate, reviewed edits to `PROJECT_CYCLE` that roll the whole cycle
+ * forward at once.
  */
 
 export type { ProjectCyclePhase }
@@ -57,6 +58,10 @@ export function getNextPhase(
 export type LivePhaseOverride = {
   // null → follow the PROJECT_CYCLE.phase default.
   phase: ProjectCyclePhase | null
+  // When set, overrides PROJECT_CYCLE.memberVoteSubmissionsOpen so Advance
+  // Phase (Senate → Member) can open the distribute UI without a redeploy.
+  // Cleared with the phase key on wrap-up / delete.
+  memberVoteSubmissionsOpen?: boolean | null
   setBy?: string
   note?: string
   setAt?: string // ISO timestamp
@@ -93,6 +98,10 @@ export async function getLivePhaseOverride(): Promise<LivePhaseOverride> {
       typeof value === 'string' ? JSON.parse(value) : value
     return {
       phase: isProjectCyclePhase(record?.phase) ? record.phase : null,
+      memberVoteSubmissionsOpen:
+        typeof record?.memberVoteSubmissionsOpen === 'boolean'
+          ? record.memberVoteSubmissionsOpen
+          : null,
       setBy: typeof record?.setBy === 'string' ? record.setBy : undefined,
       note: typeof record?.note === 'string' ? record.note : undefined,
       setAt: typeof record?.setAt === 'string' ? record.setAt : undefined,
@@ -110,6 +119,7 @@ export async function getLivePhaseOverride(): Promise<LivePhaseOverride> {
  */
 export async function setLivePhaseOverride(params: {
   phase: ProjectCyclePhase | null
+  memberVoteSubmissionsOpen?: boolean | null
   setBy?: string
   note?: string
 }): Promise<LivePhaseOverride> {
@@ -125,6 +135,10 @@ export async function setLivePhaseOverride(params: {
   }
   const record: LivePhaseOverride = {
     phase: params.phase,
+    memberVoteSubmissionsOpen:
+      typeof params.memberVoteSubmissionsOpen === 'boolean'
+        ? params.memberVoteSubmissionsOpen
+        : null,
     setBy: params.setBy,
     note: params.note,
     setAt: new Date().toISOString(),
@@ -141,4 +155,23 @@ export function resolveLivePhase(
   override: LivePhaseOverride | null | undefined
 ): ProjectCyclePhase {
   return override?.phase ?? PROJECT_CYCLE.phase
+}
+
+/**
+ * Whether Member Vote distribution submit/edit UI is open.
+ * Live override (set true on Senate → Member advance) wins over the
+ * deploy-time PROJECT_CYCLE.memberVoteSubmissionsOpen default. Legacy
+ * overrides that only stored `phase: 'member'` are treated as open —
+ * that advance meant "Open Member Vote".
+ */
+export function resolveMemberVoteSubmissionsOpen(
+  phase: ProjectCyclePhase,
+  override: LivePhaseOverride | null | undefined
+): boolean {
+  if (phase !== 'member') return false
+  if (typeof override?.memberVoteSubmissionsOpen === 'boolean') {
+    return override.memberVoteSubmissionsOpen
+  }
+  if (override?.phase === 'member') return true
+  return PROJECT_CYCLE.memberVoteSubmissionsOpen
 }

--- a/ui/lib/operator/useIsExecutive.ts
+++ b/ui/lib/operator/useIsExecutive.ts
@@ -21,6 +21,20 @@ export function useIsExecutive() {
     let cancelled = false
 
     async function check() {
+      // In local next-dev on testnet, surface the operator panel without a
+      // Privy session so the Cycle Phase UI can be previewed. Server routes
+      // still use the isOperator middleware (which also bypasses on testnet).
+      // Never enable this for production/mainnet builds.
+      if (
+        process.env.NODE_ENV === 'development' &&
+        process.env.NEXT_PUBLIC_CHAIN === 'testnet'
+      ) {
+        setIsExecutive(true)
+        setStatus('success')
+        setLastError(null)
+        return
+      }
+
       if (sessionStatus === 'loading') return
       if (sessionStatus !== 'authenticated') {
         setIsExecutive(false)

--- a/ui/lib/operator/useLivePhase.ts
+++ b/ui/lib/operator/useLivePhase.ts
@@ -1,0 +1,44 @@
+import { PROJECT_CYCLE } from 'const/config'
+import type { ProjectCyclePhase } from 'const/config'
+import useSWR from 'swr'
+import { getPhaseFlags, type PhaseFlags } from '@/lib/operator/cyclePhase'
+import fetcher from '@/lib/swr/fetcher'
+
+type PhaseStatusResponse = {
+  livePhase: ProjectCyclePhase
+  flags: PhaseFlags
+}
+
+/**
+ * Client-side live project-cycle phase.
+ *
+ * Seeds from the deploy-time `PROJECT_CYCLE.phase` defaults, then refreshes
+ * from `/api/operator/phase-status` so one-click operator advances propagate
+ * without a redeploy. Prefer this over the `IS_*_VOTE` config constants in
+ * client components that surface voting CTAs outside `/projects`.
+ */
+export function useLivePhase() {
+  const { data } = useSWR<PhaseStatusResponse>(
+    '/api/operator/phase-status',
+    fetcher,
+    {
+      revalidateOnFocus: true,
+      dedupingInterval: 60_000,
+      errorRetryCount: 1,
+      fallbackData: {
+        livePhase: PROJECT_CYCLE.phase,
+        flags: getPhaseFlags(PROJECT_CYCLE.phase),
+      },
+    }
+  )
+
+  const phase = data?.livePhase ?? PROJECT_CYCLE.phase
+  const flags = data?.flags ?? getPhaseFlags(phase)
+
+  return {
+    phase,
+    isSenateVote: flags.isSenateVote,
+    isMemberVote: flags.isMemberVote,
+    isRewardsCycle: flags.isRewardsCycle,
+  }
+}

--- a/ui/pages/api/operator/advance-phase.ts
+++ b/ui/pages/api/operator/advance-phase.ts
@@ -124,7 +124,7 @@ async function tallySenateForCurrentCycle(
 
   for (const project of pending) {
     const mdp = Number(project.MDP)
-    const base: SenateTallyResult = {
+    const base: Omit<SenateTallyResult, 'status'> = {
       mdp,
       projectId: project.id,
       name: project.name,

--- a/ui/pages/api/operator/advance-phase.ts
+++ b/ui/pages/api/operator/advance-phase.ts
@@ -358,6 +358,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
       saved = await setLivePhaseOverride({
         phase: 'member',
+        // Open distribute/submit UI with the phase flip — config defaults
+        // memberVoteSubmissionsOpen to false until a redeploy, which would
+        // leave Member Vote "open" but submissions permanently gated.
+        memberVoteSubmissionsOpen: true,
         setBy,
         note: `Advanced Senate → Member${force ? ' (forced)' : ''} from operator panel`,
       })

--- a/ui/pages/api/operator/advance-phase.ts
+++ b/ui/pages/api/operator/advance-phase.ts
@@ -352,11 +352,31 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
     }
 
-    const saved = await setLivePhaseOverride({
-      phase: 'member',
-      setBy,
-      note: `Advanced Senate → Member${force ? ' (forced)' : ''} from operator panel`,
-    })
+    // Tallies may already be on-chain at this point. Catch KV failures so the
+    // client learns tallies succeeded and can retry only the phase flip.
+    let saved: Awaited<ReturnType<typeof setLivePhaseOverride>>
+    try {
+      saved = await setLivePhaseOverride({
+        phase: 'member',
+        setBy,
+        note: `Advanced Senate → Member${force ? ' (forced)' : ''} from operator panel`,
+      })
+    } catch (err) {
+      console.error(
+        '[advance-phase] phase override failed after senate tally:',
+        err
+      )
+      return res.status(500).json({
+        error:
+          'Senate tallies succeeded on-chain, but failed to set live phase to member. Retry Advance Phase (or fix Upstash) — already-tallied proposals are skipped.',
+        currentPhase,
+        nextPhase,
+        senateTally: tally.results,
+        blockers: tally.blockers,
+        tallySucceeded: true,
+        phaseOverrideFailed: true,
+      })
+    }
 
     // Bust the ISR cache so visitors who reload (or whose phase poll triggers
     // a reload) pick up fresh Senate flags + retro distributions for the new
@@ -389,11 +409,25 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         wouldAdvance: true,
       })
     }
-    const saved = await setLivePhaseOverride({
-      phase: 'idle',
-      setBy,
-      note: 'Wrapped up cycle (Member → idle) from operator panel',
-    })
+    let saved: Awaited<ReturnType<typeof setLivePhaseOverride>>
+    try {
+      saved = await setLivePhaseOverride({
+        phase: 'idle',
+        setBy,
+        note: 'Wrapped up cycle (Member → idle) from operator panel',
+      })
+    } catch (err) {
+      console.error('[advance-phase] phase override failed (member → idle):', err)
+      return res.status(500).json({
+        error:
+          err instanceof Error
+            ? err.message
+            : 'Failed to set live phase to idle.',
+        currentPhase,
+        nextPhase,
+        phaseOverrideFailed: true,
+      })
+    }
 
     try {
       await res.revalidate('/projects')

--- a/ui/pages/api/operator/advance-phase.ts
+++ b/ui/pages/api/operator/advance-phase.ts
@@ -108,8 +108,9 @@ async function tallySenateForCurrentCycle(
 
   // Read quorum once (same value for every proposal). Fully-qualified
   // signature so thirdweb bypasses the JSON ABI (which omits getQuorum on the
-  // live contract) — same trick closeSenate.ts uses.
-  let quorum = 0
+  // live contract) — same trick closeSenate.ts uses. Abort if we can't read
+  // it: falling back to 0 would let every pending MDP pass the pre-check.
+  let quorum: number
   try {
     quorum = Number(
       await readContractWithRetry<bigint>(
@@ -119,7 +120,8 @@ async function tallySenateForCurrentCycle(
       )
     )
   } catch (error) {
-    console.warn('[advance-phase] getQuorum failed; proceeding with quorum=0', error)
+    console.error('[advance-phase] getQuorum failed:', error)
+    throw new Error('Failed to read Senate quorum from chain.')
   }
 
   for (const project of pending) {
@@ -356,6 +358,15 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       note: `Advanced Senate → Member${force ? ' (forced)' : ''} from operator panel`,
     })
 
+    // Bust the ISR cache so visitors who reload (or whose phase poll triggers
+    // a reload) pick up fresh Senate flags + retro distributions for the new
+    // phase instead of the prior-cycle getStaticProps snapshot.
+    try {
+      await res.revalidate('/projects')
+    } catch (err) {
+      console.warn('[advance-phase] failed to revalidate /projects:', err)
+    }
+
     return res.status(200).json({
       success: true,
       currentPhase,
@@ -383,6 +394,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       setBy,
       note: 'Wrapped up cycle (Member → idle) from operator panel',
     })
+
+    try {
+      await res.revalidate('/projects')
+    } catch (err) {
+      console.warn('[advance-phase] failed to revalidate /projects:', err)
+    }
+
     return res.status(200).json({
       success: true,
       currentPhase,

--- a/ui/pages/api/operator/advance-phase.ts
+++ b/ui/pages/api/operator/advance-phase.ts
@@ -1,0 +1,403 @@
+import ProposalsABI from 'const/abis/Proposals.json'
+import {
+  DEFAULT_CHAIN_V5,
+  PROJECT_CYCLE,
+  PROJECT_TABLE_NAMES,
+  PROPOSALS_ADDRESSES,
+} from 'const/config'
+import { isOperator } from 'middleware/isOperator'
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getServerSession } from 'next-auth/next'
+import {
+  getContract,
+  prepareContractCall,
+  readContract,
+  sendAndConfirmTransaction,
+} from 'thirdweb'
+import { createHSMWallet, isHSMAvailable } from '@/lib/google/hsm-signer'
+import { PROJECT_PENDING } from '@/lib/nance/types'
+import {
+  getLivePhaseOverride,
+  getNextPhase,
+  resolveLivePhase,
+  setLivePhaseOverride,
+} from '@/lib/operator/cyclePhase'
+import { getPrivyUserData } from '@/lib/privy'
+import queryTable from '@/lib/tableland/queryTable'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import { serverClient } from '@/lib/thirdweb/serverClient'
+import { authOptions } from '../auth/[...nextauth]'
+
+const chain = DEFAULT_CHAIN_V5
+const chainSlug = getChainSlug(chain)
+
+// thirdweb's RPC layer occasionally returns `undefined` for a successful view
+// call, which then crashes viem's decoder. Same retry helper used by
+// closeSenate.ts / vote.ts so a flaky read doesn't abort the whole advance.
+async function readContractWithRetry<T>(
+  contract: any,
+  method: string,
+  params: any[],
+  maxRetries = 4,
+  baseDelayMs = 400
+): Promise<T> {
+  let lastError: any
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      return (await readContract({ contract, method, params })) as T
+    } catch (error) {
+      lastError = error
+      const message = error instanceof Error ? error.message : String(error ?? '')
+      const transient =
+        (error instanceof TypeError && message.includes('buffer')) ||
+        message.includes('Block not found') ||
+        message.includes('block not found') ||
+        message.includes('rate limit') ||
+        message.includes('timeout') ||
+        message.includes('ECONNRESET')
+      if (!transient || attempt === maxRetries - 1) throw error
+      await new Promise((r) => setTimeout(r, baseDelayMs * Math.pow(2, attempt)))
+    }
+  }
+  throw lastError
+}
+
+type SenateTallyResult = {
+  mdp: number
+  projectId: number | string
+  name?: string
+  status: 'passed' | 'failed' | 'already-closed' | 'below-quorum' | 'error'
+  voteCount?: number
+  approvalCount?: number
+  quorum?: number
+  txHash?: string
+  error?: string
+}
+
+// Close the Senate Vote for every pending project proposal in the current
+// cycle by calling `Proposals.tallyVotes(mdp)` from the HSM wallet that owns
+// the Proposals contract. Mirrors closeSenate.ts (which does a single MDP),
+// but batches the whole current-quarter cohort so the operator doesn't have
+// to visit each proposal page. `tallyVotes` is a no-op below quorum, so we
+// pre-check and skip those instead of burning gas.
+async function tallySenateForCurrentCycle(
+  dryRun: boolean
+): Promise<{ results: SenateTallyResult[]; blockers: SenateTallyResult[] }> {
+  const proposalContract = getContract({
+    client: serverClient,
+    address: PROPOSALS_ADDRESSES[chainSlug],
+    abi: ProposalsABI.abi as any,
+    chain,
+  })
+
+  const projectStatement = `SELECT * FROM ${PROJECT_TABLE_NAMES[chainSlug]} WHERE quarter = ${PROJECT_CYCLE.quarter} AND year = ${PROJECT_CYCLE.year}`
+  const projects = (await queryTable(chain, projectStatement)) || []
+
+  // Only pending proposals with an MDP can be in Senate Vote.
+  const pending = projects.filter(
+    (p: any) =>
+      Number(p.active) === PROJECT_PENDING &&
+      p.MDP !== undefined &&
+      p.MDP !== null
+  )
+
+  const results: SenateTallyResult[] = []
+  const account = dryRun ? null : await createHSMWallet()
+
+  // Read quorum once (same value for every proposal). Fully-qualified
+  // signature so thirdweb bypasses the JSON ABI (which omits getQuorum on the
+  // live contract) — same trick closeSenate.ts uses.
+  let quorum = 0
+  try {
+    quorum = Number(
+      await readContractWithRetry<bigint>(
+        proposalContract,
+        'function getQuorum() view returns (uint256)',
+        []
+      )
+    )
+  } catch (error) {
+    console.warn('[advance-phase] getQuorum failed; proceeding with quorum=0', error)
+  }
+
+  for (const project of pending) {
+    const mdp = Number(project.MDP)
+    const base: SenateTallyResult = {
+      mdp,
+      projectId: project.id,
+      name: project.name,
+      quorum,
+    }
+    try {
+      const [approved, failed, voteCount, approvalCount] = await Promise.all([
+        readContractWithRetry<boolean>(
+          proposalContract,
+          'function tempCheckApproved(uint256) view returns (bool)',
+          [mdp]
+        ),
+        readContractWithRetry<boolean>(
+          proposalContract,
+          'function tempCheckFailed(uint256) view returns (bool)',
+          [mdp]
+        ),
+        readContractWithRetry<bigint>(
+          proposalContract,
+          'function tempCheckVoteCount(uint256) view returns (uint256)',
+          [mdp]
+        ),
+        readContractWithRetry<bigint>(
+          proposalContract,
+          'function tempCheckApprovalCount(uint256) view returns (uint256)',
+          [mdp]
+        ),
+      ])
+      base.voteCount = Number(voteCount)
+      base.approvalCount = Number(approvalCount)
+
+      if (approved) {
+        results.push({ ...base, status: 'passed' })
+        continue
+      }
+      if (failed) {
+        results.push({ ...base, status: 'failed' })
+        continue
+      }
+      if (Number(voteCount) < quorum) {
+        results.push({ ...base, status: 'below-quorum' })
+        continue
+      }
+
+      if (dryRun) {
+        // Would tally, but don't send. Report the expected outcome from the
+        // on-chain 2/3 supermajority rule so the operator can preview.
+        const wouldPass = Number(approvalCount) * 3 >= Number(voteCount) * 2
+        results.push({ ...base, status: wouldPass ? 'passed' : 'failed' })
+        continue
+      }
+
+      const transaction = prepareContractCall({
+        contract: proposalContract,
+        method: 'function tallyVotes(uint256)',
+        params: [BigInt(mdp)],
+      })
+      let txHash: string | undefined
+      let lastError: unknown
+      const MAX_TX_ATTEMPTS = 4
+      for (let attempt = 1; attempt <= MAX_TX_ATTEMPTS; attempt++) {
+        try {
+          const receipt = await sendAndConfirmTransaction({
+            transaction,
+            account: account as any,
+          })
+          txHash = receipt.transactionHash
+          break
+        } catch (error) {
+          lastError = error
+          const message =
+            error instanceof Error ? error.message : String(error ?? '')
+          const transient =
+            message.includes('Block not found') ||
+            message.includes('block not found') ||
+            message.includes('rate limit') ||
+            message.includes('timeout')
+          if (!transient || attempt === MAX_TX_ATTEMPTS) break
+          await new Promise((r) => setTimeout(r, 750 * Math.pow(2, attempt - 1)))
+        }
+      }
+      if (!txHash) {
+        results.push({
+          ...base,
+          status: 'error',
+          error:
+            lastError instanceof Error ? lastError.message : String(lastError),
+        })
+        continue
+      }
+
+      // Re-read to report the real outcome rather than guessing.
+      let passed = Number(approvalCount) * 3 >= Number(voteCount) * 2
+      try {
+        const [approvedAfter, failedAfter] = await Promise.all([
+          readContractWithRetry<boolean>(
+            proposalContract,
+            'function tempCheckApproved(uint256) view returns (bool)',
+            [mdp]
+          ),
+          readContractWithRetry<boolean>(
+            proposalContract,
+            'function tempCheckFailed(uint256) view returns (bool)',
+            [mdp]
+          ),
+        ])
+        passed = Boolean(approvedAfter) && !Boolean(failedAfter)
+      } catch {
+        /* fall back to the pre-tx ratio computed above */
+      }
+      results.push({ ...base, status: passed ? 'passed' : 'failed', txHash })
+    } catch (error) {
+      results.push({
+        ...base,
+        status: 'error',
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  // Blockers = anything that leaves the Senate Vote unfinished: proposals that
+  // still haven't reached quorum, or that errored during tally.
+  const blockers = results.filter(
+    (r) => r.status === 'below-quorum' || r.status === 'error'
+  )
+  return { results, blockers }
+}
+
+/**
+ * One-click phase advance for the project cycle.
+ *
+ * Body: { dryRun?: boolean, force?: boolean }
+ *
+ * - Senate → Member: closes the Senate Vote on-chain (tallyVotes per pending
+ *   MDP), then flips the live phase to 'member' (opens Member Vote + Retro).
+ *   Refuses (409) if any proposal is still below quorum or errored, unless
+ *   `force: true`. `dryRun: true` previews the tally plan without sending txs
+ *   or flipping the phase.
+ * - Member → idle: flips the live phase to 'idle' (wraps up the cycle UI).
+ *   The Member Vote on-chain tally (which moves funds / flips winners to
+ *   active) is intentionally kept behind its own dedicated action
+ *   (`POST /api/proposals/vote`, surfaced in the operator panel) with its
+ *   voting-window + snapshot safeguards, so this route does NOT run it.
+ *
+ * Advancing from 'idle' into the next cycle's Senate Vote is not a runtime
+ * flip — it requires editing PROJECT_CYCLE (new quarter/budget/retro), a
+ * reviewed config change.
+ */
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const dryRun = req.body?.dryRun === true
+  const force = req.body?.force === true
+
+  const override = await getLivePhaseOverride()
+  const currentPhase = resolveLivePhase(override)
+  const nextPhase = getNextPhase(currentPhase)
+
+  if (!nextPhase) {
+    return res.status(400).json({
+      error:
+        'Cycle is idle — nothing to advance to. Start the next cycle by editing PROJECT_CYCLE in const/config.ts (new quarter, budget, retro pool) and deploying.',
+      currentPhase,
+    })
+  }
+
+  // Resolve who is advancing the phase for the audit note (best-effort).
+  let setBy: string | undefined
+  try {
+    const session = await getServerSession(req, res, authOptions)
+    if (session?.accessToken) {
+      const privyUserData = await getPrivyUserData(session.accessToken)
+      setBy = privyUserData?.walletAddresses?.[0]
+    }
+  } catch (err) {
+    console.warn('[advance-phase] could not derive setBy address:', err)
+  }
+
+  // Senate → Member requires the on-chain Senate tally.
+  if (currentPhase === 'senate' && nextPhase === 'member') {
+    if (!dryRun && !isHSMAvailable()) {
+      return res.status(500).json({
+        error:
+          'HSM signer not available. Set GCP_SIGNER_SERVICE_ACCOUNT and GCP_PROJECT_ID.',
+      })
+    }
+
+    let tally: Awaited<ReturnType<typeof tallySenateForCurrentCycle>>
+    try {
+      tally = await tallySenateForCurrentCycle(dryRun)
+    } catch (error) {
+      console.error('[advance-phase] senate tally failed:', error)
+      return res.status(500).json({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to tally Senate votes.',
+      })
+    }
+
+    if (dryRun) {
+      return res.status(200).json({
+        dryRun: true,
+        currentPhase,
+        nextPhase,
+        senateTally: tally.results,
+        blockers: tally.blockers,
+        wouldAdvance: tally.blockers.length === 0 || force,
+      })
+    }
+
+    if (tally.blockers.length > 0 && !force) {
+      return res.status(409).json({
+        error:
+          'Senate Vote not fully closed: some proposals are below quorum or errored. Resolve them, or retry with force to advance anyway.',
+        currentPhase,
+        nextPhase,
+        senateTally: tally.results,
+        blockers: tally.blockers,
+      })
+    }
+
+    const saved = await setLivePhaseOverride({
+      phase: 'member',
+      setBy,
+      note: `Advanced Senate → Member${force ? ' (forced)' : ''} from operator panel`,
+    })
+
+    return res.status(200).json({
+      success: true,
+      currentPhase,
+      newPhase: saved.phase,
+      senateTally: tally.results,
+      blockers: tally.blockers,
+      override: saved,
+    })
+  }
+
+  // Member → idle: UI wrap-up only. The member-vote on-chain tally is a
+  // separate, safeguarded action.
+  if (currentPhase === 'member' && nextPhase === 'idle') {
+    if (dryRun) {
+      return res.status(200).json({
+        dryRun: true,
+        currentPhase,
+        nextPhase,
+        note: 'Would wrap up the cycle (set live phase to idle). Run the Member Vote tally (POST /api/proposals/vote) first if it has not been run.',
+        wouldAdvance: true,
+      })
+    }
+    const saved = await setLivePhaseOverride({
+      phase: 'idle',
+      setBy,
+      note: 'Wrapped up cycle (Member → idle) from operator panel',
+    })
+    return res.status(200).json({
+      success: true,
+      currentPhase,
+      newPhase: saved.phase,
+      reminder:
+        'Cycle UI wrapped up. Ensure the Member Vote on-chain tally has been run (operator panel → "Run Member Vote Tally").',
+      override: saved,
+    })
+  }
+
+  return res.status(400).json({
+    error: `Unsupported transition ${currentPhase} → ${nextPhase}.`,
+    currentPhase,
+    nextPhase,
+  })
+}
+
+export default withMiddleware(handler, rateLimit, isOperator)

--- a/ui/pages/api/operator/phase-status.ts
+++ b/ui/pages/api/operator/phase-status.ts
@@ -1,0 +1,37 @@
+import { PROJECT_CYCLE } from 'const/config'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  getLivePhaseOverride,
+  getNextPhase,
+  getPhaseFlags,
+  resolveLivePhase,
+} from '@/lib/operator/cyclePhase'
+
+// Public read of the current project-cycle phase. Returns the deploy-time
+// default (PROJECT_CYCLE.phase), the live override (if any), and the resolved
+// effective phase + its boolean flags. Unauthenticated on purpose: the phase
+// is already visible from the /projects UI, and both the projects page
+// (getStaticProps) and the operator panel poll this to stay in sync without a
+// redeploy. All mutation goes through the operator-gated /advance-phase route.
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const override = await getLivePhaseOverride()
+  const phase = resolveLivePhase(override)
+
+  return res.status(200).json({
+    configPhase: PROJECT_CYCLE.phase,
+    livePhase: phase,
+    override,
+    nextPhase: getNextPhase(phase),
+    flags: getPhaseFlags(phase),
+    quarter: PROJECT_CYCLE.quarter,
+    year: PROJECT_CYCLE.year,
+  })
+}

--- a/ui/pages/api/operator/phase-status.ts
+++ b/ui/pages/api/operator/phase-status.ts
@@ -5,6 +5,7 @@ import {
   getNextPhase,
   getPhaseFlags,
   resolveLivePhase,
+  resolveMemberVoteSubmissionsOpen,
 } from '@/lib/operator/cyclePhase'
 
 // Public read of the current project-cycle phase. Returns the deploy-time
@@ -31,6 +32,10 @@ export default async function handler(
     override,
     nextPhase: getNextPhase(phase),
     flags: getPhaseFlags(phase),
+    memberVoteSubmissionsOpen: resolveMemberVoteSubmissionsOpen(
+      phase,
+      override
+    ),
     quarter: PROJECT_CYCLE.quarter,
     year: PROJECT_CYCLE.year,
   })

--- a/ui/pages/projects/index.tsx
+++ b/ui/pages/projects/index.tsx
@@ -5,11 +5,15 @@ import {
   DISTRIBUTION_TABLE_NAMES,
   PROPOSALS_TABLE_NAMES,
   PROPOSALS_ADDRESSES,
-  IS_REWARDS_CYCLE,
 } from 'const/config'
+import type { ProjectCyclePhase } from 'const/config'
 import { BLOCKED_MDPS, BLOCKED_PROJECTS } from 'const/whitelist'
 import { useRouter } from 'next/router'
 import { PROJECT_ACTIVE, PROJECT_PENDING } from '@/lib/nance/types'
+import {
+  getLivePhaseOverride,
+  resolveLivePhase,
+} from '@/lib/operator/cyclePhase'
 import {
   getProjectDisplayName,
   isUntitledLike,
@@ -28,8 +32,10 @@ export default function Projects({
   pastProjects,
   distributions,
   proposalAllocations,
+  initialLivePhase,
 }: ProjectRewardsProps & {
   proposalAllocations: any[]
+  initialLivePhase: ProjectCyclePhase
 }) {
   const router = useRouter()
   useChainDefault()
@@ -40,6 +46,7 @@ export default function Projects({
       pastProjects={pastProjects}
       distributions={distributions}
       proposalAllocations={proposalAllocations}
+      initialLivePhase={initialLivePhase}
       refreshRewards={() => router.reload()}
     />
   )
@@ -49,17 +56,24 @@ export async function getStaticProps() {
   const chain = DEFAULT_CHAIN_V5
   const chainSlug = getChainSlug(chain)
 
+  // Resolve the live cycle phase (operator override in KV, else the
+  // PROJECT_CYCLE.phase default) so ISR renders match the current phase
+  // without a redeploy. Retro rewards run concurrently with the Member Vote.
+  const livePhase = resolveLivePhase(await getLivePhaseOverride())
+  const rewardsActive = livePhase === 'member'
+
   const emptyProps = {
     proposals: [] as Project[],
     currentProjects: [] as Project[],
     pastProjects: [] as Project[],
     distributions: [] as any[],
     proposalAllocations: [] as any[],
+    initialLivePhase: livePhase,
   }
 
   try {
     const { quarter, year } = getRelativeQuarter(
-      isRewardsCycle(new Date(), IS_REWARDS_CYCLE) ? -1 : 0
+      isRewardsCycle(new Date(), rewardsActive) ? -1 : 0
     )
 
     // The projects table is the one genuinely required read. If it fails
@@ -250,6 +264,7 @@ export async function getStaticProps() {
         pastProjects: pastProjects.reverse(),
         distributions,
         proposalAllocations,
+        initialLivePhase: livePhase,
       },
       revalidate: 60,
     }

--- a/ui/pages/projects/index.tsx
+++ b/ui/pages/projects/index.tsx
@@ -1,6 +1,7 @@
 import ProposalsABI from 'const/abis/Proposals.json'
 import {
   DEFAULT_CHAIN_V5,
+  PROJECT_CYCLE,
   PROJECT_TABLE_NAMES,
   DISTRIBUTION_TABLE_NAMES,
   PROPOSALS_TABLE_NAMES,
@@ -13,6 +14,7 @@ import { PROJECT_ACTIVE, PROJECT_PENDING } from '@/lib/nance/types'
 import {
   getLivePhaseOverride,
   resolveLivePhase,
+  resolveMemberVoteSubmissionsOpen,
 } from '@/lib/operator/cyclePhase'
 import {
   getProjectDisplayName,
@@ -33,9 +35,11 @@ export default function Projects({
   distributions,
   proposalAllocations,
   initialLivePhase,
+  initialMemberVoteSubmissionsOpen,
 }: ProjectRewardsProps & {
   proposalAllocations: any[]
   initialLivePhase: ProjectCyclePhase
+  initialMemberVoteSubmissionsOpen: boolean
 }) {
   const router = useRouter()
   useChainDefault()
@@ -47,6 +51,7 @@ export default function Projects({
       distributions={distributions}
       proposalAllocations={proposalAllocations}
       initialLivePhase={initialLivePhase}
+      initialMemberVoteSubmissionsOpen={initialMemberVoteSubmissionsOpen}
       refreshRewards={() => router.reload()}
     />
   )
@@ -59,7 +64,12 @@ export async function getStaticProps() {
   // Resolve the live cycle phase (operator override in KV, else the
   // PROJECT_CYCLE.phase default) so ISR renders match the current phase
   // without a redeploy. Retro rewards run concurrently with the Member Vote.
-  const livePhase = resolveLivePhase(await getLivePhaseOverride())
+  const livePhaseOverride = await getLivePhaseOverride()
+  const livePhase = resolveLivePhase(livePhaseOverride)
+  const memberVoteSubmissionsOpen = resolveMemberVoteSubmissionsOpen(
+    livePhase,
+    livePhaseOverride
+  )
   const rewardsActive = livePhase === 'member'
 
   const emptyProps = {
@@ -69,6 +79,7 @@ export async function getStaticProps() {
     distributions: [] as any[],
     proposalAllocations: [] as any[],
     initialLivePhase: livePhase,
+    initialMemberVoteSubmissionsOpen: memberVoteSubmissionsOpen,
   }
 
   try {
@@ -91,14 +102,17 @@ export async function getStaticProps() {
       return { props: emptyProps, revalidate: 60 }
     }
 
-    // The proposals that should appear on /projects are the ones that belong
-    // to the *current* calendar quarter — i.e. the cycle that's actively
-    // being voted on. `getSubmissionQuarter()` is intentionally NOT used
-    // here: past its ~3-week cutoff it advances to the *next* quarter
-    // (because a brand-new submission via /api/proposals/submit would target
-    // the next cycle), and using it for filtering causes every in-flight
-    // Q{n} proposal to vanish from the page the moment that cutoff passes.
-    const activeProposalQuarter = getRelativeQuarter(0)
+    // Proposal cohort = PROJECT_CYCLE.quarter/year — the same source
+    // advance-phase uses when batch-tallying Senate votes. Do NOT use
+    // getRelativeQuarter(0) here: at a calendar boundary or with a stale
+    // config roll those diverge and operators would close a different set
+    // of MDPs than the proposals shown on the page. Also avoid
+    // getSubmissionQuarter(): past its ~3-week cutoff it advances to the
+    // *next* quarter and would make in-flight Q{n} proposals vanish.
+    const activeProposalQuarter = {
+      quarter: PROJECT_CYCLE.quarter,
+      year: PROJECT_CYCLE.year,
+    }
     const proposals: Project[] = []
     const currentProjects: Project[] = []
     const pastProjects: Project[] = []
@@ -265,6 +279,7 @@ export async function getStaticProps() {
         distributions,
         proposalAllocations,
         initialLivePhase: livePhase,
+        initialMemberVoteSubmissionsOpen: memberVoteSubmissionsOpen,
       },
       revalidate: 60,
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes advancing the quarterly project cycle a **one-click operator action** instead of a hand-edited config flip + a redeploy + visiting each proposal page to close its Senate vote. Two deliverables the EB asked for:

1. **A single `PROJECT_CYCLE` config object** the EB edits once per quarter (phase, quarter/year, deadlines, budget, retro pool, member-vote flags). Every existing constant is now *derived* from it, so per-cycle numbers can't drift apart.
2. **A reinstated one-click "Advance Phase" button** in the operator panel that runs the required on-chain calls **and** flips the live phase at runtime — no redeploy needed.

This is the follow-up to #1480 (which did the manual Q3 flip). It supersedes that manual approach with tooling; see "Relationship to #1480" below.

## How the phase model works

The cycle has three phases: `senate` → `member` (Member Vote + Retroactive rewards run concurrently) → `idle` (wrapped up). Advancing into the *next* cycle's Senate vote stays a reviewed `PROJECT_CYCLE` edit (new quarter/budget/retro), since those numbers must be set deliberately.

- **Deploy-time default:** `PROJECT_CYCLE.phase` in `const/config.ts`.
- **Live override:** stored in Upstash Redis (the same store the rate-limiter / geo cache / RPC cache already use). Resolved as `override ?? PROJECT_CYCLE.phase`, with a safe fallback to the config default if KV is unset or unreachable.

## What advancing does (the on-chain calls)

- **Senate → Member:** `POST /api/operator/advance-phase` reads the current-cycle project proposals and signs `Proposals.tallyVotes(mdp)` (as the HSM owner wallet) for every pending MDP — idempotent, skips already-closed proposals and no-ops below quorum. Supports `dryRun` (preview the tally plan, no txs) and `force` (advance past below-quorum stragglers). On success it flips the live phase to `member`, which opens the Member Vote **and** the Retroactive rewards window together. This reuses the exact `tallyVotes` pattern already proven in `closeSenate.ts`, just batched across the cohort.
- **Member → idle:** flips the live phase to `idle` (wraps up the cycle UI). The Member Vote **on-chain tally** (which moves funds / flips winners to `active`) is deliberately kept behind its own dedicated, safeguarded action — surfaced in the panel as **"Run Member Vote Tally"** (`POST /api/proposals/vote`) — so the destructive financial tally keeps its voting-window + snapshot safeguards rather than being auto-run by a phase click.

## Files

| File | Change |
|---|---|
| `const/config.ts` | Add `PROJECT_CYCLE` + `ProjectCyclePhase`/`ProjectCycleConfig`; derive `IS_SENATE_VOTE`, `IS_MEMBER_VOTE`, `IS_REWARDS_CYCLE`, `MEMBER_VOTE_SUBMISSIONS_OPEN`, `MEMBER_VOTE_EXCLUDED_ADDRESSES`, `NEXT_QUARTER_BUDGET_USD`, `PROJECT_SYSTEM_CONFIG`, and all `RETRO_*` from it. |
| `lib/operator/cyclePhase.ts` (new) | KV-backed live-phase override (`get`/`set`/`resolve`), `getPhaseFlags`, `getNextPhase`, graceful fallback. |
| `pages/api/operator/phase-status.ts` (new) | Public GET of config/live/next phase + flags. |
| `pages/api/operator/advance-phase.ts` (new) | Operator-gated POST: on-chain senate tallies + live-phase flip; dry-run/force. |
| `pages/projects/index.tsx` | `getStaticProps` resolves the live phase (KV) to pick the retro quarter and seeds the client. |
| `components/nance/ProjectRewards.tsx` | Derives Senate/Member/Retro state from the live phase; polls `phase-status` so an advance propagates without a reload. |
| `components/operator/OperatorPanel.tsx` | New "Cycle Phase" card: phase-aware Advance button (preview/force), Member Vote tally trigger, per-MDP tally results. |

## Behavior-preserving on `main` (+ one inert fix)

The config refactor keeps every derived value identical to `main` while in the `senate` phase, with one intentional correction: `RETRO_PRIMARY_COMMUNITY_CIRCLE` no longer derives from the (rolled-forward) `NEXT_QUARTER_BUDGET_USD`; it's pinned to the retro cohort's own quarter (Q2 2026 → **$2,340.90**, not $2,431). This is inert until the retro window is active, but prevents the community-circle payout from being mis-stated once it opens.

## Security / safety

- Both mutating endpoints go through `isOperator` (EB allowlist, Privy-session verified) + `rateLimit`. `phase-status` is read-only and public (the phase is already visible in the UI).
- All on-chain writes are signed by the GCP HSM owner wallet server-side (operator EOAs can't call `onlyOwner` `tallyVotes` directly).
- KV unavailability degrades safely to the config default phase.

## Testing notes

Dependencies were installed in the sandbox to typecheck the change; a full end-to-end run needs the HSM + Upstash + Privy secrets, which aren't available here. Please verify on the Vercel preview that:
- The operator panel "Cycle Phase" card shows the live phase and a phase-appropriate button.
- "Preview (dry run)" in `senate` phase lists each pending MDP's would-be outcome without sending txs.
- Advancing flips `/projects` into Member Vote + Retro for all visitors within ~60s (no redeploy).

## Relationship to #1480

#1480 flipped the Q3 2026 cycle into Member Vote + Retro by editing the individual flags. This PR reintroduces those as fields of `PROJECT_CYCLE` and adds the tooling to advance via a button. If #1480 merges first, rebase this and set `PROJECT_CYCLE.phase = 'member'` (or just click Advance). If this merges first, #1480 becomes redundant. Recommend picking one path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ea1e90c-93e8-474b-9895-7f2060daf029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ea1e90c-93e8-474b-9895-7f2060daf029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

