### PR TITLE
fix(deprize): FeeRouter market passthroughs + per-competition registry

### DIFF
--- a/ui/components/deprize/DePrizeAdminPanel.tsx
+++ b/ui/components/deprize/DePrizeAdminPanel.tsx
@@ -1,16 +1,16 @@
 import ConditionalTokensABI from 'const/abis/ConditionalTokens.json'
+import DePrizeFeeRouterABI from 'const/abis/DePrizeFeeRouter.json'
 import DePrizeRegistryABI from 'const/abis/DePrizeRegistry.json'
 import LMSRWithTWAP from 'const/abis/LMSRWithTWAP.json'
 import {
   CONDITIONAL_TOKEN_ADDRESSES,
-  DEPRIZE_QUESTION_ID,
+  DEPRIZE_FEE_ROUTER_ADDRESSES,
   DEPRIZE_REGISTRY_ADDRESSES,
-  ORACLE_ADDRESS,
-  OPERATOR_ADDRESS,
 } from 'const/config'
 import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import { getContract, prepareContractCall, type Chain } from 'thirdweb'
+import { getDePrizeQuestionId } from '@/lib/deprize/competitions'
 import { DePrizeState, MarketStage, UNIT } from '@/lib/deprize/constants'
 import { fmt } from '@/lib/deprize/format'
 import { rpcRead } from '@/lib/deprize/read'
@@ -53,17 +53,30 @@ export default function DePrizeAdminPanel({
   const chainSlug = getChainSlug(chain)
   const registryAddress = DEPRIZE_REGISTRY_ADDRESSES[chainSlug] ?? ''
   const ctfAddress = CONDITIONAL_TOKEN_ADDRESSES[chainSlug] ?? ''
+  const feeRouterAddress = DEPRIZE_FEE_ROUTER_ADDRESSES[chainSlug] ?? ''
+  const seededQuestionId = getDePrizeQuestionId(chainSlug, deprizeId) ?? ''
 
   const [busy, setBusy] = useState(false)
   const [isRegistryOwner, setIsRegistryOwner] = useState(false)
+  const [routerOwned, setRouterOwned] = useState(false)
+  const [isMarketController, setIsMarketController] = useState(false)
+  const [isOracle, setIsOracle] = useState(false)
+  // Sticky so editing the questionId away from a match doesn't unmount the
+  // panel (and lose the input) before the user can correct it.
+  const [oracleUnlocked, setOracleUnlocked] = useState(false)
   const [winnerTeamId, setWinnerTeamId] = useState<string>('')
   const [providerAddress, setProviderAddress] = useState('')
-  const [questionId, setQuestionId] = useState(DEPRIZE_QUESTION_ID)
+  const [questionId, setQuestionId] = useState(seededQuestionId)
 
-  const isOracle =
-    !!userAddress && userAddress.toLowerCase() === ORACLE_ADDRESS.toLowerCase()
-  const isOperator =
-    !!userAddress && userAddress.toLowerCase() === OPERATOR_ADDRESS.toLowerCase()
+  // Re-seed the editable questionId when navigating between DePrizes.
+  useEffect(() => {
+    setQuestionId(seededQuestionId)
+    setOracleUnlocked(false)
+  }, [seededQuestionId, marketAddress, userAddress])
+
+  useEffect(() => {
+    if (isOracle) setOracleUnlocked(true)
+  }, [isOracle])
 
   const registry = useMemo(
     () =>
@@ -86,7 +99,20 @@ export default function DePrizeAdminPanel({
         : undefined,
     [chain, ctfAddress]
   )
+  const feeRouter = useMemo(
+    () =>
+      feeRouterAddress
+        ? getContract({
+            client,
+            chain,
+            address: feeRouterAddress,
+            abi: DePrizeFeeRouterABI as any,
+          })
+        : undefined,
+    [chain, feeRouterAddress]
+  )
 
+  // Registry owner — gates lifecycle controls.
   useEffect(() => {
     if (!registry || !userAddress) {
       setIsRegistryOwner(false)
@@ -111,7 +137,93 @@ export default function DePrizeAdminPanel({
     }
   }, [registry, userAddress])
 
-  const canSeeMarket = isOracle || isOperator
+  // Market controller — FeeRouter owner when the router owns the LMSR, else
+  // the LMSR owner directly. Also records whether calls must go through the
+  // router passthroughs.
+  useEffect(() => {
+    if (!lmsr || !userAddress) {
+      setRouterOwned(false)
+      setIsMarketController(false)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const lmsrOwner = await rpcRead<string>({
+          contract: lmsr,
+          method: 'owner' as string,
+          params: [],
+        })
+        const viaRouter =
+          !!feeRouterAddress &&
+          lmsrOwner.toLowerCase() === feeRouterAddress.toLowerCase()
+        if (cancelled) return
+        setRouterOwned(viaRouter)
+        if (viaRouter && feeRouter) {
+          const routerOwner = await rpcRead<string>({
+            contract: feeRouter,
+            method: 'owner' as string,
+            params: [],
+          })
+          if (!cancelled)
+            setIsMarketController(
+              routerOwner.toLowerCase() === userAddress.toLowerCase()
+            )
+        } else {
+          setIsMarketController(lmsrOwner.toLowerCase() === userAddress.toLowerCase())
+        }
+      } catch {
+        if (!cancelled) {
+          setRouterOwned(false)
+          setIsMarketController(false)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [lmsr, feeRouter, feeRouterAddress, userAddress])
+
+  // Oracle — derived: keccak(user, questionId, numOutcomes) must equal the
+  // market's conditionId. Re-runs when the editable questionId changes so an
+  // oracle whose id isn't in the registry can paste it and unlock the section.
+  useEffect(() => {
+    if (!ctf || !lmsr || !userAddress || !questionId || numOutcomes <= 0) {
+      setIsOracle(false)
+      return
+    }
+    if (!/^0x[0-9a-fA-F]{64}$/.test(questionId)) {
+      setIsOracle(false)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const computed = await rpcRead<string>({
+          contract: ctf,
+          method: 'getConditionId' as string,
+          params: [userAddress, questionId, BigInt(numOutcomes)],
+        })
+        const marketConditionId = await rpcRead<string>({
+          contract: lmsr,
+          method: 'conditionIds' as string,
+          params: [0n],
+        })
+        if (!cancelled)
+          setIsOracle(computed.toLowerCase() === marketConditionId.toLowerCase())
+      } catch {
+        if (!cancelled) setIsOracle(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [ctf, lmsr, userAddress, questionId, numOutcomes])
+
+  // Market unwind is visible to the controller; oracle also needs pause/close
+  // before resolving, so show it to either role. Sweep is permissionless when
+  // router-owned — exposed to any connected admin-role wallet.
+  const canSeeMarket = isMarketController || isOracle || oracleUnlocked
   if (!userAddress || (!isRegistryOwner && !canSeeMarket)) return null
 
   // Generic write helper with a toast lifecycle.
@@ -213,13 +325,37 @@ export default function DePrizeAdminPanel({
 
   const isClosed = stage === MarketStage.Closed
 
+  // Pause / resume / close: FeeRouter passthroughs when the router owns the
+  // LMSR (otherwise the direct lmsr.* calls revert for everyone but the router).
+  const pauseMarket = () =>
+    routerOwned && feeRouter
+      ? run(feeRouter, 'pauseMarket', [BigInt(deprizeId)], 'Market paused via FeeRouter.')
+      : run(lmsr, 'pause', [], 'Market paused.')
+  const resumeMarket = () =>
+    routerOwned && feeRouter
+      ? run(feeRouter, 'resumeMarket', [BigInt(deprizeId)], 'Market resumed via FeeRouter.')
+      : run(lmsr, 'resume', [], 'Market resumed.')
+  const closeMarket = () =>
+    routerOwned && feeRouter
+      ? run(
+          feeRouter,
+          'closeMarket',
+          [BigInt(deprizeId)],
+          'Market closed via FeeRouter — inventory returned to FeeRouter.'
+        )
+      : run(lmsr, 'close', [], 'Market closed — inventory returned to owner.')
+
   return (
     <div className="p-4 rounded-2xl bg-yellow-500/5 border border-yellow-500/20 flex flex-col gap-5">
       <p className="text-yellow-300 text-xs font-medium">
         Admin actions
         {isRegistryOwner ? ' · registry owner' : ''}
         {isOracle ? ' · oracle' : ''}
-        {isOperator ? ' · market owner' : ''}
+        {isMarketController
+          ? routerOwned
+            ? ' · fee-router owner'
+            : ' · market owner'
+          : ''}
       </p>
 
       {/* Registry lifecycle (registry owner) */}
@@ -396,58 +532,89 @@ export default function DePrizeAdminPanel({
         </div>
       )}
 
-      {/* Market unwind (market owner) */}
+      {/* Market unwind — FeeRouter passthroughs when router-owned */}
       {canSeeMarket && lmsr && (
         <div>
           <p className="text-gray-400 text-[11px] mb-2">
-            Market unwind: pause before resolving, close + withdraw fees after.
+            Market unwind
+            {routerOwned
+              ? ' (via FeeRouter — pause before resolving; sweep fees into the prize pool)'
+              : ' (direct LMSR — pause before resolving, close + withdraw fees after)'}
+            {!isMarketController && isOracle
+              ? ' · pause/close requires the fee-router or market owner'
+              : ''}
           </p>
           <div className="flex items-center gap-2 flex-wrap">
             <StandardButton
-              onClick={() => run(lmsr, 'pause', [], 'Market paused.')}
-              disabled={busy || stage !== MarketStage.Running}
+              onClick={pauseMarket}
+              disabled={busy || !isMarketController || stage !== MarketStage.Running}
               className="rounded-full"
               backgroundColor="bg-white/10"
             >
               Pause
             </StandardButton>
             <StandardButton
-              onClick={() => run(lmsr, 'resume', [], 'Market resumed.')}
-              disabled={busy || stage !== MarketStage.Paused}
+              onClick={resumeMarket}
+              disabled={busy || !isMarketController || stage !== MarketStage.Paused}
               className="rounded-full"
               backgroundColor="bg-white/10"
             >
               Resume
             </StandardButton>
             <StandardButton
-              onClick={() => run(lmsr, 'close', [], 'Market closed — inventory returned to owner.')}
-              disabled={busy || isClosed}
+              onClick={closeMarket}
+              disabled={busy || !isMarketController || isClosed}
               className="rounded-full"
               backgroundColor="bg-white/10"
             >
               Close market
             </StandardButton>
-            <StandardButton
-              onClick={() => run(lmsr, 'withdrawFees', [], 'Fees withdrawn to owner.')}
-              disabled={busy || !isClosed}
-              className="rounded-full"
-              backgroundColor="bg-white/10"
-            >
-              {marketFeesWei !== undefined
-                ? `Withdraw fees (${fmt(Number(marketFeesWei) / Number(UNIT), 4)} WETH)`
-                : 'Withdraw fees'}
-            </StandardButton>
+            {routerOwned && feeRouter ? (
+              <StandardButton
+                onClick={() =>
+                  run(
+                    feeRouter,
+                    'sweepFees',
+                    [BigInt(deprizeId)],
+                    'Fees swept to the prize pool.'
+                  )
+                }
+                // sweepFees is permissionless but returns 0 when the market
+                // holds no WETH — don't spend gas on a known no-op.
+                disabled={busy || marketFeesWei === 0n}
+                className="rounded-full"
+                backgroundColor="bg-white/10"
+              >
+                {marketFeesWei !== undefined
+                  ? `Sweep fees (${fmt(Number(marketFeesWei) / Number(UNIT), 4)} WETH)`
+                  : 'Sweep fees to prize pool'}
+              </StandardButton>
+            ) : (
+              <StandardButton
+                onClick={() => run(lmsr, 'withdrawFees', [], 'Fees withdrawn to owner.')}
+                disabled={busy || !isMarketController || !isClosed}
+                className="rounded-full"
+                backgroundColor="bg-white/10"
+              >
+                {marketFeesWei !== undefined
+                  ? `Withdraw fees (${fmt(Number(marketFeesWei) / Number(UNIT), 4)} WETH)`
+                  : 'Withdraw fees'}
+              </StandardButton>
+            )}
           </div>
         </div>
       )}
 
-      {/* Resolution (oracle) */}
-      {isOracle && ctf && lmsr && (
+      {/* Resolution — shown when derived oracle check passes; questionId stays editable */}
+      {ctf && lmsr && (
         <div>
           <p className="text-gray-400 text-[11px] mb-2">
             Resolution (oracle, one-shot): the market must be paused/closed first; conditionId is
             recomputed from (you, questionId, {numOutcomes}) and must match the market before
             anything is sent.
+            {!isOracle
+              ? ' Paste the condition’s questionId below — the resolve buttons appear when it matches.'
+              : ''}
           </p>
           <label className="text-xs text-gray-400">questionId</label>
           <input
@@ -456,33 +623,34 @@ export default function DePrizeAdminPanel({
             onChange={(e) => setQuestionId(e.target.value.trim())}
             className="mt-1 mb-2 w-full px-3 py-2 bg-white/5 border border-white/20 rounded-xl text-white text-xs font-mono placeholder-gray-500"
           />
-          {resolved ? (
-            <p className="text-gray-500 text-xs">
-              Already resolved — the payout vector is write-once.
-            </p>
-          ) : (
-            <div className="flex items-center gap-2 flex-wrap">
-              {Array.from({ length: numOutcomes }, (_, i) => (
+          {isOracle &&
+            (resolved ? (
+              <p className="text-gray-500 text-xs">
+                Already resolved — the payout vector is write-once.
+              </p>
+            ) : (
+              <div className="flex items-center gap-2 flex-wrap">
+                {Array.from({ length: numOutcomes }, (_, i) => (
+                  <StandardButton
+                    key={i}
+                    onClick={() => resolveWinner(i)}
+                    disabled={busy}
+                    className="rounded-full"
+                    backgroundColor="bg-white/10"
+                  >
+                    Resolve #{i + 1} wins
+                  </StandardButton>
+                ))}
                 <StandardButton
-                  key={i}
-                  onClick={() => resolveWinner(i)}
+                  onClick={resolveNoWinner}
                   disabled={busy}
                   className="rounded-full"
-                  backgroundColor="bg-white/10"
+                  backgroundColor="bg-moon-orange"
                 >
-                  Resolve #{i + 1} wins
+                  No winner (refund 1/{numOutcomes})
                 </StandardButton>
-              ))}
-              <StandardButton
-                onClick={resolveNoWinner}
-                disabled={busy}
-                className="rounded-full"
-                backgroundColor="bg-moon-orange"
-              >
-                No winner (refund 1/{numOutcomes})
-              </StandardButton>
-            </div>
-          )}
+              </div>
+            ))}
         </div>
       )}
     </div>

--- a/ui/const/abis/DePrizeFeeRouter.json
+++ b/ui/const/abis/DePrizeFeeRouter.json
@@ -12,5 +12,33 @@
     "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "deprizeId", "type": "uint256" }],
+    "name": "pauseMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "deprizeId", "type": "uint256" }],
+    "name": "resumeMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "deprizeId", "type": "uint256" }],
+    "name": "closeMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -477,6 +477,13 @@ export const DEPRIZE_FEE_ROUTER_ADDRESSES: Index = {
   sepolia: '0xbe8cbc97d4ddee28b938c0ed8245f1b5133b783a',
   'arbitrum-sepolia': '',
 }
+// ---------------------------------------------------------------------------
+// Play-harness only (`ui/pages/deprize-play.tsx`).
+// Production admin/detail pages derive oracle/questionId per DePrize via
+// `ui/lib/deprize/competitions.ts` and on-chain role checks — do not wire these
+// globals into `DePrizeAdminPanel` or `/deprize/[id]`.
+// ---------------------------------------------------------------------------
+
 // questionId used when the play market's condition was prepared
 // (prediction/deprize.config.js DEPRIZE_QUESTION_ID). Needed by reportPayouts;
 // the conditionId is keccak256(oracle, questionId, outcomeSlotCount).
@@ -489,12 +496,12 @@ export const DEPRIZE_QUESTION_ID =
 // previewRedeem/redeem take this id).
 export const DEPRIZE_PLAY_ID = 3
 
-// Oracle that prepared the CTF condition; the only address that can resolve
-// (reportPayouts). On the fresh Sepolia market this is pmoncada.eth.
+// Oracle that prepared the play market's CTF condition; the only address that
+// can resolve (reportPayouts) that harness market. pmoncada.eth.
 export const ORACLE_ADDRESS = '0x679d87D8640e66778c3419D164998E720D7495f6'
 
-// Market owner (pause/close/withdrawFees on the LMSR). Ownership of the fresh
-// Sepolia market was transferred to pmoncada.eth so one wallet runs everything.
+// Play-market owner (pause/close/withdrawFees on that LMSR). Ownership of the
+// fresh Sepolia play market was transferred to pmoncada.eth.
 export const OPERATOR_ADDRESS = '0x679d87D8640e66778c3419D164998E720D7495f6'
 
 export const MOONDAO_TREASURY: string = '0xce4a1E86a5c47CD677338f53DA22A91d85cab2c9'

--- a/ui/cypress/integration/lib/deprize/competitions.cy.ts
+++ b/ui/cypress/integration/lib/deprize/competitions.cy.ts
@@ -1,0 +1,41 @@
+import {
+  GENERIC_DEPRIZE_COMPETITION,
+  getDePrizeCompetition,
+  getDePrizeQuestionId,
+  isKnownDePrizeCompetition,
+} from '@/lib/deprize/competitions'
+
+describe('deprize competitions registry', () => {
+  it('returns the generic fallback for an unknown id on a known chain', () => {
+    const c = getDePrizeCompetition('sepolia', 999)
+    expect(c).to.deep.equal(GENERIC_DEPRIZE_COMPETITION)
+    expect(isKnownDePrizeCompetition('sepolia', 999)).to.equal(false)
+    expect(getDePrizeQuestionId('sepolia', 999)).to.equal(undefined)
+  })
+
+  it('returns the generic fallback for an unknown chain', () => {
+    const c = getDePrizeCompetition('arbitrum', 9)
+    expect(c).to.deep.equal(GENERIC_DEPRIZE_COMPETITION)
+    expect(isKnownDePrizeCompetition('arbitrum', 9)).to.equal(false)
+    expect(getDePrizeQuestionId('arbitrum', 9)).to.equal(undefined)
+  })
+
+  it('returns the generic fallback when deprizeId is undefined', () => {
+    const c = getDePrizeCompetition('sepolia', undefined)
+    expect(c).to.deep.equal(GENERIC_DEPRIZE_COMPETITION)
+    expect(isKnownDePrizeCompetition('sepolia', undefined)).to.equal(false)
+    expect(getDePrizeQuestionId('sepolia', undefined)).to.equal(undefined)
+  })
+
+  it('looks up the Sepolia DePrize 9 QA fixture (questionId from DEPRIZE_QA.md)', () => {
+    expect(isKnownDePrizeCompetition('sepolia', 9)).to.equal(true)
+    const c = getDePrizeCompetition('sepolia', 9)
+    expect(c.title).to.equal('Sepolia QA fixture')
+    expect(c.tagline).to.be.a('string').and.not.equal(GENERIC_DEPRIZE_COMPETITION.tagline)
+    expect(c.metaDescription).to.be.a('string').and.have.length.greaterThan(0)
+    expect(c.questionId).to.equal(
+      '0xab937cdea2250786bf37ee2dd06f244bbeed62159c337927074523844d5759fb'
+    )
+    expect(getDePrizeQuestionId('sepolia', 9)).to.equal(c.questionId)
+  })
+})

--- a/ui/lib/deprize/competitions.ts
+++ b/ui/lib/deprize/competitions.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-competition copy + CTF questionId registry.
+ *
+ * Production admin/detail pages look up here instead of the global
+ * DEPRIZE_QUESTION_ID / ORACLE_ADDRESS scalars (those stay for the
+ * deprize-play harness only). Tech-tree prizes seed new entries here
+ * until questionId moves on-chain.
+ *
+ * Seeding `questionId` is what lets the admin panel derive the oracle role
+ * (keccak(caller, questionId, numOutcomes) == the market's conditionId). An
+ * oracle that is neither registry owner nor fee-router owner cannot unlock the
+ * panel without an entry here — resolve via Safe + DePrizeResolve.s.sol until
+ * the competition is registered.
+ */
+
+export type DePrizeCompetition = {
+  /** <Head> title + optional page title suffix. */
+  title: string
+  /** Header paragraph under the DePrize #{id} title. */
+  tagline: string
+  /** <Head> meta description. */
+  metaDescription: string
+  /** CTF questionId used at prepareCondition (needed by reportPayouts). */
+  questionId?: string
+}
+
+export const GENERIC_DEPRIZE_COMPETITION: DePrizeCompetition = {
+  title: 'DePrize',
+  tagline:
+    'Back the team you think will win — live odds, payout when a winner is declared.',
+  metaDescription:
+    'Back the team you think will win — live odds, payout when a winner is declared.',
+}
+
+/** chainSlug → deprizeId → competition */
+const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> = {
+  sepolia: {
+    // Browser QA fixture — see docs/DEPRIZE_QA.md (DePrize 9).
+    // Oracle at prepareCondition = deployer 0x3c5e2fe76478E99d94D3ca8BfA5154907a52E011.
+    9: {
+      title: 'Sepolia QA fixture',
+      tagline:
+        'Sepolia browser QA subject — three Team NFTs, live LMSR odds, FeeRouter-owned market.',
+      metaDescription:
+        'Sepolia DePrize QA fixture with live odds. Back a team and cash out or claim when resolved.',
+      questionId:
+        '0xab937cdea2250786bf37ee2dd06f244bbeed62159c337927074523844d5759fb',
+    },
+  },
+}
+
+/** True when this (chain, id) has an explicit registry entry. */
+export function isKnownDePrizeCompetition(
+  chainSlug: string,
+  deprizeId: number | undefined
+): boolean {
+  if (deprizeId === undefined || !Number.isFinite(deprizeId)) return false
+  return !!DEPRIZE_COMPETITIONS[chainSlug]?.[deprizeId]
+}
+
+/** Competition copy for a DePrize; falls back to generic copy when unregistered. */
+export function getDePrizeCompetition(
+  chainSlug: string,
+  deprizeId: number | undefined
+): DePrizeCompetition {
+  if (deprizeId === undefined || !Number.isFinite(deprizeId)) {
+    return GENERIC_DEPRIZE_COMPETITION
+  }
+  return DEPRIZE_COMPETITIONS[chainSlug]?.[deprizeId] ?? GENERIC_DEPRIZE_COMPETITION
+}
+
+/** CTF questionId for a DePrize, or undefined when not registered. */
+export function getDePrizeQuestionId(
+  chainSlug: string,
+  deprizeId: number | undefined
+): string | undefined {
+  if (deprizeId === undefined || !Number.isFinite(deprizeId)) return undefined
+  return DEPRIZE_COMPETITIONS[chainSlug]?.[deprizeId]?.questionId
+}

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -10,6 +10,10 @@ import { getContract } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import { eth_getBalance, getRpcClient } from 'thirdweb/rpc'
 import {
+  getDePrizeCompetition,
+  isKnownDePrizeCompetition,
+} from '@/lib/deprize/competitions'
+import {
   DePrizeState,
   DEPRIZE_STATE_META,
   GAS_RESERVE_ETH,
@@ -89,6 +93,8 @@ function DePrizeDetailContent() {
   // build-time default — otherwise switching networks never re-queries DePrize.
   const { selectedChain: chain } = useContext(ChainContextV5)
   const chainSlug = getChainSlug(chain)
+  const competition = getDePrizeCompetition(chainSlug, deprizeId)
+  const knownCompetition = isKnownDePrizeCompetition(chainSlug, deprizeId)
   const account = useActiveAccount()
   const userAddress = account?.address
   const { login } = useLogin()
@@ -348,10 +354,17 @@ function DePrizeDetailContent() {
     teamContract,
   )
 
+  const shellTitle =
+    knownCompetition && deprizeId !== undefined
+      ? `DePrize #${deprizeId} — ${competition.title}`
+      : deprizeId !== undefined
+        ? `DePrize #${deprizeId}`
+        : competition.title
+
   // --- Render states ---
   if (!registryConfigured) {
     return (
-      <Shell>
+      <Shell title={shellTitle} description={competition.metaDescription}>
         <Notice tone="amber">
           The DePrize registry isn&apos;t configured on{' '}
           <span className="font-mono">{chainSlug}</span> yet.
@@ -361,48 +374,52 @@ function DePrizeDetailContent() {
   }
   if (!router.isReady) {
     return (
-      <Shell>
+      <Shell title={shellTitle} description={competition.metaDescription}>
         <div className="p-8 text-center text-gray-400">Loading DePrize…</div>
       </Shell>
     )
   }
   if (deprizeId === undefined) {
     return (
-      <Shell>
+      <Shell title={shellTitle} description={competition.metaDescription}>
         <Notice tone="amber">Invalid DePrize id.</Notice>
       </Shell>
     )
   }
   if (error) {
     return (
-      <Shell>
+      <Shell title={shellTitle} description={competition.metaDescription}>
         <Notice tone="red">Couldn&apos;t load this DePrize: {error}</Notice>
       </Shell>
     )
   }
   if (!deprize || (deprizeId !== undefined && deprize.deprizeId !== deprizeId)) {
     return (
-      <Shell>
+      <Shell title={shellTitle} description={competition.metaDescription}>
         <div className="p-8 text-center text-gray-400">Loading DePrize…</div>
       </Shell>
     )
   }
   if (deprize.state === DePrizeState.NONE) {
     return (
-      <Shell>
+      <Shell title={shellTitle} description={competition.metaDescription}>
         <Notice tone="amber">DePrize #{deprizeId} does not exist.</Notice>
       </Shell>
     )
   }
 
   return (
-    <Shell>
+    <Shell title={shellTitle} description={competition.metaDescription}>
       <div className="flex flex-col gap-6 w-full max-w-[860px] mx-auto">
         {/* Header */}
         <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
           <div className="flex items-center justify-between gap-3 flex-wrap">
             <div className="flex items-center gap-2 sm:gap-3 flex-wrap min-w-0">
-              <h1 className="text-white font-GoodTimes text-lg sm:text-xl">DePrize #{deprizeId}</h1>
+              <h1 className="text-white font-GoodTimes text-lg sm:text-xl">
+                {knownCompetition
+                  ? `DePrize #${deprizeId} — ${competition.title}`
+                  : `DePrize #${deprizeId}`}
+              </h1>
               {deprize && (
                 <StateBadge
                   state={deprize.state}
@@ -418,10 +435,7 @@ function DePrizeDetailContent() {
               ← All prizes
             </Link>
           </div>
-          <p className="text-gray-300 text-sm mt-2">
-            Back the provider you think will win the right to fly Frank + a community Candidate to
-            space.
-          </p>
+          <p className="text-gray-300 text-sm mt-2">{competition.tagline}</p>
           {effectiveDescription && (
             <p className="text-gray-500 text-sm mt-1">{effectiveDescription}</p>
           )}
@@ -674,13 +688,18 @@ function DePrizeDetailContent() {
 }
 
 // --- Small presentational helpers ---
-function Shell({ children }: { children: React.ReactNode }) {
+function Shell({
+  children,
+  title,
+  description,
+}: {
+  children: React.ReactNode
+  title: string
+  description: string
+}) {
   return (
     <div className="animate-fadeIn flex flex-col items-center">
-      <Head
-        title="DePrize"
-        description="Back a provider to fly Frank White to space, and win if they do."
-      />
+      <Head title={title} description={description} />
       <Container>
         <div className="w-full max-w-[860px] mx-auto pt-6 sm:pt-8 pb-10 px-4 sm:px-5 md:px-0">
           {children}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase A follow-up to #1482. Three fixes that unblock operating more than one DePrize, all Sepolia-only — the Arbitrum "Coming soon" gate is untouched and no contracts change.

**1. Admin panel works against FeeRouter-owned markets.** The panel called `lmsr.pause()` / `resume()` / `close()` / `withdrawFees()` directly, which reverts for every caller but the router once `DePrizeFeeRouter` owns the LMSR — the state QA left DePrize 9 in. Market ownership is now read on chain (`lmsr.owner()` vs `DEPRIZE_FEE_ROUTER_ADDRESSES[chain]`); when router-owned, the buttons call `pauseMarket` / `resumeMarket` / `closeMarket` passthroughs and "Withdraw fees" becomes the permissionless "Sweep fees to prize pool" (`sweepFees`, disabled when the market holds no WETH). Self-owned markets keep the direct path.

**2. Roles are derived, not hardcoded.** `ORACLE_ADDRESS` / `OPERATOR_ADDRESS` describe the *play* market, so the panel showed the wrong roles for real DePrizes. The market controller is now the fee-router owner (or LMSR owner), and the oracle is derived by matching `ctf.getConditionId(caller, questionId, numOutcomes)` against `lmsr.conditionIds(0)` — the same pre-flight `resolve()` already ran. The questionId stays editable so an oracle can paste one and unlock the section.

**3. Per-competition copy replaces the Frank White hardcoding.** New `ui/lib/deprize/competitions.ts` holds title, tagline, meta description, and CTF questionId keyed by chain and DePrize id, with a generic fallback. `/deprize/[id]` uses it for `<Head>`, the page title, and the header paragraph; `effectiveDescription` still carries dynamic status copy. Seeded with the Sepolia DePrize 9 fixture from `docs/DEPRIZE_QA.md`.

`DEPRIZE_QUESTION_ID` / `DEPRIZE_PLAY_ID` / `ORACLE_ADDRESS` / `OPERATOR_ADDRESS` remain in `const/config.ts`, now labeled play-harness-only.

## Test plan

- [x] `cd ui && yarn test:deprize` — 60 passing (4 new competitions-registry cases)
- [x] `cd ui && yarn tsc --noEmit` — clean
- [x] `cd ui && yarn build` — clean (the ESLint gate that failed Vercel on #1482 passes)
- [x] On-chain check of Sepolia DePrize 9: LMSR `0x6e1a…130C` owner is FeeRouter `0xbe8c…783a`, router owner is `0x3c5e…E011` (also the registry owner), and `getConditionId(0x3c5e…E011, seeded questionId, 3)` equals the market's `0x7334d1e6…560d` — so the derived market-controller and oracle roles both resolve correctly
- [ ] Wallet click-through on `/deprize/9` as `0x3c5e…E011`: Pause via router, Resume, Sweep fees, and confirm the resolve buttons appear only when the questionId matches (do **not** `reportPayouts` on the live fixture)

## Notes

- Seeding `questionId` in the registry is what lets a wallet unlock the oracle section. An oracle that is neither registry owner nor fee-router owner cannot unlock the panel without an entry there and should resolve via Safe + `DePrizeResolve.s.sol`; this is documented in the module.
- `DEPRIZE_TERMS_URL` still 404s until the docs-repo Terms PR merges. The constant already points at the intended slug, so no code change is needed here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-904c5707-822d-406b-96a7-e0b9d81c0e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-904c5707-822d-406b-96a7-e0b9d81c0e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

