### PR TITLE
fix(team): prevent removing a team's last manager

### DIFF
--- a/ui/components/subscription/TeamManageMembers.tsx
+++ b/ui/components/subscription/TeamManageMembers.tsx
@@ -2,7 +2,7 @@ import { TrashIcon, UserPlusIcon, ShieldCheckIcon, ExclamationTriangleIcon, XMar
 import { DEFAULT_CHAIN_V5, HATS_ADDRESS } from 'const/config'
 import { TEAM_CREATOR_V2_PASSTHROUGH_MODULE_PATCHED_ADDRESSES } from 'const/teams'
 import { ethers } from 'ethers'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import { readContract } from 'thirdweb'
 import { useCitizen } from '@/lib/citizen/useCitizen'
@@ -14,6 +14,7 @@ import {
   isValidEthereumAddress,
   requiresSafeTx,
   toHatIdHex,
+  wouldRemoveLastManager,
 } from '@/lib/hats/teamRoles'
 import useHatNames from '@/lib/hats/useHatNames'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
@@ -128,6 +129,7 @@ function TeamMembers({
   setHasAddedMember,
   managerHatId,
   adminHatId,
+  managerCount,
 }: any) {
   const hatNames = useHatNames(hatsContract, wearer.hatIds)
   const chainSlug = getChainSlug(selectedChain)
@@ -197,6 +199,39 @@ function TeamMembers({
                   <button
                     disabled={removingHat === hatName.hatId}
                     onClick={async () => {
+                      const removingManagerHat = isManagerHat(
+                        hatName.hatId,
+                        managerHatId
+                      )
+
+                      // Guard: never allow a team to be left with zero managers.
+                      // A team with no manager can no longer manage its own roles
+                      // (only the manager hat or Safe owner can), so it would need
+                      // super-manager intervention to recover.
+                      if (
+                        wouldRemoveLastManager(
+                          hatName.hatId,
+                          managerHatId,
+                          managerCount ?? 0
+                        )
+                      ) {
+                        return toast.error(
+                          "You can't remove the team's only manager. Assign another manager first, then remove this one."
+                        )
+                      }
+
+                      // Confirm removals of the (consequential, Safe-gated)
+                      // manager role to prevent accidental clicks.
+                      if (
+                        removingManagerHat &&
+                        typeof window !== 'undefined' &&
+                        !window.confirm(
+                          'Remove this manager? This revokes their administrative access and must be executed via the team Safe.'
+                        )
+                      ) {
+                        return
+                      }
+
                       setRemovingHat(hatName.hatId)
                       try {
                         const v2TeamCreatorPatchedPassthroughModuleAddress =
@@ -301,6 +336,15 @@ function TeamManageMembersModal({
 
   const uniqueWearers = useUniqueHatWearers(hats)
 
+  // How many distinct wallets currently wear the manager hat. Used to block
+  // removing the last manager (which would lock the team out of role management).
+  const managerCount = useMemo(() => {
+    if (!uniqueWearers) return 0
+    return uniqueWearers.filter((w: any) =>
+      w.hatIds?.some((id: string) => isManagerHat(id, managerHatId))
+    ).length
+  }, [uniqueWearers, managerHatId])
+
   const [hasAddedMember, setHasAddedMember] = useState<boolean>(false)
   const [newMemberAddress, setNewMemberAddress] = useState<string>('')
   const [selectedHatId, setSelectedHatId] = useState<any>(reversedHats?.[0]?.id)
@@ -392,6 +436,7 @@ function TeamManageMembersModal({
                   setHasAddedMember={setHasAddedMember}
                   managerHatId={managerHatId}
                   adminHatId={adminHatId}
+                  managerCount={managerCount}
                 />
               ))
             ) : (

--- a/ui/cypress/integration/unit/team-roles.cy.tsx
+++ b/ui/cypress/integration/unit/team-roles.cy.tsx
@@ -10,6 +10,7 @@ import {
   isValidEthereumAddress,
   requiresSafeTx,
   toHatIdHex,
+  wouldRemoveLastManager,
 } from '@/lib/hats/teamRoles'
 
 // Hat ids are uint256 values. The subgraph returns them as 0x-prefixed,
@@ -294,6 +295,32 @@ describe('teamRoles', () => {
       expect(remove.slice(0, 10)).to.equal(
         iface.getSighash('setHatWearerStatus')
       )
+    })
+  })
+
+  describe('wouldRemoveLastManager', () => {
+    it('blocks removing the manager hat when only one manager remains', () => {
+      expect(
+        wouldRemoveLastManager(MANAGER_HAT_HEX, MANAGER_HAT_DECIMAL, 1)
+      ).to.equal(true)
+      expect(
+        wouldRemoveLastManager(MANAGER_HAT_HEX, MANAGER_HAT_DECIMAL, 0)
+      ).to.equal(true)
+    })
+
+    it('allows removing a manager when others remain', () => {
+      expect(
+        wouldRemoveLastManager(MANAGER_HAT_HEX, MANAGER_HAT_DECIMAL, 2)
+      ).to.equal(false)
+    })
+
+    it('never blocks removing a non-manager (member) hat', () => {
+      expect(
+        wouldRemoveLastManager(MEMBER_HAT_HEX, MANAGER_HAT_DECIMAL, 1)
+      ).to.equal(false)
+      expect(
+        wouldRemoveLastManager(MEMBER_HAT_HEX, MANAGER_HAT_DECIMAL, 0)
+      ).to.equal(false)
     })
   })
 

--- a/ui/lib/hats/teamRoles.ts
+++ b/ui/lib/hats/teamRoles.ts
@@ -63,6 +63,22 @@ export function requiresSafeTx(
   return isManagerHat(hatId, managerHatId) || isAdminHat(hatId, adminHatId)
 }
 
+/**
+ * True when removing `hatId` would leave the team with no manager.
+ *
+ * `managerCount` is the number of distinct wallets currently wearing the manager
+ * hat. A team with zero managers can no longer manage its own roles (only the
+ * manager hat wearer or the Safe owner can), so the UI must block removing the
+ * manager hat while it is the last one held.
+ */
+export function wouldRemoveLastManager(
+  hatId: string | undefined | null,
+  managerHatId: string | number | bigint | undefined | null,
+  managerCount: number
+): boolean {
+  return isManagerHat(hatId, managerHatId) && (managerCount ?? 0) <= 1
+}
+
 /** Routing for a role mint/remove: 'safe' (multisig) or 'direct' (connected wallet). */
 export function getRoleTxRouting(
   hatId: string | undefined | null,


### PR DESCRIPTION
## Summary
Prevents the failure mode diagnosed for the **U.S. Space & Rocket Center Education Foundation** team (Space Camp), whose manager hat was found with **0 wearers on-chain** (`supply 0/8`) while a member remained. Once a team has zero managers it can no longer manage its own roles — only a manager-hat wearer or the Safe owner can open **Manage Team** — so it becomes locked out and needs super-manager intervention to recover.

The only in-app path to revoke a manager (the trash icon in the Manage Team modal) previously had no guard and no confirmation, making it easy to remove the last/only manager.

- Adds a `wouldRemoveLastManager()` helper in `lib/hats/teamRoles.ts` and blocks removing the manager hat while it is the last one held, with a clear toast prompting the user to assign another manager first.
- Adds a confirmation prompt for the consequential, Safe-gated manager removal to guard against accidental clicks on the small trash icon.
- Unit-tests the new guard helper alongside the existing `teamRoles` tests.

This complements the merged super-manager role-switching work (which is the *recovery* path); this PR is the *prevention* path.

## Test plan
- [ ] On a team with a single manager, open Manage Team and click the trash icon on the Manager role → removal is blocked with the "can't remove the team's only manager" toast; no Safe tx is queued.
- [ ] On a team with 2+ managers, removing one prompts a confirmation, then queues the Safe tx as before.
- [ ] Removing a **Member** role is unaffected (no confirmation, no block).
- [ ] `cypress/integration/unit/team-roles.cy.tsx` passes, including the new `wouldRemoveLastManager` cases.

Made with [Cursor](https://cursor.com)