### PR TITLE
fix(proposals): stop prose trigger false-positive; pin MDP-258 to max

### DIFF
--- a/ui/cypress/integration/unit/budget-overrides.cy.tsx
+++ b/ui/cypress/integration/unit/budget-overrides.cy.tsx
@@ -248,5 +248,39 @@ describe('budget overrides', () => {
       ].join('\n')
       expect(parseUsdBudgetFromBody(body)).to.equal(5500)
     })
+
+    // MDP-264 shape: a line-item row whose justification prose contains a
+    // trigger substring ("Unexpected project costs") must NOT hijack the $
+    // amount that appears BEFORE the trigger. The real "Total budget $4000"
+    // line, appearing later, is the correct answer.
+    it('ignores a $ amount that precedes a trigger phrase embedded in prose (MDP-264 shape)', () => {
+      const body = [
+        '# Budget (Table C)#',
+        '',
+        'Aerospace research resources        $900        Technical papers',
+        'Research assistance        $1,000        Engineering analysis',
+        'Community presentation & publication        $400        Final report',
+        'Contingency        $400        Unexpected project costs',
+        'Total budget $4000',
+      ].join('\n')
+      expect(parseUsdBudgetFromBody(body)).to.equal(4000)
+    })
+
+    // Guard: the inline trigger must still pick up an amount that follows the
+    // trigger phrase, even when other (smaller) amounts appear earlier on the
+    // line. "Total Budget: $5,000 (includes $500 contingency)" → 5000.
+    it('takes the max $ amount that appears after the trigger phrase', () => {
+      expect(
+        parseUsdBudgetFromBody('Total Budget: $5,000 (includes $500 contingency)')
+      ).to.equal(5000)
+    })
+
+    // Guard: "Total costs: (820 + 88 + 3200) $= $4108" — the arithmetic in
+    // parentheses precedes no $, and the real amount follows the trigger.
+    it('parses inline "Total costs" prose with a trailing $ total (MDP-250 shape)', () => {
+      expect(
+        parseUsdBudgetFromBody('Total costs: (820 + 88 + 3200) $= $4108')
+      ).to.equal(4108)
+    })
   })
 })

--- a/ui/lib/proposals/budgetOverrides.ts
+++ b/ui/lib/proposals/budgetOverrides.ts
@@ -44,6 +44,16 @@ export const BUDGET_OVERRIDES_USD: Record<string, number> = {
   // projection table instead of the funding ask. Correct ask is $3,000.
   '255': 3000,
 
+  // Q3 2026: MDP-258 ("Satellite Payload and Secondary Education Project").
+  // The body has a malformed total row ("| Total | USD 5,176.80" with no
+  // closing pipe) so the extractor drops it and instead picks up the
+  // "$21.63/day" figure from a Meals justification cell, displaying $21.
+  // The proposal's own table total is $5,176.80 while the author states
+  // "Requested budget: USD 4,682" (fundraising the remainder elsewhere).
+  // Pinned to the quarterly per-project maximum (MAX_BUDGET_USD =
+  // round(NEXT_QUARTER_BUDGET_USD / 5) = $4,682) per the author's request.
+  '258': 4682,
+
   // Q3 2026: MDP-259 ("Mission Cosmic Colombia"). The parser returns $0
   // because the totals row contains a mixed-currency cell ("$2430 USD
   // 1.30 ETH") which isUsdValue() rejects due to the ETH mention.

--- a/ui/lib/proposals/extractUsdBudget.ts
+++ b/ui/lib/proposals/extractUsdBudget.ts
@@ -168,26 +168,37 @@ function parseBudgetFromSection(text: string): number {
 
 /**
  * Scan each line for a budget trigger phrase and return the largest dollar
- * amount found on that same line. Taking the maximum handles patterns like:
+ * amount found AFTER the trigger phrase on that same line. Taking the maximum
+ * handles patterns like:
  *
  *   "Total Budget: $5,000 (includes $500 contingency)"  → 5000
  *   "Total costs: (820 + 88 + 3200) $= $4108"           → 4108
  *   "Total Requested from MoonDAO: $2430 USD"            → 2430
  *
- * If no `$X` pattern exists but a bare "N USD/USDC" pattern is present,
- * that value is returned instead.
+ * Only amounts that occur AFTER the trigger phrase count. Without this,
+ * a prose justification that happens to contain a trigger substring hijacks
+ * an unrelated amount earlier on the line — e.g. a line-item row
+ * "Contingency | $400 | Unexpected project costs" matched "project costs"
+ * and returned $400 as the whole budget (MDP-264).
+ *
+ * If no `$X` pattern exists but a bare "N USD/USDC" pattern is present after
+ * the trigger, that value is returned instead.
  */
 function parseInlineUsdBudget(body: string): number {
   const TRIGGER =
     /(?:total|estimated|project)\s+(?:budget|costs?|funding|requested?(?:\s+from\s+\w+)?|ask)/i
   for (const line of body.split('\n')) {
-    if (!TRIGGER.test(line)) continue
-    const dollars = Array.from(line.matchAll(/\$\s*([\d,]+(?:\.\d+)?)/g))
+    const triggerMatch = line.match(TRIGGER)
+    if (!triggerMatch || triggerMatch.index === undefined) continue
+    const afterTrigger = line.slice(triggerMatch.index + triggerMatch[0].length)
+    const dollars = Array.from(afterTrigger.matchAll(/\$\s*([\d,]+(?:\.\d+)?)/g))
       .map((m) => parseFloat(m[1].replace(/,/g, '')) || 0)
       .filter((v) => v > 0)
     if (dollars.length > 0) return Math.max(...dollars)
-    // No $ sign — try bare "N USD/USDC/DAI" on this line.
-    const bare = line.match(/\b([\d,]+(?:\.\d+)?)\s*(?:USD|USDC|USDT|DAI)\b/i)
+    // No $ sign — try bare "N USD/USDC/DAI" after the trigger phrase.
+    const bare = afterTrigger.match(
+      /\b([\d,]+(?:\.\d+)?)\s*(?:USD|USDC|USDT|DAI)\b/i
+    )
     if (bare) {
       const v = parseFloat(bare[1].replace(/,/g, '')) || 0
       if (v > 0) return v


### PR DESCRIPTION
## Summary

Follow-up to #1478 / #1479. Audited **all 12 live Q3 2026 Senate-vote proposals** by running the merged `extractUsdBudget` against each real IPFS body. Two were still displaying wrong budgets:

| MDP | Was | Now | Cause / fix |
|-----|-----|-----|-------------|
| 264 (Africa United space) | $400 | $4,000 | Parser fix (below) |
| 258 (Satellite Payload) | $21 | $4,682 | Override to max |

### MDP-264 — parser false positive (root-cause fix)
`parseInlineUsdBudget` matched the trigger substring **"project costs"** inside a line-item justification — `Contingency | $400 | Unexpected project costs` — and returned that row's `$400`, before ever reaching the real `Total budget $4000` line.

Fix: only count `$` amounts that occur **after** the trigger phrase on the line. A prose justification that merely contains a trigger substring can no longer hijack an unrelated earlier amount. Re-ran the parser against all 12 bodies: 264 now reads **$4,000** and nothing else regressed (250 → $4,108, 259 → $2,430, 262 → $4,600, 260 → $4,640, 261 → $3,200, 265 → $1,100, etc.).

### MDP-258 — pinned to max via override
Its total row is malformed — `| Total | USD 5,176.80` with **no closing pipe** — so the extractor drops it and instead picks up `$21.63/day` from a Meals justification cell. The table total is $5,176.80 while the author states *"Requested budget: USD 4,682"* (fundraising the remainder elsewhere). Pinned via `BUDGET_OVERRIDES_USD` to the quarterly per-project maximum (`MAX_BUDGET_USD = round(NEXT_QUARTER_BUDGET_USD / 5) = $4,682`) per author request.

Existing overrides for 251 ($4,000, author-revised) and 255 ($3,000, unparseable revenue-mixed section) remain necessary and unchanged.

## Test plan
- [ ] New regression tests in `budget-overrides.cy.tsx`: 264 prose false-positive, plus after-trigger guards for the 250/251 inline-total shapes — `yarn cypress run --spec 'cypress/integration/unit/budget-overrides.cy.tsx'`
- [ ] `/project/264` reads $4,000; `/project/258` reads $4,682
- [ ] Spot-check the other 10 live proposals show unchanged/correct budgets

Made with [Cursor](https://cursor.com)