### PR TITLE
fix(retroactives): deactivate on clear cohort; show all eligible active projects in retro tab

### DIFF
--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -422,17 +422,15 @@ export function ProjectRewards({
 
   const validEligibleIds = useMemo(() => {
     if (!currentProjects?.length) return new Set<string>()
+    // Mirror `eligibleProjects`: any active (`currentProjects`) project the
+    // operator has explicitly flagged eligible is part of the current retro
+    // cohort, regardless of the quarter it was originally proposed in.
     return new Set(
       currentProjects
-        .filter(
-          (p: any) =>
-            p.eligible &&
-            Number(p.quarter) === quarter &&
-            Number(p.year) === year
-        )
+        .filter((p: any) => p.eligible)
         .map((p: any) => String(p.id))
     )
-  }, [currentProjects, quarter, year])
+  }, [currentProjects])
 
   // Helper: keep only the entries whose key appears in `validKeys`. Used to
   // strip orphan project ids from a distribution loaded out of the
@@ -786,29 +784,24 @@ export function ProjectRewards({
   let citizenDistributions = distributions?.filter((_, i) => isCitizens[i])
   const nonCitizenDistributions = distributions?.filter((_, i) => !isCitizens[i])
 
-  // `eligibleProjects` is cohort-scoped on purpose: the Retroactive
-  // Rewards tab votes on a *specific* cycle's eligible cohort, so it has
-  // to track `quarter`/`year` (which adapt to the rewards-cycle flag).
-  // Otherwise projects from a closed cycle whose `eligible = 1` was
-  // never cleared would bleed into the live retro tab.
-  //
-  // `ineligibleProjects` (the Active Projects tab body) is intentionally
-  // NOT cohort-scoped. A project being "active and not yet eligible for
-  // retro" is a property of the project, not of the cycle the page is
-  // currently focused on. Scoping it to a single quarter caused the
-  // freshly-approved cohort to disappear from the Active Projects tab
-  // immediately after a Member Vote close — they're `active = 2` on
-  // chain but their quarter doesn't match the rewards-cycle quarter
-  // the page is otherwise viewing.
+  // The eligible flag on an *active* project is the operator-curated source
+  // of truth for the current retro cohort. An EB operator explicitly marks a
+  // completed project eligible (and active = 2) via the operator panel to add
+  // it to the current pool — even when it was proposed in an earlier quarter
+  // (e.g. a Q1 project settled during a Q2 cycle). So neither tab is
+  // cohort-scoped by quarter:
+  //   - `eligibleProjects` (Retroactives tab) = active projects flagged
+  //     eligible. Previously this also required the project's quarter/year to
+  //     equal the rewards-cycle quarter, which hid legitimately-marked
+  //     projects from other quarters.
+  //   - `ineligibleProjects` (Active Projects tab) = active projects not (yet)
+  //     eligible.
+  // Stale `eligible = 1` flags from a closed cycle no longer leak in because
+  // "Clear Retro Cohort" now also sets those projects to active = 0, dropping
+  // them out of `currentProjects` entirely.
   const eligibleProjects = useMemo(
-    () =>
-      currentProjects.filter(
-        (p) =>
-          p.eligible &&
-          Number(p.quarter) === quarter &&
-          Number(p.year) === year
-      ),
-    [currentProjects, quarter, year]
+    () => currentProjects.filter((p) => p.eligible),
+    [currentProjects]
   )
 
   const ineligibleProjects = useMemo(

--- a/ui/components/operator/AddToRetroactivesModal.tsx
+++ b/ui/components/operator/AddToRetroactivesModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import toast from 'react-hot-toast'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import { PROJECT_ACTIVE } from '@/lib/nance/types'
 import { Project } from '@/lib/project/useProjectData'
 import Modal from '@/components/layout/Modal'
 
@@ -12,6 +13,7 @@ type Props = {
 
 type SignStatus = 'idle' | 'submitting' | 'success' | 'error'
 type EligibleAction = 'noop' | 'set' | 'clear'
+type ActiveAction = 'noop' | 'activate' | 'deactivate'
 
 function tryParseJson(value: string): unknown | null {
   if (!value?.trim()) return null
@@ -34,7 +36,14 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
   const [eligibleAction, setEligibleAction] = useState<EligibleAction>(
     project.eligible === 1 ? 'noop' : 'set'
   )
-  const [markActive, setMarkActive] = useState(project.active !== 2)
+  // Tri-state active flag: leave unchanged, set to PROJECT_ACTIVE (2, so it
+  // joins the current pool), or set to not-active (0, PROJECT_ENDED — for a
+  // project that's no longer running but isn't a retro-reward candidate).
+  // Default proposes activating a not-yet-active project, matching the prior
+  // checkbox behavior.
+  const [activeAction, setActiveAction] = useState<ActiveAction>(
+    project.active === PROJECT_ACTIVE ? 'noop' : 'activate'
+  )
   const [status, setStatus] = useState<SignStatus>('idle')
   const [resultTxs, setResultTxs] = useState<Array<{ label: string; hash: string }>>([])
 
@@ -57,7 +66,7 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
       !rewardDistribution &&
       !upfrontPayments &&
       eligibleAction === 'noop' &&
-      !markActive
+      activeAction === 'noop'
     ) {
       toast.error('Nothing to update — fill in at least one field or toggle.', {
         style: toastStyle,
@@ -76,8 +85,9 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
     try {
       const body: Record<string, any> = {
         projectId: project.id,
-        markActive,
       }
+      if (activeAction === 'activate') body.markActive = true
+      else if (activeAction === 'deactivate') body.markInactive = true
       if (eligibleAction === 'set') body.markEligible = true
       else if (eligibleAction === 'clear') body.markEligible = false
       if (finalReportLink) body.finalReportLink = finalReportLink
@@ -250,21 +260,63 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
               </label>
             </div>
           </div>
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={markActive}
-              onChange={(e) => setMarkActive(e.target.checked)}
-              disabled={isSubmitting}
-            />
-            <span className="text-gray-200">
-              Set <code>active = 2</code> (PROJECT_ACTIVE — required so it appears in the
-              current pool)
+          <div className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wider text-gray-400 flex items-center gap-2">
+              Active flag
+              <span className="text-[11px] normal-case tracking-normal text-gray-500">
+                current: <code>{String(project.active)}</code>
+              </span>
             </span>
-            {project.active === 2 && (
-              <span className="text-[11px] text-green-400">already active</span>
-            )}
-          </label>
+            <div className="flex flex-col gap-1 mt-1">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="active-action"
+                  value="noop"
+                  checked={activeAction === 'noop'}
+                  onChange={() => setActiveAction('noop')}
+                  disabled={isSubmitting}
+                />
+                <span className="text-gray-200">Leave unchanged</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="active-action"
+                  value="activate"
+                  checked={activeAction === 'activate'}
+                  onChange={() => setActiveAction('activate')}
+                  disabled={isSubmitting}
+                />
+                <span className="text-gray-200">
+                  Set <code>active = 2</code> (PROJECT_ACTIVE — required so it
+                  appears in the current pool)
+                </span>
+                {project.active === PROJECT_ACTIVE && (
+                  <span className="text-[11px] text-green-400">already active</span>
+                )}
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="active-action"
+                  value="deactivate"
+                  checked={activeAction === 'deactivate'}
+                  onChange={() => setActiveAction('deactivate')}
+                  disabled={isSubmitting}
+                />
+                <span className="text-gray-200">
+                  Set not active (<code>active = 0</code>) — no longer running,
+                  not a retro-reward candidate
+                </span>
+                {project.active !== PROJECT_ACTIVE && (
+                  <span className="text-[11px] text-amber-400">
+                    not currently active
+                  </span>
+                )}
+              </label>
+            </div>
+          </div>
         </div>
 
         {(() => {

--- a/ui/components/operator/AddToRetroactivesModal.tsx
+++ b/ui/components/operator/AddToRetroactivesModal.tsx
@@ -42,7 +42,7 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
   // Default proposes activating a not-yet-active project, matching the prior
   // checkbox behavior.
   const [activeAction, setActiveAction] = useState<ActiveAction>(
-    project.active === PROJECT_ACTIVE ? 'noop' : 'activate'
+    Number(project.active) === PROJECT_ACTIVE ? 'noop' : 'activate'
   )
   const [status, setStatus] = useState<SignStatus>('idle')
   const [resultTxs, setResultTxs] = useState<Array<{ label: string; hash: string }>>([])
@@ -292,7 +292,7 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
                   Set <code>active = 2</code> (PROJECT_ACTIVE — required so it
                   appears in the current pool)
                 </span>
-                {project.active === PROJECT_ACTIVE && (
+                {Number(project.active) === PROJECT_ACTIVE && (
                   <span className="text-[11px] text-green-400">already active</span>
                 )}
               </label>
@@ -309,7 +309,7 @@ export default function AddToRetroactivesModal({ project, onClose, onSuccess }: 
                   Set not active (<code>active = 0</code>) — no longer running,
                   not a retro-reward candidate
                 </span>
-                {project.active !== PROJECT_ACTIVE && (
+                {Number(project.active) !== PROJECT_ACTIVE && (
                   <span className="text-[11px] text-amber-400">
                     not currently active
                   </span>

--- a/ui/components/operator/OperatorPanel.tsx
+++ b/ui/components/operator/OperatorPanel.tsx
@@ -257,7 +257,7 @@ export default function OperatorPanel({
             // Active tab (which lists active === PROJECT_ACTIVE projects that
             // aren't eligible). Skip the extra write for projects that are
             // already inactive.
-            markInactive: project.active === PROJECT_ACTIVE,
+            markInactive: Number(project.active) === PROJECT_ACTIVE,
           }),
         })
         const json = await res.json()
@@ -496,7 +496,7 @@ export default function OperatorPanel({
               className="flex-1 min-w-0 max-w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-white text-xs focus:outline-none focus:border-blue-400/40 truncate"
             >
               <option value="">Select a project…</option>
-              {currentProjects
+              {[...currentProjects, ...pastProjects]
                 .slice()
                 .sort((a, b) => b.id - a.id)
                 .map((p) => {

--- a/ui/components/operator/OperatorPanel.tsx
+++ b/ui/components/operator/OperatorPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import type { ProjectCyclePhase } from 'const/config'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import { PROJECT_ACTIVE } from '@/lib/nance/types'
 import { useIsExecutive } from '@/lib/operator/useIsExecutive'
 import { Project } from '@/lib/project/useProjectData'
 import AddToRetroactivesModal from './AddToRetroactivesModal'
@@ -228,7 +229,9 @@ export default function OperatorPanel({
       return
     }
     const confirmed = window.confirm(
-      `Clear eligible flag (set to 0) on ${eligibleCohort.length} project(s)?\n\nEach project requires one HSM-signed transaction.`
+      `Clear ${eligibleCohort.length} project(s) from the retro cohort?\n\n` +
+        `Each will be set eligible = 0 and (if still active) active = ended, ` +
+        `removing it from both the Retroactives and Active tabs.`
     )
     if (!confirmed) return
 
@@ -250,6 +253,11 @@ export default function OperatorPanel({
           body: JSON.stringify({
             projectId: project.id,
             markEligible: false,
+            // Also retire it from the current pool so it doesn't linger in the
+            // Active tab (which lists active === PROJECT_ACTIVE projects that
+            // aren't eligible). Skip the extra write for projects that are
+            // already inactive.
+            markInactive: project.active === PROJECT_ACTIVE,
           }),
         })
         const json = await res.json()
@@ -526,7 +534,10 @@ export default function OperatorPanel({
           </h4>
           <p className="text-xs text-gray-400">
             Sets <code>eligible = 0</code> on every project currently flagged
-            <code className="mx-1">eligible = 1</code>. Run this once a cycle&apos;s
+            <code className="mx-1">eligible = 1</code> and retires any that are
+            still <code className="mx-1">active = 2</code> to
+            <code className="mx-1">active = 0</code> (ended), removing them from
+            both the Retroactives and Active tabs. Run this once a cycle&apos;s
             retro voting has closed and payouts have been settled, before
             marking next cycle&apos;s projects eligible.
           </p>

--- a/ui/components/operator/OperatorPanel.tsx
+++ b/ui/components/operator/OperatorPanel.tsx
@@ -496,7 +496,7 @@ export default function OperatorPanel({
               className="flex-1 min-w-0 max-w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-white text-xs focus:outline-none focus:border-blue-400/40 truncate"
             >
               <option value="">Select a project…</option>
-              {allProjects
+              {currentProjects
                 .slice()
                 .sort((a, b) => b.id - a.id)
                 .map((p) => {

--- a/ui/pages/api/operator/project-add-to-retroactives.ts
+++ b/ui/pages/api/operator/project-add-to-retroactives.ts
@@ -8,6 +8,7 @@ import { isOperator } from 'middleware/isOperator'
 import withMiddleware from 'middleware/withMiddleware'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { getHSMSigner, isHSMAvailable } from '@/lib/google/hsm-signer'
+import { PROJECT_ACTIVE, PROJECT_ENDED } from '@/lib/nance/types'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 
 type Body = {
@@ -17,7 +18,12 @@ type Body = {
   rewardDistribution?: Record<string, number> | string
   upfrontPayments?: Record<string, any> | string
   markEligible?: boolean
+  // `markActive` → active = PROJECT_ACTIVE (2), so the project joins the
+  // current retro pool. `markInactive` → active = PROJECT_ENDED (0), so a
+  // retired project drops out of the "Active" tab and the current pool. They
+  // are mutually exclusive.
   markActive?: boolean
+  markInactive?: boolean
 }
 
 // Owner-only contract operations needed to put a completed project into the
@@ -168,10 +174,33 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     })
   }
 
+  if (body.markActive && body.markInactive) {
+    return res.status(400).json({
+      error: 'markActive and markInactive are mutually exclusive',
+    })
+  }
+
   if (body.markActive) {
     calls.push({
       label: 'updateTableCol(active=2)',
-      data: iface.encodeFunctionData('updateTableCol', [projectId, 'active', '2']),
+      data: iface.encodeFunctionData('updateTableCol', [
+        projectId,
+        'active',
+        String(PROJECT_ACTIVE),
+      ]),
+    })
+  } else if (body.markInactive) {
+    // Retire the project from the current pool. Clearing the retro cohort
+    // pairs this with `markEligible: false` so a settled project leaves both
+    // the retro tab (no longer eligible) and the Active tab (no longer
+    // active === PROJECT_ACTIVE).
+    calls.push({
+      label: 'updateTableCol(active=0)',
+      data: iface.encodeFunctionData('updateTableCol', [
+        projectId,
+        'active',
+        String(PROJECT_ENDED),
+      ]),
     })
   }
 


### PR DESCRIPTION
## Summary

Two follow-up fixes to the projects retroactives / operator flow (the earlier PR #1490 is already merged).

### 1. "Clear Retro Cohort" now also deactivates cleared projects
The Active tab lists `currentProjects.filter(p => !p.eligible)`, and `currentProjects` = projects with `active === 2`. The bulk "Clear Retro Cohort" action only set `eligible = 0`, leaving `active = 2` — so cleared projects immediately reappeared under the **Active** tab.

- `pages/api/operator/project-add-to-retroactives.ts` — add a `markInactive` option that sets `active = PROJECT_ENDED (0)` (mutually exclusive with `markActive`).
- `components/operator/OperatorPanel.tsx` — `clearCohort` now sends `markInactive: true` for projects still at `active === 2`, so cleared projects leave both the Retroactives and Active tabs. Updated the confirm dialog and card copy.

### 2. Marked-eligible projects from other quarters now show in Retroactives
The Retroactives tab (`eligibleProjects`) required `p.eligible && p.quarter === cohortQuarter && p.year === cohortYear`. A project explicitly marked eligible + active in an earlier quarter (e.g. **#92 — Q1 2026**, settled during a Q2 cycle) was filtered out. The quarter-scope only existed to keep *stale, never-cleared* eligible flags from leaking in — which fix #1 now handles (cleared projects become `active = 0` and drop out of `currentProjects`).

- `components/nance/ProjectRewards.tsx` — `eligibleProjects` and `validEligibleIds` no longer filter by cohort quarter/year. An operator-set `eligible` flag on an `active` project is the source of truth for the current retro pool.

## Test plan
- [ ] Mark a completed project eligible + `active = 2` (incl. one from a prior quarter, e.g. #92 Q1 2026) → it appears in the **Retroactives** tab.
- [ ] Run "Clear Retro Cohort" → cleared projects disappear from both the **Retroactives** and **Active** tabs (verify on-chain `eligible = 0` and `active = 0`).
- [ ] Projects already inactive in the cohort get only the `eligible = 0` write (no redundant active write).
- [ ] Retro reward distribution / payout CSV still computes correctly over the eligible set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HSM-signed on-chain `active`/`eligible` writes during cohort clear and broadens which projects appear in retro voting and payout math; mistakes could affect reward allocation until corrected on-chain.
> 
> **Overview**
> Fixes two retroactives / operator-panel bugs: cleared cohort projects lingering on **Active**, and cross-quarter eligible projects missing from **Retroactives**.
> 
> **Retroactives tab** — `eligibleProjects` and `validEligibleIds` no longer filter by rewards-cycle quarter/year. Any **active** project with operator-set `eligible` counts toward the current retro pool (e.g. a Q1 project settled in a Q2 cycle). Stale cohort leakage is handled by the clearer cohort flow below.
> 
> **Clear Retro Cohort** — Bulk clear now sets `eligible = 0` and, for projects still at `active = 2`, also sets `active = 0` via new **`markInactive`** on `project-add-to-retroactives` (mutually exclusive with `markActive`). That removes settled projects from both Retroactives and Active (`currentProjects`).
> 
> **Operator UX** — `AddToRetroactivesModal` replaces the active checkbox with a tri-state active control (unchanged / activate / deactivate). Operator project picker uses `currentProjects` + `pastProjects` only (drops proposals from the dropdown). Copy and confirm dialogs reflect the dual write on clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bad2a56c9316cdfe006a0f4c1eb8f5481c5104f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->