### PR TITLE
feat(deprize): Open Field slots and generational supersede for roster changes

### DIFF
--- a/docs/DEPRIZE_M5.md
+++ b/docs/DEPRIZE_M5.md
@@ -115,11 +115,48 @@ It returns the registry state-advance calldata plus either a plain-ETH provider 
 4. **M2 (delivered):** run with `DEPRIZE_MILESTONE=M2` (same `DEPRIZE_PRIZE_WEI`) → submit Tx 1 (70% → provider) then Tx 2 (`completeM2`).
 5. **M2 (failed / 18-month deadline):** run with `DEPRIZE_MILESTONE=REFUND` → submit `addToBalanceOf` of the 70% back into the JB project first, then `failM2` to enable refunds. `$OVERVIEW` cashOut is now live via the existing JB UI.
 
+### Field-winner settlement (Open Field slot)
+
+When the Senate names a winner who is **not** on the named roster, settle via the
+Open Field team id — **never** as two separate transactions:
+
+1. Publish the Senate vote naming the winning entity and its payout Safe.
+2. One Safe batch:
+   - `registry.settleWinner(id, OPEN_FIELD_TEAM_ID)`
+   - `registry.setProviderPayoutAddress(id, winnerSafe)`
+3. Halt the LMSR (`pauseMarket` / `closeMarket`), then `DePrizeResolve` + `reportPayouts`.
+4. Continue with M1/M2 disbursement to `winnerSafe` as usual.
+
+### Generational supersede (roster refresh, same prize pool)
+
+Announce publicly, then one ordered Safe batch. **Leave the old LMSR Running** so
+holders can keep selling; do not pause or close it at the fork.
+
+1. `feeRouter.sweepFees(oldId)` — must be first while the entry is still non-terminal,
+   so residual trade fees land in the prize pool rather than the treasury.
+2. `registry.supersede(oldId, newTeamIds, newSunset)` — returns `newId` in `DRAFT`,
+   moves `oldId` to `SUPERSEDED` (terminal, **not** refundable), rebinds the JB project.
+3. Provision the new generation: `prepareCondition` → deploy/fund LMSR →
+   `setCondition(newId, …)` → `open(newId)` → `mint.setMarket` + `feeRouter.setMarket`
+   → transfer LMSR ownership to the FeeRouter.
+
+**Roster rule:** carry every still-active competitor, plus new entrants, plus a
+fresh Open Field slot. Only drop a competitor who is verifiably ineligible to win.
+
+**While the race continues:** periodically sweep legacy-market sell fees into the
+prize pool manually (`sweepFees` on a terminal entry routes to treasury by default).
+
+**At final settlement:** pause/close **every** generation's LMSR (including
+superseded ones — `DePrizeResolve` aborts on a Running market), settle the live
+generation, then resolve each superseded condition via
+`DePrizeResolve` with `DEPRIZE_WINNING_ENTITY=<real team id>` and
+`DEPRIZE_OPEN_FIELD=<this generation's field team id>` so lineage maps correctly.
+
 ---
 
 ## Tests
 
-`forge test --match-contract 'DePrizeRegistryTest|DePrizeDisburseTest'` — **51 registry + 13 disbursement tests passing** (whole deprize suite: 150 passing).
+`forge test --match-contract 'DePrizeRegistryTest|DePrizeDisburseTest'` — **51 registry + 13 disbursement tests passing** (whole deprize suite: 204 passing).
 
 - **Registry (`setProviderPayoutAddress`):** set at `SETTLED` and `M1_RELEASED`, update between milestones, zero-address revert, wrong-state reverts (pre-settle `OPEN`, post `M2_COMPLETE`), `onlyOwner`, `UnknownDePrize`, default-zero view.
 - **`DePrizeDisburse.buildDisbursement`:** M1 = 30% → provider + `releaseM1`; M2 = 70% → provider + `completeM2`; REFUND = 70% → JB `addToBalanceOf` + `failM2`; exact split on an indivisible prize (M1 + M2 == snapshot); guards (`WrongState` per milestone, `ProviderNotSet`, `ZeroPrize`, `UnknownMilestone`, `UnknownDePrize`); tag constants match.

--- a/docs/DEPRIZE_PHASE_B1.md
+++ b/docs/DEPRIZE_PHASE_B1.md
@@ -50,6 +50,8 @@ New accessors alongside the existing ones (all pure, all mocha-testable):
 - `getDePrizeRaceBinding(chainSlug, deprizeId)` — returns `{ sharedGoalId, raceLabel, outcomes }` or `undefined`.
 - `findDePrizeIdForGoal(chainSlug, sharedGoalId)` — the reverse index the hook needs. Build it as a memoized map, and have it throw in dev if one chain maps two DePrize ids to the same goal.
 - `isDePrizeGoalMarketPublishable(chainSlug, sharedGoalId)` — the consent gate (item 5).
+  **Superseded in Phase B2** by `isDePrizeGoalMarketBound`; see
+  [DEPRIZE_PHASE_B2.md](DEPRIZE_PHASE_B2.md).
 
 Deliberate choice: consent lives here as `outcomes[].consented`, not read from the atlas `Project.rosterStatus`. `rosterStatus` isn't importable on `main`, and the binding is the right source of truth for a legal gate anyway — it sits next to the chain id and the questionId it's gating.
 
@@ -80,6 +82,11 @@ Two behaviors B2 depends on: it mounts **one** market (B2 item 2 fetches only th
 One gotcha: the component uses a bare `<a>`. An internal `hrefOverride` like `/moonbase/{projectId}` will trip the `next/link` ESLint rule that already failed a Vercel build in Phase A — use `Link` for internal hrefs.
 
 ### 5. Consent gate
+
+> **Superseded in Phase B2.** Consent was replaced by a disclaimer-first model:
+> markets on bound races are visible, and `consented` now gates branding (logo,
+> brand color) only. See [DEPRIZE_PHASE_B2.md](DEPRIZE_PHASE_B2.md). The rest of
+> this section records the original B1 reasoning.
 
 `isDePrizeGoalMarketPublishable` returns false outside `sepolia` unless every entry in `outcomes` has `consented: true`. All 8 atlas races currently carry `rosterStatus: 'listed'`, which is curatorial judgment and not agreement — this is the only item in B1/B2 with real legal exposure, so it ships in the same PR as the binding it protects, not later.
 

--- a/docs/DEPRIZE_PHASE_B2.md
+++ b/docs/DEPRIZE_PHASE_B2.md
@@ -1,0 +1,127 @@
+# DePrize Phase B2: live markets in Moon Base Zero
+
+Phase B2 wires live on-chain DePrize odds into the Moon Base Zero race panels.
+It ships in two waves because the atlas lives on a separate branch.
+
+- **Wave 1** (this document, landed): retire the consent visibility gate in favour
+  of disclosure, add the pure odds merge helper, and point bound competitors at
+  their atlas pages.
+- **Wave 2** (after the Moon Base Zero PR merges): consume the merge helper in
+  `ui/pages/moonbase/index.tsx`, wire the race panel, add atlas competitor
+  identity with claim-gated branding, and add `?race=` deep links.
+
+Part 2 of the original B2 draft — in-flight roster changes — was designed and
+built ahead of schedule. See [DEPRIZE_ROSTER_CHANGES.md](DEPRIZE_ROSTER_CHANGES.md).
+
+## Where the race binding lives
+
+`SharedGoalMarket` in the atlas carries optional `deprizeRegistryId` and
+`deprizeQuestionId` strings. **These are unused and stay unused.** They are plain
+strings with no chain dimension, and a DePrize id is chain-specific: registry
+entry 9 on Sepolia is unrelated to entry 9 on Arbitrum.
+
+The source of truth is the chain-keyed binding in
+[ui/lib/deprize/competitions.ts](../ui/lib/deprize/competitions.ts):
+
+```
+DEPRIZE_COMPETITIONS[chainSlug][deprizeId] = {
+  sharedGoalId,          // atlas SharedGoal.id this DePrize settles
+  raceLabel,
+  outcomes: [{ projectId, teamId?, consented?, field? }],
+}
+```
+
+`findDePrizeIdForGoal(chainSlug, sharedGoalId)` is the reverse lookup, and it
+resolves through `supersededBy` to the **live generation tip**, so a race that has
+been superseded keeps pointing at the generation that is actually trading.
+
+Consequence for the atlas dataset: no DePrize ids belong in
+`atlas.dataset.json`. That keeps the highest-conflict file free of chain-specific
+data, and means seeding a new race is a one-file change on the DePrize side.
+
+## Disclosure instead of a consent gate
+
+B1 shipped an all-or-nothing consent gate: outside Sepolia, a single competitor
+without `consented: true` forced the whole race to `planned` and redacted live
+odds. That was stricter than the risk warranted. Listing a public company as a
+market outcome does not require its permission — prediction markets routinely
+price named companies and candidates.
+
+The actual exposure is **implied endorsement**: presenting an organization as an
+entrant in *our* prize, with its logo and a "Back a competitor" button, can read
+as "they signed up." That is a disclosure and trademark-restraint problem, not a
+reason to hide a bound market.
+
+Wave 1 therefore:
+
+- replaces `areRaceOutcomesPublishable` with `isRaceBindingComplete` (has at least
+  one non-field competitor) and `isDePrizeGoalMarketPublishable` with
+  `isDePrizeGoalMarketBound`. No chain carve-outs; Sepolia is no longer special.
+- drops the odds redaction in `useDePrizeGoalOdds`, while **keeping** the `teamId`
+  checksum and roster-length guards. Those prevent attributing one competitor's
+  odds to another, which is correctness rather than policy.
+- repurposes `consented` as a **branding** flag via `isCompetitorClaimed`: name and
+  link always render; logo and brand color only once claimed. Wave 2 enforces this
+  when atlas identity is available.
+- adds `ROSTER_DISCLAIMER`, rendered wherever named competitors sit next to a
+  market, and section 5.3 of the Terms.
+
+Note the atlas `RosterStatus` union already contains a `'consented'` value. That
+stays **editorial** metadata driving panel copy. The binding's `consented` is
+authoritative for branding. Do not cross-wire them.
+
+This change had no live effect when it landed: Sepolia DePrize 9 was the only
+bound race, and Sepolia was already exempt from the gate.
+
+## Notes for Wave 2 (verified against `feat/lunar-simulator`)
+
+Checked while reviewing Wave 1, so the wiring does not have to rediscover them:
+
+- **Do not add a second disclaimer.** `SharedGoalPanel` already renders a
+  no-endorsement caveat, gated on `anyUnconfirmed` (`rosterStatus` of `listed` or
+  `invited`). Reconcile it with `ROSTER_DISCLAIMER` — one disclosure per surface,
+  not two near-identical paragraphs. The panel's version is also gated on
+  editorial `rosterStatus`, whereas the market disclosure should not be, so prefer
+  showing `ROSTER_DISCLAIMER` whenever the race is bound.
+- **`resolved` markets get the wrong caption today.** The panel picks its odds
+  caption off `oddsLive = status === 'live'`, so a `resolved` market falls through
+  to "Illustrative curator priors — live odds replace these when the prediction
+  market opens." Add a resolved branch when wiring the panel.
+- **The Open Field sentinel is safe with today's consumers.** Both `rankedMembers`
+  and the panel's `ranked` read `odds[project.id]`, so they never iterate the odds
+  keys and the extra `__open-field__` entry cannot become a phantom leader. It
+  needs an explicit row to be visible at all.
+- **`status === 'live'` already flips the caption** to "Odds are live
+  market-implied probabilities," so the merge needs no extra plumbing for that.
+
+## Known Wave 1 → Wave 2 dependency
+
+Bound competitors on `/deprize/{id}` link to `/moonbase/{projectId}`, which **does
+not exist until the Moon Base Zero PR merges**. The only bound race today is
+Sepolia DePrize 9, a testnet QA fixture, so the dead link is not reachable from
+any production race. Do not seed a mainnet race with `projectId`s until the
+`/moonbase/[projectId]` route is live.
+
+## The merge point
+
+Three consumers read `goal.market.impliedOdds`, all keyed by atlas `projectId`:
+the race panel bars, the district leader in `rankedMembers`, and the Legend leader
+in the `races` memo. Rather than touch all three, Wave 2 merges live odds into the
+goal's `market` **once**, upstream of `buildTechTrees`, and they all inherit it.
+
+[ui/lib/deprize/goal-market.ts](../ui/lib/deprize/goal-market.ts) is that merge, and
+it is intentionally decoupled from the atlas: it defines a structural
+`MergeableGoal` subset that the real `SharedGoal` already satisfies, and is
+generic so the caller gets its own type back. This is why Wave 1 can ship and
+unit test the helper before the atlas branch exists.
+
+It returns the goal untouched when there is nothing trustworthy to show — unbound,
+`planned` status (including superseded and still-loading), or an empty odds map —
+because curator priors are better than a blank market. Open Field mass is carried
+under `OPEN_FIELD_PROJECT_ID` so the bars still sum to roughly 1 instead of
+overstating the named competitors.
+
+## Tests
+
+- `yarn test:deprize` — merge helper, binding lookups, lineage, goal-odds mapping
+- `yarn test:cypress-unit` — atlas selectors (Wave 2 only)

--- a/docs/DEPRIZE_QA.md
+++ b/docs/DEPRIZE_QA.md
@@ -22,6 +22,7 @@
 | **DePrize 9** (browser fixture) | id **9**, JB **256**, LMSR `0x6e1a513f3DfB6288836CacdF0a9d3496b411130C`, condition `0x7334d1e6…560d`, payhook `0xec3ba013…7E66`, teams **301/302/303**, oracle = deployer `0x3c5e…E011` |
 | DePrize 9 questionId | `0xab937cdea2250786bf37ee2dd06f244bbeed62159c337927074523844d5759fb` |
 | DePrize 9 race binding (B1) | `sharedGoalId` **shared-fission-power**; outcome index → projectId: **0→westinghouse-fission-surface-power (team 301)**, **1→lockheed-fission-surface-power (team 302)**, **2→ix-fission-surface-power (team 303)** — see `ui/lib/deprize/competitions.ts` |
+| **Open Field Team NFT** (roster-changes) | **Pending mint.** Reserved symbolic id `OPEN_FIELD` / intended Sepolia token id **999**, owned by the admin Safe, metadata name `"Open Field"`, image = neutral field glyph. Once minted, set `OPEN_FIELD_TEAM_ID` in `ui/lib/deprize/competitions.ts` and record the live token id here. Ops: `MoonDAOTeamCreator.createMoonDAOTeam` (same path as `CreateTeam` UI / `script/CreateTestMissionSepolia.s.sol` `_createTeam`). DePrize 9's live roster does **not** include a field slot — reserve the field on every **new** race from here on. |
 
 UI config (`ui/const/config.ts`) wires registry / redeem / mint / fee-router. It does **not** repoint app-wide `MISSION_CREATOR_ADDRESSES` (intentional — avoids fragmenting general launchpad listing). DePrize **9** resolves its LMSR via `mint.marketOf(9)` (no config LMSR fallback needed).
 

--- a/docs/DEPRIZE_ROSTER_CHANGES.md
+++ b/docs/DEPRIZE_ROSTER_CHANGES.md
@@ -1,0 +1,510 @@
+# Adding and removing competitors after a DePrize is created
+
+## The question
+
+Long-running prizes ("fission surface power", "regolith oxygen extraction") will outlive
+their opening roster. Companies enter the field, pivot, get acquired, or drop out. Today the
+roster is frozen at registration and there is no way to change it. This document works out
+what is actually possible, what each option costs, and what we should build.
+
+## What is actually immutable (verified against the code, not assumed)
+
+Three separate layers pin the roster, and they pin it for different reasons.
+
+**The Gnosis CTF pins the outcome count into the condition's identity.**
+`getConditionId` is `keccak256(abi.encodePacked(oracle, questionId, outcomeSlotCount))`
+([CTHelpers.sol:10-12](../prediction/node_modules/@gnosis.pm/conditional-tokens-contracts/contracts/CTHelpers.sol)),
+and `prepareCondition` refuses to touch an id that already exists
+([ConditionalTokens.sol:65-73](../prediction/node_modules/@gnosis.pm/conditional-tokens-contracts/contracts/ConditionalTokens.sol)).
+A 4-slot condition is a *different condition* from the 3-slot one. There is no resize.
+
+**The LMSR pins the slot count at clone time.** `atomicOutcomeSlotCount`,
+`conditionIds`, `cumulativeProbabilities` and `positionIds` are all set in `cloneConstructor`
+([LMSRWithTWAPFactory.sol:57-100](../prediction/contracts/LMSRWithTWAPFactory.sol)) and
+`trade` hard-requires `outcomeTokenAmounts.length == atomicOutcomeSlotCount`
+([MarketMaker.sol:166](../prediction/node_modules/@gnosis.pm/conditional-tokens-market-makers/contracts/MarketMaker.sol)).
+No function resizes it.
+
+**The registry has no roster setter at all.** `teamIds` and `_isTeam` are written only
+inside the `register` loop ([DePrizeRegistry.sol:92-99](../subscription-contracts/src/deprize/DePrizeRegistry.sol)),
+and `setCondition` is DRAFT-only ([:107-112](../subscription-contracts/src/deprize/DePrizeRegistry.sol)).
+
+So: **the outcome set of a live market can never change.** Any "add a competitor" story is
+really a story about a *second* condition and a *second* market. The only open questions are
+what happens to the prize pool, what happens to existing bettors, and whether we can avoid
+the problem entirely by planning for it at registration.
+
+### The two couplings that make this hard
+
+**The Juicebox binding is write-once and never cleared.** `_deprizeIdByJBProject[jbProjectId]`
+is set in `register` ([:101](../subscription-contracts/src/deprize/DePrizeRegistry.sol)) and a
+second `register` on the same project reverts `JBProjectAlreadyBound`
+([:81](../subscription-contracts/src/deprize/DePrizeRegistry.sol)). Nothing — not `cancel`,
+not `settleNoWinner`, not `failM2` — ever clears it. The prize pool ETH and the project token
+live on that JB project, so a naive "new prize" means a new pool and orphaned token holders.
+
+**Cancelling to free things up opens the cash-out floodgates.** `LaunchPadPayHook`
+un-gates `cashOut` the moment `isRefundable` is true
+([LaunchPadPayHook.sol:153-165](../subscription-contracts/src/LaunchPadPayHook.sol)), and
+`isRefundable` covers `CANCELLED | NO_WINNER | M2_FAILED`
+([DePrizeRegistry.sol:307-310](../subscription-contracts/src/deprize/DePrizeRegistry.sol)).
+Cancel a live DePrize to re-register it and token holders can drain the prize pool pro-rata
+before you finish the migration.
+
+### One thing that is helpfully *not* coupled
+
+The prize money does **not** follow the winning Team NFT. `settleWinner` validates
+`_isTeam` ([:152](../subscription-contracts/src/deprize/DePrizeRegistry.sol)), but the payout
+destination is a free-form address the owner sets afterwards via `setProviderPayoutAddress`
+([:248-259](../subscription-contracts/src/deprize/DePrizeRegistry.sol)), and the disbursement
+script pays `providerPayoutAddress`, never an NFT owner
+([DePrizeDisburse.s.sol:91-114](../subscription-contracts/script/deprize/DePrizeDisburse.s.sol)).
+
+**This is the hinge the whole design turns on.** The outcome slot a bettor holds and the
+entity that receives the prize are already independent. That is what makes the reserved-field
+option below work with zero contract changes.
+
+---
+
+## Removal is a non-problem
+
+Worth separating, because it gets bundled with addition and it shouldn't be.
+
+Nothing breaks when a competitor drops out. The market prices them toward zero on its own.
+`settleWinner` only requires the *winner* to be on the roster, so a dead slot is inert.
+`DePrizeResolve.buildReport` pays `[0,…,1,…,0]` at the winner's index and ignores the rest
+([DePrizeResolve.s.sol:71-85](../subscription-contracts/script/deprize/DePrizeResolve.s.sol)).
+
+Removing a slot for real would be actively *harmful*: it would strip holders of that outcome
+token of the ability to sell, and there is no honest price at which to force-close them.
+Leaving the slot open lets them exit at whatever the market says it is worth.
+
+So removal is a **disclosure** feature, not a mechanism feature: mark the competitor
+withdrawn, badge them in the UI, and let the price finish the job. [docs/DEPRIZE.md:806](DEPRIZE.md)
+already proposed exactly this ("mark a provider withdrawn via Registry") and
+[:841](DEPRIZE.md) lists it as an unbuilt future enhancement.
+
+One wording to correct while we are here: DEPRIZE.md:806 says a withdrawn provider's "team
+tokens become worth 0". That is a *market outcome* — they go to zero because someone else
+wins — not an enforced write-down, and the distinction matters. If we ever implemented it as
+a write-down we would be confiscating positions. Keeping the slot tradable is what turns
+"your bet is now worthless" into "your bet is now cheap, and you can sell it".
+
+The rest of this document is about **addition**.
+
+---
+
+## Options
+
+### O1 — Do nothing. Roster locked, next roster next cycle.
+
+The shipped policy: *"Provider list is locked at DePrize-open. New providers can be added in
+future DePrizes"* ([docs/DEPRIZE.md:810](DEPRIZE.md)). Keep sunsets short so "next prize" is
+never far away.
+
+Honest baseline. Fails the actual use case: a fission-surface-power race runs to the early
+2030s, and telling a new entrant to wait for the 2031 prize is telling them to go away.
+
+### O2 — Withdrawal disclosure only
+
+Registry gains an event-only flag: `markWithdrawn(uint256 deprizeId, uint256 teamId)` emitting
+`TeamWithdrawn`, plus a `withdrawn(deprizeId, teamId)` view. It changes **no** outcome set, no
+slot count, no condition. `bet` stays open on that slot so holders can exit.
+
+UI badges the row "Withdrawn — you can still sell your position". Costs one mapping and one
+event; storage comes out of `__gap`.
+
+This is the removal half of the feature and it is nearly free. It should ship regardless of
+which addition option we choose.
+
+### O3 — DRAFT-only `setTeams`
+
+`setTeams(uint256 deprizeId, uint256[] calldata teamIds)`, guarded by `_requireDraft`, clearing
+and rewriting `_isTeam`. Only usable before `open`.
+
+This does not solve the stated problem at all — but it fixes a **live footgun**. Today a typo
+in the `register` roster is unrecoverable: you cannot re-register because the JB project is
+already bound, so a mistyped team id in DRAFT costs you the whole Juicebox project. Cheap
+insurance while we are in the registry anyway.
+
+### O4 — Reserve an "Open Field" slot at registration ⭐
+
+Register the race with one extra outcome beyond the named competitors:
+
+> `teamIds = [Westinghouse, Lockheed, IX, OPEN_FIELD]`
+
+`OPEN_FIELD` is a real MoonDAOTeam NFT owned by the admin Safe, named "Open Field". The market
+question becomes *"which provider is selected — one of these three, or anyone else?"* Bettors
+who think the eventual winner isn't on the board yet buy the field.
+
+When a late entrant wins, the settlement is a single Safe batch:
+
+```mermaid
+sequenceDiagram
+  participant Senate
+  participant Safe as Admin Safe
+  participant Reg as DePrizeRegistry
+  participant CTF
+  Senate->>Safe: vote names Company D (published, off-chain)
+  Safe->>Reg: settleWinner(id, OPEN_FIELD)
+  Note over Reg: _isTeam passes — OPEN_FIELD is on the roster
+  Safe->>Reg: setProviderPayoutAddress(id, D.safe)
+  Safe->>CTF: reportPayouts → [0,0,0,1]
+  Note over CTF: field bettors redeem 1:1
+  Safe->>Safe: M1/M2 disburse to D.safe
+```
+
+Every step is an existing function. **Zero contract changes.** `buildReport` finds
+`OPEN_FIELD` in `teamIds` so there is no `WinnerNotFound`; `DePrizeRedeem` still matches slot
+counts; the pay hook never sees a refundable state.
+
+Cost is one extra outcome's worth of LMSR seed funding and one honest limitation: field
+bettors don't know *which* unlisted company they're backing. That is a well-understood
+instrument — it is the "field" bet in horse racing and the "Other candidate" line in election
+markets — but it must be disclosed plainly rather than presented as a normal competitor.
+
+**On the M4 precedent.** [docs/DEPRIZE_M4.md:27](DEPRIZE_M4.md) rejected an extra outcome
+slot, so this needs squaring. That rejection was of a **"None flies by X date"** slot, and
+four of its five objections are about that specific slot rather than about extra slots:
+(a) it funds people whose payday is the mission failing — Open Field pays only when *someone*
+wins, so it is long the mission, not short it; (b) honest resolution must wait for the
+flight — Open Field resolves at `SETTLED` with everything else; (c) it converts the disclosed
+partial refund into a total loss — Open Field doesn't change refund math; (d) it touches the
+audited M3 router — this slot exists from registration, so nothing is retrofitted. Objection
+(e), that the multisig controls an outcome people hold positions on, **does apply** and is the
+real cost. Mitigation is procedural: publish objective field-eligibility criteria at open,
+require the Senate vote to name the entity before the Safe batch runs, and put the payout
+address in the same batch as `settleWinner` so the record is atomic.
+
+Open Field's limitation is that it must be decided **at registration**. It does nothing for
+prizes already live — which is what O5 is for.
+
+### O5 — `supersede`: prize generations
+
+A registry upgrade that atomically forks a DePrize onto a new roster while keeping the
+Juicebox project — and therefore the prize pool and the project token — intact:
+
+```solidity
+function supersede(uint256 oldDeprizeId, uint256[] calldata newTeamIds, uint256 sunset)
+    external onlyOwner returns (uint256 newDeprizeId);
+```
+
+It creates a new DRAFT entry reusing `old.jbProjectId`, rebinds
+`_deprizeIdByJBProject[jbProjectId] = newDeprizeId`, moves the old entry to a new `SUPERSEDED`
+state, and records `supersededBy[old]` / `supersedes[new]` for UI lineage. Two mappings plus
+one enum member; `__gap` goes 45 → 43.
+
+**`SUPERSEDED` must be terminal but NOT refundable.** Terminal so the old entry stops
+accepting bets and `sweepFees` routes to the treasury rather than re-inflating the pool
+(the double-count guard, [DEPRIZE_M4.md:175-182](DEPRIZE_M4.md)); not refundable so no
+cash-out window ever opens on that project. Atomicity matters: the rebind and the state change
+must be one transaction, or the pay hook briefly sees a refundable DePrize on a funded project.
+
+Then the normal provisioning run: new condition, new LMSR, `setMarket` on Mint and FeeRouter
+(both are re-pointable — neither has an "already set" guard,
+[DePrizeMint.sol:121-139](../subscription-contracts/src/deprize/DePrizeMint.sol),
+[DePrizeFeeRouter.sol:96-112](../subscription-contracts/src/deprize/DePrizeFeeRouter.sol)).
+
+**Correcting the B2 draft on bettor cost.** [.cursor/plans/deprize_phase_b2.plan.md](../.cursor/plans/deprize_phase_b2.plan.md)
+assumed superseding forces a 1/N refund on the old market. It doesn't, in the common case.
+CTF collateral is per-condition, so the two markets settle independently: if the winner is
+someone who was on the *old* roster, the old condition reports `[0,…,1,…,0]` honestly and its
+bettors redeem 1:1 from their own market's collateral, while the new condition does the same
+from its own. The 1/N refund is only forced when the winner is a competitor who exists **only**
+on the new roster — precisely the case Open Field would have covered.
+
+The unavoidable cost is **illiquidity**: the old market is paused at supersede and its holders
+cannot exit until settlement, which may be years. That is a real harm and needs disclosure,
+but it is not principal loss.
+
+### O6 — In-place reset (same `deprizeId`, new roster + new condition)
+
+The tempting shortcut: skip the new id and just let the owner overwrite `teamIds` and
+`ctfConditionId` on the existing DePrize. No rebind needed, `deprizeId` stays stable
+everywhere in the UI.
+
+**This is the trap, and it is worse than it looks.** Both the resolution and redemption paths
+read the *current* registry record to reconstruct the *historical* condition:
+
+- `DePrizeResolve.buildReport` computes `conditionId = getConditionId(oracle, questionId, n)`
+  from `n = dp.teamIds.length` and reverts `ConditionMismatch` against `dp.ctfConditionId`
+  ([DePrizeResolve.s.sol:99-102](../subscription-contracts/script/deprize/DePrizeResolve.s.sol)).
+- `DePrizeRedeem._positions` reverts `SlotCountMismatch` unless `teamIds.length` equals the
+  condition's on-chain slot count
+  ([DePrizeRedeem.sol:133-153](../subscription-contracts/src/deprize/DePrizeRedeem.sol)).
+
+Overwrite the roster and the old condition becomes **permanently unresolvable through our
+tooling** and its holders lose the redeem helper — they'd be left calling
+`ctf.redeemPositions` by hand against a condition nobody ever reported payouts for. O5 avoids
+all of this for free by leaving the old record immutable and readable.
+
+### O7 — Per-competitor binary markets
+
+Replace the one N-way categorical market with one YES/NO condition per competitor. Adding a
+competitor is then just deploying another binary market; the shared-slot constraint disappears
+entirely.
+
+Genuinely the most flexible architecture, and it is how open-ended fields are handled
+elsewhere. But probabilities no longer normalise to 1 (you get an incoherent book that has to
+be reconciled in the UI), each market needs its own seed so liquidity fragments across the
+roster, and it is a rewrite of M3/M4 plus the resolution runbook plus the odds bridge B1 just
+shipped. Right answer for a v2 architecture, wrong answer for adding a competitor next quarter.
+
+### Rejected: migrate bettor collateral from the old generation into the new one
+
+The intuition is that superseding should carry positions across so capital isn't stranded.
+It is mechanically possible — collateral is conserved, so the recovered LMSR inventory plus
+surrendered bettor positions form complete sets that `mergePositions` can unwind back to WETH
+and reissue against the new condition.
+
+It is nonetheless **less fair than doing nothing**. Migration has to price every position at
+the moment of the fork, and the two generations have different outcome sets, so P(competitor)
+genuinely differs between them: a 1:1 token swap hands people a position worth a different
+amount, and a value-based swap requires an administrative price mark. Either way somebody's
+P&L is crystallized at a number MoonDAO chose, on a question the market hadn't answered yet.
+Letting the old condition resolve honestly is the only path where no outcome depends on our
+valuation. It also re-instruments a position the holder bought without their consent, and it
+only unwinds cleanly at full participation — any non-participating holder leaves a stub that
+cannot be merged.
+
+And it solves a problem we do not have: because the legacy LMSR stays Running, holders can sell
+out at any time at a market price, so nobody is locked in and there is nothing to migrate them
+out of. Note also that nothing here dilutes anyone — each condition's collateral pays only its
+own holders, and the Juicebox prize pool is separate from both and goes to the winning company
+rather than to bettors.
+
+### Rejected: let the market refund and pay the prize anyway
+
+"Keep the roster locked; if an unlisted entrant wins, resolve the market no-winner but award
+the prize to the real winner." This is not possible without a contract change: `settleWinner`
+requires `_isTeam`, and `releaseM1`/`completeM2` require `SETTLED`
+([DePrizeRegistry.sol:176-203](../subscription-contracts/src/deprize/DePrizeRegistry.sol)).
+Calling `settleNoWinner` instead puts the prize in a refund terminal and there is no path from
+there to paying anyone. It also 1/N-refunds a market that answered its question correctly,
+which reads as a rug.
+
+---
+
+## Weighing the options
+
+| | Contract change | Handles **add** | Handles **remove** | Bettor impact | Prize pool + token | Ops cost | Ship |
+|---|---|---|---|---|---|---|---|
+| **O1** do nothing | none | ✗ | disclosure only | none | intact | none | shipped |
+| **O2** withdrawal flag | tiny (event + mapping) | ✗ | ✓ | none — can still exit | intact | 1 tx | days |
+| **O3** DRAFT `setTeams` | small, DRAFT-gated | pre-open only | pre-open only | none (no market yet) | intact | 1 tx | days |
+| **O4** Open Field ⭐ | **none** | ✓ (unnamed) | ✓ via price | none | intact | +1 outcome of seed | now |
+| **O5** supersede | registry upgrade + audit | ✓ (named) | ✓ | old market illiquid until settlement; 1/N **only** if a new-roster-only competitor wins | intact | full re-provision | ~1 quarter |
+| **O6** in-place reset | registry upgrade | ✓ | ✓ | **old condition unresolvable, redeem helper broken** | intact | full re-provision | — |
+| **O7** binary markets | architecture rewrite | ✓ | ✓ | liquidity fragmented | intact | new market per entrant | v2 |
+
+Reading across the rows: O4 dominates on every axis except one — the new competitor is
+anonymous until settlement. O5 is the only option that names a mid-flight entrant, and it pays
+for that with an audit and an illiquid legacy market. O6 is strictly worse than O5. O2 and O3
+are cheap enough that their cost barely registers.
+
+The two dimensions that actually separate them:
+
+**Can it be used on a prize that is already live?** Only O5, O6, O7. O4 must be decided at
+registration. This is why the sequencing below front-loads O4 for the Moon Base Zero races we
+have not seeded yet, and treats O5 as the escape hatch for the ones we have.
+
+**Does a bettor know what they are buying?** O4's field bettor does not, which caps how much
+of a race's probability mass should sit there. If Open Field's implied odds climb past roughly
+a third, the honest response is not to keep selling an opaque slot — it is to supersede into a
+roster that names the entrants. **O4 and O5 are complements, not alternatives**: O4 absorbs
+routine field growth, O5 handles the moment the field has genuinely reshaped.
+
+---
+
+## Recommendation
+
+### The cadence decision that reorders everything
+
+Races run as **generations over one accumulating Juicebox prize pool**. Sunsets stay in the
+18-24 month range and the race rolls into a new generation until it is won, rather than one
+prize with a 2035 deadline that nobody will lock capital against for nine years.
+
+That decision promotes O5 from escape hatch to **core infrastructure**. The Juicebox binding is
+write-once, so the only way to start a new generation while keeping the pool and the project
+token is `supersede`. The alternative — a fresh JB project per generation — splits the pool and
+orphans the previous generation's token holders, which is the opposite of accumulating.
+
+Two constraints follow directly from an accumulating pool:
+
+- **`supersede` is legal only from `OPEN` or `LOCKED`.** `DRAFT` uses `setTeams`; `SETTLED` and
+  later are excluded because the prize is already being paid and the race is over. The race
+  ends at `M2_COMPLETE`, not at a generation boundary.
+- **Sweep fees before superseding, in the same Safe batch.** `sweepFees` routes to the prize
+  pool only while the entry is non-terminal ([DePrizeFeeRouter.sol:123-155](../subscription-contracts/src/deprize/DePrizeFeeRouter.sol)),
+  so once `SUPERSEDED` is set the old market's residual fees would go to the treasury instead of
+  the pool they belong to.
+
+The bigger the pool grows across generations, the more expensive an accidental refundable state
+becomes — so the atomicity requirement and the cashOut hazard test matter more each cycle, not
+less.
+
+### Sequence
+
+**Now, no contract change.** Reserve an Open Field slot in every Moon Base Zero race we seed
+from here on (O4). Add the field-eligibility criteria and the settlement procedure to the terms
+before the first one opens. This handles entrants who show up *within* a generation, which is
+what stops every new name from forcing a supersede.
+
+**In parallel, one contract PR and one audit.** Bundle O5 (`supersede`), O2 (withdrawal flag)
+and O3 (DRAFT-only `setTeams`) into a single registry upgrade, plus an extend-only `setSunset`
+while `OPEN` so a deadline slip does not cost a full generation fork. Three new storage slots,
+`__gap` 45 to 42. Gate the work behind the Forge spike below.
+
+**Never.** O6. O7 belongs in a v2 architecture conversation, not this one.
+
+### Two related decisions
+
+**Open Field on every race whose eligibility is criteria-based.** The exemption is a race whose
+eligible set is fixed by an external gate we do not control. Beyond roster flexibility, the slot
+is a pricing fix: without it the named competitors must sum to 1, so their odds are
+systematically overstated — and B1 now feeds those odds into Moon Base Zero as `impliedOdds`.
+
+**No "None" outcome.** "Nobody qualified" already exists as `settleNoWinner` with the disclosed
+1/N equal payout. Making it a tradable slot would pay None-holders 1:1 while zeroing every team
+bettor, contradicting Terms section 6, and would settle the prize into `SETTLED` with no winner
+to pay. See the M4 discussion under O4.
+
+---
+
+## Work items
+
+### Phase 0 — Prove the constraints in CI (no production code)
+
+A Forge spike that pins today's behaviour so a future upgrade can't silently break it. This is
+the B2 plan's outstanding migration-spike item.
+
+`subscription-contracts/test/deprize/DePrizeRosterSpike.t.sol`:
+
+1. `testCannotReRegisterSameJBProject` — `JBProjectAlreadyBound`.
+2. `testSetConditionRevertsAfterOpen` — exists; assert the DRAFT gate is the only window.
+3. `testSetMarketRevertsWhenRosterLengthDiffers` — build a 4-slot condition + LMSR, try to
+   bind to a 3-team DePrize, expect `MarketSlotMismatch(4, 3)`.
+4. `testRedeemRevertsSlotCountMismatch` — currently **uncovered**. Force the divergence with
+   `vm.store` or a mock registry and assert `SlotCountMismatch`. This is the test that makes
+   the O6 failure mode visible in CI.
+5. `testCancelOpensCashOutOnBoundProject` — the migration hazard, asserted end-to-end through
+   `LaunchPadPayHook`.
+
+### Phase 1 — Open Field (O4), no contract change
+
+1. **Mint the reserved Team NFT.** One MoonDAOTeam token owned by the admin Safe, named
+   "Open Field", image = a neutral field glyph. Record the id in `docs/DEPRIZE_QA.md` next to
+   the other fixtures.
+2. **`ui/lib/deprize/competitions.ts`** — extend `DePrizeRaceOutcome` with `field?: true`.
+   A field outcome has no `projectId` in the atlas sense, so `mapOutcomeOddsToProjectIds`
+   must skip it rather than emit a bogus key: add the guard and a test in
+   `ui/cypress/integration/lib/deprize/goal-odds.cy.ts`.
+3. **UI rendering** — `DePrizeTeamLink` already takes `nameOverride` / `imageOverride` /
+   `hrefOverride` from B1, so the field slot renders as "Open Field — any qualifying entrant
+   not listed above" with a link to the eligibility criteria and no Team NFT read. Add an
+   explanatory tooltip on the bet row; this is the one outcome a bettor can misread.
+4. **Moon Base Zero bridge** — a field slot's odds are *not* a competitor's implied odds.
+   `useDePrizeGoalOdds` should return them separately (`fieldOdds`) so B2's `mergeLiveMarket`
+   can render "unlisted entrants: 12%" rather than attributing it to a project.
+5. **Terms** — new section in `ui/docs/DEPRIZE_TERMS_AND_CONDITIONS.md`: what the field slot
+   is, the objective eligibility criteria, that the Senate names the entity and the Safe
+   records the payout address atomically with settlement, and that MoonDAO's multisig is the
+   resolver for that slot.
+6. **Runbook** — `docs/DEPRIZE_M5.md`: the field-winner Safe batch is
+   `settleWinner(id, OPEN_FIELD)` + `setProviderPayoutAddress(id, winner)` in one batch, never
+   two.
+
+### Phase 2 — One registry upgrade: generations, withdrawal, DRAFT edits (O5 + O2 + O3)
+
+Single UUPS upgrade adding three storage slots (`_withdrawn`, `supersededBy`, `supersedes`),
+`__gap` 45 → 42. One audit covers all of it.
+
+**`supersede(oldId, newTeamIds, sunset)`** — new DRAFT id reusing `old.jbProjectId`, old entry
+to `SUPERSEDED`, `_deprizeIdByJBProject` rebound, lineage recorded, all in one transaction.
+Legal only from `OPEN` or `LOCKED`. `SUPERSEDED` is terminal but **not** refundable. Append the
+enum member (never insert — it is ABI) and mirror it in `ui/lib/deprize/lifecycle.ts`.
+
+**`setSunset` extend-only while `OPEN`** — closes the gap where [docs/DEPRIZE.md:886](DEPRIZE.md)
+promises a 6-month extension that `_requireDraft` makes impossible. Shortening stays forbidden
+so the deadline cannot be pulled in on bettors.
+
+Then the two smaller pieces:
+
+1. `mapping(uint256 => mapping(uint256 => bool)) private _withdrawn;`
+   `markWithdrawn(deprizeId, teamId)` / `unmarkWithdrawn` / `withdrawn(...)` view, `onlyOwner`,
+   valid in any non-terminal state, emitting `TeamWithdrawn` / `TeamReinstated`.
+   Explicitly **does not** gate `bet` — holders must be able to exit.
+2. `setTeams(deprizeId, teamIds)` behind `_requireDraft`, re-running every `register`
+   validation (`TooFewTeams`, `ZeroTeamId`, `DuplicateTeam`) and clearing the old `_isTeam`
+   entries before writing the new ones. The clear-then-write ordering is the whole bug surface
+   here; test it directly.
+3. Tests: upgrade-persistence (the existing UUPS test pattern in `DePrizeRegistry.t.sol`),
+   `setTeams` reverts after `open`, stale `_isTeam` cleared, `markWithdrawn` leaves
+   `bettingOpen` true.
+4. UI: withdrawn badge on the outcome row, and `competitions.ts` gains nothing — the flag is
+   read on-chain so it needs no redeploy to take effect.
+
+Tests for the upgrade:
+
+- **The hazard, directly:** at no point in the supersede transaction does
+  `LaunchPadPayHook.beforeCashOutRecordedWith` stop reverting for that project.
+- Supersede reverts from `DRAFT`, `SETTLED`, `M1_RELEASED` and every terminal state.
+- UUPS storage persistence across the upgrade.
+- `setTeams` reverts after open; stale `_isTeam` cleared.
+- `setSunset` cannot shorten, and cannot be called outside `DRAFT` / `OPEN`.
+- `DePrizeResolve` on the old condition, both branches: honest `[0,…,1,…,0]` when the winner
+  was on the old roster, 1/N only when the winner exists solely on the new one.
+
+Audit before mainnet. This is the first registry change that isn't purely additive at the end.
+
+### Phase 3 — Operate generations
+
+1. **Runbook** ([DEPRIZE_M5.md](DEPRIZE_M5.md)) — announce the supersede publicly, then execute
+   one ordered batch: `sweepFees(oldId)` first while the entry is still non-terminal, then
+   `supersede(...)`, then provision the new condition, LMSR, `setCondition`, `open` and
+   `setMarket` on both Mint and FeeRouter.
+
+   **Leave the old LMSR Running.** Sells go directly to the LMSR from
+   [ExitPositionModal](../ui/components/deprize/ExitPositionModal.tsx) while only
+   `DePrizeMint.bet` consults `bettingOpen`, so a `SUPERSEDED` generation becomes sell-only for
+   free: new bets blocked, exits working indefinitely through the existing UI, no contract
+   change. Pausing or closing would revert `trade` and strand holders until settlement — not an
+   acceptable price for recycling seed capital, which returns at settlement regardless.
+
+   Two consequences. Sell fees keep accruing on the legacy market and `sweepFees` routes to the
+   treasury once the entry is terminal, so while the race continues the runbook sweeps them to
+   the prize pool manually. And at final settlement the legacy LMSR must be paused or closed
+   before `reportPayouts`, because `DePrizeResolve` refuses to build a report against a Running
+   market.
+   **Blocker:** `DePrizeResolve.buildReport` reverts `WrongState` on anything outside
+   `SETTLED`/`M1_RELEASED`/`M2_COMPLETE`/`NO_WINNER`/`CANCELLED`, and a `SUPERSEDED` entry never
+   transitions again — so it needs a lineage branch that walks `supersededBy` to the settling
+   generation and maps that winner onto the old roster (named slot, else the old generation's
+   field slot, else 1/N). Without it every superseded condition is permanently unresolvable.
+2. **UI lineage** — `competitions.ts` gains `supersedes` / `supersededBy`; generations collapse
+   under one race heading via the `partitionDePrizeIndexByRace` seam from B1; the detail page
+   shows "Generation N" with a link back; withdrawn badge on outcome rows.
+3. **Terms** — the prize pool accumulates across generations and is paid to the winner on
+   success, so project tokens are only a *contingent* claim on it, realised through cashOut
+   solely in a refund terminal; outcome tokens are per-generation, but every generation resolves
+   to the same real-world winner and pays from its own collateral; a superseded market stays
+   open for selling while accepting no new bets, and its price may diverge from the live
+   generation.
+
+## Open questions
+
+1. **Does the field slot need a cap?** If Open Field trades above ~⅓ the market is telling us
+   the roster is wrong. Now that supersede is core, the natural answer is a policy trigger —
+   field odds over the threshold at any monthly review open a supersede proposal — rather than
+   a judgement call. Needs a number agreed before the first race opens.
+2. **One field slot or two?** Two would let a race distinguish "known-but-unconsented
+   entrants" from "genuinely unknown". Probably over-engineering; revisit if a race actually
+   has a large unconsented set.
+3. **Should `markWithdrawn` block new buys on that slot?** Argues both ways: blocking prevents
+   someone buying a dead outcome by mistake, but it also removes the counterparty that lets
+   existing holders exit. Current lean is not to block, and to make the UI loud instead.
+4. **Do old-generation project-token holders keep a full claim on a pool later generations
+   funded?** Only contingently. On success the pool is disbursed to the winner and cashOut never
+   opens, so the token pays nothing; in a refund terminal it is pro-rata over the whole JB
+   balance, including contributions from later generations. That rewards early participants,
+   which seems right, but someone should sanity check the dilution math before generation 2.

--- a/subscription-contracts/script/deprize/DePrizeResolve.s.sol
+++ b/subscription-contracts/script/deprize/DePrizeResolve.s.sol
@@ -175,12 +175,12 @@ contract DePrizeResolve is Script, Config {
         }
 
         // Refund terminal on the tip → every older generation also 1/N.
-        // M2_FAILED is refundable in the registry; tip CTF was already reported
-        // at SETTLED, but SUPERSEDED conditions still need an equal-payout report.
+        // M2_FAILED is not a "no winner" tip: failM2 only follows settleWinner,
+        // so winningTeamId remains set and tip CTF was already reported with a
+        // winner vector. Fall through and map that winner onto this roster.
         if (
             tipDp.state == IDePrizeRegistry.DePrizeState.NO_WINNER
                 || tipDp.state == IDePrizeRegistry.DePrizeState.CANCELLED
-                || tipDp.state == IDePrizeRegistry.DePrizeState.M2_FAILED
         ) {
             for (uint256 i = 0; i < payouts.length; i++) {
                 payouts[i] = 1;

--- a/subscription-contracts/script/deprize/DePrizeResolve.s.sol
+++ b/subscription-contracts/script/deprize/DePrizeResolve.s.sol
@@ -18,8 +18,11 @@ import "base/Config.sol";
 /// Checks (any failure aborts):
 ///   1. registry state admits a report (SETTLED/M1_RELEASED/M2_COMPLETE ->
 ///      winner vector; NO_WINNER/CANCELLED -> equal-payout vector;
-///      M2_FAILED -> refused, the CTF was already resolved at SETTLED);
-///   2. the winner is one of the DePrize's outcome slots;
+///      SUPERSEDED -> walk lineage to the settling generation and map the
+///      winner onto this generation's roster (named slot, else open-field
+///      slot, else 1/N); M2_FAILED -> refused, the CTF was already resolved
+///      at SETTLED);
+///   2. the winner is one of the DePrize's outcome slots (or field/1N path);
 ///   3. keccak256(oracle, questionId, N) matches the registry's conditionId
 ///      (catches a wrong questionId, wrong oracle, or wrong slot count);
 ///   4. the condition has not already been reported;
@@ -32,7 +35,12 @@ import "base/Config.sol";
 ///   DEPRIZE_REGISTRY=0x<registryProxy> DEPRIZE_ID=1 \
 ///   DEPRIZE_QUESTION_ID=0x... DEPRIZE_ORACLE=0x<safe> \
 ///   DEPRIZE_MARKET=0x<lmsrWithTWAP> \
+///   [DEPRIZE_WINNING_ENTITY=<teamId>] [DEPRIZE_OPEN_FIELD=<teamId>] \
 ///   forge script script/deprize/DePrizeResolve.s.sol --rpc-url $RPC
+///
+/// For SUPERSEDED generations, set DEPRIZE_WINNING_ENTITY to the real winning
+/// MoonDAOTeam id (not the field sentinel) and DEPRIZE_OPEN_FIELD to this
+/// generation's Open Field team id so a field-only winner maps correctly.
 contract DePrizeResolve is Script, Config {
     error WrongState(uint256 deprizeId, IDePrizeRegistry.DePrizeState state);
     error M2FailedCtfAlreadyFinal(uint256 deprizeId);
@@ -41,6 +49,8 @@ contract DePrizeResolve is Script, Config {
     error AlreadyReported(bytes32 conditionId, uint256 payoutDenominator);
     error MarketStillRunning(address market);
     error MarketConditionMismatch(bytes32 marketCondition, bytes32 expected);
+    error LineageUnresolved(uint256 deprizeId);
+    error SettlingGenerationUnresolved(uint256 tipDeprizeId, IDePrizeRegistry.DePrizeState state);
 
     /// @notice Abort if `market` is still tradable or settles a different
     ///         condition than the one about to be resolved.
@@ -53,12 +63,21 @@ contract DePrizeResolve is Script, Config {
 
     /// @notice Pure pre-flight: validates registry/CTF consistency and returns the
     ///         payout vector + `reportPayouts` calldata the oracle Safe must submit.
+    /// @param winningEntityTeamId Real winning MoonDAOTeam id. For non-SUPERSEDED
+    ///        states pass 0 to use `dp.winningTeamId`. For SUPERSEDED, pass the
+    ///        entity that actually won (required when the settling generation
+    ///        recorded a field-sentinel `winningTeamId`).
+    /// @param openFieldTeamId This generation's Open Field team id (0 if none).
+    ///        Used only on the SUPERSEDED path when the winning entity is not
+    ///        on this generation's roster.
     function buildReport(
         IDePrizeRegistry registry,
         IConditionalTokens ctf,
         uint256 deprizeId,
         bytes32 questionId,
-        address oracle
+        address oracle,
+        uint256 winningEntityTeamId,
+        uint256 openFieldTeamId
     ) public view returns (bytes32 conditionId, uint256[] memory payouts, bytes memory callData) {
         IDePrizeRegistry.DePrize memory dp = registry.getDePrize(deprizeId);
         uint256 n = dp.teamIds.length;
@@ -92,6 +111,8 @@ contract DePrizeResolve is Script, Config {
             for (uint256 i = 0; i < n; i++) {
                 payouts[i] = 1;
             }
+        } else if (dp.state == IDePrizeRegistry.DePrizeState.SUPERSEDED) {
+            _fillSupersededPayouts(registry, deprizeId, dp, payouts, winningEntityTeamId, openFieldTeamId);
         } else {
             revert WrongState(deprizeId, dp.state);
         }
@@ -107,6 +128,89 @@ contract DePrizeResolve is Script, Config {
         callData = abi.encodeCall(IConditionalTokens.reportPayouts, (questionId, payouts));
     }
 
+    /// @notice Backward-compatible overload — equivalent to
+    ///         `buildReport(..., winningEntityTeamId=0, openFieldTeamId=0)`.
+    function buildReport(
+        IDePrizeRegistry registry,
+        IConditionalTokens ctf,
+        uint256 deprizeId,
+        bytes32 questionId,
+        address oracle
+    ) public view returns (bytes32 conditionId, uint256[] memory payouts, bytes memory callData) {
+        return buildReport(registry, ctf, deprizeId, questionId, oracle, 0, 0);
+    }
+
+    /// @dev Walk `supersededBy` to the settling generation, resolve the winning
+    ///      entity, then map onto this generation's roster:
+    ///        1. named slot if the entity is on the roster;
+    ///        2. else open-field slot if `openFieldTeamId` is on the roster;
+    ///        3. else 1/N (fieldless legacy generation).
+    function _fillSupersededPayouts(
+        IDePrizeRegistry registry,
+        uint256 deprizeId,
+        IDePrizeRegistry.DePrize memory dp,
+        uint256[] memory payouts,
+        uint256 winningEntityTeamId,
+        uint256 openFieldTeamId
+    ) private view {
+        uint256 tip = deprizeId;
+        // Bound the walk so a corrupt lineage cannot OOG.
+        for (uint256 i = 0; i < 64; i++) {
+            uint256 next = registry.supersededBy(tip);
+            if (next == 0) break;
+            tip = next;
+        }
+        if (tip == deprizeId) revert LineageUnresolved(deprizeId);
+
+        IDePrizeRegistry.DePrize memory tipDp = registry.getDePrize(tip);
+        if (
+            tipDp.state != IDePrizeRegistry.DePrizeState.SETTLED
+                && tipDp.state != IDePrizeRegistry.DePrizeState.M1_RELEASED
+                && tipDp.state != IDePrizeRegistry.DePrizeState.M2_COMPLETE
+                && tipDp.state != IDePrizeRegistry.DePrizeState.NO_WINNER
+                && tipDp.state != IDePrizeRegistry.DePrizeState.CANCELLED
+        ) {
+            revert SettlingGenerationUnresolved(tip, tipDp.state);
+        }
+
+        // Refund terminal on the tip → every older generation also 1/N.
+        if (
+            tipDp.state == IDePrizeRegistry.DePrizeState.NO_WINNER
+                || tipDp.state == IDePrizeRegistry.DePrizeState.CANCELLED
+        ) {
+            for (uint256 i = 0; i < payouts.length; i++) {
+                payouts[i] = 1;
+            }
+            return;
+        }
+
+        // Prefer an explicit entity (runbook records the real winner when the
+        // tip settled via a field sentinel); fall back to the tip's recorded id.
+        uint256 entity = winningEntityTeamId != 0 ? winningEntityTeamId : tipDp.winningTeamId;
+
+        uint256 n = dp.teamIds.length;
+        for (uint256 i = 0; i < n; i++) {
+            if (dp.teamIds[i] == entity) {
+                payouts[i] = 1;
+                return;
+            }
+        }
+
+        if (openFieldTeamId != 0) {
+            for (uint256 i = 0; i < n; i++) {
+                if (dp.teamIds[i] == openFieldTeamId) {
+                    payouts[i] = 1;
+                    return;
+                }
+            }
+        }
+
+        // Fieldless legacy generation — equal payout is the only honest answer.
+        for (uint256 i = 0; i < n; i++) {
+            payouts[i] = 1;
+        }
+    }
+
     function run() external {
         IDePrizeRegistry registry = IDePrizeRegistry(vm.envAddress("DEPRIZE_REGISTRY"));
         IConditionalTokens ctf =
@@ -114,9 +218,11 @@ contract DePrizeResolve is Script, Config {
         uint256 deprizeId = vm.envUint("DEPRIZE_ID");
         bytes32 questionId = vm.envBytes32("DEPRIZE_QUESTION_ID");
         address oracle = vm.envAddress("DEPRIZE_ORACLE");
+        uint256 winningEntity = vm.envOr("DEPRIZE_WINNING_ENTITY", uint256(0));
+        uint256 openField = vm.envOr("DEPRIZE_OPEN_FIELD", uint256(0));
 
         (bytes32 conditionId, uint256[] memory payouts, bytes memory callData) =
-            buildReport(registry, ctf, deprizeId, questionId, oracle);
+            buildReport(registry, ctf, deprizeId, questionId, oracle, winningEntity, openField);
 
         address market = vm.envOr("DEPRIZE_MARKET", address(0));
         if (market != address(0)) {

--- a/subscription-contracts/script/deprize/DePrizeResolve.s.sol
+++ b/subscription-contracts/script/deprize/DePrizeResolve.s.sol
@@ -169,14 +169,18 @@ contract DePrizeResolve is Script, Config {
                 && tipDp.state != IDePrizeRegistry.DePrizeState.M2_COMPLETE
                 && tipDp.state != IDePrizeRegistry.DePrizeState.NO_WINNER
                 && tipDp.state != IDePrizeRegistry.DePrizeState.CANCELLED
+                && tipDp.state != IDePrizeRegistry.DePrizeState.M2_FAILED
         ) {
             revert SettlingGenerationUnresolved(tip, tipDp.state);
         }
 
         // Refund terminal on the tip → every older generation also 1/N.
+        // M2_FAILED is refundable in the registry; tip CTF was already reported
+        // at SETTLED, but SUPERSEDED conditions still need an equal-payout report.
         if (
             tipDp.state == IDePrizeRegistry.DePrizeState.NO_WINNER
                 || tipDp.state == IDePrizeRegistry.DePrizeState.CANCELLED
+                || tipDp.state == IDePrizeRegistry.DePrizeState.M2_FAILED
         ) {
             for (uint256 i = 0; i < payouts.length; i++) {
                 payouts[i] = 1;

--- a/subscription-contracts/src/deprize/DePrizeRegistry.sol
+++ b/subscription-contracts/src/deprize/DePrizeRegistry.sol
@@ -50,8 +50,17 @@ contract DePrizeRegistry is Initializable, OwnableUpgradeable, UUPSUpgradeable, 
     ///      upgrade only consumes one previously-reserved gap slot.
     mapping(uint256 => address) private _providerPayoutAddress;
 
-    /// @dev Storage gap for future upgrades (50 slots - 5 used = 45).
-    uint256[45] private __gap;
+    /// @dev Disclosure flag: competitor marked withdrawn. Does NOT gate betting —
+    ///      holders must still be able to exit. Consumes one gap slot.
+    mapping(uint256 => mapping(uint256 => bool)) private _withdrawn;
+
+    /// @dev Generation lineage. `supersededBy[old] = new` and `supersedes[new] = old`.
+    ///      Two gap slots. Walk `supersededBy` forward to find the live generation.
+    mapping(uint256 => uint256) private _supersededBy;
+    mapping(uint256 => uint256) private _supersedes;
+
+    /// @dev Storage gap for future upgrades (50 slots - 8 used = 42).
+    uint256[42] private __gap;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -113,10 +122,114 @@ contract DePrizeRegistry is Initializable, OwnableUpgradeable, UUPSUpgradeable, 
 
     /// @inheritdoc IDePrizeRegistry
     function setSunset(uint256 deprizeId, uint256 sunset) external override onlyOwner {
-        DePrize storage d = _requireDraft(deprizeId);
+        DePrize storage d = _get(deprizeId);
         if (sunset <= block.timestamp) revert InvalidSunset();
+        if (d.state == DePrizeState.DRAFT) {
+            // Any future sunset is fine in DRAFT.
+        } else if (d.state == DePrizeState.OPEN) {
+            // Extend-only: cannot pull the deadline in on bettors.
+            if (sunset <= d.sunset) revert SunsetNotExtended(d.sunset, sunset);
+        } else {
+            revert InvalidState(deprizeId, d.state);
+        }
         d.sunset = sunset;
         emit SunsetUpdated(deprizeId, sunset);
+    }
+
+    /// @inheritdoc IDePrizeRegistry
+    function setTeams(uint256 deprizeId, uint256[] calldata teamIds_) external override onlyOwner {
+        DePrize storage d = _requireDraft(deprizeId);
+        if (teamIds_.length < 2) revert TooFewTeams(teamIds_.length);
+
+        // Clear-then-write: stale _isTeam entries would otherwise survive and
+        // let settleWinner accept a team that is no longer on the roster.
+        uint256 oldLen = d.teamIds.length;
+        for (uint256 i = 0; i < oldLen; i++) {
+            _isTeam[deprizeId][d.teamIds[i]] = false;
+            // A withdrawn mark on a removed team is meaningless; clear it too.
+            _withdrawn[deprizeId][d.teamIds[i]] = false;
+        }
+        delete d.teamIds;
+
+        for (uint256 i = 0; i < teamIds_.length; i++) {
+            uint256 teamId = teamIds_[i];
+            if (teamId == 0) revert ZeroTeamId();
+            if (_isTeam[deprizeId][teamId]) revert DuplicateTeam(teamId);
+            _isTeam[deprizeId][teamId] = true;
+            d.teamIds.push(teamId);
+        }
+
+        emit TeamsUpdated(deprizeId, teamIds_);
+    }
+
+    /// @inheritdoc IDePrizeRegistry
+    function supersede(uint256 oldDeprizeId, uint256[] calldata newTeamIds, uint256 sunset)
+        external
+        override
+        onlyOwner
+        returns (uint256 newDeprizeId)
+    {
+        DePrize storage old = _get(oldDeprizeId);
+        if (old.state != DePrizeState.OPEN && old.state != DePrizeState.LOCKED) {
+            revert InvalidState(oldDeprizeId, old.state);
+        }
+        if (newTeamIds.length < 2) revert TooFewTeams(newTeamIds.length);
+        if (sunset <= block.timestamp) revert InvalidSunset();
+
+        // Abort any pending cancellation so the notice doesn't linger on a
+        // SUPERSEDED entry (betting is already closed by the terminal state).
+        if (old.cancellationNoticeAt != 0) {
+            old.cancellationNoticeAt = 0;
+            emit CancellationAborted(oldDeprizeId);
+        }
+
+        uint256 jbProjectId = old.jbProjectId;
+
+        // Create the new generation in DRAFT, reusing the Juicebox project.
+        newDeprizeId = _nextId++;
+        DePrize storage neu = _deprizes[newDeprizeId];
+        neu.jbProjectId = jbProjectId;
+        neu.sunset = sunset;
+        neu.state = DePrizeState.DRAFT;
+
+        for (uint256 i = 0; i < newTeamIds.length; i++) {
+            uint256 teamId = newTeamIds[i];
+            if (teamId == 0) revert ZeroTeamId();
+            if (_isTeam[newDeprizeId][teamId]) revert DuplicateTeam(teamId);
+            _isTeam[newDeprizeId][teamId] = true;
+            neu.teamIds.push(teamId);
+        }
+
+        // Lineage + rebind. Order matters for the cashOut hazard: the old entry
+        // must be SUPERSEDED (terminal, not refundable) BEFORE the JB mapping
+        // points at the new DRAFT, so the pay hook never sees a refundable
+        // DePrize on a funded project.
+        _supersededBy[oldDeprizeId] = newDeprizeId;
+        _supersedes[newDeprizeId] = oldDeprizeId;
+        _setState(oldDeprizeId, old, DePrizeState.SUPERSEDED);
+        _deprizeIdByJBProject[jbProjectId] = newDeprizeId;
+
+        emit DePrizeRegistered(newDeprizeId, jbProjectId, newTeamIds, sunset);
+        emit StateChanged(newDeprizeId, DePrizeState.NONE, DePrizeState.DRAFT);
+        emit DePrizeSuperseded(oldDeprizeId, newDeprizeId, newTeamIds);
+    }
+
+    /// @inheritdoc IDePrizeRegistry
+    function markWithdrawn(uint256 deprizeId, uint256 teamId) external override onlyOwner {
+        DePrize storage d = _get(deprizeId);
+        if (_isTerminalState(d.state)) revert InvalidState(deprizeId, d.state);
+        if (!_isTeam[deprizeId][teamId]) revert TeamNotOnRoster(deprizeId, teamId);
+        _withdrawn[deprizeId][teamId] = true;
+        emit TeamWithdrawn(deprizeId, teamId);
+    }
+
+    /// @inheritdoc IDePrizeRegistry
+    function unmarkWithdrawn(uint256 deprizeId, uint256 teamId) external override onlyOwner {
+        DePrize storage d = _get(deprizeId);
+        if (_isTerminalState(d.state)) revert InvalidState(deprizeId, d.state);
+        if (!_isTeam[deprizeId][teamId]) revert TeamNotOnRoster(deprizeId, teamId);
+        _withdrawn[deprizeId][teamId] = false;
+        emit TeamReinstated(deprizeId, teamId);
     }
 
     // ---------------------------------------------------------------------
@@ -324,6 +437,21 @@ contract DePrizeRegistry is Initializable, OwnableUpgradeable, UUPSUpgradeable, 
         return _nextId - 1;
     }
 
+    /// @inheritdoc IDePrizeRegistry
+    function withdrawn(uint256 deprizeId, uint256 teamId) external view override returns (bool) {
+        return _withdrawn[deprizeId][teamId];
+    }
+
+    /// @inheritdoc IDePrizeRegistry
+    function supersededBy(uint256 deprizeId) external view override returns (uint256) {
+        return _supersededBy[deprizeId];
+    }
+
+    /// @inheritdoc IDePrizeRegistry
+    function supersedes(uint256 deprizeId) external view override returns (uint256) {
+        return _supersedes[deprizeId];
+    }
+
     // ---------------------------------------------------------------------
     // Internal helpers
     // ---------------------------------------------------------------------
@@ -349,7 +477,9 @@ contract DePrizeRegistry is Initializable, OwnableUpgradeable, UUPSUpgradeable, 
     }
 
     function _isTerminalState(DePrizeState s) private pure returns (bool) {
+        // SUPERSEDED is terminal (stops bets / fee routing to prize pool) but
+        // deliberately NOT refundable — see isRefundable.
         return s == DePrizeState.M2_COMPLETE || s == DePrizeState.M2_FAILED || s == DePrizeState.CANCELLED
-            || s == DePrizeState.NO_WINNER;
+            || s == DePrizeState.NO_WINNER || s == DePrizeState.SUPERSEDED;
     }
 }

--- a/subscription-contracts/src/deprize/IDePrizeRegistry.sol
+++ b/subscription-contracts/src/deprize/IDePrizeRegistry.sol
@@ -22,7 +22,8 @@ interface IDePrizeRegistry {
         M2_COMPLETE, //   7: flight delivered, 70% released — success terminal
         M2_FAILED, //     8: post-M1 delivery failed — refund terminal
         CANCELLED, //     9: admin-cancelled after notice — refund terminal
-        NO_WINNER //     10: no eligible winner / vote failed — refund terminal
+        NO_WINNER, //    10: no eligible winner / vote failed — refund terminal
+        SUPERSEDED //    11: generation forked; terminal but NOT refundable
     }
 
     /// @notice Immutable-ish configuration + mutable lifecycle data for a DePrize.
@@ -48,6 +49,12 @@ interface IDePrizeRegistry {
     event CancellationAnnounced(uint256 indexed deprizeId, uint256 noticeAt, uint256 executableAt);
     event CancellationAborted(uint256 indexed deprizeId);
     event ProviderPayoutAddressSet(uint256 indexed deprizeId, address indexed provider);
+    /// @dev A DRAFT roster edit, NOT a new registration — indexers must not
+    ///      treat this as creating a DePrize.
+    event TeamsUpdated(uint256 indexed deprizeId, uint256[] teamIds);
+    event TeamWithdrawn(uint256 indexed deprizeId, uint256 indexed teamId);
+    event TeamReinstated(uint256 indexed deprizeId, uint256 indexed teamId);
+    event DePrizeSuperseded(uint256 indexed oldDeprizeId, uint256 indexed newDeprizeId, uint256[] newTeamIds);
 
     // ---------------------------------------------------------------------
     // Errors
@@ -69,6 +76,10 @@ interface IDePrizeRegistry {
     error CancellationNoticeNotElapsed(uint256 deprizeId, uint256 executableAt);
     /// @dev The provider payout address must be non-zero (M5 prize disbursement target).
     error ZeroProviderAddress();
+    /// @dev setSunset while OPEN may only push the deadline later, never earlier.
+    error SunsetNotExtended(uint256 current, uint256 proposed);
+    /// @dev markWithdrawn / unmarkWithdrawn on a team that is not on the roster.
+    error TeamNotOnRoster(uint256 deprizeId, uint256 teamId);
 
     // ---------------------------------------------------------------------
     // Admin: registration & configuration
@@ -86,8 +97,33 @@ interface IDePrizeRegistry {
     /// @notice Set the Gnosis ConditionalTokens condition id. Required before opening.
     function setCondition(uint256 deprizeId, bytes32 ctfConditionId) external;
 
-    /// @notice Update the sunset timestamp while still in DRAFT.
+    /// @notice Update the sunset timestamp. Allowed in DRAFT (any future value) and
+    ///         in OPEN (extend-only — the new sunset must be strictly later than the
+    ///         current one). Shortening while OPEN is forbidden so the deadline cannot
+    ///         be pulled in on bettors.
     function setSunset(uint256 deprizeId, uint256 sunset) external;
+
+    /// @notice Replace the roster while still in DRAFT. Clears and rewrites `_isTeam`.
+    ///         Re-runs every `register` validation (`TooFewTeams`, `ZeroTeamId`,
+    ///         `DuplicateTeam`). Fixes an unrecoverable typo without costing the
+    ///         Juicebox project binding.
+    function setTeams(uint256 deprizeId, uint256[] calldata teamIds) external;
+
+    /// @notice Fork this DePrize onto a new roster while keeping the Juicebox project
+    ///         (and therefore the prize pool + project token) intact. Allowed only from
+    ///         OPEN or LOCKED. Creates a new DRAFT entry, moves this entry to SUPERSEDED
+    ///         (terminal but NOT refundable — cashOut must never open), and rebinds
+    ///         `deprizeIdByJBProject` atomically.
+    function supersede(uint256 oldDeprizeId, uint256[] calldata newTeamIds, uint256 sunset)
+        external
+        returns (uint256 newDeprizeId);
+
+    /// @notice Mark a competitor withdrawn. Disclosure only — does NOT gate `bet`, so
+    ///         holders of that outcome can still exit. Valid in any non-terminal state.
+    function markWithdrawn(uint256 deprizeId, uint256 teamId) external;
+
+    /// @notice Clear a withdrawn mark.
+    function unmarkWithdrawn(uint256 deprizeId, uint256 teamId) external;
 
     // ---------------------------------------------------------------------
     // Admin: lifecycle transitions
@@ -172,4 +208,13 @@ interface IDePrizeRegistry {
 
     /// @notice Total number of registered DePrizes.
     function count() external view returns (uint256);
+
+    /// @notice Whether a competitor has been marked withdrawn (disclosure flag).
+    function withdrawn(uint256 deprizeId, uint256 teamId) external view returns (bool);
+
+    /// @notice The generation that superseded this DePrize (0 if none).
+    function supersededBy(uint256 deprizeId) external view returns (uint256);
+
+    /// @notice The generation this DePrize superseded (0 if this is generation 1).
+    function supersedes(uint256 deprizeId) external view returns (uint256);
 }

--- a/subscription-contracts/test/deprize/DePrizeGenerations.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeGenerations.t.sol
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {DePrizeRegistry} from "../../src/deprize/DePrizeRegistry.sol";
+import {IDePrizeRegistry} from "../../src/deprize/IDePrizeRegistry.sol";
+import {IConditionalTokens} from "../../src/deprize/interfaces/IConditionalTokens.sol";
+import {DePrizeResolve} from "../../script/deprize/DePrizeResolve.s.sol";
+import {MockResolvingCTF} from "./DePrizeRedeem.t.sol";
+import {MockWETH} from "./DePrizeMint.t.sol";
+import {LaunchPadPayHook} from "../../src/LaunchPadPayHook.sol";
+
+import {JBConstants} from "@nana-core-v5/libraries/JBConstants.sol";
+import {JBTokenAmount} from "@nana-core-v5/structs/JBTokenAmount.sol";
+import {JBRuleset} from "@nana-core-v5/structs/JBRuleset.sol";
+import {JBBeforeCashOutRecordedContext} from "@nana-core-v5/structs/JBBeforeCashOutRecordedContext.sol";
+
+contract GenTerminalStore {
+    uint256 public balance;
+    uint256 public withdrawn;
+
+    function setFunding(uint256 _balance, uint256 _withdrawn) external {
+        balance = _balance;
+        withdrawn = _withdrawn;
+    }
+
+    function balanceOf(address, uint256, address) external view returns (uint256) {
+        return balance;
+    }
+
+    function usedPayoutLimitOf(address, uint256, address, uint256, uint256) external view returns (uint256) {
+        return withdrawn;
+    }
+}
+
+contract GenRulesets {
+    uint112 public weight = uint112(1e18);
+
+    function getRulesetOf(uint256, uint256) external view returns (JBRuleset memory r) {
+        r.weight = weight;
+    }
+}
+
+/// @dev Trivial UUPS upgrade target to exercise storage persistence across the
+///      generations upgrade (__gap 45 → 42).
+contract DePrizeRegistryGenerationsV2 is DePrizeRegistry {
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+/// @notice Phase 2 generations / withdrawal / setTeams / setSunset / resolve lineage.
+contract DePrizeGenerationsTest is Test {
+    DePrizeRegistry registry;
+    DePrizeResolve resolveScript;
+    MockResolvingCTF ctf;
+    MockWETH weth;
+
+    address owner = address(0xA11CE);
+    address oracle;
+
+    uint256 constant JB_PROJECT = 256;
+    uint256 constant OPEN_FIELD = 999;
+    bytes32 constant CONDITION = keccak256("condition");
+    bytes32 constant Q1 = keccak256("q1");
+    bytes32 constant Q2 = keccak256("q2");
+
+    function setUp() public {
+        DePrizeRegistry impl = new DePrizeRegistry();
+        bytes memory initData = abi.encodeCall(DePrizeRegistry.initialize, (owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        registry = DePrizeRegistry(address(proxy));
+
+        weth = new MockWETH();
+        ctf = new MockResolvingCTF(address(weth));
+        resolveScript = new DePrizeResolve();
+        oracle = address(this);
+    }
+
+    function _teams3() internal pure returns (uint256[] memory t) {
+        t = new uint256[](3);
+        t[0] = 301;
+        t[1] = 302;
+        t[2] = 303;
+    }
+
+    function _teamsWithField() internal pure returns (uint256[] memory t) {
+        t = new uint256[](4);
+        t[0] = 301;
+        t[1] = 302;
+        t[2] = 303;
+        t[3] = OPEN_FIELD;
+    }
+
+    function _teamsGen2() internal pure returns (uint256[] memory t) {
+        t = new uint256[](5);
+        t[0] = 301;
+        t[1] = 302;
+        t[2] = 303;
+        t[3] = 401; // Blue Origin
+        t[4] = OPEN_FIELD;
+    }
+
+    function _registerOpen(uint256[] memory teams) internal returns (uint256 id) {
+        vm.startPrank(owner);
+        id = registry.register(JB_PROJECT, teams, block.timestamp + 30 days);
+        registry.setCondition(id, CONDITION);
+        registry.open(id);
+        vm.stopPrank();
+    }
+
+    // ---------------------------------------------------------------------
+    // supersede
+    // ---------------------------------------------------------------------
+
+    function testSupersedeFromOpen() public {
+        uint256 oldId = _registerOpen(_teamsWithField());
+        uint256 newSunset = block.timestamp + 60 days;
+
+        vm.prank(owner);
+        uint256 newId = registry.supersede(oldId, _teamsGen2(), newSunset);
+
+        assertEq(uint256(registry.state(oldId)), uint256(IDePrizeRegistry.DePrizeState.SUPERSEDED));
+        assertEq(uint256(registry.state(newId)), uint256(IDePrizeRegistry.DePrizeState.DRAFT));
+        assertEq(registry.deprizeIdByJBProject(JB_PROJECT), newId);
+        assertEq(registry.supersededBy(oldId), newId);
+        assertEq(registry.supersedes(newId), oldId);
+        assertEq(registry.getDePrize(newId).jbProjectId, JB_PROJECT);
+        assertEq(registry.getDePrize(newId).sunset, newSunset);
+        assertEq(registry.teamIds(newId).length, 5);
+        assertTrue(registry.isTerminal(oldId));
+        assertFalse(registry.isRefundable(oldId));
+        assertFalse(registry.bettingOpen(oldId));
+    }
+
+    function testSupersedeFromLocked() public {
+        uint256 oldId = _registerOpen(_teamsWithField());
+        vm.prank(owner);
+        registry.lock(oldId);
+
+        vm.prank(owner);
+        uint256 newId = registry.supersede(oldId, _teamsGen2(), block.timestamp + 60 days);
+        assertEq(uint256(registry.state(oldId)), uint256(IDePrizeRegistry.DePrizeState.SUPERSEDED));
+        assertEq(registry.deprizeIdByJBProject(JB_PROJECT), newId);
+    }
+
+    function testSupersedeRevertsFromDraft() public {
+        vm.prank(owner);
+        uint256 id = registry.register(JB_PROJECT, _teams3(), block.timestamp + 30 days);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IDePrizeRegistry.InvalidState.selector, id, IDePrizeRegistry.DePrizeState.DRAFT)
+        );
+        registry.supersede(id, _teamsGen2(), block.timestamp + 60 days);
+    }
+
+    function testSupersedeRevertsFromSettled() public {
+        uint256 id = _registerOpen(_teams3());
+        vm.startPrank(owner);
+        registry.lock(id);
+        registry.settleWinner(id, 301);
+        vm.expectRevert(
+            abi.encodeWithSelector(IDePrizeRegistry.InvalidState.selector, id, IDePrizeRegistry.DePrizeState.SETTLED)
+        );
+        registry.supersede(id, _teamsGen2(), block.timestamp + 60 days);
+        vm.stopPrank();
+    }
+
+    function testSupersedeDoesNotOpenCashOut() public {
+        GenTerminalStore store = new GenTerminalStore();
+        GenRulesets rulesets = new GenRulesets();
+        LaunchPadPayHook hook =
+            new LaunchPadPayHook(10 ether, block.timestamp + 28 days, 14 days, address(store), address(rulesets), owner);
+
+        uint256 oldId = _registerOpen(_teamsWithField());
+        vm.prank(owner);
+        hook.setDePrizeRegistry(address(registry));
+
+        // Pre: cashOut blocked.
+        vm.expectRevert("DePrize is active. Refunds are disabled.");
+        hook.beforeCashOutRecordedWith(_cashOutCtx(JB_PROJECT));
+
+        vm.prank(owner);
+        uint256 newId = registry.supersede(oldId, _teamsGen2(), block.timestamp + 60 days);
+
+        // Post: still blocked — SUPERSEDED is not refundable, and the JB mapping
+        // now points at a DRAFT which is also not refundable.
+        assertEq(registry.deprizeIdByJBProject(JB_PROJECT), newId);
+        vm.expectRevert("DePrize is active. Refunds are disabled.");
+        hook.beforeCashOutRecordedWith(_cashOutCtx(JB_PROJECT));
+        assertEq(hook.stage(address(this), JB_PROJECT), 1);
+    }
+
+    // ---------------------------------------------------------------------
+    // setTeams
+    // ---------------------------------------------------------------------
+
+    function testSetTeamsRewritesRosterAndClearsStale() public {
+        vm.prank(owner);
+        uint256 id = registry.register(JB_PROJECT, _teams3(), block.timestamp + 30 days);
+
+        uint256[] memory neu = new uint256[](2);
+        neu[0] = 401;
+        neu[1] = 402;
+
+        vm.prank(owner);
+        registry.setTeams(id, neu);
+
+        assertEq(registry.teamIds(id).length, 2);
+        assertTrue(registry.isTeam(id, 401));
+        assertTrue(registry.isTeam(id, 402));
+        assertFalse(registry.isTeam(id, 301));
+        assertFalse(registry.isTeam(id, 302));
+        assertFalse(registry.isTeam(id, 303));
+    }
+
+    /// @dev A roster edit must not look like a registration to an indexer.
+    function testSetTeamsEmitsTeamsUpdatedNotRegistered() public {
+        vm.prank(owner);
+        uint256 id = registry.register(JB_PROJECT, _teams3(), block.timestamp + 30 days);
+
+        uint256[] memory neu = new uint256[](2);
+        neu[0] = 401;
+        neu[1] = 402;
+
+        vm.recordLogs();
+        vm.prank(owner);
+        registry.setTeams(id, neu);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 registered = keccak256("DePrizeRegistered(uint256,uint256,uint256[],uint256)");
+        bytes32 updated = keccak256("TeamsUpdated(uint256,uint256[])");
+        bool sawUpdated;
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != registered, "setTeams must not emit DePrizeRegistered");
+            if (logs[i].topics[0] == updated) sawUpdated = true;
+        }
+        assertTrue(sawUpdated, "setTeams must emit TeamsUpdated");
+    }
+
+    function testSetTeamsRevertsAfterOpen() public {
+        uint256 id = _registerOpen(_teams3());
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IDePrizeRegistry.InvalidState.selector, id, IDePrizeRegistry.DePrizeState.OPEN)
+        );
+        registry.setTeams(id, _teamsWithField());
+    }
+
+    // ---------------------------------------------------------------------
+    // markWithdrawn
+    // ---------------------------------------------------------------------
+
+    function testMarkWithdrawnDoesNotGateBetting() public {
+        uint256 id = _registerOpen(_teams3());
+        vm.prank(owner);
+        registry.markWithdrawn(id, 302);
+
+        assertTrue(registry.withdrawn(id, 302));
+        assertTrue(registry.bettingOpen(id));
+        assertTrue(registry.isTeam(id, 302));
+    }
+
+    function testMarkWithdrawnRevertsUnknownTeam() public {
+        uint256 id = _registerOpen(_teams3());
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IDePrizeRegistry.TeamNotOnRoster.selector, id, 9999));
+        registry.markWithdrawn(id, 9999);
+    }
+
+    // ---------------------------------------------------------------------
+    // setSunset extend-only while OPEN
+    // ---------------------------------------------------------------------
+
+    function testSetSunsetExtendWhileOpen() public {
+        uint256 id = _registerOpen(_teams3());
+        uint256 current = registry.getDePrize(id).sunset;
+        vm.prank(owner);
+        registry.setSunset(id, current + 7 days);
+        assertEq(registry.getDePrize(id).sunset, current + 7 days);
+    }
+
+    function testSetSunsetCannotShortenWhileOpen() public {
+        uint256 id = _registerOpen(_teams3());
+        uint256 current = registry.getDePrize(id).sunset;
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IDePrizeRegistry.SunsetNotExtended.selector, current, current - 1 days));
+        registry.setSunset(id, current - 1 days);
+    }
+
+    function testSetSunsetRevertsWhenLocked() public {
+        uint256 id = _registerOpen(_teams3());
+        vm.prank(owner);
+        registry.lock(id);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IDePrizeRegistry.InvalidState.selector, id, IDePrizeRegistry.DePrizeState.LOCKED)
+        );
+        registry.setSunset(id, block.timestamp + 90 days);
+    }
+
+    // ---------------------------------------------------------------------
+    // UUPS persistence
+    // ---------------------------------------------------------------------
+
+    function testUpgradePersistsLineageAndGap() public {
+        uint256 oldId = _registerOpen(_teamsWithField());
+        vm.prank(owner);
+        uint256 newId = registry.supersede(oldId, _teamsGen2(), block.timestamp + 60 days);
+        vm.prank(owner);
+        registry.markWithdrawn(newId, 401);
+
+        DePrizeRegistryGenerationsV2 v2 = new DePrizeRegistryGenerationsV2();
+        vm.prank(owner);
+        registry.upgradeToAndCall(address(v2), "");
+
+        assertEq(DePrizeRegistryGenerationsV2(address(registry)).version(), 2);
+        assertEq(registry.supersededBy(oldId), newId);
+        assertEq(registry.supersedes(newId), oldId);
+        assertEq(registry.deprizeIdByJBProject(JB_PROJECT), newId);
+        assertTrue(registry.withdrawn(newId, 401));
+        assertEq(uint256(registry.state(oldId)), uint256(IDePrizeRegistry.DePrizeState.SUPERSEDED));
+    }
+
+    // ---------------------------------------------------------------------
+    // DePrizeResolve SUPERSEDED lineage
+    // ---------------------------------------------------------------------
+
+    function testBuildReportSupersededNamedWinner() public {
+        // Gen1: 301/302/303/FIELD on C1. Supersede → Gen2. Settle Gen2 to 301.
+        bytes32 c1 = ctf.getConditionId(oracle, Q1, 4);
+        ctf.prepareCondition(oracle, Q1, 4);
+
+        vm.startPrank(owner);
+        uint256 g1 = registry.register(JB_PROJECT, _teamsWithField(), block.timestamp + 30 days);
+        registry.setCondition(g1, c1);
+        registry.open(g1);
+        uint256 g2 = registry.supersede(g1, _teamsGen2(), block.timestamp + 60 days);
+        bytes32 c2 = ctf.getConditionId(oracle, Q2, 5);
+        ctf.prepareCondition(oracle, Q2, 5);
+        registry.setCondition(g2, c2);
+        registry.open(g2);
+        registry.lock(g2);
+        registry.settleWinner(g2, 301);
+        vm.stopPrank();
+
+        (, uint256[] memory payouts,) = resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)),
+            IConditionalTokens(address(ctf)),
+            g1,
+            Q1,
+            oracle,
+            301,
+            OPEN_FIELD
+        );
+        assertEq(payouts.length, 4);
+        assertEq(payouts[0], 1); // Westinghouse
+        assertEq(payouts[1], 0);
+        assertEq(payouts[2], 0);
+        assertEq(payouts[3], 0);
+    }
+
+    function testBuildReportSupersededFieldWinner() public {
+        // Blue Origin (401) wins on Gen2 — maps to Gen1 Open Field.
+        bytes32 c1 = ctf.getConditionId(oracle, Q1, 4);
+        ctf.prepareCondition(oracle, Q1, 4);
+
+        vm.startPrank(owner);
+        uint256 g1 = registry.register(JB_PROJECT, _teamsWithField(), block.timestamp + 30 days);
+        registry.setCondition(g1, c1);
+        registry.open(g1);
+        uint256 g2 = registry.supersede(g1, _teamsGen2(), block.timestamp + 60 days);
+        bytes32 c2 = ctf.getConditionId(oracle, Q2, 5);
+        ctf.prepareCondition(oracle, Q2, 5);
+        registry.setCondition(g2, c2);
+        registry.open(g2);
+        registry.lock(g2);
+        registry.settleWinner(g2, 401);
+        vm.stopPrank();
+
+        (, uint256[] memory payouts,) = resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)),
+            IConditionalTokens(address(ctf)),
+            g1,
+            Q1,
+            oracle,
+            401,
+            OPEN_FIELD
+        );
+        assertEq(payouts[0], 0);
+        assertEq(payouts[1], 0);
+        assertEq(payouts[2], 0);
+        assertEq(payouts[3], 1); // Open Field
+    }
+
+    function testBuildReportSupersededFieldlessFallsBackToEqualPayout() public {
+        // Gen1 has no field slot; Gen2 introduces 401 and wins with it → 1/N on Gen1.
+        bytes32 c1 = ctf.getConditionId(oracle, Q1, 3);
+        ctf.prepareCondition(oracle, Q1, 3);
+
+        vm.startPrank(owner);
+        uint256 g1 = registry.register(JB_PROJECT, _teams3(), block.timestamp + 30 days);
+        registry.setCondition(g1, c1);
+        registry.open(g1);
+        uint256 g2 = registry.supersede(g1, _teamsGen2(), block.timestamp + 60 days);
+        bytes32 c2 = ctf.getConditionId(oracle, Q2, 5);
+        ctf.prepareCondition(oracle, Q2, 5);
+        registry.setCondition(g2, c2);
+        registry.open(g2);
+        registry.lock(g2);
+        registry.settleWinner(g2, 401);
+        vm.stopPrank();
+
+        // openFieldTeamId = 0 → equal payout
+        (, uint256[] memory payouts,) = resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)), IConditionalTokens(address(ctf)), g1, Q1, oracle, 401, 0
+        );
+        assertEq(payouts.length, 3);
+        assertEq(payouts[0], 1);
+        assertEq(payouts[1], 1);
+        assertEq(payouts[2], 1);
+    }
+
+    function _cashOutCtx(uint256 projectId) internal view returns (JBBeforeCashOutRecordedContext memory) {
+        return JBBeforeCashOutRecordedContext({
+            terminal: address(this),
+            holder: address(0xCAFE),
+            projectId: projectId,
+            rulesetId: 1,
+            cashOutCount: 5e18,
+            totalSupply: 0,
+            surplus: JBTokenAmount({token: JBConstants.NATIVE_TOKEN, decimals: 18, currency: 0, value: 0}),
+            useTotalSurplus: false,
+            cashOutTaxRate: 0,
+            metadata: ""
+        });
+    }
+}

--- a/subscription-contracts/test/deprize/DePrizeGenerationsE2E.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeGenerationsE2E.t.sol
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+import {DePrizeRegistry} from "../../src/deprize/DePrizeRegistry.sol";
+import {IDePrizeRegistry} from "../../src/deprize/IDePrizeRegistry.sol";
+import {DePrizeMint} from "../../src/deprize/DePrizeMint.sol";
+import {DePrizeRedeem} from "../../src/deprize/DePrizeRedeem.sol";
+import {IConditionalTokens} from "../../src/deprize/interfaces/IConditionalTokens.sol";
+import {DePrizeResolve} from "../../script/deprize/DePrizeResolve.s.sol";
+import {MockResolvingCTF} from "./DePrizeRedeem.t.sol";
+import {MockWETH, MockJBTerminal} from "./DePrizeMint.t.sol";
+
+/// @dev LMSR stand-in that supports BOTH directions. Buys mint outcome tokens and
+///      deliver them through the ERC-1155 acceptance hook (mirroring the real
+///      market's splitPosition-then-transfer); sells pull the trader's tokens and
+///      pay collateral back. Selling is what keeps a superseded generation's
+///      holders whole, so the mock has to model it.
+contract GenMarket is IERC1155Receiver {
+    MockResolvingCTF public immutable ctfC;
+    MockWETH public immutable wethC;
+    uint256 public immutable slots;
+    uint256 public immutable price; // WETH per outcome token, 1e18 fixed point
+    bytes32 public condition;
+    uint8 private _stage; // 0 Running, 1 Paused, 2 Closed
+    uint64 private _fee = 1e16; // 1%
+
+    constructor(address ctf_, address weth_, uint256 slots_, uint256 price_, bytes32 condition_) {
+        ctfC = MockResolvingCTF(ctf_);
+        wethC = MockWETH(payable(weth_));
+        slots = slots_;
+        price = price_;
+        condition = condition_;
+    }
+
+    function pmSystem() external view returns (address) {
+        return address(ctfC);
+    }
+
+    function collateralToken() external view returns (address) {
+        return address(wethC);
+    }
+
+    function atomicOutcomeSlotCount() external view returns (uint256) {
+        return slots;
+    }
+
+    function conditionIds(uint256) external view returns (bytes32) {
+        return condition;
+    }
+
+    function fee() public view returns (uint64) {
+        return _fee;
+    }
+
+    function stage() external view returns (uint8) {
+        return _stage;
+    }
+
+    function setStage(uint8 s) external {
+        _stage = s;
+    }
+
+    function updateCumulativeTWAP() external {}
+
+    function calcMarginalPrice(uint8) external view returns (uint256) {
+        return price;
+    }
+
+    function calcNetCost(int256[] memory amounts) public view returns (int256 cost) {
+        for (uint256 i = 0; i < amounts.length; i++) {
+            cost += (amounts[i] * int256(price)) / 1e18;
+        }
+    }
+
+    function calcMarketFee(uint256 outcomeTokenCost) public view returns (uint256) {
+        return (outcomeTokenCost * uint256(fee())) / 1e18;
+    }
+
+    function positionId(uint256 i) public view returns (uint256) {
+        return ctfC.getPositionId(address(wethC), ctfC.getCollectionId(bytes32(0), condition, 1 << i));
+    }
+
+    function trade(int256[] memory amounts, int256 collateralLimit) external returns (int256 total) {
+        require(_stage == 0, "market halted");
+        int256 net = calcNetCost(amounts);
+
+        uint256 n;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            if (amounts[i] != 0) n++;
+        }
+        uint256[] memory ids = new uint256[](n);
+        uint256[] memory values = new uint256[](n);
+        uint256 j;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            if (amounts[i] == 0) continue;
+            ids[j] = positionId(i);
+            values[j] = uint256(amounts[i] >= 0 ? amounts[i] : -amounts[i]);
+            j++;
+        }
+
+        if (net > 0) {
+            total = net + int256(calcMarketFee(uint256(net)));
+            require(total <= collateralLimit, "limit");
+            wethC.transferFrom(msg.sender, address(this), uint256(total));
+            for (uint256 i = 0; i < n; i++) {
+                ctfC.mint(address(this), ids[i], values[i]);
+            }
+            ctfC.safeBatchTransferFrom(address(this), msg.sender, ids, values, "");
+        } else {
+            uint256 gross = uint256(-net);
+            uint256 f = calcMarketFee(gross);
+            total = net + int256(f);
+            require(collateralLimit <= total, "limit");
+            ctfC.safeBatchTransferFrom(msg.sender, address(this), ids, values, "");
+            require(wethC.transfer(msg.sender, gross - f), "payout failed");
+        }
+    }
+
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IERC1155Receiver).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+}
+
+/// @notice End-to-end generational supersede: real registry, real mint router,
+///         real redeem helper, faithful CTF. Money goes in as bets on generation 1,
+///         the roster forks, and every holder either sells out or redeems against a
+///         lineage-resolved payout vector. Nothing is stranded.
+contract DePrizeGenerationsE2ETest is Test {
+    DePrizeRegistry registry;
+    DePrizeMint mint;
+    DePrizeRedeem redeemer;
+    DePrizeResolve resolveScript;
+    MockResolvingCTF ctf;
+    MockWETH weth;
+    MockJBTerminal terminal;
+
+    address owner = address(0xA11CE);
+    address oracle;
+    address alice = address(0xA11A);
+    address bob = address(0xB0B);
+    address carol = address(0xCAC0);
+
+    uint256 constant JB_PROJECT = 256;
+    uint256 constant OPEN_FIELD = 999;
+    uint256 constant PRICE = 1e17; // 0.1 WETH per outcome token
+    uint256 constant QTY = 10e18; // 10 outcome tokens per bet
+
+    bytes32 constant Q1 = keccak256("q1");
+    bytes32 constant Q2 = keccak256("q2");
+    bytes32 constant Q3 = keccak256("q3");
+
+    function setUp() public {
+        weth = new MockWETH();
+        ctf = new MockResolvingCTF(address(weth));
+        terminal = new MockJBTerminal();
+        resolveScript = new DePrizeResolve();
+        oracle = address(this);
+
+        DePrizeRegistry regImpl = new DePrizeRegistry();
+        registry = DePrizeRegistry(
+            address(new ERC1967Proxy(address(regImpl), abi.encodeCall(DePrizeRegistry.initialize, (owner))))
+        );
+
+        DePrizeMint mintImpl = new DePrizeMint();
+        mint = DePrizeMint(
+            payable(
+                address(
+                    new ERC1967Proxy(
+                        address(mintImpl),
+                        abi.encodeCall(
+                            DePrizeMint.initialize,
+                            (owner, address(registry), address(terminal), address(weth), address(ctf))
+                        )
+                    )
+                )
+            )
+        );
+
+        redeemer = new DePrizeRedeem(address(registry), address(ctf), address(weth));
+
+        // Collateral backing for redemptions (the real CTF holds it from splitPosition).
+        // The remainder seeds each generation's market so it can buy positions back.
+        vm.deal(address(this), 5000 ether);
+        weth.deposit{value: 2000 ether}();
+        weth.transfer(address(ctf), 1000 ether);
+
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+        vm.deal(carol, 100 ether);
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    function _teamsGen1() internal pure returns (uint256[] memory t) {
+        t = new uint256[](4);
+        t[0] = 301;
+        t[1] = 302;
+        t[2] = 303;
+        t[3] = OPEN_FIELD;
+    }
+
+    function _teamsGen2() internal pure returns (uint256[] memory t) {
+        t = new uint256[](5);
+        t[0] = 301;
+        t[1] = 302;
+        t[2] = 303;
+        t[3] = 401; // new entrant
+        t[4] = OPEN_FIELD;
+    }
+
+    function _teamsGen3() internal pure returns (uint256[] memory t) {
+        t = new uint256[](6);
+        t[0] = 301;
+        t[1] = 302;
+        t[2] = 303;
+        t[3] = 401;
+        t[4] = 501; // another new entrant
+        t[5] = OPEN_FIELD;
+    }
+
+    function _pos(bytes32 cond, uint256 i) internal view returns (uint256) {
+        return ctf.getPositionId(address(weth), ctf.getCollectionId(bytes32(0), cond, 1 << i));
+    }
+
+    /// @dev Provision a generation end to end: condition on the CTF, registry
+    ///      binding, open for betting, and a live market wired into the router.
+    function _provision(uint256 deprizeId, bytes32 questionId, uint256 slots)
+        internal
+        returns (bytes32 conditionId, GenMarket market)
+    {
+        conditionId = ctf.getConditionId(oracle, questionId, slots);
+        ctf.prepareCondition(oracle, questionId, slots);
+        market = new GenMarket(address(ctf), address(weth), slots, PRICE, conditionId);
+
+        // Seed the market so it can buy positions back from sellers.
+        weth.transfer(address(market), 50 ether);
+
+        vm.startPrank(owner);
+        registry.setCondition(deprizeId, conditionId);
+        if (registry.state(deprizeId) == IDePrizeRegistry.DePrizeState.DRAFT) registry.open(deprizeId);
+        mint.setMarket(deprizeId, address(market));
+        vm.stopPrank();
+    }
+
+    function _bet(address who, uint256 deprizeId, uint256 outcomeIndex) internal {
+        vm.prank(who);
+        mint.bet{value: 3 ether}(deprizeId, outcomeIndex, QTY, 3 ether);
+    }
+
+    /// @dev Push the resolve script's payout vector on-chain as the oracle.
+    function _report(uint256 deprizeId, bytes32 questionId, uint256 winningTeamId, uint256 fieldTeamId) internal {
+        (, uint256[] memory payouts,) = resolveScript.buildReport(
+            IDePrizeRegistry(address(registry)),
+            IConditionalTokens(address(ctf)),
+            deprizeId,
+            questionId,
+            oracle,
+            winningTeamId,
+            fieldTeamId
+        );
+        ctf.reportPayouts(questionId, payouts);
+    }
+
+    // ---------------------------------------------------------------------
+    // The full journey
+    // ---------------------------------------------------------------------
+
+    function testE2ESupersedeMoneyFlowEndToEnd() public {
+        // --- Generation 1 opens and takes real bets ------------------------
+        vm.prank(owner);
+        uint256 g1 = registry.register(JB_PROJECT, _teamsGen1(), block.timestamp + 30 days);
+        (bytes32 c1, GenMarket m1) = _provision(g1, Q1, 4);
+
+        _bet(alice, g1, 0); // Alice backs team 301
+        _bet(bob, g1, 3); // Bob backs the Open Field
+
+        assertEq(ctf.balanceOf(alice, _pos(c1, 0)), QTY, "alice holds 301 tokens");
+        assertEq(ctf.balanceOf(bob, _pos(c1, 3)), QTY, "bob holds field tokens");
+        uint256 poolAfterGen1Bets = terminal.totalReceived();
+        assertGt(poolAfterGen1Bets, 0, "prize pool took the 5% slices");
+
+        // --- The roster forks ----------------------------------------------
+        vm.prank(owner);
+        uint256 g2 = registry.supersede(g1, _teamsGen2(), block.timestamp + 60 days);
+
+        assertEq(uint256(registry.state(g1)), uint256(IDePrizeRegistry.DePrizeState.SUPERSEDED));
+        assertFalse(registry.isRefundable(g1), "supersede must not open refunds");
+
+        // New bets on the old generation are refused...
+        vm.prank(carol);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeMint.BettingClosed.selector, g1));
+        mint.bet{value: 3 ether}(g1, 0, QTY, 3 ether);
+
+        // ...but the old market is still Running, so holders can exit at will.
+        assertEq(m1.stage(), 0, "old market stays running as a sell-only venue");
+        uint256 aliceEthBefore = weth.balanceOf(alice);
+        int256[] memory sell = new int256[](4);
+        sell[0] = -int256(QTY / 2); // Alice sells half her position
+        vm.startPrank(alice);
+        ctf.setApprovalForAll(address(m1), true);
+        m1.trade(sell, type(int256).min);
+        vm.stopPrank();
+
+        assertEq(ctf.balanceOf(alice, _pos(c1, 0)), QTY / 2, "half the position was sold");
+        assertGt(weth.balanceOf(alice) - aliceEthBefore, 0, "alice was paid for the exit");
+
+        // --- Generation 2 carries the same prize pool ------------------------
+        assertEq(registry.deprizeIdByJBProject(JB_PROJECT), g2, "pool follows the live generation");
+        assertEq(registry.getDePrize(g2).jbProjectId, JB_PROJECT);
+
+        (bytes32 c2,) = _provision(g2, Q2, 5);
+        _bet(carol, g2, 3); // Carol backs the new entrant 401
+        assertEq(ctf.balanceOf(carol, _pos(c2, 3)), QTY);
+        assertGt(terminal.totalReceived(), poolAfterGen1Bets, "pool keeps accumulating across generations");
+
+        // --- 401 wins on generation 2 ----------------------------------------
+        vm.startPrank(owner);
+        registry.lock(g2);
+        registry.settleWinner(g2, 401);
+        vm.stopPrank();
+
+        _report(g2, Q2, 401, OPEN_FIELD);
+        _report(g1, Q1, 401, OPEN_FIELD); // lineage: 401 was unlisted on gen 1 -> Open Field
+
+        assertEq(ctf.payoutNumerators(c1, 3), 1, "gen1 field slot pays");
+        assertEq(ctf.payoutNumerators(c1, 0), 0, "gen1 named loser pays nothing");
+        assertEq(ctf.payoutNumerators(c2, 3), 1, "gen2 winner pays");
+
+        // --- Everyone settles up ---------------------------------------------
+        uint256 carolBefore = carol.balance;
+        vm.startPrank(carol);
+        ctf.setApprovalForAll(address(redeemer), true);
+        redeemer.redeem(g2);
+        vm.stopPrank();
+        assertEq(carol.balance - carolBefore, QTY, "gen2 winner redeemed in full");
+
+        uint256 bobBefore = bob.balance;
+        vm.startPrank(bob);
+        ctf.setApprovalForAll(address(redeemer), true);
+        redeemer.redeem(g1);
+        vm.stopPrank();
+        assertEq(bob.balance - bobBefore, QTY, "gen1 field backer redeemed in full");
+
+        // Alice's remaining gen1 position on a losing team pays zero — but the call
+        // still succeeds, so she is never stuck holding an unredeemable token.
+        uint256 aliceBefore = alice.balance;
+        vm.startPrank(alice);
+        ctf.setApprovalForAll(address(redeemer), true);
+        redeemer.redeem(g1);
+        vm.stopPrank();
+        assertEq(alice.balance - aliceBefore, 0, "losing position redeems to zero, not a revert");
+        assertEq(ctf.balanceOf(alice, _pos(c1, 0)), 0, "position burned");
+    }
+
+    /// @dev Two hops of lineage: a generation superseded twice still resolves.
+    function testE2EThreeGenerationLineage() public {
+        vm.prank(owner);
+        uint256 g1 = registry.register(JB_PROJECT, _teamsGen1(), block.timestamp + 30 days);
+        (bytes32 c1,) = _provision(g1, Q1, 4);
+        _bet(bob, g1, 3); // Bob backs the Open Field on the earliest generation
+
+        vm.prank(owner);
+        uint256 g2 = registry.supersede(g1, _teamsGen2(), block.timestamp + 60 days);
+        _provision(g2, Q2, 5);
+
+        vm.prank(owner);
+        uint256 g3 = registry.supersede(g2, _teamsGen3(), block.timestamp + 90 days);
+        (bytes32 c3,) = _provision(g3, Q3, 6);
+        _bet(carol, g3, 4); // Carol backs 501, which only exists on gen 3
+
+        vm.startPrank(owner);
+        registry.lock(g3);
+        registry.settleWinner(g3, 501);
+        vm.stopPrank();
+
+        assertEq(registry.supersededBy(g1), g2);
+        assertEq(registry.supersededBy(g2), g3);
+
+        _report(g3, Q3, 501, OPEN_FIELD);
+        _report(g1, Q1, 501, OPEN_FIELD); // walks g1 -> g2 -> g3
+
+        assertEq(ctf.payoutNumerators(c1, 3), 1, "gen1 field slot absorbs a gen3 winner");
+        assertEq(ctf.payoutNumerators(c3, 4), 1);
+
+        uint256 bobBefore = bob.balance;
+        vm.startPrank(bob);
+        ctf.setApprovalForAll(address(redeemer), true);
+        redeemer.redeem(g1);
+        vm.stopPrank();
+        assertEq(bob.balance - bobBefore, QTY, "oldest generation still pays out");
+    }
+
+    /// @dev A named competitor that survives the fork pays its own slot on every
+    ///      generation, not the field.
+    function testE2ESupersedeNamedSurvivorWins() public {
+        vm.prank(owner);
+        uint256 g1 = registry.register(JB_PROJECT, _teamsGen1(), block.timestamp + 30 days);
+        (bytes32 c1,) = _provision(g1, Q1, 4);
+        _bet(alice, g1, 0); // 301, still on the gen2 roster
+
+        vm.prank(owner);
+        uint256 g2 = registry.supersede(g1, _teamsGen2(), block.timestamp + 60 days);
+        _provision(g2, Q2, 5);
+
+        vm.startPrank(owner);
+        registry.lock(g2);
+        registry.settleWinner(g2, 301);
+        vm.stopPrank();
+
+        _report(g1, Q1, 301, OPEN_FIELD);
+        assertEq(ctf.payoutNumerators(c1, 0), 1, "named survivor pays its own slot");
+        assertEq(ctf.payoutNumerators(c1, 3), 0, "field pays nothing when the winner was listed");
+
+        uint256 aliceBefore = alice.balance;
+        vm.startPrank(alice);
+        ctf.setApprovalForAll(address(redeemer), true);
+        redeemer.redeem(g1);
+        vm.stopPrank();
+        assertEq(alice.balance - aliceBefore, QTY);
+    }
+
+    /// @dev previewRedeem must agree with what redeem actually pays on a
+    ///      lineage-resolved generation (the UI quotes this number).
+    function testE2EPreviewMatchesPayoutOnSupersededGeneration() public {
+        vm.prank(owner);
+        uint256 g1 = registry.register(JB_PROJECT, _teamsGen1(), block.timestamp + 30 days);
+        _provision(g1, Q1, 4);
+        _bet(bob, g1, 3);
+
+        vm.prank(owner);
+        uint256 g2 = registry.supersede(g1, _teamsGen2(), block.timestamp + 60 days);
+        _provision(g2, Q2, 5);
+        vm.startPrank(owner);
+        registry.lock(g2);
+        registry.settleWinner(g2, 401);
+        vm.stopPrank();
+
+        assertEq(redeemer.previewRedeem(g1, bob), 0, "no quote before the oracle reports");
+        _report(g1, Q1, 401, OPEN_FIELD);
+
+        uint256 quoted = redeemer.previewRedeem(g1, bob);
+        uint256 before = bob.balance;
+        vm.startPrank(bob);
+        ctf.setApprovalForAll(address(redeemer), true);
+        redeemer.redeem(g1);
+        vm.stopPrank();
+        assertEq(quoted, bob.balance - before, "preview matches the actual payout");
+    }
+}

--- a/subscription-contracts/test/deprize/DePrizeRosterSpike.t.sol
+++ b/subscription-contracts/test/deprize/DePrizeRosterSpike.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {DePrizeRegistry} from "../../src/deprize/DePrizeRegistry.sol";
+import {IDePrizeRegistry} from "../../src/deprize/IDePrizeRegistry.sol";
+import {DePrizeMint} from "../../src/deprize/DePrizeMint.sol";
+import {DePrizeRedeem} from "../../src/deprize/DePrizeRedeem.sol";
+import {LaunchPadPayHook} from "../../src/LaunchPadPayHook.sol";
+import {MockWETH, MockJBTerminal, MockCTF, MockMarket} from "./DePrizeMint.t.sol";
+import {MockResolvingCTF} from "./DePrizeRedeem.t.sol";
+
+import {JBConstants} from "@nana-core-v5/libraries/JBConstants.sol";
+import {JBTokenAmount} from "@nana-core-v5/structs/JBTokenAmount.sol";
+import {JBRuleset} from "@nana-core-v5/structs/JBRuleset.sol";
+import {JBBeforeCashOutRecordedContext} from "@nana-core-v5/structs/JBBeforeCashOutRecordedContext.sol";
+
+/// @dev Minimal IJBTerminalStore stand-in (same surface as LaunchPadPayHookDePrize.t.sol).
+contract SpikeTerminalStore {
+    uint256 public balance;
+    uint256 public withdrawn;
+
+    function setFunding(uint256 _balance, uint256 _withdrawn) external {
+        balance = _balance;
+        withdrawn = _withdrawn;
+    }
+
+    function balanceOf(address, uint256, address) external view returns (uint256) {
+        return balance;
+    }
+
+    function usedPayoutLimitOf(address, uint256, address, uint256, uint256) external view returns (uint256) {
+        return withdrawn;
+    }
+}
+
+contract SpikeRulesets {
+    uint112 public weight = uint112(1e18);
+
+    function getRulesetOf(uint256, uint256) external view returns (JBRuleset memory r) {
+        r.weight = weight;
+    }
+}
+
+/// @notice Pins today's roster / JB-binding immutability constraints in CI before
+///         the generations upgrade lands. See docs/DEPRIZE_ROSTER_CHANGES.md Phase 0.
+contract DePrizeRosterSpikeTest is Test {
+    DePrizeRegistry registry;
+    address owner = address(0xA11CE);
+
+    uint256 constant JB_PROJECT = 256;
+    bytes32 constant CONDITION = keccak256("condition");
+
+    function setUp() public {
+        DePrizeRegistry impl = new DePrizeRegistry();
+        bytes memory initData = abi.encodeCall(DePrizeRegistry.initialize, (owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        registry = DePrizeRegistry(address(proxy));
+    }
+
+    function _teams3() internal pure returns (uint256[] memory t) {
+        t = new uint256[](3);
+        t[0] = 301;
+        t[1] = 302;
+        t[2] = 303;
+    }
+
+    function _registerDraft() internal returns (uint256 id) {
+        vm.prank(owner);
+        id = registry.register(JB_PROJECT, _teams3(), block.timestamp + 30 days);
+    }
+
+    function _registerOpen() internal returns (uint256 id) {
+        id = _registerDraft();
+        vm.startPrank(owner);
+        registry.setCondition(id, CONDITION);
+        registry.open(id);
+        vm.stopPrank();
+    }
+
+    // ---------------------------------------------------------------------
+    // 1. JB binding is write-once
+    // ---------------------------------------------------------------------
+
+    function testCannotReRegisterSameJBProject() public {
+        _registerDraft();
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IDePrizeRegistry.JBProjectAlreadyBound.selector, JB_PROJECT));
+        registry.register(JB_PROJECT, _teams3(), block.timestamp + 60 days);
+    }
+
+    // ---------------------------------------------------------------------
+    // 2. setCondition is DRAFT-only
+    // ---------------------------------------------------------------------
+
+    function testSetConditionRevertsAfterOpen() public {
+        uint256 id = _registerOpen();
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IDePrizeRegistry.InvalidState.selector, id, IDePrizeRegistry.DePrizeState.OPEN)
+        );
+        registry.setCondition(id, keccak256("other"));
+    }
+
+    // ---------------------------------------------------------------------
+    // 3. Mint refuses a market whose slot count differs from teamIds.length
+    // ---------------------------------------------------------------------
+
+    function testSetMarketRevertsWhenRosterLengthDiffers() public {
+        uint256 id = _registerOpen();
+
+        MockWETH weth = new MockWETH();
+        MockCTF ctf = new MockCTF();
+        MockJBTerminal terminal = new MockJBTerminal();
+
+        DePrizeMint mintImpl = new DePrizeMint();
+        bytes memory mintInit =
+            abi.encodeCall(DePrizeMint.initialize, (owner, address(registry), address(terminal), address(weth), address(ctf)));
+        DePrizeMint mint = DePrizeMint(payable(address(new ERC1967Proxy(address(mintImpl), mintInit))));
+
+        // 4-slot market vs 3-team DePrize — the in-place roster edit failure mode.
+        MockMarket badMarket = new MockMarket(address(ctf), address(weth), 4, 1e17);
+        badMarket.setConditionId(CONDITION);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(DePrizeMint.MarketSlotMismatch.selector, 4, 3));
+        mint.setMarket(id, address(badMarket));
+    }
+
+    // ---------------------------------------------------------------------
+    // 4. Redeem refuses when teamIds.length != CTF outcome slot count
+    // ---------------------------------------------------------------------
+
+    function testRedeemRevertsSlotCountMismatch() public {
+        MockWETH weth = new MockWETH();
+        MockResolvingCTF ctf = new MockResolvingCTF(address(weth));
+        address oracle = address(0x1234);
+        bytes32 questionId = keccak256("q");
+
+        // Prepare a 4-slot condition, bind a 3-team DePrize to it.
+        ctf.prepareCondition(oracle, questionId, 4);
+        bytes32 conditionId = ctf.getConditionId(oracle, questionId, 4);
+
+        uint256 id = _registerDraft();
+        vm.startPrank(owner);
+        registry.setCondition(id, conditionId);
+        registry.open(id);
+        vm.stopPrank();
+
+        DePrizeRedeem redeem = new DePrizeRedeem(address(registry), address(ctf), address(weth));
+
+        vm.expectRevert(abi.encodeWithSelector(DePrizeRedeem.SlotCountMismatch.selector, id, 3, 4));
+        redeem.previewRedeem(id, address(this));
+    }
+
+    // ---------------------------------------------------------------------
+    // 5. Cancel opens cashOut on the bound Juicebox project
+    // ---------------------------------------------------------------------
+
+    function testCancelOpensCashOutOnBoundProject() public {
+        SpikeTerminalStore store = new SpikeTerminalStore();
+        SpikeRulesets rulesets = new SpikeRulesets();
+        uint256 deadline = block.timestamp + 28 days;
+
+        LaunchPadPayHook hook = new LaunchPadPayHook(
+            10 ether, deadline, 14 days, address(store), address(rulesets), owner
+        );
+
+        uint256 id = _registerOpen();
+        vm.prank(owner);
+        hook.setDePrizeRegistry(address(registry));
+
+        // Active: cashOut blocked.
+        vm.expectRevert("DePrize is active. Refunds are disabled.");
+        hook.beforeCashOutRecordedWith(_cashOutCtx(address(this), JB_PROJECT));
+
+        // Cancel through the notice window.
+        vm.startPrank(owner);
+        registry.announceCancellation(id);
+        vm.warp(block.timestamp + registry.CANCELLATION_NOTICE());
+        registry.cancel(id);
+        vm.stopPrank();
+
+        store.setFunding(8 ether, 2 ether);
+        (, uint256 cashOutCount,,) = hook.beforeCashOutRecordedWith(_cashOutCtx(address(this), JB_PROJECT));
+        assertEq(cashOutCount, 5e18);
+        assertEq(hook.stage(address(this), JB_PROJECT), 3);
+    }
+
+    function _cashOutCtx(address terminal, uint256 projectId)
+        internal
+        pure
+        returns (JBBeforeCashOutRecordedContext memory)
+    {
+        return JBBeforeCashOutRecordedContext({
+            terminal: terminal,
+            holder: address(0xCAFE),
+            projectId: projectId,
+            rulesetId: 1,
+            cashOutCount: 5e18,
+            totalSupply: 0,
+            surplus: JBTokenAmount({token: JBConstants.NATIVE_TOKEN, decimals: 18, currency: 0, value: 0}),
+            useTotalSurplus: false,
+            cashOutTaxRate: 0,
+            metadata: ""
+        });
+    }
+}

--- a/ui/components/deprize/DePrizeTeamCard.tsx
+++ b/ui/components/deprize/DePrizeTeamCard.tsx
@@ -24,6 +24,10 @@ type DePrizeTeamCardProps = {
   userConnected: boolean
   onBet: (index: number) => void
   onCashOut: (index: number) => void
+  /** Open Field slot — render overrides + tooltip instead of a Team NFT. */
+  isField?: boolean
+  /** Disclosure: competitor marked withdrawn on-chain. Slot stays tradable. */
+  withdrawn?: boolean
 }
 
 function PnlSuffix({ pnl }: { pnl: number | undefined }) {
@@ -54,6 +58,8 @@ export default function DePrizeTeamCard({
   userConnected,
   onBet,
   onCashOut,
+  isField = false,
+  withdrawn = false,
 }: DePrizeTeamCardProps) {
   const holding = Number.isFinite(outcome.balance) && outcome.balance > 0
   const realizedValue = resolved ? redeemValueEth : sellQuoteEth
@@ -116,7 +122,30 @@ export default function DePrizeTeamCard({
             color={color}
             size={40}
             className="text-base font-semibold text-white hover:text-indigo-200"
+            nameOverride={isField ? 'Open Field' : undefined}
+            imageOverride={
+              isField
+                ? 'data:image/svg+xml,' +
+                  encodeURIComponent(
+                    `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" rx="8" fill="#1e293b"/><circle cx="20" cy="20" r="10" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4 3"/></svg>`
+                  )
+                : undefined
+            }
+            hrefOverride={isField ? '/deprize#open-field' : undefined}
           />
+          {isField && (
+            <p
+              className="text-xs text-gray-400 pl-12"
+              title="Pays if any qualifying entrant not listed above is selected as the winner. The Senate names the entity; the admin Safe records the payout address in the same settlement batch."
+            >
+              Any qualifying entrant not listed above
+            </p>
+          )}
+          {withdrawn && !isField && (
+            <p className="text-xs text-amber-400/90 pl-12">
+              Withdrawn — you can still sell your position
+            </p>
+          )}
           {showWinSubtitle && (
             // Align under the team name (avatar 40px + gap-2 8px).
             <p className="text-xs text-gray-500 pl-12">
@@ -134,7 +163,7 @@ export default function DePrizeTeamCard({
             disabled={busy || !userConnected}
             className="rounded-xl shadow-purple-500/10"
           >
-            Back this team
+            {isField ? 'Back the field' : 'Back this team'}
           </StandardButton>
         )}
       </div>

--- a/ui/components/deprize/DePrizeTeamCard.tsx
+++ b/ui/components/deprize/DePrizeTeamCard.tsx
@@ -28,7 +28,29 @@ type DePrizeTeamCardProps = {
   isField?: boolean
   /** Disclosure: competitor marked withdrawn on-chain. Slot stays tradable. */
   withdrawn?: boolean
+  /**
+   * Link target for a bound competitor (e.g. `/moonbase/{projectId}`), for
+   * organizations that will never hold a Team NFT. Ignored for field slots,
+   * which keep their own target. Defaults to `/team/{id}`.
+   */
+  hrefOverride?: string
+  /** Atlas org display name, for competitors with no Team NFT. */
+  nameOverride?: string
+  /** Atlas org logo. Suppressed when `unclaimed`. */
+  imageOverride?: string
+  /**
+   * Competitor has not claimed its listing: show the name but no logo, so the
+   * listing never reads as an endorsement. See ROSTER_DISCLAIMER.
+   */
+  unclaimed?: boolean
 }
+
+/** Dashed-circle mark for the Open Field slot, which has no Team NFT. */
+const FIELD_AVATAR =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" rx="8" fill="#1e293b"/><circle cx="20" cy="20" r="10" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4 3"/></svg>`
+  )
 
 function PnlSuffix({ pnl }: { pnl: number | undefined }) {
   if (pnl === undefined) return null
@@ -60,6 +82,10 @@ export default function DePrizeTeamCard({
   onCashOut,
   isField = false,
   withdrawn = false,
+  hrefOverride,
+  nameOverride,
+  imageOverride,
+  unclaimed = false,
 }: DePrizeTeamCardProps) {
   const holding = Number.isFinite(outcome.balance) && outcome.balance > 0
   const realizedValue = resolved ? redeemValueEth : sellQuoteEth
@@ -122,16 +148,12 @@ export default function DePrizeTeamCard({
             color={color}
             size={40}
             className="text-base font-semibold text-white hover:text-indigo-200"
-            nameOverride={isField ? 'Open Field' : undefined}
-            imageOverride={
-              isField
-                ? 'data:image/svg+xml,' +
-                  encodeURIComponent(
-                    `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" rx="8" fill="#1e293b"/><circle cx="20" cy="20" r="10" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4 3"/></svg>`
-                  )
-                : undefined
-            }
-            hrefOverride={isField ? '/deprize#open-field' : undefined}
+            nameOverride={isField ? 'Open Field' : nameOverride}
+            imageOverride={isField ? FIELD_AVATAR : imageOverride}
+            hrefOverride={isField ? '/deprize#open-field' : hrefOverride}
+            // The field slot is not an organization, so its own placeholder mark
+            // must survive the unclaimed logo suppression.
+            unclaimed={!isField && unclaimed}
           />
           {isField && (
             <p

--- a/ui/components/deprize/DePrizeTeamLink.tsx
+++ b/ui/components/deprize/DePrizeTeamLink.tsx
@@ -19,6 +19,14 @@ type DePrizeTeamLinkProps = {
   imageOverride?: string
   /** Override link target (e.g. `/moonbase/{projectId}`). Defaults to `/team/{id}`. */
   hrefOverride?: string
+  /**
+   * Competitor has not claimed its listing: render the name but never a logo,
+   * so we don't imply endorsement by displaying someone's mark. Forces the
+   * neutral monogram and suppresses both `imageOverride` and the NFT image.
+   * A `nameOverride` alone then counts as complete identity, so we also skip
+   * the doomed NFT read.
+   */
+  unclaimed?: boolean
 }
 
 /** Two-letter monogram from a team name (falls back to the numeric id). */
@@ -111,9 +119,11 @@ export default function DePrizeTeamLink({
   nameOverride,
   imageOverride,
   hrefOverride,
+  unclaimed = false,
 }: DePrizeTeamLinkProps) {
-  // Only skip the NFT read when neither name nor image would come from it.
-  const identityOverridden = !!nameOverride && !!imageOverride
+  // Only skip the NFT read when neither name nor image would come from it. An
+  // unclaimed competitor shows no logo at all, so a name is the whole identity.
+  const identityOverridden = !!nameOverride && (!!imageOverride || unclaimed)
 
   const { data: teamNFT } = useReadContract(getNFT, {
     contract: teamContract,
@@ -127,7 +137,7 @@ export default function DePrizeTeamLink({
   // and an empty override must not blank the row.
   const name =
     nameOverride || (teamNFT as any)?.metadata?.name || `Team #${teamId.toString()}`
-  const image = imageOverride || (teamNFT as any)?.metadata?.image || ''
+  const image = unclaimed ? '' : imageOverride || (teamNFT as any)?.metadata?.image || ''
   const href = hrefOverride || `/team/${teamId.toString()}`
 
   const linkClassName = `group inline-flex items-center gap-2 min-w-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 transition-opacity hover:opacity-90 ${className}`

--- a/ui/const/abis/DePrizeRegistry.json
+++ b/ui/const/abis/DePrizeRegistry.json
@@ -1,256 +1,762 @@
 [
   {
-    "type": "function",
-    "name": "state",
-    "stateMutability": "view",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "uint8" }]
-  },
-  {
-    "type": "function",
-    "name": "getDePrize",
-    "stateMutability": "view",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "components": [
-          { "name": "jbProjectId", "type": "uint256" },
-          { "name": "ctfConditionId", "type": "bytes32" },
-          { "name": "sunset", "type": "uint256" },
-          { "name": "winningTeamId", "type": "uint256" },
-          { "name": "cancellationNoticeAt", "type": "uint256" },
-          { "name": "state", "type": "uint8" },
-          { "name": "teamIds", "type": "uint256[]" }
-        ]
-      }
-    ]
-  },
-  {
-    "type": "function",
-    "name": "teamIds",
-    "stateMutability": "view",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "uint256[]" }]
-  },
-  {
-    "type": "function",
-    "name": "isTeam",
-    "stateMutability": "view",
-    "inputs": [
-      { "name": "deprizeId", "type": "uint256" },
-      { "name": "teamId", "type": "uint256" }
-    ],
-    "outputs": [{ "name": "", "type": "bool" }]
-  },
-  {
-    "type": "function",
-    "name": "winningTeamId",
-    "stateMutability": "view",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "uint256" }]
-  },
-  {
-    "type": "function",
-    "name": "bettingOpen",
-    "stateMutability": "view",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "bool" }]
-  },
-  {
-    "type": "function",
-    "name": "isRefundable",
-    "stateMutability": "view",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "bool" }]
-  },
-  {
-    "type": "function",
-    "name": "isTerminal",
-    "stateMutability": "view",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "bool" }]
-  },
-  {
-    "type": "function",
-    "name": "cancellationPending",
-    "stateMutability": "view",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "bool" }]
-  },
-  {
-    "type": "function",
-    "name": "count",
-    "stateMutability": "view",
+    "type": "constructor",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256" }]
-  },
-  {
-    "type": "function",
-    "name": "deprizeIdByJBProject",
-    "stateMutability": "view",
-    "inputs": [{ "name": "jbProjectId", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "uint256" }]
-  },
-  {
-    "type": "function",
-    "name": "providerPayoutAddress",
-    "stateMutability": "view",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": [{ "name": "", "type": "address" }]
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "CANCELLATION_NOTICE",
-    "stateMutability": "view",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256" }]
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
-    "name": "owner",
-    "stateMutability": "view",
+    "name": "UPGRADE_INTERFACE_VERSION",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "address" }]
-  },
-  {
-    "type": "function",
-    "name": "register",
-    "stateMutability": "nonpayable",
-    "inputs": [
-      { "name": "jbProjectId", "type": "uint256" },
-      { "name": "teamIds", "type": "uint256[]" },
-      { "name": "sunset", "type": "uint256" }
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
     ],
-    "outputs": [{ "name": "deprizeId", "type": "uint256" }]
-  },
-  {
-    "type": "function",
-    "name": "setCondition",
-    "stateMutability": "nonpayable",
-    "inputs": [
-      { "name": "deprizeId", "type": "uint256" },
-      { "name": "ctfConditionId", "type": "bytes32" }
-    ],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "setSunset",
-    "stateMutability": "nonpayable",
-    "inputs": [
-      { "name": "deprizeId", "type": "uint256" },
-      { "name": "sunset", "type": "uint256" }
-    ],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "open",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "lock",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "startVote",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "settleWinner",
-    "stateMutability": "nonpayable",
-    "inputs": [
-      { "name": "deprizeId", "type": "uint256" },
-      { "name": "winningTeamId", "type": "uint256" }
-    ],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "settleNoWinner",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "releaseM1",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "completeM2",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "failM2",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "type": "function",
-    "name": "announceCancellation",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
+    "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "abortCancellation",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "announceCancellation",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "bettingOpen",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "cancel",
-    "stateMutability": "nonpayable",
-    "inputs": [{ "name": "deprizeId", "type": "uint256" }],
-    "outputs": []
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancellationPending",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "completeM2",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "count",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deprizeIdByJBProject",
+    "inputs": [
+      {
+        "name": "jbProjectId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "failM2",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getDePrize",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IDePrizeRegistry.DePrize",
+        "components": [
+          {
+            "name": "jbProjectId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ctfConditionId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "sunset",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "winningTeamId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "cancellationNoticeAt",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "state",
+            "type": "uint8",
+            "internalType": "enum IDePrizeRegistry.DePrizeState"
+          },
+          {
+            "name": "teamIds",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isRefundable",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isTeam",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isTerminal",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lock",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "markWithdrawn",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "open",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "providerPayoutAddress",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "register",
+    "inputs": [
+      {
+        "name": "jbProjectId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "sunset",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "releaseM1",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setCondition",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ctfConditionId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "setProviderPayoutAddress",
-    "stateMutability": "nonpayable",
     "inputs": [
-      { "name": "deprizeId", "type": "uint256" },
-      { "name": "provider", "type": "address" }
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "provider",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    "outputs": []
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setSunset",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "sunset",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setTeams",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleNoWinner",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleWinner",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "winningTeamId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "startVote",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "state",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum IDePrizeRegistry.DePrizeState"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "supersede",
+    "inputs": [
+      {
+        "name": "oldDeprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "newTeamIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "sunset",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "newDeprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "supersededBy",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "supersedes",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "teamIds",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unmarkWithdrawn",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "winningTeamId",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "withdrawn",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "event",
-    "name": "StateChanged",
+    "name": "CancellationAborted",
     "inputs": [
-      { "name": "deprizeId", "type": "uint256", "indexed": true },
-      { "name": "from", "type": "uint8", "indexed": true },
-      { "name": "to", "type": "uint8", "indexed": true }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "WinnerDeclared",
-    "inputs": [
-      { "name": "deprizeId", "type": "uint256", "indexed": true },
-      { "name": "winningTeamId", "type": "uint256", "indexed": true }
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
     ],
     "anonymous": false
   },
@@ -258,10 +764,541 @@
     "type": "event",
     "name": "CancellationAnnounced",
     "inputs": [
-      { "name": "deprizeId", "type": "uint256", "indexed": true },
-      { "name": "noticeAt", "type": "uint256", "indexed": false },
-      { "name": "executableAt", "type": "uint256", "indexed": false }
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "noticeAt",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "executableAt",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
     ],
     "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ConditionSet",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ctfConditionId",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DePrizeRegistered",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "jbProjectId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamIds",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "sunset",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DePrizeSuperseded",
+    "inputs": [
+      {
+        "name": "oldDeprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newDeprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newTeamIds",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProviderPayoutAddressSet",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "provider",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "StateChanged",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "from",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "enum IDePrizeRegistry.DePrizeState"
+      },
+      {
+        "name": "to",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "enum IDePrizeRegistry.DePrizeState"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SunsetUpdated",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "sunset",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TeamReinstated",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TeamWithdrawn",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TeamsUpdated",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamIds",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WinnerDeclared",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "winningTeamId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "CancellationAlreadyPending",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "CancellationNoticeNotElapsed",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "executableAt",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ConditionNotSet",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "DuplicateTeam",
+    "inputs": [
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidJBProject",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidState",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "current",
+        "type": "uint8",
+        "internalType": "enum IDePrizeRegistry.DePrizeState"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidSunset",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "JBProjectAlreadyBound",
+    "inputs": [
+      {
+        "name": "jbProjectId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoCancellationPending",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "SunsetNotExtended",
+    "inputs": [
+      {
+        "name": "current",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "proposed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "TeamNotOnRoster",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "TooFewTeams",
+    "inputs": [
+      {
+        "name": "provided",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnknownDePrize",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnknownTeam",
+    "inputs": [
+      {
+        "name": "deprizeId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "teamId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroProviderAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroTeamId",
+    "inputs": []
   }
 ]

--- a/ui/cypress/integration/lib/deprize/competitions.cy.ts
+++ b/ui/cypress/integration/lib/deprize/competitions.cy.ts
@@ -3,12 +3,16 @@ import {
   areRaceOutcomesPublishable,
   chainHasRaceBindings,
   findDePrizeIdForGoal,
+  generationNumberOf,
   getDePrizeCompetition,
+  getDePrizeGenerationNumber,
   getDePrizeQuestionId,
   getDePrizeRaceBinding,
   isDePrizeGoalMarketPublishable,
   isKnownDePrizeCompetition,
+  liveTipOf,
   partitionDePrizeIndexByRace,
+  resolveLiveDePrizeId,
 } from '@/lib/deprize/competitions'
 
 describe('deprize competitions registry', () => {
@@ -89,6 +93,14 @@ describe('deprize competitions registry', () => {
     expect(areRaceOutcomesPublishable('arbitrum', consented)).to.equal(true)
     expect(areRaceOutcomesPublishable('sepolia', unconsented)).to.equal(true)
     expect(areRaceOutcomesPublishable('arbitrum', undefined)).to.equal(false)
+
+    // Field slots are not competitors — skip them for the consent gate.
+    expect(
+      areRaceOutcomesPublishable('arbitrum', [
+        { projectId: 'a', consented: true },
+        { projectId: '__open-field__', field: true },
+      ])
+    ).to.equal(true)
   })
 
   it('partitions the index by raceLabel and keeps unbound chains flat', () => {
@@ -112,5 +124,49 @@ describe('deprize competitions registry', () => {
     expect(arbitrum).to.deep.equal([
       { raceLabel: null, deprizeIds: [1, 2, 3], showHeading: false },
     ])
+  })
+})
+
+describe('deprize generation lineage', () => {
+  // g1 -> g2 -> g3, the shape a twice-superseded race leaves behind.
+  const chain = {
+    1: { supersededBy: 2 },
+    2: { supersedes: 1, supersededBy: 3 },
+    3: { supersedes: 2 },
+  }
+
+  it('walks every generation forward to the same live tip', () => {
+    expect(liveTipOf(chain, 1)).to.equal(3)
+    expect(liveTipOf(chain, 2)).to.equal(3)
+    expect(liveTipOf(chain, 3)).to.equal(3)
+  })
+
+  it('numbers generations 1-indexed walking backward', () => {
+    expect(generationNumberOf(chain, 1)).to.equal(1)
+    expect(generationNumberOf(chain, 2)).to.equal(2)
+    expect(generationNumberOf(chain, 3)).to.equal(3)
+  })
+
+  it('treats an unlinked or unknown id as a lone first generation', () => {
+    expect(liveTipOf({}, 7)).to.equal(7)
+    expect(generationNumberOf({}, 7)).to.equal(1)
+    expect(liveTipOf({ 7: {} }, 7)).to.equal(7)
+    expect(generationNumberOf({ 7: {} }, 7)).to.equal(1)
+  })
+
+  it('stops at the last distinct generation on a malformed cyclic registry', () => {
+    const cyclic = {
+      1: { supersedes: 2, supersededBy: 2 },
+      2: { supersedes: 1, supersededBy: 1 },
+    }
+    expect(liveTipOf(cyclic, 1)).to.equal(2)
+    expect(generationNumberOf(cyclic, 1)).to.equal(2)
+  })
+
+  it('is a no-op on the real registry, which has no lineage seeded yet', () => {
+    expect(resolveLiveDePrizeId('sepolia', 9)).to.equal(9)
+    expect(getDePrizeGenerationNumber('sepolia', 9)).to.equal(1)
+    expect(resolveLiveDePrizeId('sepolia', undefined)).to.equal(undefined)
+    expect(getDePrizeGenerationNumber('sepolia', undefined)).to.equal(1)
   })
 })

--- a/ui/cypress/integration/lib/deprize/competitions.cy.ts
+++ b/ui/cypress/integration/lib/deprize/competitions.cy.ts
@@ -1,6 +1,5 @@
 import {
   GENERIC_DEPRIZE_COMPETITION,
-  areRaceOutcomesPublishable,
   chainHasRaceBindings,
   findDePrizeIdForGoal,
   generationNumberOf,
@@ -8,8 +7,10 @@ import {
   getDePrizeGenerationNumber,
   getDePrizeQuestionId,
   getDePrizeRaceBinding,
-  isDePrizeGoalMarketPublishable,
+  isCompetitorClaimed,
+  isDePrizeGoalMarketBound,
   isKnownDePrizeCompetition,
+  isRaceBindingComplete,
   liveTipOf,
   partitionDePrizeIndexByRace,
   resolveLiveDePrizeId,
@@ -75,32 +76,40 @@ describe('deprize competitions registry', () => {
     expect(findDePrizeIdForGoal('sepolia', undefined)).to.equal(undefined)
   })
 
-  it('publishes the Sepolia fixture and refuses unbound / unconsented non-Sepolia', () => {
-    expect(isDePrizeGoalMarketPublishable('sepolia', 'shared-fission-power')).to.equal(true)
-    expect(isDePrizeGoalMarketPublishable('sepolia', 'shared-landing-pads')).to.equal(false)
-    expect(isDePrizeGoalMarketPublishable('arbitrum', 'shared-fission-power')).to.equal(false)
+  it('reports a bound race regardless of consent, and unbound goals as unbound', () => {
+    expect(isDePrizeGoalMarketBound('sepolia', 'shared-fission-power')).to.equal(true)
+    expect(isDePrizeGoalMarketBound('sepolia', 'shared-landing-pads')).to.equal(false)
+    // Arbitrum has no binding at all, so there is no market to report.
+    expect(isDePrizeGoalMarketBound('arbitrum', 'shared-fission-power')).to.equal(false)
+    expect(isDePrizeGoalMarketBound('sepolia', undefined)).to.equal(false)
+  })
 
-    // Pure consent helper: non-Sepolia requires every outcome consented.
-    const unconsented = [
-      { projectId: 'a', consented: true },
-      { projectId: 'b' },
-    ]
-    const consented = [
-      { projectId: 'a', consented: true },
-      { projectId: 'b', consented: true },
-    ]
-    expect(areRaceOutcomesPublishable('arbitrum', unconsented)).to.equal(false)
-    expect(areRaceOutcomesPublishable('arbitrum', consented)).to.equal(true)
-    expect(areRaceOutcomesPublishable('sepolia', unconsented)).to.equal(true)
-    expect(areRaceOutcomesPublishable('arbitrum', undefined)).to.equal(false)
-
-    // Field slots are not competitors — skip them for the consent gate.
+  it('treats binding completeness as chain-agnostic and independent of consent', () => {
+    // Consent is no longer a visibility gate: an unconsented roster is publishable.
     expect(
-      areRaceOutcomesPublishable('arbitrum', [
-        { projectId: 'a', consented: true },
+      isRaceBindingComplete([{ projectId: 'a', consented: true }, { projectId: 'b' }])
+    ).to.equal(true)
+    expect(isRaceBindingComplete([{ projectId: 'a' }, { projectId: 'b' }])).to.equal(true)
+    expect(isRaceBindingComplete(undefined)).to.equal(false)
+    expect(isRaceBindingComplete([])).to.equal(false)
+
+    // A field-only roster names nobody, so there is nothing to price.
+    expect(
+      isRaceBindingComplete([{ projectId: '__open-field__', field: true }])
+    ).to.equal(false)
+    expect(
+      isRaceBindingComplete([
+        { projectId: 'a' },
         { projectId: '__open-field__', field: true },
       ])
     ).to.equal(true)
+  })
+
+  it('gates branding on claim status without touching visibility', () => {
+    expect(isCompetitorClaimed({ projectId: 'a', consented: true })).to.equal(true)
+    expect(isCompetitorClaimed({ projectId: 'a' })).to.equal(false)
+    expect(isCompetitorClaimed({ projectId: 'a', consented: false })).to.equal(false)
+    expect(isCompetitorClaimed(undefined)).to.equal(false)
   })
 
   it('partitions the index by raceLabel and keeps unbound chains flat', () => {

--- a/ui/cypress/integration/lib/deprize/goal-market.cy.ts
+++ b/ui/cypress/integration/lib/deprize/goal-market.cy.ts
@@ -1,0 +1,129 @@
+import { OPEN_FIELD_PROJECT_ID } from '@/lib/deprize/competitions'
+import {
+  type LiveGoalOdds,
+  type MergeableGoal,
+  mergeLiveMarket,
+  mergeLiveMarketInto,
+} from '@/lib/deprize/goal-market'
+
+// Hand-written fixture: this module must not depend on the atlas dataset, which
+// ships on the Moon Base Zero branch.
+function goal(): MergeableGoal {
+  return {
+    id: 'shared-fission-power',
+    market: {
+      status: 'planned',
+      impliedOdds: {
+        'westinghouse-fission-surface-power': 0.34,
+        'lockheed-fission-surface-power': 0.35,
+        'ix-fission-surface-power': 0.31,
+      },
+    },
+  }
+}
+
+const liveOdds: LiveGoalOdds = {
+  deprizeId: 9,
+  oddsByProjectId: {
+    'westinghouse-fission-surface-power': 0.5,
+    'lockheed-fission-surface-power': 0.3,
+    'ix-fission-surface-power': 0.2,
+  },
+  fieldOdds: undefined,
+  status: 'live',
+}
+
+describe('mergeLiveMarket', () => {
+  it('replaces curator priors with live odds and flips status', () => {
+    const merged = mergeLiveMarket(goal(), liveOdds)
+    expect(merged.market?.status).to.equal('live')
+    expect(merged.market?.impliedOdds).to.deep.equal(liveOdds.oddsByProjectId)
+  })
+
+  it('does not mutate the input goal', () => {
+    const g = goal()
+    mergeLiveMarket(g, liveOdds)
+    expect(g.market?.status).to.equal('planned')
+    expect(g.market?.impliedOdds?.['westinghouse-fission-surface-power']).to.equal(0.34)
+  })
+
+  it('carries Open Field mass under the sentinel key so bars still sum to ~1', () => {
+    const merged = mergeLiveMarket(goal(), {
+      ...liveOdds,
+      oddsByProjectId: {
+        'westinghouse-fission-surface-power': 0.4,
+        'lockheed-fission-surface-power': 0.3,
+        'ix-fission-surface-power': 0.15,
+      },
+      fieldOdds: 0.15,
+    })
+    expect(merged.market?.impliedOdds?.[OPEN_FIELD_PROJECT_ID]).to.equal(0.15)
+    const sum = Object.values(merged.market!.impliedOdds!).reduce((a, b) => a + b, 0)
+    expect(sum).to.be.closeTo(1, 1e-9)
+  })
+
+  it('keeps priors when the race is unbound, planned, or has no odds', () => {
+    const g = goal()
+    expect(mergeLiveMarket(g, undefined)).to.equal(g)
+    expect(mergeLiveMarket(g, { ...liveOdds, deprizeId: undefined })).to.equal(g)
+    // Superseded / loading generations report planned — must not blank the panel.
+    expect(mergeLiveMarket(g, { ...liveOdds, status: 'planned' })).to.equal(g)
+    expect(mergeLiveMarket(g, { ...liveOdds, oddsByProjectId: undefined })).to.equal(g)
+    expect(mergeLiveMarket(g, { ...liveOdds, oddsByProjectId: {} })).to.equal(g)
+  })
+
+  it('marks a resolved market resolved', () => {
+    const merged = mergeLiveMarket(goal(), { ...liveOdds, status: 'resolved' })
+    expect(merged.market?.status).to.equal('resolved')
+  })
+
+  it('synthesizes a market block for a goal that never had one', () => {
+    const bare: MergeableGoal = { id: 'shared-fission-power' }
+    const merged = mergeLiveMarket(bare, liveOdds)
+    expect(merged.market?.status).to.equal('live')
+    expect(merged.market?.impliedOdds).to.deep.equal(liveOdds.oddsByProjectId)
+  })
+
+  it('preserves atlas-only market fields the panel still reads', () => {
+    // The real SharedGoalMarket also carries resolutionAuthority / payoutSplit /
+    // budgetGate. Overwriting the block instead of spreading it would blank them.
+    const withExtras = {
+      id: 'shared-fission-power',
+      market: {
+        status: 'planned' as const,
+        resolutionAuthority: 'senate',
+        payoutSplit: { capability: 0.3, flight: 0.7 },
+        budgetGate: 'flight-demo quote <= prize-pool TWAP',
+      },
+    }
+    const merged = mergeLiveMarket(withExtras, liveOdds)
+    expect(merged.market.resolutionAuthority).to.equal('senate')
+    expect(merged.market.payoutSplit).to.deep.equal({ capability: 0.3, flight: 0.7 })
+    expect(merged.market.budgetGate).to.equal('flight-demo quote <= prize-pool TWAP')
+    expect(merged.market.status).to.equal('live')
+  })
+
+  it('ignores a non-finite fieldOdds rather than writing NaN into the bars', () => {
+    const merged = mergeLiveMarket(goal(), { ...liveOdds, fieldOdds: NaN })
+    expect(merged.market?.impliedOdds).to.not.have.property(OPEN_FIELD_PROJECT_ID)
+  })
+})
+
+describe('mergeLiveMarketInto', () => {
+  const goals: MergeableGoal[] = [goal(), { id: 'shared-habitat', market: { status: 'planned' } }]
+
+  it('merges only the mounted race and preserves identity elsewhere', () => {
+    const next = mergeLiveMarketInto(goals, 'shared-fission-power', liveOdds)
+    expect(next[0].market?.status).to.equal('live')
+    expect(next[1]).to.equal(goals[1])
+  })
+
+  it('returns the same array when nothing merged, so memos do not recompute', () => {
+    expect(mergeLiveMarketInto(goals, undefined, liveOdds)).to.equal(goals)
+    expect(mergeLiveMarketInto(goals, 'shared-fission-power', undefined)).to.equal(goals)
+    expect(
+      mergeLiveMarketInto(goals, 'shared-fission-power', { ...liveOdds, status: 'planned' })
+    ).to.equal(goals)
+    expect(mergeLiveMarketInto(goals, 'shared-nonexistent', liveOdds)).to.equal(goals)
+  })
+})

--- a/ui/cypress/integration/lib/deprize/goal-odds.cy.ts
+++ b/ui/cypress/integration/lib/deprize/goal-odds.cy.ts
@@ -14,9 +14,12 @@ describe('mapOutcomeOddsToProjectIds', () => {
       probabilities: [34, 35, 31],
     })
     expect(mapped).to.deep.equal({
-      'westinghouse-fission-surface-power': 0.34,
-      'lockheed-fission-surface-power': 0.35,
-      'ix-fission-surface-power': 0.31,
+      oddsByProjectId: {
+        'westinghouse-fission-surface-power': 0.34,
+        'lockheed-fission-surface-power': 0.35,
+        'ix-fission-surface-power': 0.31,
+      },
+      fieldOdds: undefined,
     })
   })
 
@@ -57,8 +60,11 @@ describe('mapOutcomeOddsToProjectIds', () => {
       probabilities: [34, NaN, 31],
     })
     expect(mapped).to.deep.equal({
-      'westinghouse-fission-surface-power': 0.34,
-      'ix-fission-surface-power': 0.31,
+      oddsByProjectId: {
+        'westinghouse-fission-surface-power': 0.34,
+        'ix-fission-surface-power': 0.31,
+      },
+      fieldOdds: undefined,
     })
   })
 
@@ -83,7 +89,10 @@ describe('mapOutcomeOddsToProjectIds', () => {
       teamIds: [1n, 2n],
       probabilities: [60, 40],
     })
-    expect(mapped).to.deep.equal({ a: 0.6, b: 0.4 })
+    expect(mapped).to.deep.equal({
+      oddsByProjectId: { a: 0.6, b: 0.4 },
+      fieldOdds: undefined,
+    })
   })
 
   it('returns undefined for an empty outcomes array', () => {
@@ -94,5 +103,24 @@ describe('mapOutcomeOddsToProjectIds', () => {
         probabilities: [],
       })
     ).to.equal(undefined)
+  })
+
+  it('routes field slots into fieldOdds and never into oddsByProjectId', () => {
+    const mapped = mapOutcomeOddsToProjectIds({
+      outcomes: [
+        { projectId: 'westinghouse-fission-surface-power', teamId: 301 },
+        { projectId: 'lockheed-fission-surface-power', teamId: 302 },
+        { projectId: '__open-field__', teamId: 999, field: true },
+      ],
+      teamIds: [301n, 302n, 999n],
+      probabilities: [40, 45, 15],
+    })
+    expect(mapped).to.deep.equal({
+      oddsByProjectId: {
+        'westinghouse-fission-surface-power': 0.4,
+        'lockheed-fission-surface-power': 0.45,
+      },
+      fieldOdds: 0.15,
+    })
   })
 })

--- a/ui/cypress/integration/lib/deprize/lifecycle.cy.ts
+++ b/ui/cypress/integration/lib/deprize/lifecycle.cy.ts
@@ -138,11 +138,12 @@ describe('deprize lifecycle derivations', () => {
       }
     })
 
-    it('surfaces when registry is settled / refundable / post-M1', () => {
+    it('surfaces when registry is settled / refundable / post-M1 / superseded', () => {
       for (const registryState of [
         DePrizeState.SETTLED,
         DePrizeState.M1_RELEASED,
         DePrizeState.M2_COMPLETE,
+        DePrizeState.SUPERSEDED,
         DePrizeState.NO_WINNER,
         DePrizeState.CANCELLED,
         DePrizeState.M2_FAILED,

--- a/ui/cypress/integration/lib/deprize/lifecycle.cy.ts
+++ b/ui/cypress/integration/lib/deprize/lifecycle.cy.ts
@@ -28,32 +28,34 @@ describe('deprize lifecycle derivations', () => {
         DePrizeState.M2_FAILED,
         DePrizeState.CANCELLED,
         DePrizeState.NO_WINNER,
+        DePrizeState.SUPERSEDED,
       ]) {
         expect(deriveDePrizeFlags(s, 0n).bettingOpen, `state ${s}`).to.equal(false)
       }
     })
 
-    it('refundable terminals are exactly CANCELLED / NO_WINNER / M2_FAILED', () => {
+    it('refundable terminals are exactly CANCELLED / NO_WINNER / M2_FAILED (not SUPERSEDED)', () => {
       const refundable = [
         DePrizeState.CANCELLED,
         DePrizeState.NO_WINNER,
         DePrizeState.M2_FAILED,
       ]
-      for (let s = 0; s <= 10; s++) {
+      for (let s = 0; s <= 11; s++) {
         const expected = refundable.includes(s)
         expect(deriveDePrizeFlags(s, 0n).isRefundable, `state ${s}`).to.equal(expected)
         expect(isRefundableState(s), `helper state ${s}`).to.equal(expected)
       }
     })
 
-    it('terminal states are the refundables plus M2_COMPLETE', () => {
+    it('terminal states are the refundables plus M2_COMPLETE and SUPERSEDED', () => {
       const terminal = [
         DePrizeState.M2_COMPLETE,
         DePrizeState.M2_FAILED,
         DePrizeState.CANCELLED,
         DePrizeState.NO_WINNER,
+        DePrizeState.SUPERSEDED,
       ]
-      for (let s = 0; s <= 10; s++) {
+      for (let s = 0; s <= 11; s++) {
         const expected = terminal.includes(s)
         expect(deriveDePrizeFlags(s, 0n).isTerminal, `state ${s}`).to.equal(expected)
         expect(isTerminalState(s), `helper state ${s}`).to.equal(expected)
@@ -66,7 +68,7 @@ describe('deprize lifecycle derivations', () => {
     })
 
     it('has display metadata for every state', () => {
-      for (let s = 0; s <= 10; s++) {
+      for (let s = 0; s <= 11; s++) {
         const meta = DEPRIZE_STATE_META[s as DePrizeState]
         expect(meta, `state ${s}`).to.not.equal(undefined)
         expect(meta.label.length).to.be.greaterThan(0)

--- a/ui/docs/DEPRIZE_TERMS_AND_CONDITIONS.md
+++ b/ui/docs/DEPRIZE_TERMS_AND_CONDITIONS.md
@@ -134,6 +134,29 @@ refund-terminal state); on a successful prize payout they do not redeem against
 the pool. A superseded market's price may diverge from the live generation's
 odds — treat it as an exit quote, not the race's official odds.
 
+### 5.3 Named competitors and no endorsement
+
+Competitors are named at **MoonDAO's editorial discretion**, based on publicly
+available information about who is credibly pursuing the capability. Being listed
+as an outcome **does not mean** the organization has entered the DePrize,
+registered, agreed to participate, endorsed MoonDAO, or is affiliated with,
+sponsored by, or partnered with MoonDAO or this prize in any way. No listed
+organization is required to do anything, and none receives an entry obligation by
+being named.
+
+Your bet is on an **outcome** — whether that organization achieves the capability
+first as judged under Section 5 — and **not** on any affiliation, partnership, or
+endorsement. Organization names and marks are the property of their respective
+owners and are used only to identify the subject of an outcome (nominative use).
+Logos and brand styling are shown **only** for competitors that have claimed their
+listing; unclaimed competitors are displayed with a neutral placeholder mark.
+
+If you are an organization named in a DePrize and want your listing corrected,
+rebranded, or removed from future generations, contact MoonDAO using Section 15.
+An entrant who is verifiably ineligible to win may be dropped from the next
+generation's roster under Section 5.2; a live generation's outcome set cannot be
+edited.
+
 ## 6. Cancellation, no winner, and the equal-payout refund
 
 A DePrize may end in a **refund-terminal** state — **cancelled**, **no eligible

--- a/ui/docs/DEPRIZE_TERMS_AND_CONDITIONS.md
+++ b/ui/docs/DEPRIZE_TERMS_AND_CONDITIONS.md
@@ -105,6 +105,35 @@ on-chain, the result cannot be reversed, altered, or refunded by MoonDAO, by you
 or by any third party. Redemption is **permissionless** — you (or anyone) can
 redeem a resolved position directly against the CTF contract.
 
+### 5.1 Open Field outcome
+
+Some DePrizes include an **Open Field** outcome slot: a bet that the eventual
+winner is a qualifying entrant **not listed among the named competitors** at
+registration. The objective eligibility criteria for the field are published with
+the DePrize's rules. If the Senate selects a field entrant, MoonDAO's
+administrator Safe settles the market to the Open Field slot and records that
+entrant's payout address **in the same transaction batch** as the winner
+declaration. Backing the field is a bet on an unnamed class of entrants, not on a
+specific company; you accept that uncertainty.
+
+There is **no tradable "None" / "nobody wins" outcome**. If nobody qualifies, the
+DePrize resolves under Section 6 (equal-payout refund), not as a field win.
+
+### 5.2 Generations and an accumulating prize pool
+
+Long-running races may proceed in **generations**. A generation has its own
+outcome roster, CTF condition, and market. The Juicebox prize pool and project
+token are shared across generations and **accumulate** until a winner is paid.
+When a generation is **superseded**, new bets on that generation close, but you
+may still **sell** your position back to its market at the prevailing price. The
+position is **locked only if you choose not to sell**; it is not refunded or
+repriced at supersede. Every generation resolves to the **same real-world winner**
+when the race settles, each from its own market's collateral. Project tokens are
+only a **contingent** claim on the prize pool (realised via Launchpad cashOut in a
+refund-terminal state); on a successful prize payout they do not redeem against
+the pool. A superseded market's price may diverge from the live generation's
+odds — treat it as an exit quote, not the race's official odds.
+
 ## 6. Cancellation, no winner, and the equal-payout refund
 
 A DePrize may end in a **refund-terminal** state — **cancelled**, **no eligible

--- a/ui/lib/deprize/competitions.ts
+++ b/ui/lib/deprize/competitions.ts
@@ -37,8 +37,10 @@ export type DePrizeRaceOutcome = {
    */
   teamId?: number
   /**
-   * Competitor consent for public markets. Outside sepolia, every non-field
-   * outcome must be consented before the bridge reports status `live`.
+   * True once the organization has claimed its listing. Gates BRANDING ONLY
+   * (logo + brand color); it never gates market visibility. See
+   * {@link isCompetitorClaimed}. Distinct from the atlas `RosterStatus`, which
+   * stays editorial metadata for panel copy — do not cross-wire them.
    */
   consented?: boolean
   /**
@@ -69,7 +71,7 @@ export type DePrizeCompetition = {
   raceLabel?: string
   /**
    * CTF outcome index → atlas competitor. Order MUST match registry teamIds.
-   * `teamId` is the alignment checksum; `consented` gates public markets.
+   * `teamId` is the alignment checksum; `consented` gates branding only.
    */
   outcomes?: DePrizeRaceOutcome[]
   /** Prior generation this entry superseded (off-chain lineage mirror). */
@@ -311,19 +313,18 @@ export function findDePrizeIdForGoal(
 }
 
 /**
- * Pure consent check on an outcomes array.
- * Sepolia is always publishable (QA). Elsewhere every non-field outcome must
- * have `consented: true`. Field slots are not competitors and are skipped.
+ * A binding is usable when it names at least one real competitor. This is a
+ * completeness check, NOT a consent check: listing a public company as a market
+ * outcome does not require its permission, and hiding a bound market behind an
+ * all-or-nothing consent flag was stricter than the disclosure it stood in for.
+ * Implied endorsement is handled by the roster disclaimer plus withholding
+ * trademarks until a competitor claims — see {@link isCompetitorClaimed}.
  */
-export function areRaceOutcomesPublishable(
-  chainSlug: string,
+export function isRaceBindingComplete(
   outcomes: readonly DePrizeRaceOutcome[] | undefined
 ): boolean {
   if (!outcomes?.length) return false
-  if (chainSlug === 'sepolia') return true
-  const competitors = outcomes.filter((o) => !o.field)
-  if (!competitors.length) return false
-  return competitors.every((o) => o.consented === true)
+  return outcomes.some((o) => !o.field)
 }
 
 /** True when this outcome is the Open Field slot. */
@@ -334,10 +335,30 @@ export function isOpenFieldOutcome(
 }
 
 /**
- * Consent gate for reporting a race market as live.
- * Unbound goals are not publishable. See {@link areRaceOutcomesPublishable}.
+ * Has this competitor claimed its listing? Gates BRANDING ONLY (logo, brand
+ * color) — never market visibility. Unclaimed competitors still render their
+ * name and link, just with a neutral monogram instead of their mark.
  */
-export function isDePrizeGoalMarketPublishable(
+export function isCompetitorClaimed(
+  outcome: DePrizeRaceOutcome | undefined
+): boolean {
+  return outcome?.consented === true
+}
+
+/**
+ * Shown wherever named competitors appear next to a market. This is the control
+ * that replaced the consent gate, so it must render on any surface that lists
+ * outcomes: the DePrize detail roster and the Moon Base Zero race panel.
+ * Mirrors section 5.3 of the Terms.
+ */
+export const ROSTER_DISCLAIMER =
+  'Competitors are listed at MoonDAO’s editorial discretion. Listing does not mean the organization has entered, endorsed, or is affiliated with this prize. Bets are on outcomes, not on any affiliation.'
+
+/**
+ * True when a race is bound to an on-chain DePrize with a usable roster, so the
+ * bridge may report live odds. Unbound goals keep their curator priors.
+ */
+export function isDePrizeGoalMarketBound(
   chainSlug: string,
   sharedGoalId: string | undefined
 ): boolean {
@@ -345,7 +366,7 @@ export function isDePrizeGoalMarketPublishable(
   const deprizeId = findDePrizeIdForGoal(chainSlug, sharedGoalId)
   if (deprizeId === undefined) return false
   const binding = getDePrizeRaceBinding(chainSlug, deprizeId)
-  return areRaceOutcomesPublishable(chainSlug, binding?.outcomes)
+  return isRaceBindingComplete(binding?.outcomes)
 }
 
 export type DePrizeIndexRaceGroup = {

--- a/ui/lib/deprize/competitions.ts
+++ b/ui/lib/deprize/competitions.ts
@@ -19,6 +19,15 @@
  * either side writes atlas seed data that conflicts.
  */
 
+/**
+ * Reserved MoonDAOTeam id for the Open Field outcome slot.
+ * Pending ops mint on Sepolia — see docs/DEPRIZE_QA.md. Intended id 999.
+ */
+export const OPEN_FIELD_TEAM_ID = 999
+
+/** Stable projectId key for field outcomes (never rendered as an atlas competitor). */
+export const OPEN_FIELD_PROJECT_ID = '__open-field__'
+
 export type DePrizeRaceOutcome = {
   /** Atlas competitor project id (SharedGoal.projectIds / impliedOdds key). */
   projectId: string
@@ -28,10 +37,15 @@ export type DePrizeRaceOutcome = {
    */
   teamId?: number
   /**
-   * Competitor consent for public markets. Outside sepolia, every outcome must
-   * be consented before the bridge reports status `live`.
+   * Competitor consent for public markets. Outside sepolia, every non-field
+   * outcome must be consented before the bridge reports status `live`.
    */
   consented?: boolean
+  /**
+   * Open Field slot — any qualifying entrant not listed above. Odds land in
+   * `fieldOdds`, never in `oddsByProjectId`.
+   */
+  field?: boolean
 }
 
 export type DePrizeRaceBinding = {
@@ -58,6 +72,10 @@ export type DePrizeCompetition = {
    * `teamId` is the alignment checksum; `consented` gates public markets.
    */
   outcomes?: DePrizeRaceOutcome[]
+  /** Prior generation this entry superseded (off-chain lineage mirror). */
+  supersedes?: number
+  /** Next generation that superseded this entry (off-chain lineage mirror). */
+  supersededBy?: number
 }
 
 export const GENERIC_DEPRIZE_COMPETITION: DePrizeCompetition = {
@@ -178,8 +196,54 @@ function isProductionEnv(): boolean {
   return (globalThis as any)?.process?.env?.NODE_ENV === 'production'
 }
 
-// Memoized reverse index: chainSlug → sharedGoalId → deprizeId.
+// Memoized reverse index: chainSlug → sharedGoalId → live tip deprizeId.
 const goalIndexByChain = new Map<string, Map<string, number>>()
+
+/** The two lineage links a generation can carry. */
+export type DePrizeGenerationLinks = {
+  supersedes?: number
+  supersededBy?: number
+}
+
+/**
+ * Walk `supersededBy` forward to the newest generation.
+ * Tolerates a malformed registry: a cycle stops the walk instead of hanging.
+ */
+export function liveTipOf(
+  generations: Record<number, DePrizeGenerationLinks>,
+  deprizeId: number
+): number {
+  let tip = deprizeId
+  const seen = new Set<number>([tip])
+  for (;;) {
+    const next = generations[tip]?.supersededBy
+    if (next === undefined || !Number.isFinite(next) || seen.has(next)) break
+    seen.add(next)
+    tip = next
+  }
+  return tip
+}
+
+/**
+ * 1-indexed generation number, found by walking `supersedes` backward.
+ * Tolerates a malformed registry: a cycle stops the walk instead of hanging.
+ */
+export function generationNumberOf(
+  generations: Record<number, DePrizeGenerationLinks>,
+  deprizeId: number
+): number {
+  let gen = 1
+  let cur = deprizeId
+  const seen = new Set<number>([cur])
+  for (;;) {
+    const prev = generations[cur]?.supersedes
+    if (prev === undefined || !Number.isFinite(prev) || seen.has(prev)) break
+    seen.add(prev)
+    gen++
+    cur = prev
+  }
+  return gen
+}
 
 function goalIndexForChain(chainSlug: string): Map<string, number> {
   const cached = goalIndexByChain.get(chainSlug)
@@ -190,37 +254,66 @@ function goalIndexForChain(chainSlug: string): Map<string, number> {
   for (const [idStr, comp] of Object.entries(entries)) {
     if (!comp.sharedGoalId) continue
     const deprizeId = Number(idStr)
+    const tip = liveTipOf(entries, deprizeId)
     if (map.has(comp.sharedGoalId)) {
-      const message = `Duplicate DePrize race binding on ${chainSlug}: sharedGoalId "${comp.sharedGoalId}" maps to both #${map.get(comp.sharedGoalId)} and #${deprizeId}`
+      const existingTip = map.get(comp.sharedGoalId)!
+      // Same race lineage (generations share a goal) — keep the live tip.
+      if (existingTip === tip) continue
+      const message = `Duplicate DePrize race binding on ${chainSlug}: sharedGoalId "${comp.sharedGoalId}" maps to both #${existingTip} and #${tip}`
       // Loud in dev/test so the seed error is caught before merge; in
       // production keep the first binding rather than crashing the page.
       if (!isProductionEnv()) throw new Error(message)
       console.error(`[deprize] ${message}`)
       continue
     }
-    map.set(comp.sharedGoalId, deprizeId)
+    map.set(comp.sharedGoalId, tip)
   }
   goalIndexByChain.set(chainSlug, map)
   return map
 }
 
 /**
- * Reverse lookup: Moon Base Zero SharedGoal.id → DePrize id on this chain.
- * Returns undefined when unbound. Throws outside production if the registry
- * maps two DePrize ids to the same goal (built once, then cached).
+ * Walk off-chain `supersededBy` links to the live generation tip.
+ * The live generation is the only one that feeds Moon Base Zero odds.
+ */
+export function resolveLiveDePrizeId(
+  chainSlug: string,
+  deprizeId: number | undefined
+): number | undefined {
+  if (deprizeId === undefined || !Number.isFinite(deprizeId)) return undefined
+  return liveTipOf(DEPRIZE_COMPETITIONS[chainSlug] ?? {}, deprizeId)
+}
+
+/**
+ * Generation number (1-indexed) by walking `supersedes` links backward.
+ */
+export function getDePrizeGenerationNumber(
+  chainSlug: string,
+  deprizeId: number | undefined
+): number {
+  if (deprizeId === undefined || !Number.isFinite(deprizeId)) return 1
+  return generationNumberOf(DEPRIZE_COMPETITIONS[chainSlug] ?? {}, deprizeId)
+}
+
+/**
+ * Reverse lookup: Moon Base Zero SharedGoal.id → live DePrize id on this chain.
+ * When multiple generations share a goal, returns the tip (newest) generation.
+ * Throws outside production if the registry maps two unrelated DePrize ids to
+ * the same goal (built once, then cached).
  */
 export function findDePrizeIdForGoal(
   chainSlug: string,
   sharedGoalId: string | undefined
 ): number | undefined {
   if (!sharedGoalId) return undefined
-  return goalIndexForChain(chainSlug).get(sharedGoalId)
+  const bound = goalIndexForChain(chainSlug).get(sharedGoalId)
+  return resolveLiveDePrizeId(chainSlug, bound)
 }
 
 /**
  * Pure consent check on an outcomes array.
- * Sepolia is always publishable (QA). Elsewhere every outcome must have
- * `consented: true`.
+ * Sepolia is always publishable (QA). Elsewhere every non-field outcome must
+ * have `consented: true`. Field slots are not competitors and are skipped.
  */
 export function areRaceOutcomesPublishable(
   chainSlug: string,
@@ -228,7 +321,16 @@ export function areRaceOutcomesPublishable(
 ): boolean {
   if (!outcomes?.length) return false
   if (chainSlug === 'sepolia') return true
-  return outcomes.every((o) => o.consented === true)
+  const competitors = outcomes.filter((o) => !o.field)
+  if (!competitors.length) return false
+  return competitors.every((o) => o.consented === true)
+}
+
+/** True when this outcome is the Open Field slot. */
+export function isOpenFieldOutcome(
+  outcome: DePrizeRaceOutcome | undefined
+): boolean {
+  return !!outcome?.field
 }
 
 /**

--- a/ui/lib/deprize/goal-market.ts
+++ b/ui/lib/deprize/goal-market.ts
@@ -1,0 +1,99 @@
+/**
+ * Merge live DePrize odds into a Moon Base Zero shared goal.
+ *
+ * Deliberately NOT typed against `@/lib/lunar-atlas` — those types ship with the
+ * Moon Base Zero branch, and this module has to build and unit test without them.
+ * The structural types below are a subset that the atlas `SharedGoal` already
+ * satisfies, so the page can call this with its concrete type and get it back
+ * unchanged.
+ *
+ * Keep dependency-free for yarn test:deprize.
+ */
+
+import { OPEN_FIELD_PROJECT_ID } from './competitions'
+
+/** Subset of the atlas `MarketStatus` union. */
+export type MergeableMarketStatus = 'none' | 'planned' | 'live' | 'resolved'
+
+/** Subset of the atlas `SharedGoalMarket`. */
+export type MergeableMarket = {
+  status: MergeableMarketStatus
+  /** Fractions of 1 keyed by atlas projectId. */
+  impliedOdds?: Record<string, number>
+}
+
+/** Subset of the atlas `SharedGoal`. */
+export type MergeableGoal = {
+  id: string
+  market?: MergeableMarket
+}
+
+/** What the goal-odds bridge produces for one race. */
+export type LiveGoalOdds = {
+  deprizeId: number | undefined
+  oddsByProjectId: Record<string, number> | undefined
+  fieldOdds: number | undefined
+  status: 'live' | 'resolved' | 'planned'
+}
+
+/**
+ * Swap a goal's curator priors for live market-implied odds.
+ *
+ * Returns the goal untouched when there is nothing trustworthy to show: no bound
+ * DePrize, a `planned` bridge status (unbound, superseded, or still loading), or
+ * an empty odds map. Curator priors are better than a blank market, so a partial
+ * result must never overwrite them.
+ *
+ * Open Field mass is carried under {@link OPEN_FIELD_PROJECT_ID} so the rendered
+ * bars still sum to ~1 rather than silently overstating the named competitors.
+ */
+export function mergeLiveMarket<T extends MergeableGoal>(
+  goal: T,
+  live: LiveGoalOdds | undefined
+): T {
+  if (!live || live.deprizeId === undefined) return goal
+  if (live.status === 'planned') return goal
+
+  const odds = live.oddsByProjectId
+  if (!odds || Object.keys(odds).length === 0) return goal
+
+  const impliedOdds: Record<string, number> = { ...odds }
+  if (live.fieldOdds !== undefined && Number.isFinite(live.fieldOdds)) {
+    impliedOdds[OPEN_FIELD_PROJECT_ID] = live.fieldOdds
+  }
+
+  return {
+    ...goal,
+    market: {
+      // A goal can be bound before a curator ever wrote a market block.
+      ...(goal.market ?? { status: 'planned' as MergeableMarketStatus }),
+      status: live.status,
+      impliedOdds,
+    },
+  }
+}
+
+/**
+ * Merge live odds into whichever goal in the list the bridge was mounted for.
+ * Every other goal is returned by reference so downstream memos that key on
+ * identity (buildTechTrees, the races memo) only recompute when they must.
+ *
+ * Takes and returns a mutable array on purpose: `buildTechTrees(projects,
+ * sharedGoals: SharedGoal[])` rejects `readonly`, and copying the result to
+ * satisfy that would defeat the identity preservation above.
+ */
+export function mergeLiveMarketInto<T extends MergeableGoal>(
+  goals: T[],
+  sharedGoalId: string | undefined,
+  live: LiveGoalOdds | undefined
+): T[] {
+  if (!sharedGoalId || !live) return goals
+  let changed = false
+  const next = goals.map((g) => {
+    if (g.id !== sharedGoalId) return g
+    const merged = mergeLiveMarket(g, live)
+    if (merged !== g) changed = true
+    return merged
+  })
+  return changed ? next : goals
+}

--- a/ui/lib/deprize/goal-odds.ts
+++ b/ui/lib/deprize/goal-odds.ts
@@ -10,25 +10,38 @@ export type GoalOddsOutcome = {
   projectId: string
   /** When set, must equal teamIds[i] or the mapper returns undefined. */
   teamId?: number
+  /**
+   * Open Field slot — not an atlas competitor. Odds go to `fieldOdds` rather
+   * than `oddsByProjectId` so they are never attributed to a projectId.
+   */
+  field?: boolean
+}
+
+export type MappedGoalOdds = {
+  /** Fractions of 1 keyed by atlas projectId (field slots excluded). */
+  oddsByProjectId: Record<string, number>
+  /** Fraction of 1 on the Open Field slot, if any finite field odds exist. */
+  fieldOdds: number | undefined
 }
 
 /**
  * Map LMSR outcome probabilities onto atlas project ids.
  *
- * Returns fractions of 1, drops non-finite entries, and returns `undefined` on
- * any length mismatch or teamId checksum failure. Blank is recoverable; wrong
+ * Returns fractions of 1, drops non-finite entries, skips `field: true` slots
+ * (their mass lands in `fieldOdds`), and returns `undefined` on any length
+ * mismatch or teamId checksum failure. Blank is recoverable; wrong
  * attribution (Lockheed's odds on Westinghouse) is not.
  *
- * Also returns `undefined` when no finite odds survive — a loading or closed
- * market reads all-NaN, and an empty map would let a merge overwrite curator
- * priors with nothing.
+ * Also returns `undefined` when no finite competitor-or-field odds survive —
+ * a loading or closed market reads all-NaN, and an empty map would let a merge
+ * overwrite curator priors with nothing.
  */
 export function mapOutcomeOddsToProjectIds(args: {
   outcomes: GoalOddsOutcome[]
   teamIds: readonly bigint[]
   /** Percents as returned by useDePrizeMarket (`calcMarginalPrice * 100`). */
   probabilities: readonly number[]
-}): Record<string, number> | undefined {
+}): MappedGoalOdds | undefined {
   const { outcomes, teamIds, probabilities } = args
   const n = outcomes.length
   if (n === 0) return undefined
@@ -40,13 +53,19 @@ export function mapOutcomeOddsToProjectIds(args: {
     if (teamIds[i] !== BigInt(expected)) return undefined
   }
 
-  const out: Record<string, number> = {}
+  const oddsByProjectId: Record<string, number> = {}
+  let fieldOdds: number | undefined
   let finite = 0
   for (let i = 0; i < n; i++) {
     const p = probabilities[i]
     if (!Number.isFinite(p)) continue
-    out[outcomes[i].projectId] = p / 100
+    const fraction = p / 100
     finite++
+    if (outcomes[i].field) {
+      fieldOdds = (fieldOdds ?? 0) + fraction
+      continue
+    }
+    oddsByProjectId[outcomes[i].projectId] = fraction
   }
-  return finite > 0 ? out : undefined
+  return finite > 0 ? { oddsByProjectId, fieldOdds } : undefined
 }

--- a/ui/lib/deprize/lifecycle.ts
+++ b/ui/lib/deprize/lifecycle.ts
@@ -159,6 +159,7 @@ export function shouldSurfaceResolution(opts: {
     registryState === DePrizeState.SETTLED ||
     registryState === DePrizeState.M1_RELEASED ||
     registryState === DePrizeState.M2_COMPLETE ||
+    registryState === DePrizeState.SUPERSEDED ||
     isRefundableState(registryState)
   ) {
     return true

--- a/ui/lib/deprize/lifecycle.ts
+++ b/ui/lib/deprize/lifecycle.ts
@@ -15,6 +15,7 @@ export enum DePrizeState {
   M2_FAILED = 8,
   CANCELLED = 9,
   NO_WINNER = 10,
+  SUPERSEDED = 11,
 }
 
 export const DEPRIZE_STATE_META: Record<
@@ -65,6 +66,11 @@ export const DEPRIZE_STATE_META: Record<
     label: 'No winner',
     description: 'No eligible winner was declared. Refunds are available.',
   },
+  [DePrizeState.SUPERSEDED]: {
+    label: 'Superseded',
+    description:
+      'This generation was forked into a newer roster. New bets are closed; you can still sell your position. The prize pool continues on the next generation.',
+  },
 }
 
 export const REFUNDABLE_STATES: ReadonlySet<DePrizeState> = new Set([
@@ -78,6 +84,7 @@ export const TERMINAL_STATES: ReadonlySet<DePrizeState> = new Set([
   DePrizeState.M2_FAILED,
   DePrizeState.CANCELLED,
   DePrizeState.NO_WINNER,
+  DePrizeState.SUPERSEDED,
 ])
 
 export const isRefundableState = (s: DePrizeState | undefined) =>

--- a/ui/lib/deprize/useDePrizeGoalOdds.tsx
+++ b/ui/lib/deprize/useDePrizeGoalOdds.tsx
@@ -3,7 +3,7 @@ import type { Chain } from 'thirdweb'
 import {
   findDePrizeIdForGoal,
   getDePrizeRaceBinding,
-  isDePrizeGoalMarketPublishable,
+  isDePrizeGoalMarketBound,
 } from './competitions'
 import { DePrizeState } from './constants'
 import { mapOutcomeOddsToProjectIds } from './goal-odds'
@@ -26,10 +26,10 @@ export type UseDePrizeGoalOddsResult = {
 
 function deriveGoalMarketStatus(
   registryState: DePrizeState | undefined,
-  publishable: boolean,
+  bound: boolean,
 ): DePrizeGoalMarketStatus {
-  // Consent gate: never surface live (or resolved) without publishable roster.
-  if (!publishable) return 'planned'
+  // An unbound race has no on-chain market to report; it keeps curator priors.
+  if (!bound) return 'planned'
   if (registryState === undefined) return 'planned'
 
   // Superseded generations are not the live race — treat as planned so the
@@ -72,7 +72,7 @@ export function useDePrizeGoalOdds(
   const chainSlug = getChainSlug(chain)
   const deprizeId = findDePrizeIdForGoal(chainSlug, sharedGoalId)
   const binding = getDePrizeRaceBinding(chainSlug, deprizeId)
-  const publishable = isDePrizeGoalMarketPublishable(chainSlug, sharedGoalId)
+  const bound = isDePrizeGoalMarketBound(chainSlug, sharedGoalId)
 
   const { deprize, loading: registryLoading } = useDePrize(deprizeId, chain)
   const numOutcomes = deprize?.teamIds.length ?? 0
@@ -86,18 +86,19 @@ export function useDePrizeGoalOdds(
   })
 
   const mapped = useMemo(() => {
-    // Consent gate: do not expose live LMSR fractions for non-public races.
-    if (!publishable) return undefined
+    if (!bound) return undefined
     if (!binding?.outcomes.length || !deprize?.teamIds.length) return undefined
+    // Alignment guard (correctness, not policy): a roster whose length has
+    // drifted from the market would attribute odds to the wrong competitor.
     if (market.outcomes.length !== binding.outcomes.length) return undefined
     return mapOutcomeOddsToProjectIds({
       outcomes: binding.outcomes,
       teamIds: deprize.teamIds,
       probabilities: market.outcomes.map((o) => o.probability),
     })
-  }, [binding, deprize?.teamIds, market.outcomes, publishable])
+  }, [binding, deprize?.teamIds, market.outcomes, bound])
 
-  const status = deriveGoalMarketStatus(deprize?.state, publishable)
+  const status = deriveGoalMarketStatus(deprize?.state, bound)
 
   return {
     deprizeId,

--- a/ui/lib/deprize/useDePrizeGoalOdds.tsx
+++ b/ui/lib/deprize/useDePrizeGoalOdds.tsx
@@ -18,6 +18,8 @@ export type UseDePrizeGoalOddsResult = {
   deprizeId: number | undefined
   /** Fractions of 1 keyed by atlas projectId. Undefined when unbound / mismatched. */
   oddsByProjectId: Record<string, number> | undefined
+  /** Fraction of 1 on the Open Field slot, if any. */
+  fieldOdds: number | undefined
   status: DePrizeGoalMarketStatus
   loading: boolean
 }
@@ -29,6 +31,11 @@ function deriveGoalMarketStatus(
   // Consent gate: never surface live (or resolved) without publishable roster.
   if (!publishable) return 'planned'
   if (registryState === undefined) return 'planned'
+
+  // Superseded generations are not the live race — treat as planned so the
+  // bridge only surfaces odds from the tip generation findDePrizeIdForGoal
+  // already resolves to.
+  if (registryState === DePrizeState.SUPERSEDED) return 'planned'
 
   if (
     registryState === DePrizeState.SETTLED ||
@@ -56,6 +63,7 @@ function deriveGoalMarketStatus(
  * Bridge one Moon Base Zero race to its bound DePrize market.
  * Mounts a single market (call for the open race only — do not fan out to all 8).
  * Inherits ODDS_POLL_MS / hidden-tab skip from useDePrizeMarket.
+ * Resolves to the live generation tip when a race has been superseded.
  */
 export function useDePrizeGoalOdds(
   chain: Chain,
@@ -77,7 +85,7 @@ export function useDePrizeGoalOdds(
     registryState: deprize?.state,
   })
 
-  const oddsByProjectId = useMemo(() => {
+  const mapped = useMemo(() => {
     // Consent gate: do not expose live LMSR fractions for non-public races.
     if (!publishable) return undefined
     if (!binding?.outcomes.length || !deprize?.teamIds.length) return undefined
@@ -93,7 +101,8 @@ export function useDePrizeGoalOdds(
 
   return {
     deprizeId,
-    oddsByProjectId,
+    oddsByProjectId: mapped?.oddsByProjectId,
+    fieldOdds: mapped?.fieldOdds,
     status,
     loading: !!deprizeId && (registryLoading || market.loading),
   }

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -15,10 +15,12 @@ import { getContract } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import { eth_getBalance, getRpcClient } from 'thirdweb/rpc'
 import {
+  ROSTER_DISCLAIMER,
   getDePrizeCompetition,
   getDePrizeGenerationNumber,
   getDePrizeRaceBinding,
   isKnownDePrizeCompetition,
+  isRaceBindingComplete,
 } from '@/lib/deprize/competitions'
 import {
   DePrizeState,
@@ -652,6 +654,11 @@ function DePrizeDetailContent() {
         {numOutcomes > 0 && (
           <div className="flex flex-col gap-3">
             <h3 className="title-text-colors text-lg font-GoodTimes">Providers</h3>
+            {isRaceBindingComplete(raceBinding?.outcomes) && (
+              <p className="text-gray-500 text-xs leading-relaxed max-w-3xl">
+                {ROSTER_DISCLAIMER}
+              </p>
+            )}
             {market.outcomes.map((o) => {
               const teamId = deprize?.teamIds[o.index] ?? 0n
               const invested = costBasis[o.index] ?? 0
@@ -689,6 +696,11 @@ function DePrizeDetailContent() {
                   onCashOut={(i) => setExitIndex(i)}
                   isField={isField}
                   withdrawn={!!withdrawnByTeamId[teamId.toString()]}
+                  hrefOverride={
+                    outcomeBinding?.projectId
+                      ? `/moonbase/${outcomeBinding.projectId}`
+                      : undefined
+                  }
                 />
               )
             })}

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -1,6 +1,11 @@
+import DePrizeRegistryABI from 'const/abis/DePrizeRegistry.json'
 import LMSRWithTWAP from 'const/abis/LMSRWithTWAP.json'
 import TeamABI from 'const/abis/Team.json'
-import { DEPRIZE_MINT_ADDRESSES, TEAM_ADDRESSES } from 'const/config'
+import {
+  DEPRIZE_MINT_ADDRESSES,
+  DEPRIZE_REGISTRY_ADDRESSES,
+  TEAM_ADDRESSES,
+} from 'const/config'
 import { useLogin } from '@privy-io/react-auth'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -11,6 +16,8 @@ import { useActiveAccount } from 'thirdweb/react'
 import { eth_getBalance, getRpcClient } from 'thirdweb/rpc'
 import {
   getDePrizeCompetition,
+  getDePrizeGenerationNumber,
+  getDePrizeRaceBinding,
   isKnownDePrizeCompetition,
 } from '@/lib/deprize/competitions'
 import {
@@ -68,7 +75,9 @@ function StateBadge({
         ? 'bg-emerald-500/20 text-emerald-200 border-emerald-500/40'
         : [DePrizeState.CANCELLED, DePrizeState.NO_WINNER, DePrizeState.M2_FAILED].includes(state)
           ? 'bg-red-500/10 text-red-200 border-red-500/30'
-          : 'bg-white/10 text-gray-200 border-white/20'
+          : state === DePrizeState.SUPERSEDED
+            ? 'bg-amber-500/15 text-amber-200 border-amber-500/40'
+            : 'bg-white/10 text-gray-200 border-white/20'
   return (
     <span className={`px-3 py-1 rounded-full text-xs font-medium border ${tone}`}>
       {labelOverride ?? meta?.label ?? 'Unknown'}
@@ -94,6 +103,8 @@ function DePrizeDetailContent() {
   const { selectedChain: chain } = useContext(ChainContextV5)
   const chainSlug = getChainSlug(chain)
   const competition = getDePrizeCompetition(chainSlug, deprizeId)
+  const raceBinding = getDePrizeRaceBinding(chainSlug, deprizeId)
+  const generationNumber = getDePrizeGenerationNumber(chainSlug, deprizeId)
   const knownCompetition = isKnownDePrizeCompetition(chainSlug, deprizeId)
   const account = useActiveAccount()
   const userAddress = account?.address
@@ -106,6 +117,7 @@ function DePrizeDetailContent() {
     refresh: refreshRegistry,
   } = useDePrize(deprizeId, chain)
   const numOutcomes = deprize?.teamIds.length ?? 0
+  const [withdrawnByTeamId, setWithdrawnByTeamId] = useState<Record<string, boolean>>({})
 
   const market = useDePrizeMarket({
     deprizeId,
@@ -137,6 +149,42 @@ function DePrizeDetailContent() {
   const [exitIndex, setExitIndex] = useState<number | null>(null)
 
   const readChain = useMemo(() => deprizeReadChain(chain.id), [chain.id])
+
+  // Disclosure flags: withdrawn competitors stay tradable but are badged.
+  useEffect(() => {
+    const address = DEPRIZE_REGISTRY_ADDRESSES[chainSlug] ?? ''
+    if (!deprize?.teamIds.length || !address || deprizeId === undefined) {
+      setWithdrawnByTeamId({})
+      return
+    }
+    let cancelled = false
+    const registry = getContract({
+      client: deprizeReadClient,
+      chain: readChain,
+      address,
+      abi: DePrizeRegistryABI as any,
+    })
+    ;(async () => {
+      const entries = await Promise.all(
+        deprize.teamIds.map(async (teamId) => {
+          try {
+            const w = await rpcRead<boolean>({
+              contract: registry,
+              method: 'withdrawn' as string,
+              params: [BigInt(deprizeId), teamId],
+            })
+            return [teamId.toString(), !!w] as const
+          } catch {
+            return [teamId.toString(), false] as const
+          }
+        }),
+      )
+      if (!cancelled) setWithdrawnByTeamId(Object.fromEntries(entries))
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [deprize?.teamIds, deprizeId, chainSlug, readChain, refreshNonce])
 
   const teamContract = useMemo(
     () =>
@@ -427,6 +475,11 @@ function DePrizeDetailContent() {
                   toneOverride={statusLabelOverride ? 'amber' : undefined}
                 />
               )}
+              {knownCompetition && generationNumber > 1 && (
+                <span className="px-3 py-1 rounded-full text-xs font-medium border bg-white/10 text-gray-200 border-white/20">
+                  Generation {generationNumber}
+                </span>
+              )}
             </div>
             <Link
               href="/deprize"
@@ -436,6 +489,39 @@ function DePrizeDetailContent() {
             </Link>
           </div>
           <p className="text-gray-300 text-sm mt-2">{competition.tagline}</p>
+          {deprize?.state === DePrizeState.SUPERSEDED && (
+            <p className="text-amber-200/90 text-sm mt-2">
+              This generation was superseded
+              {competition.supersededBy
+                ? ` by DePrize #${competition.supersededBy}`
+                : ''}
+              . New bets are closed; you can still sell your position at the market price. Odds for
+              this race live on the current generation.
+              {competition.supersededBy && (
+                <>
+                  {' '}
+                  <Link
+                    href={`/deprize/${competition.supersededBy}`}
+                    className="underline underline-offset-2 hover:text-amber-100"
+                  >
+                    Open generation {generationNumber + 1}
+                  </Link>
+                </>
+              )}
+            </p>
+          )}
+          {competition.supersedes !== undefined && deprize?.state !== DePrizeState.SUPERSEDED && (
+            <p className="text-gray-500 text-xs mt-2">
+              Continues from{' '}
+              <Link
+                href={`/deprize/${competition.supersedes}`}
+                className="text-indigo-300/90 underline underline-offset-2 hover:text-indigo-200"
+              >
+                generation {generationNumber - 1} (DePrize #{competition.supersedes})
+              </Link>
+              . Legacy positions remain sellable there until the race settles.
+            </p>
+          )}
           {effectiveDescription && (
             <p className="text-gray-500 text-sm mt-1">{effectiveDescription}</p>
           )}
@@ -569,6 +655,8 @@ function DePrizeDetailContent() {
             {market.outcomes.map((o) => {
               const teamId = deprize?.teamIds[o.index] ?? 0n
               const invested = costBasis[o.index] ?? 0
+              const outcomeBinding = raceBinding?.outcomes[o.index]
+              const isField = !!outcomeBinding?.field
               const redeemValueEth =
                 showResolved && o.balanceWei !== undefined
                   ? Number(
@@ -599,6 +687,8 @@ function DePrizeDetailContent() {
                   userConnected={!!userAddress}
                   onBet={(i) => setBetIndex(i)}
                   onCashOut={(i) => setExitIndex(i)}
+                  isField={isField}
+                  withdrawn={!!withdrawnByTeamId[teamId.toString()]}
                 />
               )
             })}
@@ -647,7 +737,11 @@ function DePrizeDetailContent() {
         <BetModal
           deprizeId={deprizeId}
           outcomeIndex={betIndex}
-          teamName={`Team #${betIndex + 1}`}
+          teamName={
+            raceBinding?.outcomes[betIndex]?.field
+              ? 'Open Field'
+              : `Team #${betIndex + 1}`
+          }
           probability={market.outcomes[betIndex]?.probability ?? NaN}
           numOutcomes={numOutcomes}
           mintAddress={mintAddress}
@@ -669,7 +763,11 @@ function DePrizeDetailContent() {
         <ExitPositionModal
           deprizeId={deprizeId}
           outcomeIndex={exitIndex}
-          teamName={`Team #${exitIndex + 1}`}
+          teamName={
+            raceBinding?.outcomes[exitIndex]?.field
+              ? 'Open Field'
+              : `Team #${exitIndex + 1}`
+          }
           balanceWei={market.outcomes[exitIndex]?.balanceWei ?? 0n}
           positionId={market.outcomes[exitIndex]?.positionId ?? 0n}
           numOutcomes={numOutcomes}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Depends on #1499 (Phase B1). Retarget to `main` after that merges.

## Summary
- Long-running DePrizes can now change competitors without breaking CTF/LMSR immutability: reserve an **Open Field** outcome at registration, and **supersede** into a new generation that keeps the same Juicebox prize pool (pools accumulate across generations).
- Registry upgrade adds `SUPERSEDED` (terminal, not refundable), `supersede`, DRAFT-only `setTeams`, `markWithdrawn` / `unmarkWithdrawn`, and extend-only `setSunset` while OPEN. Old LMSRs stay Running so holders can keep selling; new bets are blocked via `bettingOpen`.
- `DePrizeResolve` walks lineage for superseded generations (named slot → Open Field → 1/N). UI surfaces Open Field, withdrawn badges, generation lineage, and terms/runbook disclosures.

## Test plan
- [x] `forge test --match-path 'test/deprize/*'` — 204 passing (includes spike, generations, and E2E money-flow suites)
- [x] E2E: bet → supersede → sell on old market → settle tip → redeem both generations (named survivor, field winner, 3-gen lineage, preview == payout)
- [x] `yarn test:deprize` — 79 passing (field odds, SUPERSEDED lifecycle, lineage walkers)
- [x] `yarn tsc --noEmit` clean; ABI is a strict superset of the previous `DePrizeRegistry.json`
- [ ] Review Safe-batch supersede runbook in `docs/DEPRIZE_M5.md` and Open Field / generations disclosure in terms
- [ ] After deploy: mint Open Field MoonDAOTeam NFT and record id per `docs/DEPRIZE_QA.md` (`OPEN_FIELD_TEAM_ID = 999`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-904c5707-822d-406b-96a7-e0b9d81c0e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-904c5707-822d-406b-96a7-e0b9d81c0e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

