### PR TITLE
fix(ui): stop Suspense hydration race in Layout shell

### DIFF
--- a/ui/components/layout/Layout.tsx
+++ b/ui/components/layout/Layout.tsx
@@ -5,9 +5,7 @@ import useTranslation from 'next-translate/useTranslation'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import React from 'react'
-import { useState } from 'react'
-import { useContext } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 import { Toaster } from 'react-hot-toast'
 import CitizenContext from '@/lib/citizen/citizen-context'
 import useNavigation from '@/lib/navigation/useNavigation'
@@ -40,6 +38,20 @@ const ProjectBanner = dynamic(() => import('./ProjectBanner'), {
 const CookieBanner = dynamic(() => import('./CookieBanner'), {
   ssr: false,
 })
+
+
+// Gate `ssr: false` dynamics so they never enter the SSR tree as dehydrated
+// Suspense boundaries. Mounting them only after hydration avoids React 18's
+// "Suspense boundary received an update before it finished hydrating" when a
+// sibling effect (theme, auth, banners) updates during the same pass.
+function ClientOnly({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+  if (!mounted) return null
+  return <>{children}</>
+}
 
 interface Layout {
   children: JSX.Element
@@ -101,7 +113,9 @@ export default function Layout({ children, lightMode, setLightMode }: Layout) {
         !lightMode ? 'dark background-dark' : 'background-light'
       } min-h-screen relative`}
     >
-      <SpaceBackground />
+      <ClientOnly>
+        <SpaceBackground />
+      </ClientOnly>
       <>
         {/* Mobile menu top bar - for screens smaller than xl */}
         <div className="xl:hidden">
@@ -147,19 +161,24 @@ export default function Layout({ children, lightMode, setLightMode }: Layout) {
           </div>
         </main>
 
-        {/* Global Search - Sticky on all pages */}
-        <GlobalSearch />
+        <ClientOnly>
+          {/* Global Search - Sticky on all pages */}
+          <GlobalSearch />
 
-        {/* Mission Banner - Fixed at bottom */}
-        <MissionBanner />
+          {/* Mission Banner - Fixed at bottom */}
+          <MissionBanner />
 
-        {/* Project Banner - Fixed at bottom (when mission banner is hidden) */}
-        <ProjectBanner />
+          {/* Project Banner - Fixed at bottom (when mission banner is hidden) */}
+          <ProjectBanner />
+
+          <CookieBanner />
+        </ClientOnly>
       </>
 
-      <CookieBanner />
-      <Toaster />
-      <Analytics />
+      <ClientOnly>
+        <Toaster />
+        <Analytics />
+      </ClientOnly>
     </div>
   )
 

--- a/ui/lib/utils/hooks/useLightMode.ts
+++ b/ui/lib/utils/hooks/useLightMode.ts
@@ -1,15 +1,17 @@
 import { useEffect, useState } from 'react'
 
 export function useLightMode() {
-  const [lightMode, setLightMode] = useState<any>(undefined)
+  // Always start as `false` on both server and client. Reading localStorage
+  // during the first client effect used to flip `undefined` → boolean while
+  // Layout's `dynamic(..., { ssr: false })` Suspense boundaries were still
+  // hydrating, which triggers React 18's
+  // "Suspense boundary received an update before it finished hydrating".
+  // The app forces dark mode anyway; keep storage in sync after the fact.
+  const [lightMode, setLightMode] = useState(false)
 
   useEffect(() => {
-    if (lightMode === undefined) {
-      setLightMode(localStorage.getItem('lightMode') === 'true')
-    } else {
-      localStorage.setItem('lightMode', lightMode.toString())
-    }
+    localStorage.setItem('lightMode', lightMode.toString())
   }, [lightMode])
 
-  return [lightMode, setLightMode]
+  return [lightMode, setLightMode] as const
 }

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_CHAIN_V5 } from 'const/defaultChain'
 import { FlagProvider } from 'const/flags'
 import { SessionProvider } from 'next-auth/react'
 import { NextQueryParamProvider } from 'next-query-params'
-import React, { useEffect, useState, useMemo } from 'react'
+import React, { useEffect, useState, useMemo, startTransition } from 'react'
 import { Chain as ChainV5 } from 'thirdweb/chains'
 import { useLightMode } from '../lib/utils/hooks/useLightMode'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
@@ -25,10 +25,12 @@ function App({ Component, pageProps: { session, ...pageProps } }: any) {
 
   const [lightMode, setLightMode] = useLightMode()
 
-  // Force dark mode once on mount (the site has no light theme); a missing
-  // dependency array here used to re-run this after every render.
+  // Force dark mode once on mount (the site has no light theme). useLightMode
+  // already initializes to false, so this is a no-op unless something flipped
+  // it; wrap in startTransition so it cannot race Layout's dehydrated
+  // Suspense boundaries during hydration.
   useEffect(() => {
-    setLightMode(false)
+    startTransition(() => setLightMode(false))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -65,9 +67,7 @@ function App({ Component, pageProps: { session, ...pageProps } }: any) {
               // one (e.g. via SMS/social on a magic-link invite) so they have an
               // address to receive their sponsored citizen mint.
               embeddedWallets: {
-                ethereum: {
-                  createOnLogin: 'users-without-wallets',
-                },
+                createOnLogin: 'users-without-wallets',
               },
               appearance: {
                 theme: '#252c4d',

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -67,7 +67,9 @@ function App({ Component, pageProps: { session, ...pageProps } }: any) {
               // one (e.g. via SMS/social on a magic-link invite) so they have an
               // address to receive their sponsored citizen mint.
               embeddedWallets: {
-                createOnLogin: 'users-without-wallets',
+                ethereum: {
+                  createOnLogin: 'users-without-wallets',
+                },
               },
               appearance: {
                 theme: '#252c4d',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the React 18 runtime overlay:

> This Suspense boundary received an update before it finished hydrating…

This was a site-wide first-load race (homepage and `/lunar-atlas` both hit it). Layout’s `dynamic(..., { ssr: false })` widgets — plus `@vercel/analytics` / `Toaster` — entered the SSR tree as dehydrated Suspense boundaries (`<!--$--><!--/$-->`). A sibling mount update (notably `useLightMode` flipping `undefined` → boolean) interrupted hydration and forced client rendering.

### Changes
- **`Layout`**: gate `SpaceBackground`, banners, `CookieBanner`, `Toaster`, and `Analytics` behind a `ClientOnly` mount so they never SSR as dehydrated Suspense.
- **`useLightMode`**: initialize to `false` (the app forces dark mode) instead of `undefined`, avoiding a hydration-time theme state update.
- **`_app`**: wrap the force-dark `setLightMode(false)` in `startTransition`.

### Verification
Reproduced with Playwright before/after on `/lunar-atlas` and `/`:
- Before: Suspense hydration error on both pages; SSR HTML contained an empty `<!--$--><!--/$-->` marker after the toast host.
- After: 0 page errors; marker gone; lunar-atlas WebGL canvas still mounts.

## Test plan
- [ ] Hard-reload `/` and `/lunar-atlas` — no Next.js “Unhandled Runtime Error” overlay
- [ ] Confirm space background, cookie banner, and toasts still appear after first paint
- [ ] Confirm dark theme is still the default

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf6d15ea-c617-4ec4-ae58-73f93c659fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf6d15ea-c617-4ec4-ae58-73f93c659fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

