### PR TITLE
Redesign /join as a conversion-focused sales page

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -51,3 +51,4 @@ scripts/generated/*
 !scripts/generated/.gitkeep
 .claude
 .vscode/
+.env*

--- a/ui/components/join/FeaturedCitizensMarquee.tsx
+++ b/ui/components/join/FeaturedCitizensMarquee.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link'
+import AdaptiveImage from '@/components/layout/AdaptiveImage'
+import Reveal from '@/components/home/landing/Reveal'
+import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
+
+export type FeaturedCitizen = {
+  id: string | number
+  name: string
+  image: string
+  role: string
+}
+
+function CitizenCard({ citizen }: { citizen: FeaturedCitizen }) {
+  return (
+    <Link
+      href={`/citizen/${generatePrettyLinkWithId(citizen.name, citizen.id)}`}
+      className="group flex w-40 flex-shrink-0 flex-col items-center gap-3 text-center md:w-48"
+    >
+      <div className="relative">
+        <div className="absolute -inset-2 rounded-full bg-gradient-to-br from-[#425EEB]/0 to-[#6C407D]/0 blur-xl transition-all duration-500 group-hover:from-[#425EEB]/40 group-hover:to-[#6C407D]/40" />
+        <div className="relative rounded-full bg-gradient-to-br from-[#3044A9] to-[#743F72] p-[3px]">
+          <AdaptiveImage
+            src={citizen.image}
+            alt={citizen.name}
+            width={200}
+            height={200}
+            className="h-24 w-24 rounded-full object-cover transition-transform duration-500 group-hover:scale-105 md:h-32 md:w-32"
+          />
+        </div>
+      </div>
+      <div>
+        <h3 className="font-GoodTimes text-sm text-white md:text-base">{citizen.name}</h3>
+        <p className="mt-1 text-xs text-white/60 md:text-sm">{citizen.role}</p>
+      </div>
+    </Link>
+  )
+}
+
+export default function FeaturedCitizensMarquee({
+  citizens,
+}: {
+  citizens: FeaturedCitizen[]
+}) {
+  if (!citizens?.length) return null
+
+  // Duplicate the list so the -50% translate loops seamlessly
+  const doubled = [...citizens, ...citizens]
+
+  return (
+    <section className="relative overflow-hidden bg-[#010208] py-16 md:py-24">
+      <div className="mx-auto flex w-full max-w-[1400px] flex-col gap-10 px-5 md:px-10">
+        <Reveal>
+          <p className="text-center font-RobotoMono text-xs uppercase tracking-[0.35em] text-white/50">
+            Featured Citizens
+          </p>
+        </Reveal>
+        <div className="group relative overflow-hidden">
+          <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-24 bg-gradient-to-r from-[#010208] to-transparent md:w-40" />
+          <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-24 bg-gradient-to-l from-[#010208] to-transparent md:w-40" />
+          <div className="flex w-max items-center gap-8 py-2 md:gap-12 motion-reduce:animate-none animate-marquee-reverse group-hover:[animation-play-state:paused]">
+            {doubled.map((citizen, i) => (
+              <CitizenCard key={`${citizen.id}-${i}`} citizen={citizen} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/ui/components/join/FeaturedTeamsMarquee.tsx
+++ b/ui/components/join/FeaturedTeamsMarquee.tsx
@@ -1,0 +1,58 @@
+import Link from 'next/link'
+import AdaptiveImage from '@/components/layout/AdaptiveImage'
+import Reveal from '@/components/home/landing/Reveal'
+import { generatePrettyLink } from '@/lib/subscription/pretty-links'
+
+export type FeaturedTeam = {
+  id: string | number
+  name: string
+  image: string
+}
+
+function TeamCard({ team }: { team: FeaturedTeam }) {
+  return (
+    <Link
+      href={`/team/${generatePrettyLink(team.name)}`}
+      className="group flex w-40 flex-shrink-0 flex-col items-center gap-3 text-center md:w-48"
+    >
+      <div className="relative flex h-24 w-24 items-center justify-center rounded-2xl bg-white/5 ring-1 ring-white/10 transition-all duration-300 group-hover:ring-white/30 md:h-28 md:w-28">
+        <AdaptiveImage
+          src={team.image}
+          alt={team.name}
+          width={200}
+          height={200}
+          className="h-full w-full rounded-2xl object-cover transition-transform duration-500 group-hover:scale-105"
+        />
+      </div>
+      <h3 className="font-GoodTimes text-sm text-white md:text-base">{team.name}</h3>
+    </Link>
+  )
+}
+
+export default function FeaturedTeamsMarquee({ teams }: { teams: FeaturedTeam[] }) {
+  if (!teams?.length) return null
+
+  // Duplicate the list so the -50% translate loops seamlessly
+  const doubled = [...teams, ...teams]
+
+  return (
+    <section className="relative overflow-hidden bg-[#010208] py-16 md:py-24">
+      <div className="mx-auto flex w-full max-w-[1400px] flex-col gap-10 px-5 md:px-10">
+        <Reveal>
+          <p className="text-center font-RobotoMono text-xs uppercase tracking-[0.35em] text-white/50">
+            Teams in the Network
+          </p>
+        </Reveal>
+        <div className="group relative overflow-hidden">
+          <div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-24 bg-gradient-to-r from-[#010208] to-transparent md:w-40" />
+          <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-24 bg-gradient-to-l from-[#010208] to-transparent md:w-40" />
+          <div className="flex w-max items-center gap-8 py-2 md:gap-12 motion-reduce:animate-none animate-marquee group-hover:[animation-play-state:paused]">
+            {doubled.map((team, i) => (
+              <TeamCard key={`${team.id}-${i}`} team={team} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/ui/components/join/InlineJoinCTA.tsx
+++ b/ui/components/join/InlineJoinCTA.tsx
@@ -1,0 +1,33 @@
+import CtaButton from '@/components/home/landing/CtaButton'
+import Reveal from '@/components/home/landing/Reveal'
+
+type InlineJoinCTAProps = {
+  headline: string
+  subtext?: string
+}
+
+// A lightweight, repeatable "Become a Citizen" nudge dropped between other
+// sections — the page's primary conversion goal, so it shouldn't only live in
+// the hero and the pricing cards at the very bottom.
+export default function InlineJoinCTA({ headline, subtext }: InlineJoinCTAProps) {
+  return (
+    <section className="relative overflow-hidden bg-[#010208] py-16 md:py-20">
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_50%,rgba(66,94,235,0.12),transparent_60%)]" />
+      <div className="relative z-10 mx-auto flex w-full max-w-[800px] flex-col items-center gap-6 px-6 text-center md:px-10">
+        <Reveal>
+          <h3 className="font-GoodTimes text-xl text-white md:text-2xl">{headline}</h3>
+        </Reveal>
+        {subtext && (
+          <Reveal delay={0.1}>
+            <p className="text-sm text-white/65 md:text-base">{subtext}</p>
+          </Reveal>
+        )}
+        <Reveal delay={0.2}>
+          <CtaButton href="/citizen" variant="primary">
+            Become a Citizen
+          </CtaButton>
+        </Reveal>
+      </div>
+    </section>
+  )
+}

--- a/ui/components/join/JoinHero.tsx
+++ b/ui/components/join/JoinHero.tsx
@@ -1,0 +1,87 @@
+import Image from 'next/image'
+import CountUp from '@/components/home/landing/CountUp'
+import CtaButton from '@/components/home/landing/CtaButton'
+import Reveal from '@/components/home/landing/Reveal'
+import Starfield from '@/components/home/landing/Starfield'
+
+type JoinHeroProps = {
+  citizenCount: number
+  teamCount: number
+}
+
+export default function JoinHero({ citizenCount, teamCount }: JoinHeroProps) {
+  const stats = [
+    { value: citizenCount, suffix: '+', label: 'Citizens' },
+    { value: teamCount, suffix: '+', label: 'Teams' },
+    { value: 8, prefix: '$', suffix: 'M+', label: 'Raised onchain' },
+    { value: 2, suffix: '', label: 'Astronauts sent to space' },
+  ]
+
+  return (
+    <>
+      <section className="relative flex h-[100svh] w-full flex-col overflow-hidden bg-[#010208]">
+        <div className="absolute inset-0 scale-[1.1]">
+          <Image
+            src="/assets/NetworkHero.webp"
+            alt="Space Acceleration Network"
+            fill
+            priority
+            className="object-cover"
+          />
+        </div>
+        <div className="absolute inset-0 bg-gradient-to-b from-[#010208]/80 via-[#010208]/35 to-[#010208]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_-20%,rgba(66,94,235,0.28),transparent_60%)]" />
+        <Starfield className="opacity-70" />
+
+        <div className="relative z-10 mx-auto flex w-full max-w-4xl flex-1 flex-col items-center justify-center px-6 py-24 text-center md:px-10">
+          <Reveal>
+            <h1 className="font-GoodTimes leading-[1.1] text-white text-4xl md:text-6xl 2xl:text-7xl drop-shadow-lg">
+              Join the Space Acceleration Network
+            </h1>
+          </Reveal>
+          <Reveal delay={0.1}>
+            <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-white/85 md:text-xl drop-shadow-lg">
+              An onchain startup society funding, training, and flying everyday
+              people to space — governed by its members, transparent by
+              design.
+            </p>
+          </Reveal>
+          <Reveal delay={0.2}>
+            <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+              <CtaButton href="/citizen" variant="primary">
+                Become a Citizen
+              </CtaButton>
+              <CtaButton href="/team" variant="secondary">
+                Create a Team
+              </CtaButton>
+            </div>
+          </Reveal>
+        </div>
+      </section>
+
+      <div className="relative z-10 border-t border-white/10 bg-[#010208]">
+        <div className="mx-auto grid w-full max-w-[1400px] grid-cols-2 divide-x divide-white/10 lg:grid-cols-4">
+          {stats.map((stat, i) => (
+            <Reveal
+              key={stat.label}
+              delay={i * 0.08}
+              className={`flex flex-col items-center gap-1 px-4 py-5 md:py-7 ${
+                i >= 2 ? 'border-t border-white/10 lg:border-t-0' : ''
+              }`}
+            >
+              <CountUp
+                to={stat.value}
+                prefix={stat.prefix}
+                suffix={stat.suffix}
+                className="font-GoodTimes text-2xl text-white md:text-4xl"
+              />
+              <span className="font-RobotoMono text-[10px] uppercase tracking-[0.2em] text-white/50 md:text-xs">
+                {stat.label}
+              </span>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/ui/components/join/TestimonialsCarousel.tsx
+++ b/ui/components/join/TestimonialsCarousel.tsx
@@ -1,0 +1,172 @@
+import { motion, useReducedMotion } from 'framer-motion'
+import { useEffect, useState } from 'react'
+import AdaptiveImage from '@/components/layout/AdaptiveImage'
+import Reveal from '@/components/home/landing/Reveal'
+import SectionHeading from '@/components/home/landing/SectionHeading'
+import type { TestimonialWithPhoto } from 'const/joinPageContent'
+
+function getInitials(name: string) {
+  return name
+    .replace(/'.*'/, '')
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('')
+}
+
+const AUTOPLAY_MS = 7000
+
+function Slide({
+  testimonial,
+  active,
+}: {
+  testimonial: TestimonialWithPhoto
+  active: boolean
+}) {
+  const reduceMotion = useReducedMotion()
+  return (
+    <motion.div
+      // All slides share the same grid cell (see the parent's `grid` +
+      // `[grid-area:1/1]` below) so the container's height is always the
+      // tallest slide, and switching the active one never shifts layout.
+      className={`[grid-area:1/1] flex flex-col items-center gap-8 text-center ${
+        active ? '' : 'pointer-events-none'
+      }`}
+      aria-hidden={!active}
+      animate={{ opacity: active ? 1 : 0, y: reduceMotion ? 0 : active ? 0 : 8 }}
+      transition={{ duration: 0.5, ease: [0.21, 0.47, 0.32, 0.98] }}
+    >
+      <div className="relative">
+        <div className="absolute -inset-2 rounded-full bg-gradient-to-br from-[#425EEB]/30 to-[#6C407D]/30 blur-xl" />
+        {testimonial.image ? (
+          <div className="relative rounded-full bg-gradient-to-br from-[#3044A9] to-[#743F72] p-[3px]">
+            <AdaptiveImage
+              src={testimonial.image}
+              alt={testimonial.name}
+              width={320}
+              height={320}
+              className="h-32 w-32 rounded-full object-cover md:h-40 md:w-40"
+            />
+          </div>
+        ) : (
+          <div className="relative flex h-32 w-32 items-center justify-center rounded-full bg-gradient-to-br from-[#3044A9] to-[#743F72] font-GoodTimes text-3xl text-white md:h-40 md:w-40">
+            {getInitials(testimonial.name)}
+          </div>
+        )}
+      </div>
+
+      <svg
+        className="h-8 w-8 text-[#7c8cff]/50"
+        viewBox="0 0 32 24"
+        fill="currentColor"
+        aria-hidden
+      >
+        <path d="M9.5 0C4.3 3 0 8.6 0 14.8 0 20 3.6 24 8.6 24c4.3 0 7.4-3.3 7.4-7.4 0-3.9-2.8-6.8-6.4-6.8-.7 0-1.4.1-1.9.3C8.4 6 11 2.8 14.6 1.1L9.5 0Zm17 0C21.3 3 17 8.6 17 14.8 17 20 20.6 24 25.6 24c4.3 0 7.4-3.3 7.4-7.4 0-3.9-2.8-6.8-6.4-6.8-.7 0-1.4.1-1.9.3C25.4 6 28 2.8 31.6 1.1L26.5 0Z" />
+      </svg>
+
+      <p className="max-w-2xl text-lg leading-relaxed text-white/85 md:text-xl">
+        &ldquo;{testimonial.quote}&rdquo;
+      </p>
+
+      <div>
+        <p className="font-GoodTimes text-base text-white">{testimonial.name}</p>
+        <p className="mt-1 text-sm text-white/55">{testimonial.affiliation}</p>
+      </div>
+    </motion.div>
+  )
+}
+
+export default function TestimonialsCarousel({
+  testimonials,
+}: {
+  testimonials: TestimonialWithPhoto[]
+}) {
+  const [index, setIndex] = useState(0)
+  const [paused, setPaused] = useState(false)
+  const reduceMotion = useReducedMotion()
+
+  useEffect(() => {
+    if (paused || reduceMotion || testimonials.length <= 1) return
+    const timer = setInterval(() => {
+      setIndex((i) => (i + 1) % testimonials.length)
+    }, AUTOPLAY_MS)
+    return () => clearInterval(timer)
+  }, [paused, reduceMotion, testimonials.length])
+
+  if (!testimonials.length) return null
+
+  const goTo = (i: number) => setIndex(((i % testimonials.length) + testimonials.length) % testimonials.length)
+
+  return (
+    <section className="relative overflow-hidden bg-[#010208] py-24 md:py-36">
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,rgba(108,64,125,0.16),transparent_55%)]" />
+
+      <div className="relative z-10 mx-auto w-full max-w-[1000px] px-5 md:px-10">
+        <SectionHeading
+          eyebrow="Voices of MoonDAO"
+          title={
+            <>
+              Don&apos;t Take Our{' '}
+              <span className="bg-gradient-to-r from-[#7c8cff] to-[#22d3ee] bg-clip-text text-transparent">
+                Word for It
+              </span>
+            </>
+          }
+          description="Citizens, teams, and astronauts on what joining the network actually made possible."
+        />
+
+        <div
+          className="relative mt-14"
+          onMouseEnter={() => setPaused(true)}
+          onMouseLeave={() => setPaused(false)}
+        >
+          <div className="grid">
+            {testimonials.map((testimonial, i) => (
+              <Slide key={testimonial.name} testimonial={testimonial} active={i === index} />
+            ))}
+          </div>
+
+          {testimonials.length > 1 && (
+            <>
+              <button
+                type="button"
+                aria-label="Previous testimonial"
+                onClick={() => goTo(index - 1)}
+                className="absolute left-0 top-1/2 hidden -translate-y-1/2 rounded-full border border-white/15 bg-white/5 p-2 text-white/60 backdrop-blur-md transition-all hover:border-white/30 hover:text-white md:block"
+              >
+                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                  <path d="m15 18-6-6 6-6" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                aria-label="Next testimonial"
+                onClick={() => goTo(index + 1)}
+                className="absolute right-0 top-1/2 hidden -translate-y-1/2 rounded-full border border-white/15 bg-white/5 p-2 text-white/60 backdrop-blur-md transition-all hover:border-white/30 hover:text-white md:block"
+              >
+                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              </button>
+
+              <div className="mt-10 flex items-center justify-center gap-2">
+                {testimonials.map((t, i) => (
+                  <button
+                    key={t.name}
+                    type="button"
+                    aria-label={`Show testimonial from ${t.name}`}
+                    onClick={() => goTo(i)}
+                    className={`h-2 rounded-full transition-all duration-300 ${
+                      i === index ? 'w-6 bg-white' : 'w-2 bg-white/25 hover:bg-white/50'
+                    }`}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/ui/components/join/WhyJoinSection.tsx
+++ b/ui/components/join/WhyJoinSection.tsx
@@ -1,0 +1,53 @@
+import Image from 'next/image'
+import Reveal from '@/components/home/landing/Reveal'
+import SectionHeading from '@/components/home/landing/SectionHeading'
+import { whyJoinPillars } from 'const/joinPageContent'
+
+export default function WhyJoinSection() {
+  return (
+    <section className="relative overflow-hidden bg-[#010208] py-24 md:py-36">
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_50%_0%,rgba(66,94,235,0.14),transparent_55%)]" />
+
+      <div className="relative z-10 mx-auto w-full max-w-[1400px] px-5 md:px-10">
+        <SectionHeading
+          eyebrow="Why Join"
+          title={
+            <>
+              Everything You Need to{' '}
+              <span className="bg-gradient-to-r from-[#7c8cff] to-[#22d3ee] bg-clip-text text-transparent">
+                Get Involved
+              </span>
+            </>
+          }
+          description="MoonDAO is more than a membership — it's funding, a network, and a direct path to the space industry."
+        />
+
+        <div className="mt-14 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 md:gap-6">
+          {whyJoinPillars.map((pillar, i) => (
+            <Reveal key={pillar.header} delay={0.08 * (i % 3)} className="h-full">
+              <div className="flex h-full flex-col gap-5 rounded-3xl border border-white/10 bg-white/[0.04] p-7 backdrop-blur-md transition-all duration-300 hover:border-white/30 hover:bg-white/[0.06] md:p-8">
+                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-[#425EEB]/30 to-[#6C407D]/30 ring-1 ring-white/15">
+                  <Image
+                    src={pillar.icon}
+                    alt={pillar.iconAlt}
+                    width={30}
+                    height={30}
+                    className="h-7 w-7"
+                  />
+                </div>
+                <div className="flex flex-1 flex-col gap-3">
+                  <h3 className="font-GoodTimes text-lg text-white md:text-xl">
+                    {pillar.header}
+                  </h3>
+                  <p className="text-sm leading-relaxed text-white/65 md:text-base">
+                    {pillar.paragraph}
+                  </p>
+                </div>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/ui/const/joinPageContent.ts
+++ b/ui/const/joinPageContent.ts
@@ -1,0 +1,106 @@
+export type Testimonial = {
+  name: string
+  quote: string
+  affiliation: string
+}
+
+// Testimonial with its matched citizen photo attached (see getStaticProps in
+// pages/join.tsx) — image is null (not undefined) when no citizen match was
+// found, since getStaticProps props must be JSON-serializable.
+export type TestimonialWithPhoto = Testimonial & { image?: string | null }
+
+// Explicit testimonial-name -> citizen-id overrides, for cases where the
+// on-chain display name doesn't resemble the name used in the testimonial
+// (e.g. Giovanna's citizen profile is named "Astro.gio"). Checked before the
+// fuzzy name match in getStaticProps.
+export const TESTIMONIAL_CITIZEN_IDS: Record<string, number> = {
+  Giovanna: 24,
+}
+
+// Matched at build time (see getStaticProps in pages/join.tsx) against
+// on-chain citizen records by name, to pull each person's real citizen
+// profile photo. If a name doesn't match, the card falls back to an
+// initials avatar — check the build log for a warning when that happens.
+export const testimonials: Testimonial[] = [
+  {
+    name: 'Rachel Williams',
+    affiliation: 'Open Lunar',
+    quote:
+      "We've used MoonDAO's job board for every Open Lunar role we've posted, and the quality of applicants has been consistently outstanding. The submissions are high-signal and thoughtful, coming from people who are genuinely mission-aligned and already engaged in the space ecosystem — not just mass applicants clicking through generic postings. In a hiring landscape increasingly flooded with low-quality, AI-generated applications, MoonDAO has been a refreshing exception.",
+  },
+  {
+    name: "Andrew 'Titan' Parris",
+    affiliation: 'MoonDAO Citizen',
+    quote:
+      "We needed to reach a dedicated, space-positive audience to support our growth. MoonDAO's Space Acceleration Network provided exactly that. By setting up our Team page, we were able to directly engage with a community aligned with our mission to make space more accessible to all. Within weeks of listing our Spaceflight Training classes, we secured our first direct sale.",
+  },
+  {
+    name: 'Eiman',
+    affiliation: 'Citizen Astronaut, Blue Origin',
+    quote:
+      "None of the things I've achieved over the past few years would have come true without being selected as MoonDAO's second Citizen astronaut and embarking on my flight with Blue Origin. I dreamed of becoming an astronaut for many decades and finally found my path to space through MoonDAO. I'm so grateful to be part of this community and to be able to continue playing an active role in shaping our future in space.",
+  },
+  {
+    name: 'Anastasia',
+    affiliation: 'MoonDAO Citizen',
+    quote:
+      'MoonDAO is a great way to secure funding for the early stages of a project. This support becomes a powerful catalyst, helping your project gain momentum while bypassing much of the traditional bureaucracy associated with conventional funding. The process is fast, efficient, and accessible. Beyond the financial support, the genuine encouragement from the community and the opportunity to build new connections were incredibly meaningful.',
+  },
+  {
+    name: 'Giovanna',
+    affiliation: 'MoonDAO Citizen',
+    quote:
+      "Thanks to MoonDAO, I've had opportunities that once felt out of reach. I took part in a Zero-G flight alongside astronauts, witnessed my first SpaceX launch at Starbase, and experienced a Blue Origin launch. Beyond these incredible moments, MoonDAO creates something even more valuable: community. Here, I realized my dreams are not strange... they are shared. I love being part of MoonDAO!",
+  },
+  {
+    name: 'Lakshmi',
+    affiliation: 'LunARC',
+    quote:
+      "MoonDAO funded our riskiest idea and gave LunARC the momentum to keep going. Funding for radical space imagination is hard to find, especially in the philanthropic sector when your work sits outside traditional categories. MoonDAO's support for our Bolivia workshop gave LunARC the second wind we needed — not just to prove the idea could work, but to build real momentum. That momentum carried us straight into our next lab in Cairo, with more on the horizon.",
+  },
+]
+
+export type WhyJoinPillar = {
+  icon: string
+  iconAlt: string
+  header: string
+  paragraph: string
+}
+
+export const whyJoinPillars: WhyJoinPillar[] = [
+  {
+    icon: '/assets/icon-ethereum.svg',
+    iconAlt: 'Funding',
+    header: 'Fund Your Project, Fast',
+    paragraph:
+      'Skip the grant-cycle bureaucracy. Pitch the community directly and get funded in weeks, not years — even for the ambitious, hard-to-categorize ideas traditional funders pass on.',
+  },
+  {
+    icon: '/assets/icon-org.svg',
+    iconAlt: 'Jobs',
+    header: 'Real Jobs, Real Teams',
+    paragraph:
+      'Access a jobs board full of high-signal roles from teams already building in space — no mass-applicant noise, just people genuinely aligned with the mission.',
+  },
+  {
+    icon: '/assets/icon-astronaut.svg',
+    iconAlt: 'Astronaut',
+    header: 'Flights & Experiences',
+    paragraph:
+      "From Zero-G flights to Blue Origin launches, MoonDAO has sent everyday citizens to space and keeps opening doors to experiences that once felt impossible.",
+  },
+  {
+    icon: '/assets/icon-governance.svg',
+    iconAlt: 'Governance',
+    header: 'Governance & Ownership',
+    paragraph:
+      'Every proposal, vote, and treasury movement is onchain. As a citizen, you help decide where the mission goes next — not just watch from the sidelines.',
+  },
+  {
+    icon: '/assets/icon-dao.svg',
+    iconAlt: 'Community',
+    header: 'A Global Community',
+    paragraph:
+      'Meet friends and collaborators across the space industry, from founders to astronauts — a place where working on space is celebrated, not strange.',
+  },
+]

--- a/ui/const/whitelist.ts
+++ b/ui/const/whitelist.ts
@@ -20,3 +20,27 @@ export const BLOCKED_MDPS: any = new Set(
 export const BLOCKED_PROPOSALS: any = new Set([221])
 
 export const FEATURED_TEAMS: any = [6, 7, 8, 13, 1, 9, 5, 4, 2]
+
+// Citizen token ids to spotlight on /join as social proof (astronauts,
+// founders, notable community members). Edit this list directly to change
+// who appears in the featured-citizens marquee.
+export const FEATURED_CITIZENS: number[] = [
+  22, 4, 158, 45, 77, 175, 17, 111, 162, 8, 217, 186,
+]
+
+// Marketing tagline shown under each featured citizen's name — not derivable
+// from on-chain data, so it's maintained here alongside the id list above.
+export const FEATURED_CITIZEN_ROLES: Record<number, string> = {
+  22: 'NASA Astronaut Candidate · Inspiration4 Pilot',
+  4: 'Citizen Astronaut · Blue Origin',
+  158: 'Inspiration4 Mission Astronaut',
+  45: 'Civil Rights Advocate · Blue Origin Astronaut',
+  77: 'Author, The Overview Effect',
+  175: '668th Human in Space · Virgin Galactic',
+  17: 'Founder, SpaceFund & EarthLight Foundation',
+  111: 'Executive Director, The Mars Society',
+  162: 'Commercial Astronaut · Physician',
+  8: 'Founder of LifeShip',
+  217: 'NASA Astronaut',
+  186: 'Virgin Galactic Spaceflight Participant · Galactic 07',
+}

--- a/ui/pages/join.tsx
+++ b/ui/pages/join.tsx
@@ -13,7 +13,17 @@ import {
   TEAM_TABLE_ADDRESSES,
   TEAM_TABLE_NAMES,
 } from 'const/config'
-import { BLOCKED_CITIZENS, BLOCKED_TEAMS, FEATURED_TEAMS } from 'const/whitelist'
+import {
+  BLOCKED_CITIZENS,
+  BLOCKED_TEAMS,
+  FEATURED_CITIZENS,
+  FEATURED_CITIZEN_ROLES,
+  FEATURED_TEAMS,
+} from 'const/whitelist'
+import {
+  testimonials as testimonialsContent,
+  TESTIMONIAL_CITIZEN_IDS,
+} from 'const/joinPageContent'
 import useTranslation from 'next-translate/useTranslation'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
@@ -43,9 +53,14 @@ import CardSkeleton from '@/components/layout/CardSkeleton'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import PaginationButtons from '@/components/layout/PaginationButtons'
 import Search from '@/components/layout/Search'
+import { SectionSkeleton } from '@/components/layout/SkeletonLoader'
 import StandardButton from '@/components/layout/StandardButton'
 import StandardDetailCard from '@/components/layout/StandardDetailCard'
 import Tab from '@/components/layout/Tab'
+import JoinHero from '@/components/join/JoinHero'
+import type { FeaturedCitizen } from '@/components/join/FeaturedCitizensMarquee'
+import type { FeaturedTeam } from '@/components/join/FeaturedTeamsMarquee'
+import type { TestimonialWithPhoto } from 'const/joinPageContent'
 import JobsABI from '../const/abis/JobBoardTable.json'
 
 // Dynamic imports for globe components. Only one globe is mounted at a time
@@ -53,11 +68,35 @@ import JobsABI from '../const/abis/JobBoardTable.json'
 const LazyEarth = dynamic(() => import('@/components/globe/LazyEarth'), { ssr: false })
 const Moon = dynamic(() => import('@/components/globe/Moon'), { ssr: false })
 
+// Below-the-fold marketing sections are code-split the same way the homepage
+// splits its landing sections (see pages/index.tsx) to keep initial JS light.
+const FeaturedCitizensMarquee = dynamic(
+  () => import('@/components/join/FeaturedCitizensMarquee'),
+  { loading: () => <SectionSkeleton minHeight="min-h-[300px]" /> }
+)
+const FeaturedTeamsMarquee = dynamic(() => import('@/components/join/FeaturedTeamsMarquee'), {
+  loading: () => <SectionSkeleton minHeight="min-h-[300px]" />,
+})
+const WhyJoinSection = dynamic(() => import('@/components/join/WhyJoinSection'), {
+  loading: () => <SectionSkeleton />,
+})
+const TestimonialsCarousel = dynamic(() => import('@/components/join/TestimonialsCarousel'), {
+  loading: () => <SectionSkeleton />,
+})
+const InlineJoinCTA = dynamic(() => import('@/components/join/InlineJoinCTA'), {
+  loading: () => <SectionSkeleton minHeight="min-h-[200px]" />,
+})
+
 type JoinProps = {
   filteredTeams: any[]
   filteredCitizens: any[]
   jobs: JobType[]
   citizensLocationData?: any[]
+  featuredCitizens?: FeaturedCitizen[]
+  featuredTeams?: FeaturedTeam[]
+  testimonials?: TestimonialWithPhoto[]
+  citizenCount?: number
+  teamCount?: number
 }
 
 export default function Join({
@@ -65,6 +104,11 @@ export default function Join({
   filteredCitizens = [],
   jobs = [],
   citizensLocationData = [],
+  featuredCitizens = [],
+  featuredTeams = [],
+  testimonials = [],
+  citizenCount = 0,
+  teamCount = 0,
 }: JoinProps) {
   const { t } = useTranslation('common')
   const { selectedChain } = useContext(ChainContextV5)
@@ -85,7 +129,7 @@ export default function Join({
     })
   }
 
-  const [tab, setTab] = useState<string>('citizens')
+  const [tab, setTab] = useState<string>('map')
   const [mapView, setMapView] = useState<string>('earth') // For map sub-tabs
 
   function loadByTab(tab: string) {
@@ -230,7 +274,7 @@ export default function Join({
   }
 
   return (
-    <section id="join-container" className="overflow-hidden">
+    <section id="join-container" className="overflow-hidden bg-[#010208]">
       <Head
         title={'Join MoonDAO - Space Acceleration Network'}
         description={
@@ -243,50 +287,25 @@ export default function Join({
         <link rel="preload" as="image" href="/assets/citizen-default.webp" />
         <link rel="preload" as="image" href="/assets/team_image.webp" />
       </Head>
-      <Container>
-        {/* Hero Section */}
-        <div className="relative w-full h-screen rounded-3xl overflow-hidden">
-          <Image
-            src="/assets/NetworkHero.webp"
-            alt="Space Acceleration Network"
-            fill
-            className="object-cover"
-            priority
-          />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="text-center max-w-4xl px-8">
-              <h1 className="header font-GoodTimes text-white drop-shadow-lg mb-4">
-                Join the Space Acceleration Network
-              </h1>
-              <p className="sub-header text-white/90 drop-shadow-lg mb-8">
-                An onchain startup society focused on building a permanent settlement on the Moon
-                and beyond
-              </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <StandardButton
-                  className="gradient-2 hover:opacity-90 transition-opacity"
-                  textColor="text-white"
-                  borderRadius="rounded-xl"
-                  hoverEffect={false}
-                  link="/citizen"
-                >
-                  Become a Citizen
-                </StandardButton>
-                <StandardButton
-                  className="gradient-2 hover:opacity-90 transition-opacity"
-                  textColor="text-white"
-                  borderRadius="rounded-xl"
-                  hoverEffect={false}
-                  link="/team"
-                >
-                  Create a Team
-                </StandardButton>
-              </div>
-            </div>
-          </div>
-        </div>
-      </Container>
+      <JoinHero citizenCount={citizenCount} teamCount={teamCount} />
+
+      <FeaturedCitizensMarquee citizens={featuredCitizens} />
+
+      <FeaturedTeamsMarquee teams={featuredTeams} />
+
+      <InlineJoinCTA
+        headline="Ready to be part of the network?"
+        subtext="Join the citizens and teams building humanity's future in space."
+      />
+
+      <WhyJoinSection />
+
+      <TestimonialsCarousel testimonials={testimonials} />
+
+      <InlineJoinCTA
+        headline="Be Part of the First Space Program by and for the People"
+        subtext="Vote on proposals, access the jobs board, and help decide where humanity goes next."
+      />
 
       <Container>
         {/* Join MoonDAO Section */}
@@ -307,16 +326,20 @@ export default function Join({
 
           <div className="relative z-10 max-w-6xl mx-auto px-6">
             <div className="text-center mb-8">
-              <h2 className="header font-GoodTimes text-white mb-4 drop-shadow-lg">Join MoonDAO</h2>
+              <h2 className="header font-GoodTimes text-white mb-4 drop-shadow-lg">
+                Ready to Join?
+              </h2>
               <p className="sub-header text-white/90 max-w-3xl mx-auto drop-shadow-lg">
-                Join our decentralized space collective and help accelerate humanity's expansion to
-                the Moon and beyond
+                Pick your path into the Space Acceleration Network
               </p>
             </div>
 
-            <div className="flex flex-col lg:flex-row gap-6">
-              <div className="flex-1">
-                <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6 h-full">
+            <div className="flex flex-col lg:flex-row gap-6 items-stretch">
+              <div className="flex-1 lg:max-w-md lg:mx-auto">
+                <div className="relative bg-white/5 backdrop-blur-sm border-2 border-blue-400/40 rounded-2xl p-6 h-full shadow-[0_0_40px_rgba(37,99,235,0.15)]">
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-blue-500 text-white text-xs font-bold px-4 py-1 rounded-full uppercase tracking-wide">
+                    Most Popular
+                  </div>
                   <div className="flex flex-col items-center text-center">
                     <div className="w-24 h-24 mb-6 rounded-xl overflow-hidden">
                       <Image
@@ -328,11 +351,12 @@ export default function Join({
                       />
                     </div>
                     <h3 className="text-2xl font-GoodTimes text-white mb-4">Become a Citizen</h3>
-                    <p className="text-slate-300 mb-6 leading-relaxed">
-                      Citizens are the trailblazers supporting the creation of off-world
-                      settlements. Whether you're already part of a team or seeking to join one,
-                      everyone has a crucial role to play in this mission.
-                    </p>
+                    <ul className="text-slate-300 mb-6 leading-relaxed text-left space-y-2 w-full max-w-xs">
+                      <li>✓ Vote on proposals &amp; funding</li>
+                      <li>✓ Access the jobs board</li>
+                      <li>✓ Eligible for flights &amp; experiences</li>
+                      <li>✓ A permanent onchain identity</li>
+                    </ul>
                     <div className="flex flex-col items-center mb-6">
                       <div className="text-2xl font-semibold text-white">
                         ~${Math.round(citizenUsdPrice || 0)} / Year
@@ -343,7 +367,7 @@ export default function Join({
                       </div>
                     </div>
                     <StandardButton
-                      className="gradient-2 hover:opacity-90 transition-opacity"
+                      className="gradient-2 hover:opacity-90 transition-opacity w-full"
                       textColor="text-white"
                       borderRadius="rounded-xl"
                       hoverEffect={false}
@@ -355,7 +379,7 @@ export default function Join({
                 </div>
               </div>
 
-              <div className="flex-1">
+              <div className="flex-1 lg:max-w-md lg:mx-auto">
                 <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6 h-full">
                   <div className="flex flex-col items-center text-center">
                     <div className="w-24 h-24 mb-6 rounded-xl overflow-hidden">
@@ -368,11 +392,12 @@ export default function Join({
                       />
                     </div>
                     <h3 className="text-2xl font-GoodTimes text-white mb-4">Create a Team</h3>
-                    <p className="text-slate-300 mb-6 leading-relaxed">
-                      Teams are driving innovation and tackling ambitious space challenges together.
-                      From non-profits to startups and university teams, every group has something
-                      to contribute to our multiplanetary future.
-                    </p>
+                    <ul className="text-slate-300 mb-6 leading-relaxed text-left space-y-2 w-full max-w-xs">
+                      <li>✓ List roles on the jobs board</li>
+                      <li>✓ Raise funding through missions</li>
+                      <li>✓ Reach a space-positive audience</li>
+                      <li>✓ A permanent onchain identity</li>
+                    </ul>
                     <div className="flex flex-col items-center mb-6">
                       <div className="text-2xl font-semibold text-white">
                         ~${Math.round(teamUsdPrice || 0)} / Year
@@ -383,7 +408,7 @@ export default function Join({
                       </div>
                     </div>
                     <StandardButton
-                      className="gradient-2 hover:opacity-90 transition-opacity"
+                      className="gradient-2 hover:opacity-90 transition-opacity w-full"
                       textColor="text-white"
                       borderRadius="rounded-xl"
                       hoverEffect={false}
@@ -805,6 +830,75 @@ function toDirectoryItem(nft: any, type: 'team' | 'citizen') {
   }
 }
 
+// Strips a citizen NFT down to what the /join featured-citizens marquee
+// renders, and attaches the marketing tagline from FEATURED_CITIZEN_ROLES
+// (not on-chain data, so it's maintained in const/whitelist.ts).
+function toFeaturedCitizen(nft: any) {
+  const id = nft.id ?? nft.metadata?.id ?? ''
+  return {
+    id,
+    name: nft.metadata?.name ?? '',
+    image: nft.metadata?.image ?? '',
+    role: FEATURED_CITIZEN_ROLES[Number(id)] ?? '',
+  }
+}
+
+// Strips a team NFT down to what the /join featured-teams marquee renders.
+function toFeaturedTeam(nft: any) {
+  return {
+    id: nft.id ?? nft.metadata?.id ?? '',
+    name: nft.metadata?.name ?? '',
+    image: nft.metadata?.image ?? '',
+  }
+}
+
+// Loosely normalize a name for matching testimonial authors against on-chain
+// citizen records — strips quoted nicknames (e.g. "Andrew 'Titan' Parris")
+// and collapses whitespace so first-name-only testimonials still match.
+function normalizeName(name: string) {
+  return name
+    .toLowerCase()
+    .replace(/["'][^"']*["']/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+// Best-effort match of a testimonial author to their citizen profile photo.
+// Checks the explicit TESTIMONIAL_CITIZEN_IDS override first (for cases where
+// the on-chain display name doesn't resemble the testimonial name), then
+// falls back to a fuzzy name match. Falls back to no image (component renders
+// an initials avatar) when neither finds a match — logged so it's visible in
+// build output.
+function matchCitizenPhotoByName(name: string, citizens: any[]): string | null {
+  const overrideId = TESTIMONIAL_CITIZEN_IDS[name]
+  if (overrideId !== undefined) {
+    const overrideMatch = citizens.find(
+      (nft: any) => Number(nft.id ?? nft.metadata?.id) === overrideId
+    )
+    if (overrideMatch) return overrideMatch.metadata?.image || null
+  }
+
+  const needle = normalizeName(name)
+  const matches = citizens.filter((nft: any) => {
+    const rowName = normalizeName(nft.metadata?.name ?? '')
+    return rowName && (rowName.includes(needle) || needle.includes(rowName))
+  })
+  if (!matches.length) {
+    console.warn(
+      `[join] No citizen match found for testimonial name "${name}" — using fallback avatar.`
+    )
+    return null
+  }
+  if (matches.length > 1) {
+    console.warn(
+      `[join] Multiple citizen matches for testimonial name "${name}" — using the first match.`
+    )
+  }
+  // getStaticProps props must be JSON-serializable — undefined isn't allowed,
+  // so an unset image on the citizen record falls back to null, not undefined.
+  return matches[0].metadata?.image || null
+}
+
 export async function getStaticProps() {
   try {
     const chain = DEFAULT_CHAIN_V5
@@ -922,6 +1016,27 @@ export async function getStaticProps() {
     const { fetchCitizensWithLocation } = await import('@/lib/citizen/citizenDataService')
     const citizensLocationData = await fetchCitizensWithLocation(chain)
 
+    // Social-proof data for the /join sales sections — sourced from the same
+    // valid (non-expired) citizen rows already fetched above, no extra queries.
+    const featuredCitizens = FEATURED_CITIZENS.map((id: number) =>
+      filteredValidCitizens.find(
+        (nft: any) => Number(nft.id ?? nft.metadata?.id) === Number(id)
+      )
+    )
+      .filter(Boolean)
+      .map(toFeaturedCitizen)
+
+    const testimonialsWithPhotos = testimonialsContent.map((testimonial) => ({
+      ...testimonial,
+      image: matchCitizenPhotoByName(testimonial.name, filteredValidCitizens),
+    }))
+
+    const featuredTeams = FEATURED_TEAMS.map((id: number) =>
+      sortedValidTeams.find((nft: any) => Number(nft.id ?? nft.metadata?.id) === Number(id))
+    )
+      .filter(Boolean)
+      .map(toFeaturedTeam)
+
     return {
       props: {
         filteredTeams: sortedValidTeams.map((nft: any) => toDirectoryItem(nft, 'team')),
@@ -930,6 +1045,11 @@ export async function getStaticProps() {
           .map((nft: any) => toDirectoryItem(nft, 'citizen')),
         jobs: jobs || [],
         citizensLocationData: citizensLocationData,
+        featuredCitizens,
+        featuredTeams,
+        testimonials: testimonialsWithPhotos,
+        citizenCount: filteredValidCitizens.length,
+        teamCount: sortedValidTeams.length,
       },
       revalidate: 60,
     }
@@ -941,6 +1061,11 @@ export async function getStaticProps() {
         filteredCitizens: [],
         jobs: [],
         citizensLocationData: [],
+        featuredCitizens: [],
+        featuredTeams: [],
+        testimonials: testimonialsContent,
+        citizenCount: 0,
+        teamCount: 0,
       },
       revalidate: 60,
     }


### PR DESCRIPTION
Replaces the bare hero + directory with real social proof: a marquee of high-profile citizens (astronauts, founders) and a marquee of network teams, both pulled live from Tableland/IPFS; an auto-sliding testimonials carousel; benefit-focused "why join" copy; and inline citizen CTAs throughout, since converting new citizens is the page's primary goal. Directory now defaults to the map view instead of the citizens list, and the member pricing cards visually promote Citizen over Team.