### PR TITLE
feat(deprize): Phase B1 race binding and goal-odds bridge

### DIFF
--- a/docs/DEPRIZE_PHASE_B1.md
+++ b/docs/DEPRIZE_PHASE_B1.md
@@ -1,0 +1,112 @@
+# DePrize Phase B1 Plan
+
+> Design draft — not an implementation PR. Read and discuss before building.
+
+# Phase B1: race binding and the odds bridge
+
+## Goal and hard constraint
+
+B2 ([docs/DEPRIZE_PHASE_B2.md](DEPRIZE_PHASE_B2.md)) opens with two prerequisites: the chain-keyed race binding in [ui/lib/deprize/competitions.ts](../ui/lib/deprize/competitions.ts) and a `useDePrizeGoalOdds` bridge returning odds keyed by `projectId`. B1 builds exactly those, plus the two supporting pieces B2 assumes (competitor identity overrides, index grouping).
+
+**The constraint that shapes everything:** Moon Base Zero is not merged. PR #1405 is open on `origin/feat/lunar-simulator`; `ui/lib/lunar-atlas/`, `ui/components/lunar-atlas/`, and `ui/pages/moonbase/` do not exist on `main`. So B1 must not import a single atlas type. The binding stores plain strings that structurally match the atlas shape, which makes B1 mergeable today and reduces B2 to wiring. It also keeps the highest-conflict file (`atlas.dataset.json`) untouched.
+
+```mermaid
+graph LR
+  binding["competitions.ts binding<br/>goalId, outcomes projectId"] --> hook["useDePrizeGoalOdds"]
+  reg["useDePrize teamIds"] --> hook
+  mkt["useDePrizeMarket<br/>probability percent"] --> pure["mapOutcomeOddsToProjectIds<br/>pure, divides by 100"]
+  hook --> pure
+  pure --> out["oddsByProjectId<br/>fractions of 1"]
+  out --> b2["B2: mergeLiveMarket in moonbase"]
+  binding --> idx["index grouping by race"]
+```
+
+## The two traps worth naming up front
+
+**1. Percent vs fraction.** [ui/lib/deprize/useDePrizeMarket.tsx](../ui/lib/deprize/useDePrizeMarket.tsx) L405-414 computes `probability` as `(Number(p as bigint) / 2 ** 64) * 100` — a percent. The atlas `SharedGoalMarket.impliedOdds` type comment says "as fractions of 1" and `SharedGoalPanel` renders `Math.round(p * 100)`. The bridge must divide by 100. This lives in one pure function with a unit test asserting the scale, because visually 3400% and 34% both "look like a number rendered".
+
+**2. Index alignment.** Registry `teamIds[i]` aligns with LMSR outcome index `i`. The binding's `outcomes` array must be in the same order. A mis-ordered array silently attributes Lockheed's odds to Westinghouse — plausible-looking and undetectable by eye. The mapper must **verify and refuse**, not trust: if `outcomes.length !== numOutcomes`, or any `outcomes[i].teamId` disagrees with `teamIds[i]`, return no odds. Blank is recoverable; wrong is not.
+
+## Work items
+
+### 1. Extend the binding in `competitions.ts`
+
+Add to `DePrizeCompetition` ([ui/lib/deprize/competitions.ts](../ui/lib/deprize/competitions.ts) L16-25):
+
+```ts
+/** Moon Base Zero capability race this DePrize settles (SharedGoal.id). */
+sharedGoalId?: string
+/** Short race label for index grouping, e.g. "Fission surface power". */
+raceLabel?: string
+/**
+ * CTF outcome index -> atlas competitor. Order MUST match registry teamIds.
+ * `teamId` is the alignment checksum; `consented` gates public markets.
+ */
+outcomes?: { projectId: string; teamId?: number; consented?: boolean }[]
+```
+
+New accessors alongside the existing ones (all pure, all mocha-testable):
+
+- `getDePrizeRaceBinding(chainSlug, deprizeId)` — returns `{ sharedGoalId, raceLabel, outcomes }` or `undefined`.
+- `findDePrizeIdForGoal(chainSlug, sharedGoalId)` — the reverse index the hook needs. Build it as a memoized map, and have it throw in dev if one chain maps two DePrize ids to the same goal.
+- `isDePrizeGoalMarketPublishable(chainSlug, sharedGoalId)` — the consent gate (item 5).
+
+Deliberate choice: consent lives here as `outcomes[].consented`, not read from the atlas `Project.rosterStatus`. `rosterStatus` isn't importable on `main`, and the binding is the right source of truth for a legal gate anyway — it sits next to the chain id and the questionId it's gating.
+
+### 2. Pure mapper
+
+New `ui/lib/deprize/goal-odds.ts` (pure module, no React — `yarn test:deprize` runs under mocha and cannot render hooks):
+
+```ts
+export function mapOutcomeOddsToProjectIds(args: {
+  outcomes: { projectId: string; teamId?: number }[]
+  teamIds: bigint[]
+  probabilities: number[] // percent, as useDePrizeMarket returns
+}): Record<string, number> | undefined
+```
+
+Returns fractions of 1, drops non-finite entries, and returns `undefined` on any length or `teamId` mismatch. This is where both traps are contained.
+
+### 3. `useDePrizeGoalOdds` hook
+
+Thin wrapper in `ui/lib/deprize/useDePrizeGoalOdds.tsx`: `findDePrizeIdForGoal` → `useDePrize` → `useDePrizeMarket` → `mapOutcomeOddsToProjectIds`. Returns `{ deprizeId, oddsByProjectId, status, loading }` where `status` is `'live' | 'resolved' | 'planned'` so B2 can drop it straight onto `market.status`.
+
+Two behaviors B2 depends on: it mounts **one** market (B2 item 2 fetches only the open race — eight concurrent 30s polls on the r3f scene is the thing being avoided), and it inherits the existing `ODDS_POLL_MS = 30000` and hidden-tab skip from [ui/lib/deprize/constants.ts](../ui/lib/deprize/constants.ts) rather than introducing a new cadence. It reports `'planned'` — never `'live'` — when the consent gate fails.
+
+### 4. Competitor identity overrides on `DePrizeTeamLink`
+
+[ui/components/deprize/DePrizeTeamLink.tsx](../ui/components/deprize/DePrizeTeamLink.tsx) reads `getNFT` and links to `/team/{teamId}`. ICON, Redwire, and Westinghouse will never hold a Team NFT. Add optional `nameOverride`, `imageOverride`, `hrefOverride`, and set `queryOptions.enabled` false when name and image are both supplied so we skip a doomed NFT read. Keep the NFT path as fallback.
+
+One gotcha: the component uses a bare `<a>`. An internal `hrefOverride` like `/moonbase/{projectId}` will trip the `next/link` ESLint rule that already failed a Vercel build in Phase A — use `Link` for internal hrefs.
+
+### 5. Consent gate
+
+`isDePrizeGoalMarketPublishable` returns false outside `sepolia` unless every entry in `outcomes` has `consented: true`. All 8 atlas races currently carry `rosterStatus: 'listed'`, which is curatorial judgment and not agreement — this is the only item in B1/B2 with real legal exposure, so it ships in the same PR as the binding it protects, not later.
+
+### 6. Group the index by race
+
+[ui/components/deprize/DePrizeIndexContent.tsx](../ui/components/deprize/DePrizeIndexContent.tsx) L571-581 renders a flat `Array.from({ length: count })`, and each row self-hides unless its async-resolved bucket matches the active tab. So a naive parent-rendered heading can appear above zero visible rows.
+
+The fix is already available: the parent holds `statusMap` (L417-422). Partition ids by `raceLabel` from the synchronous binding, and render a heading only when some id in that group satisfies `statusMap[id] === activeTab`. Unbound ids collect under "Other challenges". When a chain has no bindings at all, render the current flat list unchanged so `main` and Arbitrum look exactly as they do today.
+
+### 7. Right-size the outcome cap
+
+The audit result here is better than expected. Production is already dynamic: `numOutcomes = deprize?.teamIds.length ?? 0` ([ui/pages/deprize/[id].tsx](../ui/pages/deprize/[id].tsx) L108-117), and `MAX_OUTCOMES = 3` ([ui/const/config.ts](../ui/const/config.ts) L450) is referenced only by the `deprize-play` harness and `ui/archive/`. The largest planned race is 4 competitors (landing pads, comms), not 8.
+
+So: move the constant into [ui/pages/deprize-play.tsx](../ui/pages/deprize-play.tsx) as a local (or rename to `PLAY_MAX_OUTCOMES`) so nobody mistakes it for a production limit, and extend `OUTCOME_COLORS` ([ui/lib/deprize/constants.ts](../ui/lib/deprize/constants.ts) L41-48) from 6 to 8 entries since it wraps with `% length`. The index's `ranked.slice(0, 3)` (L215-229) plus the existing `teamIds.length > 3` footer (L392-395) already degrade correctly for 4 competitors — leave them.
+
+### 8. Sepolia end-to-end fixture
+
+Bind existing Sepolia DePrize 9 (3 Team NFTs, live LMSR, FeeRouter-owned) to `shared-fission-power`, whose 3 competitors (`westinghouse-fission-surface-power`, `lockheed-fission-surface-power`, `ix-fission-surface-power`) match the fixture's outcome count exactly. Record the index-to-project mapping in `docs/DEPRIZE_QA.md`. This gives B2 a real live race to merge against on day one instead of a mock.
+
+### 9. Tests — `yarn test:deprize`
+
+Extend [ui/cypress/integration/lib/deprize/competitions.cy.ts](../ui/cypress/integration/lib/deprize/competitions.cy.ts) for the new accessors and add `goal-odds.cy.ts`: the percent-to-fraction scale, `undefined` on length mismatch, `undefined` on `teamId` mismatch, non-finite entries dropped, reverse lookup hit and miss, and the consent gate returning false on a non-Sepolia chain with an unconsented competitor.
+
+## Raise with Miguel before merging
+
+B1 defines the binding, so B2 item 7 becomes actionable now: `SharedGoalMarket.deprizeRegistryId` and `deprizeQuestionId` are plain strings with no chain dimension, but a DePrize id is chain-specific. Nothing on `feat/lunar-simulator` reads either field yet, so the cheap resolution is to drop both in favor of the chain-keyed binding. Worth settling before either side writes code.
+
+## Scope boundary
+
+B1 touches only `ui/lib/deprize/` and `ui/components/deprize/`. No file under `ui/pages/moonbase/`, `ui/components/lunar-atlas/`, or `ui/lib/lunar-atlas/` — that is all B2, after #1405 merges. Zero merge conflicts with Miguel by construction.

--- a/docs/DEPRIZE_QA.md
+++ b/docs/DEPRIZE_QA.md
@@ -21,6 +21,7 @@
 | MissionTable (fresh) | `0x0AbB0DB4CffFed867C8A94893e7cFae6ee39F807` |
 | **DePrize 9** (browser fixture) | id **9**, JB **256**, LMSR `0x6e1a513f3DfB6288836CacdF0a9d3496b411130C`, condition `0x7334d1e6…560d`, payhook `0xec3ba013…7E66`, teams **301/302/303**, oracle = deployer `0x3c5e…E011` |
 | DePrize 9 questionId | `0xab937cdea2250786bf37ee2dd06f244bbeed62159c337927074523844d5759fb` |
+| DePrize 9 race binding (B1) | `sharedGoalId` **shared-fission-power**; outcome index → projectId: **0→westinghouse-fission-surface-power (team 301)**, **1→lockheed-fission-surface-power (team 302)**, **2→ix-fission-surface-power (team 303)** — see `ui/lib/deprize/competitions.ts` |
 
 UI config (`ui/const/config.ts`) wires registry / redeem / mint / fee-router. It does **not** repoint app-wide `MISSION_CREATOR_ADDRESSES` (intentional — avoids fragmenting general launchpad listing). DePrize **9** resolves its LMSR via `mint.marketOf(9)` (no config LMSR fallback needed).
 
@@ -187,6 +188,16 @@ Ran 2026-07-22 against `http://localhost:3000` (PR branch). Screenshots under `.
 ## G. Fresh Running LMSR + full in-browser QA (DePrize 9)
 
 Provisioned 2026-07-22 on Sepolia: new mission (JB **256** via `MissionCreator` `0xa692…`), CTF condition + LMSR (0.03 ETH funding), `register`/`setCondition`/`open`, `mint.setMarket` + `feeRouter.setMarket`, LMSR ownership → FeeRouter. State **OPEN (2)**, LMSR **Running (0)**.
+
+**Phase B1 race binding:** DePrize 9 is bound in `ui/lib/deprize/competitions.ts` to Moon Base Zero `shared-fission-power`. Registry `teamIds` order is the outcome order:
+
+| Index | Team NFT | Atlas `projectId` |
+|---|---|---|
+| 0 | 301 | `westinghouse-fission-surface-power` |
+| 1 | 302 | `lockheed-fission-surface-power` |
+| 2 | 303 | `ix-fission-surface-power` |
+
+**Schema note for Miguel (PR #1405):** prefer the chain-keyed binding in `competitions.ts` over `SharedGoalMarket.deprizeRegistryId` / `deprizeQuestionId` (plain strings with no chain dimension). Neither field has a runtime consumer on `feat/lunar-simulator` yet — cheapest fix is to drop both before atlas seed data lands.
 
 | ID | Check | Result |
 |---|---|---|

--- a/ui/archive/components/betting/Market.tsx
+++ b/ui/archive/components/betting/Market.tsx
@@ -8,7 +8,6 @@ import {
   COLLATERAL_TOKEN_ADDRESSES,
   ORACLE_ADDRESS,
   COLLATERAL_DECIMALS,
-  MAX_OUTCOMES,
   DEFAULT_CHAIN_V5,
 } from 'const/config'
 import { ethers } from 'ethers'
@@ -19,6 +18,9 @@ import { useActiveAccount } from 'thirdweb/react'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import useContract from '@/lib/thirdweb/hooks/useContract'
 import Layout from './Layout'
+
+/** Archived betting UI only — not a production DePrize limit. */
+const MAX_OUTCOMES = 3
 
 BigNumber.config({ EXPONENTIAL_AT: 50 })
 

--- a/ui/components/deprize/DePrizeIndexContent.tsx
+++ b/ui/components/deprize/DePrizeIndexContent.tsx
@@ -1,10 +1,11 @@
 import TeamABI from 'const/abis/Team.json'
 import { DEPRIZE_MINT_ADDRESSES, TEAM_ADDRESSES } from 'const/config'
 import { useLogin } from '@privy-io/react-auth'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { Fragment, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { getContract, type Chain } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import { eth_getBalance, getRpcClient } from 'thirdweb/rpc'
+import { partitionDePrizeIndexByRace } from '@/lib/deprize/competitions'
 import {
   DePrizeState,
   DEPRIZE_STATE_META,
@@ -439,6 +440,22 @@ export default function DePrizeIndexContent() {
   const stillResolving = count !== undefined && resolvedCount < count
   const activeCount = activeTab === 'live' ? liveCount : closedCount
 
+  // Group by raceLabel when the chain has bindings; otherwise one flat group.
+  // Rows still always mount (to resolve buckets); headings only render when the
+  // active tab has at least one matching id in that group.
+  const raceGroups = useMemo(
+    () => (count ? partitionDePrizeIndexByRace(chainSlug, count) : []),
+    [chainSlug, count],
+  )
+
+  const anyRaceGroupVisible = useMemo(
+    () =>
+      raceGroups.some(
+        (g) => g.raceLabel !== null && g.deprizeIds.some((id) => statusMap[id] === activeTab),
+      ),
+    [raceGroups, statusMap, activeTab],
+  )
+
   const readChain = useMemo(() => deprizeReadChain(chain.id), [chain.id])
 
   const teamContract = useMemo(
@@ -567,18 +584,39 @@ export default function DePrizeIndexContent() {
                 </div>
 
                 {/* Rows: every DePrize mounts (to resolve its bucket) but each
-                    self-hides unless it matches the active tab. */}
-                {Array.from({ length: count }, (_, i) => (
-                  <DePrizeListRow
-                    key={i + 1}
-                    deprizeId={i + 1}
-                    teamContract={teamContract}
-                    chain={chain}
-                    activeTab={activeTab}
-                    onBet={handleBet}
-                    onStatus={handleStatus}
-                  />
-                ))}
+                    self-hides unless it matches the active tab. Grouped by
+                    race when competitions.ts has bindings on this chain. */}
+                {raceGroups.map((group) => {
+                  const groupVisible = group.deprizeIds.some(
+                    (id) => statusMap[id] === activeTab,
+                  )
+                  // Don't label the leftovers when no race section is showing —
+                  // a lone "Other challenges" heading reads as a bug.
+                  const headingVisible =
+                    group.showHeading &&
+                    groupVisible &&
+                    (group.raceLabel !== null || anyRaceGroupVisible)
+                  return (
+                    <Fragment key={group.raceLabel ?? '__other'}>
+                      {headingVisible && (
+                        <h2 className="text-white/80 font-GoodTimes text-sm tracking-wide pt-2">
+                          {group.raceLabel ?? 'Other challenges'}
+                        </h2>
+                      )}
+                      {group.deprizeIds.map((id) => (
+                        <DePrizeListRow
+                          key={id}
+                          deprizeId={id}
+                          teamContract={teamContract}
+                          chain={chain}
+                          activeTab={activeTab}
+                          onBet={handleBet}
+                          onStatus={handleStatus}
+                        />
+                      ))}
+                    </Fragment>
+                  )
+                })}
 
                 {/* Only skeleton when this tab has nothing to show yet. Once any
                     matching card is up, don't append another — remaining ids may

--- a/ui/components/deprize/DePrizeTeamLink.tsx
+++ b/ui/components/deprize/DePrizeTeamLink.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useEffect, useState, type MouseEvent } from 'react'
 import { getNFT } from 'thirdweb/extensions/erc721'
 import { useReadContract } from 'thirdweb/react'
 import { getIPFSGateway } from '@/lib/ipfs/gateway'
@@ -12,6 +13,12 @@ type DePrizeTeamLinkProps = {
   /** When true, only render name (no avatar). */
   nameOnly?: boolean
   size?: number
+  /** Atlas / external display name — skips NFT name when set with imageOverride. */
+  nameOverride?: string
+  /** Atlas / external logo URI — skips NFT image when set with nameOverride. */
+  imageOverride?: string
+  /** Override link target (e.g. `/moonbase/{projectId}`). Defaults to `/team/{id}`. */
+  hrefOverride?: string
 }
 
 /** Two-letter monogram from a team name (falls back to the numeric id). */
@@ -85,9 +92,14 @@ function TeamAvatar({
   )
 }
 
+function isInternalHref(href: string): boolean {
+  return href.startsWith('/') && !href.startsWith('//')
+}
+
 /**
- * Team identity that navigates to `/team/{id}`. Used anywhere DePrize lists
- * competing providers so the profile is one click away.
+ * Team identity that navigates to `/team/{id}` by default. Optional overrides
+ * let Moon Base Zero feed atlas org name/logo and link to `/moonbase/{projectId}`
+ * for competitors that will never hold a Team NFT.
  */
 export default function DePrizeTeamLink({
   teamId,
@@ -96,23 +108,34 @@ export default function DePrizeTeamLink({
   className = '',
   nameOnly = false,
   size = 28,
+  nameOverride,
+  imageOverride,
+  hrefOverride,
 }: DePrizeTeamLinkProps) {
+  // Only skip the NFT read when neither name nor image would come from it.
+  const identityOverridden = !!nameOverride && !!imageOverride
+
   const { data: teamNFT } = useReadContract(getNFT, {
     contract: teamContract,
     tokenId: BigInt(teamId),
-    queryOptions: { enabled: !!teamContract && teamId > 0n },
+    queryOptions: {
+      enabled: !identityOverridden && !!teamContract && teamId > 0n,
+    },
   })
-  const name = (teamNFT as any)?.metadata?.name || `Team #${teamId.toString()}`
-  const image = (teamNFT as any)?.metadata?.image || ''
-  const href = `/team/${teamId.toString()}`
 
-  return (
-    <a
-      href={href}
-      className={`group inline-flex items-center gap-2 min-w-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 transition-opacity hover:opacity-90 ${className}`}
-      title={`View ${name} profile`}
-      onClick={(e) => e.stopPropagation()}
-    >
+  // `||` (not `??`): an empty metadata name must still fall back to the id,
+  // and an empty override must not blank the row.
+  const name =
+    nameOverride || (teamNFT as any)?.metadata?.name || `Team #${teamId.toString()}`
+  const image = imageOverride || (teamNFT as any)?.metadata?.image || ''
+  const href = hrefOverride || `/team/${teamId.toString()}`
+
+  const linkClassName = `group inline-flex items-center gap-2 min-w-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 transition-opacity hover:opacity-90 ${className}`
+  const title = `View ${name} profile`
+  const onClick = (e: MouseEvent) => e.stopPropagation()
+
+  const body = (
+    <>
       {!nameOnly && (
         <TeamAvatar
           name={name}
@@ -125,6 +148,20 @@ export default function DePrizeTeamLink({
       <span className="text-sm font-medium truncate underline-offset-2 group-hover:underline text-white/90 group-hover:text-indigo-200">
         {name}
       </span>
+    </>
+  )
+
+  if (isInternalHref(href)) {
+    return (
+      <Link href={href} className={linkClassName} title={title} onClick={onClick}>
+        {body}
+      </Link>
+    )
+  }
+
+  return (
+    <a href={href} className={linkClassName} title={title} onClick={onClick}>
+      {body}
     </a>
   )
 }

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -447,7 +447,6 @@ export const COLLATERAL_TOKEN_ADDRESSES: Index = {
   'arbitrum-sepolia': '0xA441f20115c868dc66bC1977E1c17D4B9A0189c7',
 }
 export const COLLATERAL_DECIMALS = 18
-export const MAX_OUTCOMES = 3
 
 // M4 close-out stack (DePrizeRedeem helper + DePrizeRegistry). Populate per
 // chain once `script/deprize/DePrizeRedeem.s.sol` / the registry deploy run;

--- a/ui/cypress/integration/lib/deprize/competitions.cy.ts
+++ b/ui/cypress/integration/lib/deprize/competitions.cy.ts
@@ -1,8 +1,14 @@
 import {
   GENERIC_DEPRIZE_COMPETITION,
+  areRaceOutcomesPublishable,
+  chainHasRaceBindings,
+  findDePrizeIdForGoal,
   getDePrizeCompetition,
   getDePrizeQuestionId,
+  getDePrizeRaceBinding,
+  isDePrizeGoalMarketPublishable,
   isKnownDePrizeCompetition,
+  partitionDePrizeIndexByRace,
 } from '@/lib/deprize/competitions'
 
 describe('deprize competitions registry', () => {
@@ -30,12 +36,81 @@ describe('deprize competitions registry', () => {
   it('looks up the Sepolia DePrize 9 QA fixture (questionId from DEPRIZE_QA.md)', () => {
     expect(isKnownDePrizeCompetition('sepolia', 9)).to.equal(true)
     const c = getDePrizeCompetition('sepolia', 9)
-    expect(c.title).to.equal('Sepolia QA fixture')
+    expect(c.title).to.equal('Fission surface power')
     expect(c.tagline).to.be.a('string').and.not.equal(GENERIC_DEPRIZE_COMPETITION.tagline)
     expect(c.metaDescription).to.be.a('string').and.have.length.greaterThan(0)
     expect(c.questionId).to.equal(
       '0xab937cdea2250786bf37ee2dd06f244bbeed62159c337927074523844d5759fb'
     )
     expect(getDePrizeQuestionId('sepolia', 9)).to.equal(c.questionId)
+  })
+
+  it('binds Sepolia DePrize 9 to shared-fission-power with teamId checksums', () => {
+    const binding = getDePrizeRaceBinding('sepolia', 9)
+    expect(binding).to.not.equal(undefined)
+    expect(binding!.sharedGoalId).to.equal('shared-fission-power')
+    expect(binding!.raceLabel).to.equal('Fission surface power')
+    expect(binding!.outcomes.map((o) => o.projectId)).to.deep.equal([
+      'westinghouse-fission-surface-power',
+      'lockheed-fission-surface-power',
+      'ix-fission-surface-power',
+    ])
+    expect(binding!.outcomes.map((o) => o.teamId)).to.deep.equal([301, 302, 303])
+  })
+
+  it('returns a stable binding identity so consumers can memoize on it', () => {
+    expect(getDePrizeRaceBinding('sepolia', 9)).to.equal(getDePrizeRaceBinding('sepolia', 9))
+    expect(getDePrizeRaceBinding('sepolia', 1)).to.equal(undefined)
+    expect(getDePrizeRaceBinding('sepolia', 1)).to.equal(getDePrizeRaceBinding('sepolia', 1))
+  })
+
+  it('reverse-looks up the DePrize id for a bound goal (hit and miss)', () => {
+    expect(findDePrizeIdForGoal('sepolia', 'shared-fission-power')).to.equal(9)
+    expect(findDePrizeIdForGoal('sepolia', 'shared-landing-pads')).to.equal(undefined)
+    expect(findDePrizeIdForGoal('arbitrum', 'shared-fission-power')).to.equal(undefined)
+    expect(findDePrizeIdForGoal('sepolia', undefined)).to.equal(undefined)
+  })
+
+  it('publishes the Sepolia fixture and refuses unbound / unconsented non-Sepolia', () => {
+    expect(isDePrizeGoalMarketPublishable('sepolia', 'shared-fission-power')).to.equal(true)
+    expect(isDePrizeGoalMarketPublishable('sepolia', 'shared-landing-pads')).to.equal(false)
+    expect(isDePrizeGoalMarketPublishable('arbitrum', 'shared-fission-power')).to.equal(false)
+
+    // Pure consent helper: non-Sepolia requires every outcome consented.
+    const unconsented = [
+      { projectId: 'a', consented: true },
+      { projectId: 'b' },
+    ]
+    const consented = [
+      { projectId: 'a', consented: true },
+      { projectId: 'b', consented: true },
+    ]
+    expect(areRaceOutcomesPublishable('arbitrum', unconsented)).to.equal(false)
+    expect(areRaceOutcomesPublishable('arbitrum', consented)).to.equal(true)
+    expect(areRaceOutcomesPublishable('sepolia', unconsented)).to.equal(true)
+    expect(areRaceOutcomesPublishable('arbitrum', undefined)).to.equal(false)
+  })
+
+  it('partitions the index by raceLabel and keeps unbound chains flat', () => {
+    expect(chainHasRaceBindings('sepolia')).to.equal(true)
+    expect(chainHasRaceBindings('arbitrum')).to.equal(false)
+
+    const sepolia = partitionDePrizeIndexByRace('sepolia', 10)
+    expect(sepolia[0]).to.deep.equal({
+      raceLabel: 'Fission surface power',
+      deprizeIds: [9],
+      showHeading: true,
+    })
+    const other = sepolia.find((g) => g.raceLabel === null)
+    expect(other).to.not.equal(undefined)
+    expect(other!.showHeading).to.equal(true)
+    expect(other!.deprizeIds).to.include(1)
+    expect(other!.deprizeIds).to.include(10)
+    expect(other!.deprizeIds).to.not.include(9)
+
+    const arbitrum = partitionDePrizeIndexByRace('arbitrum', 3)
+    expect(arbitrum).to.deep.equal([
+      { raceLabel: null, deprizeIds: [1, 2, 3], showHeading: false },
+    ])
   })
 })

--- a/ui/cypress/integration/lib/deprize/goal-odds.cy.ts
+++ b/ui/cypress/integration/lib/deprize/goal-odds.cy.ts
@@ -1,0 +1,98 @@
+import { mapOutcomeOddsToProjectIds } from '@/lib/deprize/goal-odds'
+
+describe('mapOutcomeOddsToProjectIds', () => {
+  const outcomes = [
+    { projectId: 'westinghouse-fission-surface-power', teamId: 301 },
+    { projectId: 'lockheed-fission-surface-power', teamId: 302 },
+    { projectId: 'ix-fission-surface-power', teamId: 303 },
+  ]
+
+  it('converts LMSR percent probabilities to fractions of 1', () => {
+    const mapped = mapOutcomeOddsToProjectIds({
+      outcomes,
+      teamIds: [301n, 302n, 303n],
+      probabilities: [34, 35, 31],
+    })
+    expect(mapped).to.deep.equal({
+      'westinghouse-fission-surface-power': 0.34,
+      'lockheed-fission-surface-power': 0.35,
+      'ix-fission-surface-power': 0.31,
+    })
+  })
+
+  it('returns undefined on outcomes / teamIds length mismatch', () => {
+    expect(
+      mapOutcomeOddsToProjectIds({
+        outcomes,
+        teamIds: [301n, 302n],
+        probabilities: [34, 35, 31],
+      })
+    ).to.equal(undefined)
+  })
+
+  it('returns undefined on outcomes / probabilities length mismatch', () => {
+    expect(
+      mapOutcomeOddsToProjectIds({
+        outcomes,
+        teamIds: [301n, 302n, 303n],
+        probabilities: [34, 35],
+      })
+    ).to.equal(undefined)
+  })
+
+  it('returns undefined when a teamId checksum disagrees with the roster', () => {
+    expect(
+      mapOutcomeOddsToProjectIds({
+        outcomes,
+        teamIds: [301n, 999n, 303n],
+        probabilities: [34, 35, 31],
+      })
+    ).to.equal(undefined)
+  })
+
+  it('drops non-finite probabilities but keeps finite siblings', () => {
+    const mapped = mapOutcomeOddsToProjectIds({
+      outcomes,
+      teamIds: [301n, 302n, 303n],
+      probabilities: [34, NaN, 31],
+    })
+    expect(mapped).to.deep.equal({
+      'westinghouse-fission-surface-power': 0.34,
+      'ix-fission-surface-power': 0.31,
+    })
+  })
+
+  it('returns undefined when no finite odds survive (loading / closed market)', () => {
+    // A closed LMSR reads all-NaN. An empty map here would let a merge
+    // overwrite curator priors with nothing.
+    expect(
+      mapOutcomeOddsToProjectIds({
+        outcomes,
+        teamIds: [301n, 302n, 303n],
+        probabilities: [NaN, NaN, NaN],
+      })
+    ).to.equal(undefined)
+  })
+
+  it('allows outcomes without a teamId checksum', () => {
+    const mapped = mapOutcomeOddsToProjectIds({
+      outcomes: [
+        { projectId: 'a' },
+        { projectId: 'b' },
+      ],
+      teamIds: [1n, 2n],
+      probabilities: [60, 40],
+    })
+    expect(mapped).to.deep.equal({ a: 0.6, b: 0.4 })
+  })
+
+  it('returns undefined for an empty outcomes array', () => {
+    expect(
+      mapOutcomeOddsToProjectIds({
+        outcomes: [],
+        teamIds: [],
+        probabilities: [],
+      })
+    ).to.equal(undefined)
+  })
+})

--- a/ui/lib/deprize/competitions.ts
+++ b/ui/lib/deprize/competitions.ts
@@ -1,5 +1,5 @@
 /**
- * Per-competition copy + CTF questionId registry.
+ * Per-competition copy + CTF questionId registry + Moon Base Zero race binding.
  *
  * Production admin/detail pages look up here instead of the global
  * DEPRIZE_QUESTION_ID / ORACLE_ADDRESS scalars (those stay for the
@@ -11,7 +11,34 @@
  * oracle that is neither registry owner nor fee-router owner cannot unlock the
  * panel without an entry here — resolve via Safe + DePrizeResolve.s.sol until
  * the competition is registered.
+ *
+ * Race binding (`sharedGoalId` / `outcomes`) is chain-keyed here on purpose:
+ * a DePrize id is chain-specific, so Moon Base Zero's plain-string
+ * `SharedGoalMarket.deprizeRegistryId` / `deprizeQuestionId` should be dropped
+ * (or made a per-chain map) rather than duplicated — agree with Miguel before
+ * either side writes atlas seed data that conflicts.
  */
+
+export type DePrizeRaceOutcome = {
+  /** Atlas competitor project id (SharedGoal.projectIds / impliedOdds key). */
+  projectId: string
+  /**
+   * Registry teamIds[i] checksum. When set, mapOutcomeOddsToProjectIds refuses
+   * to emit odds if it disagrees with the on-chain roster at that index.
+   */
+  teamId?: number
+  /**
+   * Competitor consent for public markets. Outside sepolia, every outcome must
+   * be consented before the bridge reports status `live`.
+   */
+  consented?: boolean
+}
+
+export type DePrizeRaceBinding = {
+  sharedGoalId: string
+  raceLabel: string
+  outcomes: DePrizeRaceOutcome[]
+}
 
 export type DePrizeCompetition = {
   /** <Head> title + optional page title suffix. */
@@ -22,6 +49,15 @@ export type DePrizeCompetition = {
   metaDescription: string
   /** CTF questionId used at prepareCondition (needed by reportPayouts). */
   questionId?: string
+  /** Moon Base Zero capability race this DePrize settles (SharedGoal.id). */
+  sharedGoalId?: string
+  /** Short race label for index grouping, e.g. "Fission surface power". */
+  raceLabel?: string
+  /**
+   * CTF outcome index → atlas competitor. Order MUST match registry teamIds.
+   * `teamId` is the alignment checksum; `consented` gates public markets.
+   */
+  outcomes?: DePrizeRaceOutcome[]
 }
 
 export const GENERIC_DEPRIZE_COMPETITION: DePrizeCompetition = {
@@ -37,14 +73,32 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
   sepolia: {
     // Browser QA fixture — see docs/DEPRIZE_QA.md (DePrize 9).
     // Oracle at prepareCondition = deployer 0x3c5e2fe76478E99d94D3ca8BfA5154907a52E011.
+    // Bound to Moon Base Zero shared-fission-power; teamIds 301/302/303 map 1:1
+    // to the race's three competitors in registry order.
     9: {
-      title: 'Sepolia QA fixture',
+      title: 'Fission surface power',
       tagline:
-        'Sepolia browser QA subject — three Team NFTs, live LMSR odds, FeeRouter-owned market.',
+        'Sepolia QA fixture for the fission surface power race — three Team NFTs, live LMSR odds, FeeRouter-owned market.',
       metaDescription:
-        'Sepolia DePrize QA fixture with live odds. Back a team and cash out or claim when resolved.',
+        'Sepolia DePrize bound to the Moon Base Zero fission surface power race. Back a competitor and cash out or claim when resolved.',
       questionId:
         '0xab937cdea2250786bf37ee2dd06f244bbeed62159c337927074523844d5759fb',
+      sharedGoalId: 'shared-fission-power',
+      raceLabel: 'Fission surface power',
+      outcomes: [
+        {
+          projectId: 'westinghouse-fission-surface-power',
+          teamId: 301,
+        },
+        {
+          projectId: 'lockheed-fission-surface-power',
+          teamId: 302,
+        },
+        {
+          projectId: 'ix-fission-surface-power',
+          teamId: 303,
+        },
+      ],
     },
   },
 }
@@ -76,4 +130,178 @@ export function getDePrizeQuestionId(
 ): string | undefined {
   if (deprizeId === undefined || !Number.isFinite(deprizeId)) return undefined
   return DEPRIZE_COMPETITIONS[chainSlug]?.[deprizeId]?.questionId
+}
+
+// Bindings are derived from a static registry, so cache them: callers memoize
+// on binding identity, and a fresh object per call busts those memos on every
+// render (React consumers would recompute odds forever).
+const bindingCache = new Map<string, DePrizeRaceBinding | undefined>()
+
+/**
+ * Race binding for a DePrize, or undefined when unregistered / unbound.
+ * Identity is stable across calls for the same (chain, id).
+ */
+export function getDePrizeRaceBinding(
+  chainSlug: string,
+  deprizeId: number | undefined
+): DePrizeRaceBinding | undefined {
+  if (deprizeId === undefined || !Number.isFinite(deprizeId)) return undefined
+
+  const key = `${chainSlug}:${deprizeId}`
+  if (bindingCache.has(key)) return bindingCache.get(key)
+
+  const c = DEPRIZE_COMPETITIONS[chainSlug]?.[deprizeId]
+  const binding =
+    !c?.sharedGoalId || !c.raceLabel || !c.outcomes?.length
+      ? undefined
+      : Object.freeze({
+          sharedGoalId: c.sharedGoalId,
+          raceLabel: c.raceLabel,
+          outcomes: c.outcomes,
+        })
+  bindingCache.set(key, binding)
+  return binding
+}
+
+/** True when this chain has at least one race-bound competition entry. */
+export function chainHasRaceBindings(chainSlug: string): boolean {
+  const entries = DEPRIZE_COMPETITIONS[chainSlug]
+  if (!entries) return false
+  return Object.values(entries).some(
+    (c) => !!c.sharedGoalId && !!c.raceLabel && !!c.outcomes?.length
+  )
+}
+
+// Read through globalThis: this module is also compiled by the dependency-free
+// mocha runner, which has no node type definitions for a bare `process`.
+function isProductionEnv(): boolean {
+  return (globalThis as any)?.process?.env?.NODE_ENV === 'production'
+}
+
+// Memoized reverse index: chainSlug → sharedGoalId → deprizeId.
+const goalIndexByChain = new Map<string, Map<string, number>>()
+
+function goalIndexForChain(chainSlug: string): Map<string, number> {
+  const cached = goalIndexByChain.get(chainSlug)
+  if (cached) return cached
+
+  const map = new Map<string, number>()
+  const entries = DEPRIZE_COMPETITIONS[chainSlug] ?? {}
+  for (const [idStr, comp] of Object.entries(entries)) {
+    if (!comp.sharedGoalId) continue
+    const deprizeId = Number(idStr)
+    if (map.has(comp.sharedGoalId)) {
+      const message = `Duplicate DePrize race binding on ${chainSlug}: sharedGoalId "${comp.sharedGoalId}" maps to both #${map.get(comp.sharedGoalId)} and #${deprizeId}`
+      // Loud in dev/test so the seed error is caught before merge; in
+      // production keep the first binding rather than crashing the page.
+      if (!isProductionEnv()) throw new Error(message)
+      console.error(`[deprize] ${message}`)
+      continue
+    }
+    map.set(comp.sharedGoalId, deprizeId)
+  }
+  goalIndexByChain.set(chainSlug, map)
+  return map
+}
+
+/**
+ * Reverse lookup: Moon Base Zero SharedGoal.id → DePrize id on this chain.
+ * Returns undefined when unbound. Throws outside production if the registry
+ * maps two DePrize ids to the same goal (built once, then cached).
+ */
+export function findDePrizeIdForGoal(
+  chainSlug: string,
+  sharedGoalId: string | undefined
+): number | undefined {
+  if (!sharedGoalId) return undefined
+  return goalIndexForChain(chainSlug).get(sharedGoalId)
+}
+
+/**
+ * Pure consent check on an outcomes array.
+ * Sepolia is always publishable (QA). Elsewhere every outcome must have
+ * `consented: true`.
+ */
+export function areRaceOutcomesPublishable(
+  chainSlug: string,
+  outcomes: readonly DePrizeRaceOutcome[] | undefined
+): boolean {
+  if (!outcomes?.length) return false
+  if (chainSlug === 'sepolia') return true
+  return outcomes.every((o) => o.consented === true)
+}
+
+/**
+ * Consent gate for reporting a race market as live.
+ * Unbound goals are not publishable. See {@link areRaceOutcomesPublishable}.
+ */
+export function isDePrizeGoalMarketPublishable(
+  chainSlug: string,
+  sharedGoalId: string | undefined
+): boolean {
+  if (!sharedGoalId) return false
+  const deprizeId = findDePrizeIdForGoal(chainSlug, sharedGoalId)
+  if (deprizeId === undefined) return false
+  const binding = getDePrizeRaceBinding(chainSlug, deprizeId)
+  return areRaceOutcomesPublishable(chainSlug, binding?.outcomes)
+}
+
+export type DePrizeIndexRaceGroup = {
+  /** Null means the unbound "Other challenges" bucket. */
+  raceLabel: string | null
+  deprizeIds: number[]
+  /** False when the chain has no race bindings — render a flat list. */
+  showHeading: boolean
+}
+
+/**
+ * Partition registry ids 1..count by raceLabel for the index page.
+ * Unbound ids collect under raceLabel null ("Other challenges").
+ * When the chain has no bindings, returns one flat group with showHeading false.
+ */
+export function partitionDePrizeIndexByRace(
+  chainSlug: string,
+  count: number
+): DePrizeIndexRaceGroup[] {
+  if (!Number.isFinite(count) || count <= 0) return []
+
+  const hasBindings = chainHasRaceBindings(chainSlug)
+  if (!hasBindings) {
+    return [
+      {
+        raceLabel: null,
+        deprizeIds: Array.from({ length: count }, (_, i) => i + 1),
+        showHeading: false,
+      },
+    ]
+  }
+
+  const byLabel = new Map<string, number[]>()
+  const other: number[] = []
+  const labelOrder: string[] = []
+
+  for (let id = 1; id <= count; id++) {
+    const binding = getDePrizeRaceBinding(chainSlug, id)
+    if (!binding) {
+      other.push(id)
+      continue
+    }
+    const existing = byLabel.get(binding.raceLabel)
+    if (existing) {
+      existing.push(id)
+    } else {
+      byLabel.set(binding.raceLabel, [id])
+      labelOrder.push(binding.raceLabel)
+    }
+  }
+
+  const groups: DePrizeIndexRaceGroup[] = labelOrder.map((raceLabel) => ({
+    raceLabel,
+    deprizeIds: byLabel.get(raceLabel)!,
+    showHeading: true,
+  }))
+  if (other.length > 0) {
+    groups.push({ raceLabel: null, deprizeIds: other, showHeading: true })
+  }
+  return groups
 }

--- a/ui/lib/deprize/constants.ts
+++ b/ui/lib/deprize/constants.ts
@@ -38,6 +38,7 @@ export const GAS_RESERVE_WEI = 10n ** 15n // 0.001 ETH
 export const GAS_RESERVE_ETH = Number(GAS_RESERVE_WEI) / 1e18
 
 // Per-outcome line/accent colors, shared across the chart and team cards.
+// Sized for the largest planned race (4) plus headroom; wraps via `% length`.
 export const OUTCOME_COLORS = [
   '#22c55e',
   '#3b82f6',
@@ -45,6 +46,8 @@ export const OUTCOME_COLORS = [
   '#f59e0b',
   '#ef4444',
   '#06b6d4',
+  '#ec4899',
+  '#84cc16',
 ]
 
 // Odds-history sampling cadence for the live chart.

--- a/ui/lib/deprize/goal-odds.ts
+++ b/ui/lib/deprize/goal-odds.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure LMSR-index → atlas projectId odds mapping.
+ *
+ * useDePrizeMarket returns `probability` as a percent (0–100). Moon Base Zero
+ * `SharedGoalMarket.impliedOdds` is fractions of 1. This module is the only
+ * place that conversion happens — keep it dependency-free for yarn test:deprize.
+ */
+
+export type GoalOddsOutcome = {
+  projectId: string
+  /** When set, must equal teamIds[i] or the mapper returns undefined. */
+  teamId?: number
+}
+
+/**
+ * Map LMSR outcome probabilities onto atlas project ids.
+ *
+ * Returns fractions of 1, drops non-finite entries, and returns `undefined` on
+ * any length mismatch or teamId checksum failure. Blank is recoverable; wrong
+ * attribution (Lockheed's odds on Westinghouse) is not.
+ *
+ * Also returns `undefined` when no finite odds survive — a loading or closed
+ * market reads all-NaN, and an empty map would let a merge overwrite curator
+ * priors with nothing.
+ */
+export function mapOutcomeOddsToProjectIds(args: {
+  outcomes: GoalOddsOutcome[]
+  teamIds: readonly bigint[]
+  /** Percents as returned by useDePrizeMarket (`calcMarginalPrice * 100`). */
+  probabilities: readonly number[]
+}): Record<string, number> | undefined {
+  const { outcomes, teamIds, probabilities } = args
+  const n = outcomes.length
+  if (n === 0) return undefined
+  if (teamIds.length !== n || probabilities.length !== n) return undefined
+
+  for (let i = 0; i < n; i++) {
+    const expected = outcomes[i].teamId
+    if (expected === undefined) continue
+    if (teamIds[i] !== BigInt(expected)) return undefined
+  }
+
+  const out: Record<string, number> = {}
+  let finite = 0
+  for (let i = 0; i < n; i++) {
+    const p = probabilities[i]
+    if (!Number.isFinite(p)) continue
+    out[outcomes[i].projectId] = p / 100
+    finite++
+  }
+  return finite > 0 ? out : undefined
+}

--- a/ui/lib/deprize/useDePrizeGoalOdds.tsx
+++ b/ui/lib/deprize/useDePrizeGoalOdds.tsx
@@ -24,7 +24,7 @@ export type UseDePrizeGoalOddsResult = {
 
 function deriveGoalMarketStatus(
   registryState: DePrizeState | undefined,
-  publishable: boolean
+  publishable: boolean,
 ): DePrizeGoalMarketStatus {
   // Consent gate: never surface live (or resolved) without publishable roster.
   if (!publishable) return 'planned'
@@ -59,7 +59,7 @@ function deriveGoalMarketStatus(
  */
 export function useDePrizeGoalOdds(
   chain: Chain,
-  sharedGoalId: string | undefined
+  sharedGoalId: string | undefined,
 ): UseDePrizeGoalOddsResult {
   const chainSlug = getChainSlug(chain)
   const deprizeId = findDePrizeIdForGoal(chainSlug, sharedGoalId)
@@ -78,6 +78,8 @@ export function useDePrizeGoalOdds(
   })
 
   const oddsByProjectId = useMemo(() => {
+    // Consent gate: do not expose live LMSR fractions for non-public races.
+    if (!publishable) return undefined
     if (!binding?.outcomes.length || !deprize?.teamIds.length) return undefined
     if (market.outcomes.length !== binding.outcomes.length) return undefined
     return mapOutcomeOddsToProjectIds({
@@ -85,7 +87,7 @@ export function useDePrizeGoalOdds(
       teamIds: deprize.teamIds,
       probabilities: market.outcomes.map((o) => o.probability),
     })
-  }, [binding, deprize?.teamIds, market.outcomes])
+  }, [binding, deprize?.teamIds, market.outcomes, publishable])
 
   const status = deriveGoalMarketStatus(deprize?.state, publishable)
 

--- a/ui/lib/deprize/useDePrizeGoalOdds.tsx
+++ b/ui/lib/deprize/useDePrizeGoalOdds.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from 'react'
+import type { Chain } from 'thirdweb'
+import {
+  findDePrizeIdForGoal,
+  getDePrizeRaceBinding,
+  isDePrizeGoalMarketPublishable,
+} from './competitions'
+import { DePrizeState } from './constants'
+import { mapOutcomeOddsToProjectIds } from './goal-odds'
+import { useDePrize } from './useDePrize'
+import { useDePrizeMarket } from './useDePrizeMarket'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+
+/** Atlas SharedGoalMarket.status values the bridge can emit. */
+export type DePrizeGoalMarketStatus = 'live' | 'resolved' | 'planned'
+
+export type UseDePrizeGoalOddsResult = {
+  deprizeId: number | undefined
+  /** Fractions of 1 keyed by atlas projectId. Undefined when unbound / mismatched. */
+  oddsByProjectId: Record<string, number> | undefined
+  status: DePrizeGoalMarketStatus
+  loading: boolean
+}
+
+function deriveGoalMarketStatus(
+  registryState: DePrizeState | undefined,
+  publishable: boolean
+): DePrizeGoalMarketStatus {
+  // Consent gate: never surface live (or resolved) without publishable roster.
+  if (!publishable) return 'planned'
+  if (registryState === undefined) return 'planned'
+
+  if (
+    registryState === DePrizeState.SETTLED ||
+    registryState === DePrizeState.M1_RELEASED ||
+    registryState === DePrizeState.M2_COMPLETE ||
+    registryState === DePrizeState.M2_FAILED ||
+    registryState === DePrizeState.CANCELLED ||
+    registryState === DePrizeState.NO_WINNER
+  ) {
+    return 'resolved'
+  }
+
+  if (
+    registryState === DePrizeState.OPEN ||
+    registryState === DePrizeState.LOCKED ||
+    registryState === DePrizeState.VOTING
+  ) {
+    return 'live'
+  }
+
+  return 'planned'
+}
+
+/**
+ * Bridge one Moon Base Zero race to its bound DePrize market.
+ * Mounts a single market (call for the open race only — do not fan out to all 8).
+ * Inherits ODDS_POLL_MS / hidden-tab skip from useDePrizeMarket.
+ */
+export function useDePrizeGoalOdds(
+  chain: Chain,
+  sharedGoalId: string | undefined
+): UseDePrizeGoalOddsResult {
+  const chainSlug = getChainSlug(chain)
+  const deprizeId = findDePrizeIdForGoal(chainSlug, sharedGoalId)
+  const binding = getDePrizeRaceBinding(chainSlug, deprizeId)
+  const publishable = isDePrizeGoalMarketPublishable(chainSlug, sharedGoalId)
+
+  const { deprize, loading: registryLoading } = useDePrize(deprizeId, chain)
+  const numOutcomes = deprize?.teamIds.length ?? 0
+
+  const market = useDePrizeMarket({
+    deprizeId,
+    conditionId: deprize?.conditionId,
+    numOutcomes,
+    chain,
+    registryState: deprize?.state,
+  })
+
+  const oddsByProjectId = useMemo(() => {
+    if (!binding?.outcomes.length || !deprize?.teamIds.length) return undefined
+    if (market.outcomes.length !== binding.outcomes.length) return undefined
+    return mapOutcomeOddsToProjectIds({
+      outcomes: binding.outcomes,
+      teamIds: deprize.teamIds,
+      probabilities: market.outcomes.map((o) => o.probability),
+    })
+  }, [binding, deprize?.teamIds, market.outcomes])
+
+  const status = deriveGoalMarketStatus(deprize?.state, publishable)
+
+  return {
+    deprizeId,
+    oddsByProjectId,
+    status,
+    loading: !!deprizeId && (registryLoading || market.loading),
+  }
+}

--- a/ui/pages/deprize-play.tsx
+++ b/ui/pages/deprize-play.tsx
@@ -8,7 +8,6 @@ import {
   CONDITIONAL_TOKEN_ADDRESSES,
   COLLATERAL_TOKEN_ADDRESSES,
   COLLATERAL_DECIMALS,
-  MAX_OUTCOMES,
   ORACLE_ADDRESS,
   OPERATOR_ADDRESS,
   DEFAULT_CHAIN_V5,
@@ -44,6 +43,10 @@ import type { OddsSample } from '@/components/deprize/OddsHistoryChart'
 const OddsHistoryChart = dynamic(() => import('@/components/deprize/OddsHistoryChart'), {
   ssr: false,
 })
+
+/** Play-harness only — production DePrize UI sizes outcomes from teamIds.length. */
+const PLAY_MAX_OUTCOMES = 3
+const MAX_OUTCOMES = PLAY_MAX_OUTCOMES
 
 // Per-outcome line colors (also used as accents elsewhere if needed).
 const OUTCOME_COLORS = ['#22c55e', '#3b82f6', '#a855f7', '#f59e0b', '#ef4444', '#06b6d4']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase B1 foundations for wiring DePrize into Moon Base Zero (PR #1405), without importing any atlas types so this can land on `main` independently.

- **Race binding** in `ui/lib/deprize/competitions.ts`: `sharedGoalId`, `raceLabel`, `outcomes[{ projectId, teamId?, consented? }]`, reverse lookup, consent gate, index partitioning
- **Pure mapper** `mapOutcomeOddsToProjectIds`: LMSR percents → atlas fractions of 1; refuses length/`teamId` mismatches; returns `undefined` when no finite odds (avoids wiping curator priors)
- **`useDePrizeGoalOdds`**: mounts one market, returns `{ deprizeId, oddsByProjectId, status, loading }`
- **`DePrizeTeamLink` overrides** for orgs without Team NFTs (`name`/`image`/`href`), using `next/link` for internal routes
- **Index grouping** by race when bindings exist; flat list otherwise
- **Outcome cap cleanup**: `MAX_OUTCOMES` scoped to play/archive harness; `OUTCOME_COLORS` extended to 8
- **Sepolia fixture**: DePrize 9 → `shared-fission-power` (teams 301/302/303 → Westinghouse/Lockheed/IX)
- Plan + QA notes: `docs/DEPRIZE_PHASE_B1.md`, binding table + Miguel schema note in `docs/DEPRIZE_QA.md`

## Test plan

- [x] `cd ui && yarn test:deprize` — 73 passing
- [x] `cd ui && yarn tsc --noEmit`
- [x] Browser harness (local Playwright): `useDePrizeGoalOdds(sepolia, 'shared-fission-power')` → `deprizeId=9`, `status=live`, odds as fractions of 1 summing ≈ 1.0 for the three project ids (~3.5s)
- [x] On-chain: `teamIds(9)` on Sepolia registry = `[301, 302, 303]`
- [ ] Review with Miguel: drop `SharedGoalMarket.deprizeRegistryId` / `deprizeQuestionId` in favor of this chain-keyed binding before atlas seed conflicts

## Out of scope

Moon Base Zero page wiring (`mergeLiveMarket`, SharedGoalPanel link, deep links) — that is Phase B2 after #1405 merges.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-904c5707-822d-406b-96a7-e0b9d81c0e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-904c5707-822d-406b-96a7-e0b9d81c0e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

