### PR TITLE
feat(team): open team registration to EU/EEA visitors

### DIFF
--- a/ui/pages/team/index.tsx
+++ b/ui/pages/team/index.tsx
@@ -1,5 +1,4 @@
 import { useContext, useState } from 'react'
-import useRegionRestriction from '@/lib/geo/useRegionRestriction'
 import ChainContextV5 from '@/lib/thirdweb/chain-context-v5'
 import { useChainDefault } from '@/lib/thirdweb/hooks/useChainDefault'
 import Container from '@/components/layout/Container'
@@ -8,7 +7,6 @@ import Head from '@/components/layout/Head'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import ApplyModal from '@/components/onboarding/ApplyModal'
 import CreateTeam from '@/components/onboarding/CreateTeam'
-import RegionRestrictedNotice from '@/components/onboarding/RegionRestrictedNotice'
 import TeamTier from '@/components/onboarding/TeamTier'
 
 export default function TeamJoin() {
@@ -16,16 +14,6 @@ export default function TeamJoin() {
 
   const [selectedTier, setSelectedTier] = useState<'team' | 'citizen'>()
   const [applyModalEnabled, setApplyModalEnabled] = useState(false)
-
-  // EU/EEA visitors may browse the site but cannot permanently store personal
-  // data on chain (GDPR), so they don't get the team creation flow. If geo
-  // can't be resolved we fail closed (treat it as restricted) rather than risk
-  // showing the flow to a restricted visitor.
-  const {
-    isRestricted,
-    isLoading: isResolvingRegion,
-    isError: regionError,
-  } = useRegionRestriction()
 
   // Ensure default chain settings
   useChainDefault()
@@ -39,22 +27,6 @@ export default function TeamJoin() {
       image="https://ipfs.io/ipfs/QmX7FHDoRhsQ4Ube179qjCnvcVQqwJhVRRASUGLEeqwdh2"
     />
   )
-
-  // Wait until geo resolves so we never flash the creation flow to a restricted
-  // visitor. Keep <Head> mounted (SEO/metadata) and render a light placeholder
-  // instead of returning null and flashing a blank page.
-  if (isResolvingRegion) {
-    return (
-      <>
-        {head}
-        <div className="min-h-screen" />
-      </>
-    )
-  }
-
-  if (isRestricted || regionError) {
-    return <RegionRestrictedNotice type="team" />
-  }
 
   // If "team" is selected, render CreateTeam component
   if (selectedTier === 'team') {


### PR DESCRIPTION
## Summary
- Team creation was blocked for EU/EEA (GDPR-restricted) visitors via `useRegionRestriction()` + `RegionRestrictedNotice`.
- A Team registers an organization rather than a personal profile, so the GDPR on-chain personal-data concern that justifies the block does not apply to teams.
- Removed the region-restriction gate (hook usage, loading placeholder, and restricted notice) from `ui/pages/team/index.tsx`.
- Citizen registration remains geo-restricted (both client gate in `pages/citizen/index.tsx` and server-side `enforceRegionNotRestricted` guards in `freeMint.ts` / `citizen-image.ts` are untouched).

## Test plan
- [ ] From an EU/EEA IP (or mock `/api/geo/country` to return a restricted country), visit `/team` and confirm the team tier / creation flow renders instead of the "Not Available in Your Region" notice.
- [ ] Confirm `/citizen` still shows `RegionRestrictedNotice` for the same restricted geo.
- [ ] From a non-restricted IP, confirm `/team` behaves exactly as before.

Made with [Cursor](https://cursor.com)