### PR TITLE
feat(teams): add MoonDAO stewards as co-signers on new team Safes (2/3)

### DIFF
--- a/subscription-contracts/src/MoonDAOTeamCreator.sol
+++ b/subscription-contracts/src/MoonDAOTeamCreator.sol
@@ -190,7 +190,11 @@ contract MoonDAOTeamCreator is Ownable {
         for (uint i = 1; i < ownersLength; i++) {
             owners[i] = members[i - 1];
         }
-        uint256 threshold = owners.length / 2 + 1;
+        // Default to a 1-of-N Safe so the team lead OR any MoonDAO steward
+        // co-signer can operate the treasury (e.g. mint manager/member hats)
+        // while groups new to multisigs get set up. Teams can raise the
+        // threshold later from the Manage Team portal once established.
+        uint256 threshold = 1;
         //see https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L84
         bytes memory proxyInitData = abi.encodeWithSelector(
             // function selector (setup)

--- a/subscription-contracts/src/MoonDAOTeamCreator.sol
+++ b/subscription-contracts/src/MoonDAOTeamCreator.sol
@@ -190,11 +190,7 @@ contract MoonDAOTeamCreator is Ownable {
         for (uint i = 1; i < ownersLength; i++) {
             owners[i] = members[i - 1];
         }
-        // Default to a 1-of-N Safe so the team lead OR any MoonDAO steward
-        // co-signer can operate the treasury (e.g. mint manager/member hats)
-        // while groups new to multisigs get set up. Teams can raise the
-        // threshold later from the Manage Team portal once established.
-        uint256 threshold = 1;
+        uint256 threshold = owners.length / 2 + 1;
         //see https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol#L84
         bytes memory proxyInitData = abi.encodeWithSelector(
             // function selector (setup)

--- a/ui/components/onboarding/CreateTeam.tsx
+++ b/ui/components/onboarding/CreateTeam.tsx
@@ -1,6 +1,7 @@
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { Widget } from '@typeform/embed-react'
 import {
+  DEFAULT_TEAM_MULTISIG_SIGNERS,
   DEPLOYED_ORIGIN,
   DISCORD_CITIZEN_ROLE_ID,
   TEAM_ADDRESSES,
@@ -312,6 +313,13 @@ export default function CreateTeam({ selectedChain, setSelectedTier }: any) {
         return toast.error('Image upload to IPFS failed. Try a smaller file.')
       }
 
+      // Add MoonDAO stewards as co-signers on the team Safe (the creator is
+      // added as the first owner by the contract). Filter the creator out to
+      // avoid a duplicate-owner revert if a steward is creating the team.
+      const defaultSigners = DEFAULT_TEAM_MULTISIG_SIGNERS.filter(
+        (signer) => signer.toLowerCase() !== address.toLowerCase()
+      )
+
       const transaction = prepareContractCall({
         contract: teamCreatorContract,
         method: 'createMoonDAOTeam' as string,
@@ -335,7 +343,7 @@ export default function CreateTeam({ selectedChain, setSelectedTier }: any) {
             _view: teamData.view,
             formId: escapeSingleQuotes(teamData.formResponseId),
           },
-          [],
+          defaultSigners,
         ],
         value: cost,
       })
@@ -405,7 +413,9 @@ export default function CreateTeam({ selectedChain, setSelectedTier }: any) {
             _view: teamData.view,
             formId: escapeSingleQuotes(teamData.formResponseId || '0000'),
           },
-          [],
+          DEFAULT_TEAM_MULTISIG_SIGNERS.filter(
+            (signer) => signer.toLowerCase() !== address.toLowerCase()
+          ),
         ],
         value: cost,
       })
@@ -671,7 +681,9 @@ export default function CreateTeam({ selectedChain, setSelectedTier }: any) {
                         <h3 className="font-GoodTimes text-base mb-3 text-white">Treasury</h3>
                         <p className="text-slate-400 text-sm leading-relaxed">
                           A self-custodied multisignature treasury will secure your organization's
-                          assets. You can add more signers later via your Team management portal.
+                          assets. Your wallet plus two MoonDAO stewards are added as co-signers so we
+                          can help you get set up. You can add, remove, or change signers anytime via
+                          your Team management portal.
                         </p>
                       </div>
                       <div className="bg-slate-800/30 border border-white/[0.06] rounded-2xl p-5">

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -820,6 +820,16 @@ export const SUPER_MANAGERS: string[] = [
   '0xaf6f2a7643a97b849bd9cf6d3f57e142c5bbb0da', // miguel.eth
 ]
 
+// MoonDAO steward wallets added as co-signers on every new team's Safe (in
+// addition to the team lead/creator), so a steward can help teams that are new
+// to multisigs get set up — e.g. mint manager/member hats — without needing the
+// lead online. Combined with the team creator's 1-of-N threshold this produces a
+// default 1/3 Safe (lead + Ryan + Pablo). Checksummed for Safe owner setup.
+export const DEFAULT_TEAM_MULTISIG_SIGNERS: string[] = [
+  '0xB2d3900807094D4Fe47405871B0C8AdB58E10D42', // ryand2d.eth
+  '0x679d87D8640e66778c3419D164998E720D7495f6', // pmoncada.eth
+]
+
 // Hard-coded allowlist of wallet addresses that can use the operator panel
 // on /projects (start the retro cycle, mark projects eligible, etc.).
 // Lowercase for cheap comparison.

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -821,10 +821,11 @@ export const SUPER_MANAGERS: string[] = [
 ]
 
 // MoonDAO steward wallets added as co-signers on every new team's Safe (in
-// addition to the team lead/creator), so a steward can help teams that are new
-// to multisigs get set up — e.g. mint manager/member hats — without needing the
-// lead online. Combined with the team creator's 1-of-N threshold this produces a
-// default 1/3 Safe (lead + Ryan + Pablo). Checksummed for Safe owner setup.
+// addition to the team lead/creator). The MoonDAOTeamCreator contract passes the
+// members array straight through as the Safe owners and uses a majority
+// threshold, so lead + Ryan + Pablo yields a 2/3 Safe: the two stewards can help
+// teams that are new to multisigs get set up (mint manager/member hats) without
+// needing the lead online. Checksummed for Safe owner setup.
 export const DEFAULT_TEAM_MULTISIG_SIGNERS: string[] = [
   '0xB2d3900807094D4Fe47405871B0C8AdB58E10D42', // ryand2d.eth
   '0x679d87D8640e66778c3419D164998E720D7495f6', // pmoncada.eth


### PR DESCRIPTION
## Summary
Fixes the gap where MoonDAO stewards have "super manager" access but **can't add people to a team unless they're on that team's Safe** — the problem behind the Space Camp incident. New teams previously got a **1/1 Safe** with only the creator as signer.

New teams now include **Ryan + Pablo as co-signers** alongside the team lead. Since the existing `MoonDAOTeamCreator` passes the `members` array straight through as the Safe owners and uses a **majority** threshold, this yields a **2/3 Safe** (lead + Ryan + Pablo). The two stewards can act together (without needing the lead online) to help groups that are new to multisigs get set up — mint manager/member hats, add members, etc.

**No contract deploy or Hats rewiring required** — this works against the already-deployed creator.

### Changes
- **`const/config.ts`**: adds `DEFAULT_TEAM_MULTISIG_SIGNERS` (Ryan, Pablo, checksummed).
- **`CreateTeam.tsx`**: passes those stewards as Safe co-signers on `createMoonDAOTeam` (both the mint and gas-estimate calls). The creator is filtered out of the injected list to avoid a duplicate-owner revert if a steward creates the team.
- Review-step **Treasury copy** updated to explain the co-signers.

### Behavior
- Normal team (lead is not a steward): owners `[lead, Ryan, Pablo]`, threshold **2/3**.
- Steward creates the team: owners `[Ryan, Pablo]` (deduped), threshold **2/2**.
- The contract caps owners at 5 and computes `threshold = owners/2 + 1` — unchanged.

### Why 2/3 (not 1/3)
1/3 (any single signer acts alone) would require deploying a new creator contract **and** rewiring the shared MoonDAOTeam NFT + Tableland table + Hats tree to authorize it — significant ops. 2/3 solves the actual problem (stewards on the multisig, able to help without the lead) with a UI-only change. Teams can change signers/threshold anytime via **Manage Team**.

## Test plan
- [ ] Create a team as a non-steward → resulting Safe has owners `[lead, Ryan, Pablo]`, threshold `2`.
- [ ] Create a team as Ryan (a steward) → owners `[Ryan, Pablo]` (no duplicate), threshold `2`; no revert.
- [ ] Ryan + Pablo can open Manage Team on a newly created team and add a manager/member (Safe tx executes with two steward signatures).
- [ ] Existing behavior for teams created with no extra signers is unchanged.