### PR TITLE
fix(ui): stop Suspense hydration race on Lunar Atlas

### DIFF
--- a/ui/components/layout/Layout.tsx
+++ b/ui/components/layout/Layout.tsx
@@ -5,9 +5,7 @@ import useTranslation from 'next-translate/useTranslation'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import React from 'react'
-import { useState } from 'react'
-import { useContext } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 import { Toaster } from 'react-hot-toast'
 import CitizenContext from '@/lib/citizen/citizen-context'
 import useNavigation from '@/lib/navigation/useNavigation'
@@ -40,6 +38,19 @@ const ProjectBanner = dynamic(() => import('./ProjectBanner'), {
 const CookieBanner = dynamic(() => import('./CookieBanner'), {
   ssr: false,
 })
+
+// Gate `ssr: false` dynamics so they never enter the SSR tree as dehydrated
+// Suspense boundaries. Mounting them only after hydration avoids React 18's
+// "Suspense boundary received an update before it finished hydrating" when a
+// sibling effect (theme, auth, banners) updates during the same pass.
+function ClientOnly({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+  if (!mounted) return null
+  return <>{children}</>
+}
 
 interface Layout {
   children: JSX.Element
@@ -103,7 +114,9 @@ export default function Layout({ children, lightMode, setLightMode }: Layout) {
         !lightMode ? 'dark background-dark' : 'background-light'
       } min-h-screen relative`}
     >
-      <SpaceBackground />
+      <ClientOnly>
+        <SpaceBackground />
+      </ClientOnly>
       <>
         {/* Mobile menu top bar - for screens smaller than xl */}
         <div className="xl:hidden">
@@ -149,19 +162,24 @@ export default function Layout({ children, lightMode, setLightMode }: Layout) {
           </div>
         </main>
 
-        {/* Global Search - Sticky on all pages */}
-        <GlobalSearch />
+        <ClientOnly>
+          {/* Global Search - Sticky on all pages */}
+          <GlobalSearch />
 
-        {/* Mission Banner - Fixed at bottom */}
-        <MissionBanner />
+          {/* Mission Banner - Fixed at bottom */}
+          <MissionBanner />
 
-        {/* Project Banner - Fixed at bottom (when mission banner is hidden) */}
-        <ProjectBanner />
+          {/* Project Banner - Fixed at bottom (when mission banner is hidden) */}
+          <ProjectBanner />
+
+          <CookieBanner />
+        </ClientOnly>
       </>
 
-      <CookieBanner />
-      <Toaster />
-      <Analytics />
+      <ClientOnly>
+        <Toaster />
+        <Analytics />
+      </ClientOnly>
     </div>
   )
 

--- a/ui/components/lunar-atlas/MoonGlobeLazy.tsx
+++ b/ui/components/lunar-atlas/MoonGlobeLazy.tsx
@@ -32,23 +32,31 @@ export default function MoonGlobeLazy(props: MoonGlobeProps) {
     const el = containerRef.current
     if (!el) return
 
-    // Mount immediately if already visible; otherwise wait for intersection.
+    let cancelled = false
+    let mountTimer: ReturnType<typeof setTimeout> | undefined
+
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries.some((e) => e.isIntersecting)) {
-          // Mounting swaps content inside next/dynamic's lazy boundary; if it
-          // lands while the page is still hydrating, React 18 throws
-          // "Suspense boundary received an update before it finished
-          // hydrating". Marking it as a transition lets React schedule it
-          // after hydration instead.
+        if (!entries.some((e) => e.isIntersecting)) return
+        observer.disconnect()
+        // IntersectionObserver can fire synchronously from observe() inside
+        // this effect — i.e. during React's hydration passive-effects flush.
+        // Mounting a next/dynamic boundary in that same turn races dehydrated
+        // Suspense siblings and throws. Defer to a macrotask, then mark the
+        // update as a transition so React schedules it after hydration.
+        mountTimer = setTimeout(() => {
+          if (cancelled) return
           startTransition(() => setHasMounted(true))
-          observer.disconnect()
-        }
+        }, 0)
       },
       { rootMargin: '200px' }
     )
     observer.observe(el)
-    return () => observer.disconnect()
+    return () => {
+      cancelled = true
+      observer.disconnect()
+      if (mountTimer) clearTimeout(mountTimer)
+    }
   }, [hasMounted])
 
   return (

--- a/ui/lib/utils/hooks/useLightMode.ts
+++ b/ui/lib/utils/hooks/useLightMode.ts
@@ -1,15 +1,17 @@
 import { useEffect, useState } from 'react'
 
 export function useLightMode() {
-  const [lightMode, setLightMode] = useState<any>(undefined)
+  // Always start as `false` on both server and client. Reading localStorage
+  // during the first client effect used to flip `undefined` → boolean while
+  // Layout's `dynamic(..., { ssr: false })` Suspense boundaries were still
+  // hydrating, which triggers React 18's
+  // "Suspense boundary received an update before it finished hydrating".
+  // The app forces dark mode anyway; keep storage in sync after the fact.
+  const [lightMode, setLightMode] = useState(false)
 
   useEffect(() => {
-    if (lightMode === undefined) {
-      setLightMode(localStorage.getItem('lightMode') === 'true')
-    } else {
-      localStorage.setItem('lightMode', lightMode.toString())
-    }
+    localStorage.setItem('lightMode', lightMode.toString())
   }, [lightMode])
 
-  return [lightMode, setLightMode]
+  return [lightMode, setLightMode] as const
 }

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_CHAIN_V5 } from 'const/defaultChain'
 import { FlagProvider } from 'const/flags'
 import { SessionProvider } from 'next-auth/react'
 import { NextQueryParamProvider } from 'next-query-params'
-import React, { useEffect, useState, useMemo } from 'react'
+import React, { useEffect, useState, useMemo, startTransition } from 'react'
 import { Chain as ChainV5 } from 'thirdweb/chains'
 import { useLightMode } from '../lib/utils/hooks/useLightMode'
 import PrivyWalletContext from '@/lib/privy/privy-wallet-context'
@@ -25,10 +25,12 @@ function App({ Component, pageProps: { session, ...pageProps } }: any) {
 
   const [lightMode, setLightMode] = useLightMode()
 
-  // Force dark mode once on mount (the site has no light theme); a missing
-  // dependency array here used to re-run this after every render.
+  // Force dark mode once on mount (the site has no light theme). useLightMode
+  // already initializes to false, so this is a no-op unless something flipped
+  // it; wrap in startTransition so it cannot race Layout's dehydrated
+  // Suspense boundaries during hydration.
   useEffect(() => {
-    setLightMode(false)
+    startTransition(() => setLightMode(false))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the React 18 overlay on `/lunar-atlas` (and site-wide):

> This Suspense boundary received an update before it finished hydrating…

Same root cause as #1483 (Layout `ssr: false` dynamics + Analytics/Toaster dehydrated Suspense racing a theme state update). This PR targets `feat/lunar-simulator` so the fix is available on PR #1405 without waiting for a main merge, and also hardens `MoonGlobeLazy` to defer its dynamic mount past the hydration pass.

### Changes
- Layout `ClientOnly` gate for `ssr: false` widgets + Analytics/Toaster
- `useLightMode` initializes to `false` (no hydration thrash)
- `_app` force-dark update wrapped in `startTransition`
- `MoonGlobeLazy`: defer IntersectionObserver-triggered mount with `setTimeout` + `startTransition`

Sister PR against main: #1483

## Test plan
- [ ] Hard-reload http://localhost:3000/lunar-atlas — no Suspense overlay
- [ ] Globe still mounts (WebGL canvas) after the brief “Rendering the Moon…” fallback
- [ ] Hotspots / timeline / race markers still interactive

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf6d15ea-c617-4ec4-ae58-73f93c659fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf6d15ea-c617-4ec4-ae58-73f93c659fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

