### PR TITLE
fix(advance-phase): skip UI-blocked proposals; show MDP titles in tally

### DIFF
--- a/ui/components/operator/OperatorPanel.tsx
+++ b/ui/components/operator/OperatorPanel.tsx
@@ -457,7 +457,8 @@ export default function OperatorPanel({
                   <ul className="mt-1 ml-4 list-disc space-y-0.5">
                     {(advanceResult.senateTally as SenateTallyRow[]).map((r) => (
                       <li key={r.mdp}>
-                        MDP-{r.mdp}: {r.status}
+                        MDP-{r.mdp}
+                        {r.name ? ` “${r.name}”` : ''}: {r.status}
                         {r.approvalCount != null && r.voteCount != null
                           ? ` (${r.approvalCount}/${r.voteCount})`
                           : ''}

--- a/ui/docs/PROJECT_CYCLE_OPERATOR_RUNBOOK.md
+++ b/ui/docs/PROJECT_CYCLE_OPERATOR_RUNBOOK.md
@@ -66,10 +66,14 @@ Optional prep while senators vote:
 When senators have voted (quorum met on the proposals you intend to advance):
 
 1. Go to `/projects` → **Operator Panel** → **Cycle Phase**.
-2. Click **Preview (dry run)**. Review the per-MDP list:
+2. Click **Preview (dry run)**. Review the per-MDP list (each row shows the
+   MDP number **and title**):
    - `passed` / `failed` — would tally
    - `below-quorum` — still needs senators (or Force later)
    - `already-closed` / `passed`/`failed` from prior close — already done
+   - Proposals blocked from the UI (withdrawn / resubmitted / in
+     `BLOCKED_MDPS` or `BLOCKED_PROJECTS`) are **skipped automatically** — they
+     never show up as blockers, so a withdrawn proposal can't stall the advance.
 3. Click **Close Senate & Open Member Vote**. Confirm the dialog.
 4. The server will:
    - Sign `Proposals.tallyVotes(mdp)` for every pending current-cycle MDP
@@ -153,7 +157,8 @@ cohort you just closed, `phase: 'senate'`), PR, deploy.
 | Operator Panel missing | Wallet not in `OPERATORS` / not signed in | Sign in with an allowlisted wallet |
 | Advance fails: HSM not available | Missing `GCP_SIGNER_*` env on Vercel | Restore HSM env; do not transfer ownership to a personal EOA |
 | `OwnableUnauthorizedAccount` | HSM is not contract owner | Transfer ownership back to `GCP_HSM_SIGNER_ADDRESS` |
-| Advance 409 with blockers | Quorum not met on some MDPs | Wait for votes, or Force if intentional |
+| Advance 409 with blockers | Quorum not met on some real (non-blocked) MDPs | Wait for votes, or Force if intentional |
+| A withdrawn/resubmitted proposal shows as a blocker | It isn't in `BLOCKED_MDPS`/`BLOCKED_PROJECTS` yet | Add it to `const/whitelist.ts` and deploy; it will then be skipped |
 | UI still on Senate after Advance | Stale ISR / cache | Wait ~60s or hard-refresh; panel polls `/api/operator/phase-status` |
 | Phase stuck / wrong after deploy | Live KV override still set | Expected — override wins over `PROJECT_CYCLE.phase`. Wrap up or advance, or clear the Redis key `moondao:operator:cycle_phase` |
 

--- a/ui/docs/PROJECT_CYCLE_OPERATOR_RUNBOOK.md
+++ b/ui/docs/PROJECT_CYCLE_OPERATOR_RUNBOOK.md
@@ -71,9 +71,12 @@ When senators have voted (quorum met on the proposals you intend to advance):
    - `passed` / `failed` — would tally
    - `below-quorum` — still needs senators (or Force later)
    - `already-closed` / `passed`/`failed` from prior close — already done
-   - Proposals blocked from the UI (withdrawn / resubmitted / in
-     `BLOCKED_MDPS` or `BLOCKED_PROJECTS`) are **skipped automatically** — they
-     never show up as blockers, so a withdrawn proposal can't stall the advance.
+   - Proposals hidden from the Senate Vote UI are **skipped automatically** —
+     they never show up as blockers:
+     - `BLOCKED_MDPS` / `BLOCKED_PROJECTS` (withdrawn / resubmitted)
+     - Author-deleted proposals (`deleted: true` in the proposal IPFS JSON,
+       from the author-delete flow in PR #1475)
+     - Non-project proposals (`nonProjectProposal: true`)
 3. Click **Close Senate & Open Member Vote**. Confirm the dialog.
 4. The server will:
    - Sign `Proposals.tallyVotes(mdp)` for every pending current-cycle MDP
@@ -159,6 +162,7 @@ cohort you just closed, `phase: 'senate'`), PR, deploy.
 | `OwnableUnauthorizedAccount` | HSM is not contract owner | Transfer ownership back to `GCP_HSM_SIGNER_ADDRESS` |
 | Advance 409 with blockers | Quorum not met on some real (non-blocked) MDPs | Wait for votes, or Force if intentional |
 | A withdrawn/resubmitted proposal shows as a blocker | It isn't in `BLOCKED_MDPS`/`BLOCKED_PROJECTS` yet | Add it to `const/whitelist.ts` and deploy; it will then be skipped |
+| An author-deleted proposal shows as a blocker | Its IPFS JSON is missing `deleted: true`, or the IPFS fetch failed open | Confirm the author-delete re-pin landed; advance skips any proposal whose JSON has `deleted: true` |
 | UI still on Senate after Advance | Stale ISR / cache | Wait ~60s or hard-refresh; panel polls `/api/operator/phase-status` |
 | Phase stuck / wrong after deploy | Live KV override still set | Expected — override wins over `PROJECT_CYCLE.phase`. Wrap up or advance, or clear the Redis key `moondao:operator:cycle_phase` |
 

--- a/ui/pages/api/operator/advance-phase.ts
+++ b/ui/pages/api/operator/advance-phase.ts
@@ -5,6 +5,7 @@ import {
   PROJECT_TABLE_NAMES,
   PROPOSALS_ADDRESSES,
 } from 'const/config'
+import { BLOCKED_MDPS, BLOCKED_PROJECTS } from 'const/whitelist'
 import { isOperator } from 'middleware/isOperator'
 import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
@@ -95,12 +96,19 @@ async function tallySenateForCurrentCycle(
   const projectStatement = `SELECT * FROM ${PROJECT_TABLE_NAMES[chainSlug]} WHERE quarter = ${PROJECT_CYCLE.quarter} AND year = ${PROJECT_CYCLE.year}`
   const projects = (await queryTable(chain, projectStatement)) || []
 
-  // Only pending proposals with an MDP can be in Senate Vote.
+  // Only pending proposals with an MDP can be in Senate Vote. Proposals that
+  // are blocked from the /projects UI (withdrawn, resubmitted, or otherwise
+  // removed via `BLOCKED_MDPS` / `BLOCKED_PROJECTS`) are excluded here too —
+  // they were pulled from Senate voting, so senators never voted on them and
+  // they'd otherwise show up as permanent below-quorum blockers. This mirrors
+  // the `isCurrentPending` filter in `pages/projects/index.tsx`.
   const pending = projects.filter(
     (p: any) =>
       Number(p.active) === PROJECT_PENDING &&
       p.MDP !== undefined &&
-      p.MDP !== null
+      p.MDP !== null &&
+      !BLOCKED_PROJECTS.has(Number(p.id)) &&
+      !BLOCKED_MDPS.has(Number(p.MDP))
   )
 
   const results: SenateTallyResult[] = []

--- a/ui/pages/api/operator/advance-phase.ts
+++ b/ui/pages/api/operator/advance-phase.ts
@@ -116,8 +116,8 @@ async function tallySenateForCurrentCycle(
   // delete re-pins the proposal JSON with `deleted: true`, and non-project
   // proposals are governance-only. Both are hidden from the Senate Vote UI,
   // so they must not appear as below-quorum blockers here either. A failed
-  // IPFS fetch is treated as skip (same spirit as the projects page, which
-  // won't surface a proposal without readable JSON for delete checks).
+  // IPFS fetch must still include the proposal (same as /projects): senators
+  // still see it as open, so it must be tallied / able to block advance.
   const pending: any[] = []
   await Promise.all(
     pendingCandidates.map(async (project: any) => {
@@ -125,8 +125,9 @@ async function tallySenateForCurrentCycle(
         const res = await fetch(project.proposalIPFS)
         if (!res.ok) {
           console.warn(
-            `[advance-phase] skipping MDP-${project.MDP}: proposalIPFS HTTP ${res.status}`
+            `[advance-phase] proposalIPFS HTTP ${res.status} for MDP-${project.MDP}; including for tally`
           )
+          pending.push(project)
           return
         }
         const proposalJSON = await res.json()
@@ -145,9 +146,10 @@ async function tallySenateForCurrentCycle(
         pending.push(project)
       } catch (error) {
         console.warn(
-          `[advance-phase] skipping MDP-${project.MDP}: failed to read proposalIPFS`,
+          `[advance-phase] failed to read proposalIPFS for MDP-${project.MDP}; including for tally`,
           error
         )
+        pending.push(project)
       }
     })
   )

--- a/ui/pages/api/operator/advance-phase.ts
+++ b/ui/pages/api/operator/advance-phase.ts
@@ -102,13 +102,54 @@ async function tallySenateForCurrentCycle(
   // they were pulled from Senate voting, so senators never voted on them and
   // they'd otherwise show up as permanent below-quorum blockers. This mirrors
   // the `isCurrentPending` filter in `pages/projects/index.tsx`.
-  const pending = projects.filter(
+  const pendingCandidates = projects.filter(
     (p: any) =>
       Number(p.active) === PROJECT_PENDING &&
       p.MDP !== undefined &&
       p.MDP !== null &&
       !BLOCKED_PROJECTS.has(Number(p.id)) &&
-      !BLOCKED_MDPS.has(Number(p.MDP))
+      !BLOCKED_MDPS.has(Number(p.MDP)) &&
+      !!p.proposalIPFS
+  )
+
+  // Mirror the IPFS filters in `pages/projects/index.tsx` / PR #1475: author
+  // delete re-pins the proposal JSON with `deleted: true`, and non-project
+  // proposals are governance-only. Both are hidden from the Senate Vote UI,
+  // so they must not appear as below-quorum blockers here either. A failed
+  // IPFS fetch is treated as skip (same spirit as the projects page, which
+  // won't surface a proposal without readable JSON for delete checks).
+  const pending: any[] = []
+  await Promise.all(
+    pendingCandidates.map(async (project: any) => {
+      try {
+        const res = await fetch(project.proposalIPFS)
+        if (!res.ok) {
+          console.warn(
+            `[advance-phase] skipping MDP-${project.MDP}: proposalIPFS HTTP ${res.status}`
+          )
+          return
+        }
+        const proposalJSON = await res.json()
+        if (proposalJSON?.deleted) {
+          console.log(
+            `[advance-phase] skipping MDP-${project.MDP}: author-deleted (IPFS deleted:true)`
+          )
+          return
+        }
+        if (proposalJSON?.nonProjectProposal) {
+          console.log(
+            `[advance-phase] skipping MDP-${project.MDP}: non-project proposal`
+          )
+          return
+        }
+        pending.push(project)
+      } catch (error) {
+        console.warn(
+          `[advance-phase] skipping MDP-${project.MDP}: failed to read proposalIPFS`,
+          error
+        )
+      }
+    })
   )
 
   const results: SenateTallyResult[] = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Senate → Member phase advance getting stuck on proposals that were **removed from the Senate Vote UI** (withdrawn / resubmitted / blocked). Also shows each proposal’s title in the operator panel’s full Senate tally list.

## Problem

Advancing Senate → Member reported 5 permanent blockers:

- MDP-252, 253, 256, 257, 263 — all `below-quorum (0/0)`

Those MDPs are in `BLOCKED_MDPS` on mainnet (`const/whitelist.ts`) and are already filtered out of `/projects` Senate voting. Senators never saw them, so they never hit quorum — but `advance-phase` still treated them as blockers and returned 409.

## Fix

1. **Skip UI-blocked proposals** in `pages/api/operator/advance-phase.ts` — apply the same `BLOCKED_MDPS` / `BLOCKED_PROJECTS` filter used by `pages/projects/index.tsx` (`isCurrentPending`). Blocked proposals are excluded from the tally cohort entirely, so they cannot stall the advance.
2. **Show titles** in the Operator Panel “Senate tally detail” list: `MDP-250 “…”: passed (5/7)` (blockers list already had titles).
3. **Runbook** note that UI-blocked proposals are auto-skipped.

## Expected result for the current cycle

After this lands, the 5 blocked MDPs no longer appear as blockers. Remaining closed outcomes (e.g. MDP-255 failed, MDP-264 failed) are not blockers — the advance should proceed without needing **Force**.

## Test plan

- [ ] On the Vercel preview, as an operator, open `/projects` → Operator Panel → **Preview (dry run)**
- [ ] Confirm MDP-252/253/256/257/263 do **not** appear in blockers or the tally list
- [ ] Confirm remaining MDPs show titles in the detail list
- [ ] Confirm Advance can proceed without Force once all live (non-blocked) proposals are closed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ea1e90c-93e8-474b-9895-7f2060daf029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ea1e90c-93e8-474b-9895-7f2060daf029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

