### PR TITLE
feat(deprize): Phase B2 Wave 1 — live-odds merge and disclaimer-first markets

### DIFF
--- a/docs/DEPRIZE_PHASE_B1.md
+++ b/docs/DEPRIZE_PHASE_B1.md
@@ -50,6 +50,8 @@ New accessors alongside the existing ones (all pure, all mocha-testable):
 - `getDePrizeRaceBinding(chainSlug, deprizeId)` — returns `{ sharedGoalId, raceLabel, outcomes }` or `undefined`.
 - `findDePrizeIdForGoal(chainSlug, sharedGoalId)` — the reverse index the hook needs. Build it as a memoized map, and have it throw in dev if one chain maps two DePrize ids to the same goal.
 - `isDePrizeGoalMarketPublishable(chainSlug, sharedGoalId)` — the consent gate (item 5).
+  **Superseded in Phase B2** by `isDePrizeGoalMarketBound`; see
+  [DEPRIZE_PHASE_B2.md](DEPRIZE_PHASE_B2.md).
 
 Deliberate choice: consent lives here as `outcomes[].consented`, not read from the atlas `Project.rosterStatus`. `rosterStatus` isn't importable on `main`, and the binding is the right source of truth for a legal gate anyway — it sits next to the chain id and the questionId it's gating.
 
@@ -80,6 +82,11 @@ Two behaviors B2 depends on: it mounts **one** market (B2 item 2 fetches only th
 One gotcha: the component uses a bare `<a>`. An internal `hrefOverride` like `/moonbase/{projectId}` will trip the `next/link` ESLint rule that already failed a Vercel build in Phase A — use `Link` for internal hrefs.
 
 ### 5. Consent gate
+
+> **Superseded in Phase B2.** Consent was replaced by a disclaimer-first model:
+> markets on bound races are visible, and `consented` now gates branding (logo,
+> brand color) only. See [DEPRIZE_PHASE_B2.md](DEPRIZE_PHASE_B2.md). The rest of
+> this section records the original B1 reasoning.
 
 `isDePrizeGoalMarketPublishable` returns false outside `sepolia` unless every entry in `outcomes` has `consented: true`. All 8 atlas races currently carry `rosterStatus: 'listed'`, which is curatorial judgment and not agreement — this is the only item in B1/B2 with real legal exposure, so it ships in the same PR as the binding it protects, not later.
 

--- a/docs/DEPRIZE_PHASE_B2.md
+++ b/docs/DEPRIZE_PHASE_B2.md
@@ -1,0 +1,127 @@
+# DePrize Phase B2: live markets in Moon Base Zero
+
+Phase B2 wires live on-chain DePrize odds into the Moon Base Zero race panels.
+It ships in two waves because the atlas lives on a separate branch.
+
+- **Wave 1** (this document, landed): retire the consent visibility gate in favour
+  of disclosure, add the pure odds merge helper, and point bound competitors at
+  their atlas pages.
+- **Wave 2** (after the Moon Base Zero PR merges): consume the merge helper in
+  `ui/pages/moonbase/index.tsx`, wire the race panel, add atlas competitor
+  identity with claim-gated branding, and add `?race=` deep links.
+
+Part 2 of the original B2 draft — in-flight roster changes — was designed and
+built ahead of schedule. See [DEPRIZE_ROSTER_CHANGES.md](DEPRIZE_ROSTER_CHANGES.md).
+
+## Where the race binding lives
+
+`SharedGoalMarket` in the atlas carries optional `deprizeRegistryId` and
+`deprizeQuestionId` strings. **These are unused and stay unused.** They are plain
+strings with no chain dimension, and a DePrize id is chain-specific: registry
+entry 9 on Sepolia is unrelated to entry 9 on Arbitrum.
+
+The source of truth is the chain-keyed binding in
+[ui/lib/deprize/competitions.ts](../ui/lib/deprize/competitions.ts):
+
+```
+DEPRIZE_COMPETITIONS[chainSlug][deprizeId] = {
+  sharedGoalId,          // atlas SharedGoal.id this DePrize settles
+  raceLabel,
+  outcomes: [{ projectId, teamId?, consented?, field? }],
+}
+```
+
+`findDePrizeIdForGoal(chainSlug, sharedGoalId)` is the reverse lookup, and it
+resolves through `supersededBy` to the **live generation tip**, so a race that has
+been superseded keeps pointing at the generation that is actually trading.
+
+Consequence for the atlas dataset: no DePrize ids belong in
+`atlas.dataset.json`. That keeps the highest-conflict file free of chain-specific
+data, and means seeding a new race is a one-file change on the DePrize side.
+
+## Disclosure instead of a consent gate
+
+B1 shipped an all-or-nothing consent gate: outside Sepolia, a single competitor
+without `consented: true` forced the whole race to `planned` and redacted live
+odds. That was stricter than the risk warranted. Listing a public company as a
+market outcome does not require its permission — prediction markets routinely
+price named companies and candidates.
+
+The actual exposure is **implied endorsement**: presenting an organization as an
+entrant in *our* prize, with its logo and a "Back a competitor" button, can read
+as "they signed up." That is a disclosure and trademark-restraint problem, not a
+reason to hide a bound market.
+
+Wave 1 therefore:
+
+- replaces `areRaceOutcomesPublishable` with `isRaceBindingComplete` (has at least
+  one non-field competitor) and `isDePrizeGoalMarketPublishable` with
+  `isDePrizeGoalMarketBound`. No chain carve-outs; Sepolia is no longer special.
+- drops the odds redaction in `useDePrizeGoalOdds`, while **keeping** the `teamId`
+  checksum and roster-length guards. Those prevent attributing one competitor's
+  odds to another, which is correctness rather than policy.
+- repurposes `consented` as a **branding** flag via `isCompetitorClaimed`: name and
+  link always render; logo and brand color only once claimed. Wave 2 enforces this
+  when atlas identity is available.
+- adds `ROSTER_DISCLAIMER`, rendered wherever named competitors sit next to a
+  market, and section 5.3 of the Terms.
+
+Note the atlas `RosterStatus` union already contains a `'consented'` value. That
+stays **editorial** metadata driving panel copy. The binding's `consented` is
+authoritative for branding. Do not cross-wire them.
+
+This change had no live effect when it landed: Sepolia DePrize 9 was the only
+bound race, and Sepolia was already exempt from the gate.
+
+## Notes for Wave 2 (verified against `feat/lunar-simulator`)
+
+Checked while reviewing Wave 1, so the wiring does not have to rediscover them:
+
+- **Do not add a second disclaimer.** `SharedGoalPanel` already renders a
+  no-endorsement caveat, gated on `anyUnconfirmed` (`rosterStatus` of `listed` or
+  `invited`). Reconcile it with `ROSTER_DISCLAIMER` — one disclosure per surface,
+  not two near-identical paragraphs. The panel's version is also gated on
+  editorial `rosterStatus`, whereas the market disclosure should not be, so prefer
+  showing `ROSTER_DISCLAIMER` whenever the race is bound.
+- **`resolved` markets get the wrong caption today.** The panel picks its odds
+  caption off `oddsLive = status === 'live'`, so a `resolved` market falls through
+  to "Illustrative curator priors — live odds replace these when the prediction
+  market opens." Add a resolved branch when wiring the panel.
+- **The Open Field sentinel is safe with today's consumers.** Both `rankedMembers`
+  and the panel's `ranked` read `odds[project.id]`, so they never iterate the odds
+  keys and the extra `__open-field__` entry cannot become a phantom leader. It
+  needs an explicit row to be visible at all.
+- **`status === 'live'` already flips the caption** to "Odds are live
+  market-implied probabilities," so the merge needs no extra plumbing for that.
+
+## Known Wave 1 → Wave 2 dependency
+
+Bound competitors on `/deprize/{id}` link to `/moonbase/{projectId}`, which **does
+not exist until the Moon Base Zero PR merges**. The only bound race today is
+Sepolia DePrize 9, a testnet QA fixture, so the dead link is not reachable from
+any production race. Do not seed a mainnet race with `projectId`s until the
+`/moonbase/[projectId]` route is live.
+
+## The merge point
+
+Three consumers read `goal.market.impliedOdds`, all keyed by atlas `projectId`:
+the race panel bars, the district leader in `rankedMembers`, and the Legend leader
+in the `races` memo. Rather than touch all three, Wave 2 merges live odds into the
+goal's `market` **once**, upstream of `buildTechTrees`, and they all inherit it.
+
+[ui/lib/deprize/goal-market.ts](../ui/lib/deprize/goal-market.ts) is that merge, and
+it is intentionally decoupled from the atlas: it defines a structural
+`MergeableGoal` subset that the real `SharedGoal` already satisfies, and is
+generic so the caller gets its own type back. This is why Wave 1 can ship and
+unit test the helper before the atlas branch exists.
+
+It returns the goal untouched when there is nothing trustworthy to show — unbound,
+`planned` status (including superseded and still-loading), or an empty odds map —
+because curator priors are better than a blank market. Open Field mass is carried
+under `OPEN_FIELD_PROJECT_ID` so the bars still sum to roughly 1 instead of
+overstating the named competitors.
+
+## Tests
+
+- `yarn test:deprize` — merge helper, binding lookups, lineage, goal-odds mapping
+- `yarn test:cypress-unit` — atlas selectors (Wave 2 only)

--- a/ui/components/deprize/DePrizeTeamCard.tsx
+++ b/ui/components/deprize/DePrizeTeamCard.tsx
@@ -28,7 +28,29 @@ type DePrizeTeamCardProps = {
   isField?: boolean
   /** Disclosure: competitor marked withdrawn on-chain. Slot stays tradable. */
   withdrawn?: boolean
+  /**
+   * Link target for a bound competitor (e.g. `/moonbase/{projectId}`), for
+   * organizations that will never hold a Team NFT. Ignored for field slots,
+   * which keep their own target. Defaults to `/team/{id}`.
+   */
+  hrefOverride?: string
+  /** Atlas org display name, for competitors with no Team NFT. */
+  nameOverride?: string
+  /** Atlas org logo. Suppressed when `unclaimed`. */
+  imageOverride?: string
+  /**
+   * Competitor has not claimed its listing: show the name but no logo, so the
+   * listing never reads as an endorsement. See ROSTER_DISCLAIMER.
+   */
+  unclaimed?: boolean
 }
+
+/** Dashed-circle mark for the Open Field slot, which has no Team NFT. */
+const FIELD_AVATAR =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" rx="8" fill="#1e293b"/><circle cx="20" cy="20" r="10" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4 3"/></svg>`
+  )
 
 function PnlSuffix({ pnl }: { pnl: number | undefined }) {
   if (pnl === undefined) return null
@@ -60,6 +82,10 @@ export default function DePrizeTeamCard({
   onCashOut,
   isField = false,
   withdrawn = false,
+  hrefOverride,
+  nameOverride,
+  imageOverride,
+  unclaimed = false,
 }: DePrizeTeamCardProps) {
   const holding = Number.isFinite(outcome.balance) && outcome.balance > 0
   const realizedValue = resolved ? redeemValueEth : sellQuoteEth
@@ -122,16 +148,12 @@ export default function DePrizeTeamCard({
             color={color}
             size={40}
             className="text-base font-semibold text-white hover:text-indigo-200"
-            nameOverride={isField ? 'Open Field' : undefined}
-            imageOverride={
-              isField
-                ? 'data:image/svg+xml,' +
-                  encodeURIComponent(
-                    `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" rx="8" fill="#1e293b"/><circle cx="20" cy="20" r="10" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="4 3"/></svg>`
-                  )
-                : undefined
-            }
-            hrefOverride={isField ? '/deprize#open-field' : undefined}
+            nameOverride={isField ? 'Open Field' : nameOverride}
+            imageOverride={isField ? FIELD_AVATAR : imageOverride}
+            hrefOverride={isField ? '/deprize#open-field' : hrefOverride}
+            // The field slot is not an organization, so its own placeholder mark
+            // must survive the unclaimed logo suppression.
+            unclaimed={!isField && unclaimed}
           />
           {isField && (
             <p

--- a/ui/components/deprize/DePrizeTeamLink.tsx
+++ b/ui/components/deprize/DePrizeTeamLink.tsx
@@ -19,6 +19,14 @@ type DePrizeTeamLinkProps = {
   imageOverride?: string
   /** Override link target (e.g. `/moonbase/{projectId}`). Defaults to `/team/{id}`. */
   hrefOverride?: string
+  /**
+   * Competitor has not claimed its listing: render the name but never a logo,
+   * so we don't imply endorsement by displaying someone's mark. Forces the
+   * neutral monogram and suppresses both `imageOverride` and the NFT image.
+   * A `nameOverride` alone then counts as complete identity, so we also skip
+   * the doomed NFT read.
+   */
+  unclaimed?: boolean
 }
 
 /** Two-letter monogram from a team name (falls back to the numeric id). */
@@ -111,9 +119,11 @@ export default function DePrizeTeamLink({
   nameOverride,
   imageOverride,
   hrefOverride,
+  unclaimed = false,
 }: DePrizeTeamLinkProps) {
-  // Only skip the NFT read when neither name nor image would come from it.
-  const identityOverridden = !!nameOverride && !!imageOverride
+  // Only skip the NFT read when neither name nor image would come from it. An
+  // unclaimed competitor shows no logo at all, so a name is the whole identity.
+  const identityOverridden = !!nameOverride && (!!imageOverride || unclaimed)
 
   const { data: teamNFT } = useReadContract(getNFT, {
     contract: teamContract,
@@ -127,7 +137,7 @@ export default function DePrizeTeamLink({
   // and an empty override must not blank the row.
   const name =
     nameOverride || (teamNFT as any)?.metadata?.name || `Team #${teamId.toString()}`
-  const image = imageOverride || (teamNFT as any)?.metadata?.image || ''
+  const image = unclaimed ? '' : imageOverride || (teamNFT as any)?.metadata?.image || ''
   const href = hrefOverride || `/team/${teamId.toString()}`
 
   const linkClassName = `group inline-flex items-center gap-2 min-w-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 transition-opacity hover:opacity-90 ${className}`

--- a/ui/cypress/integration/lib/deprize/competitions.cy.ts
+++ b/ui/cypress/integration/lib/deprize/competitions.cy.ts
@@ -1,6 +1,5 @@
 import {
   GENERIC_DEPRIZE_COMPETITION,
-  areRaceOutcomesPublishable,
   chainHasRaceBindings,
   findDePrizeIdForGoal,
   generationNumberOf,
@@ -8,8 +7,10 @@ import {
   getDePrizeGenerationNumber,
   getDePrizeQuestionId,
   getDePrizeRaceBinding,
-  isDePrizeGoalMarketPublishable,
+  isCompetitorClaimed,
+  isDePrizeGoalMarketBound,
   isKnownDePrizeCompetition,
+  isRaceBindingComplete,
   liveTipOf,
   partitionDePrizeIndexByRace,
   resolveLiveDePrizeId,
@@ -75,32 +76,40 @@ describe('deprize competitions registry', () => {
     expect(findDePrizeIdForGoal('sepolia', undefined)).to.equal(undefined)
   })
 
-  it('publishes the Sepolia fixture and refuses unbound / unconsented non-Sepolia', () => {
-    expect(isDePrizeGoalMarketPublishable('sepolia', 'shared-fission-power')).to.equal(true)
-    expect(isDePrizeGoalMarketPublishable('sepolia', 'shared-landing-pads')).to.equal(false)
-    expect(isDePrizeGoalMarketPublishable('arbitrum', 'shared-fission-power')).to.equal(false)
+  it('reports a bound race regardless of consent, and unbound goals as unbound', () => {
+    expect(isDePrizeGoalMarketBound('sepolia', 'shared-fission-power')).to.equal(true)
+    expect(isDePrizeGoalMarketBound('sepolia', 'shared-landing-pads')).to.equal(false)
+    // Arbitrum has no binding at all, so there is no market to report.
+    expect(isDePrizeGoalMarketBound('arbitrum', 'shared-fission-power')).to.equal(false)
+    expect(isDePrizeGoalMarketBound('sepolia', undefined)).to.equal(false)
+  })
 
-    // Pure consent helper: non-Sepolia requires every outcome consented.
-    const unconsented = [
-      { projectId: 'a', consented: true },
-      { projectId: 'b' },
-    ]
-    const consented = [
-      { projectId: 'a', consented: true },
-      { projectId: 'b', consented: true },
-    ]
-    expect(areRaceOutcomesPublishable('arbitrum', unconsented)).to.equal(false)
-    expect(areRaceOutcomesPublishable('arbitrum', consented)).to.equal(true)
-    expect(areRaceOutcomesPublishable('sepolia', unconsented)).to.equal(true)
-    expect(areRaceOutcomesPublishable('arbitrum', undefined)).to.equal(false)
-
-    // Field slots are not competitors — skip them for the consent gate.
+  it('treats binding completeness as chain-agnostic and independent of consent', () => {
+    // Consent is no longer a visibility gate: an unconsented roster is publishable.
     expect(
-      areRaceOutcomesPublishable('arbitrum', [
-        { projectId: 'a', consented: true },
+      isRaceBindingComplete([{ projectId: 'a', consented: true }, { projectId: 'b' }])
+    ).to.equal(true)
+    expect(isRaceBindingComplete([{ projectId: 'a' }, { projectId: 'b' }])).to.equal(true)
+    expect(isRaceBindingComplete(undefined)).to.equal(false)
+    expect(isRaceBindingComplete([])).to.equal(false)
+
+    // A field-only roster names nobody, so there is nothing to price.
+    expect(
+      isRaceBindingComplete([{ projectId: '__open-field__', field: true }])
+    ).to.equal(false)
+    expect(
+      isRaceBindingComplete([
+        { projectId: 'a' },
         { projectId: '__open-field__', field: true },
       ])
     ).to.equal(true)
+  })
+
+  it('gates branding on claim status without touching visibility', () => {
+    expect(isCompetitorClaimed({ projectId: 'a', consented: true })).to.equal(true)
+    expect(isCompetitorClaimed({ projectId: 'a' })).to.equal(false)
+    expect(isCompetitorClaimed({ projectId: 'a', consented: false })).to.equal(false)
+    expect(isCompetitorClaimed(undefined)).to.equal(false)
   })
 
   it('partitions the index by raceLabel and keeps unbound chains flat', () => {

--- a/ui/cypress/integration/lib/deprize/goal-market.cy.ts
+++ b/ui/cypress/integration/lib/deprize/goal-market.cy.ts
@@ -1,0 +1,129 @@
+import { OPEN_FIELD_PROJECT_ID } from '@/lib/deprize/competitions'
+import {
+  type LiveGoalOdds,
+  type MergeableGoal,
+  mergeLiveMarket,
+  mergeLiveMarketInto,
+} from '@/lib/deprize/goal-market'
+
+// Hand-written fixture: this module must not depend on the atlas dataset, which
+// ships on the Moon Base Zero branch.
+function goal(): MergeableGoal {
+  return {
+    id: 'shared-fission-power',
+    market: {
+      status: 'planned',
+      impliedOdds: {
+        'westinghouse-fission-surface-power': 0.34,
+        'lockheed-fission-surface-power': 0.35,
+        'ix-fission-surface-power': 0.31,
+      },
+    },
+  }
+}
+
+const liveOdds: LiveGoalOdds = {
+  deprizeId: 9,
+  oddsByProjectId: {
+    'westinghouse-fission-surface-power': 0.5,
+    'lockheed-fission-surface-power': 0.3,
+    'ix-fission-surface-power': 0.2,
+  },
+  fieldOdds: undefined,
+  status: 'live',
+}
+
+describe('mergeLiveMarket', () => {
+  it('replaces curator priors with live odds and flips status', () => {
+    const merged = mergeLiveMarket(goal(), liveOdds)
+    expect(merged.market?.status).to.equal('live')
+    expect(merged.market?.impliedOdds).to.deep.equal(liveOdds.oddsByProjectId)
+  })
+
+  it('does not mutate the input goal', () => {
+    const g = goal()
+    mergeLiveMarket(g, liveOdds)
+    expect(g.market?.status).to.equal('planned')
+    expect(g.market?.impliedOdds?.['westinghouse-fission-surface-power']).to.equal(0.34)
+  })
+
+  it('carries Open Field mass under the sentinel key so bars still sum to ~1', () => {
+    const merged = mergeLiveMarket(goal(), {
+      ...liveOdds,
+      oddsByProjectId: {
+        'westinghouse-fission-surface-power': 0.4,
+        'lockheed-fission-surface-power': 0.3,
+        'ix-fission-surface-power': 0.15,
+      },
+      fieldOdds: 0.15,
+    })
+    expect(merged.market?.impliedOdds?.[OPEN_FIELD_PROJECT_ID]).to.equal(0.15)
+    const sum = Object.values(merged.market!.impliedOdds!).reduce((a, b) => a + b, 0)
+    expect(sum).to.be.closeTo(1, 1e-9)
+  })
+
+  it('keeps priors when the race is unbound, planned, or has no odds', () => {
+    const g = goal()
+    expect(mergeLiveMarket(g, undefined)).to.equal(g)
+    expect(mergeLiveMarket(g, { ...liveOdds, deprizeId: undefined })).to.equal(g)
+    // Superseded / loading generations report planned — must not blank the panel.
+    expect(mergeLiveMarket(g, { ...liveOdds, status: 'planned' })).to.equal(g)
+    expect(mergeLiveMarket(g, { ...liveOdds, oddsByProjectId: undefined })).to.equal(g)
+    expect(mergeLiveMarket(g, { ...liveOdds, oddsByProjectId: {} })).to.equal(g)
+  })
+
+  it('marks a resolved market resolved', () => {
+    const merged = mergeLiveMarket(goal(), { ...liveOdds, status: 'resolved' })
+    expect(merged.market?.status).to.equal('resolved')
+  })
+
+  it('synthesizes a market block for a goal that never had one', () => {
+    const bare: MergeableGoal = { id: 'shared-fission-power' }
+    const merged = mergeLiveMarket(bare, liveOdds)
+    expect(merged.market?.status).to.equal('live')
+    expect(merged.market?.impliedOdds).to.deep.equal(liveOdds.oddsByProjectId)
+  })
+
+  it('preserves atlas-only market fields the panel still reads', () => {
+    // The real SharedGoalMarket also carries resolutionAuthority / payoutSplit /
+    // budgetGate. Overwriting the block instead of spreading it would blank them.
+    const withExtras = {
+      id: 'shared-fission-power',
+      market: {
+        status: 'planned' as const,
+        resolutionAuthority: 'senate',
+        payoutSplit: { capability: 0.3, flight: 0.7 },
+        budgetGate: 'flight-demo quote <= prize-pool TWAP',
+      },
+    }
+    const merged = mergeLiveMarket(withExtras, liveOdds)
+    expect(merged.market.resolutionAuthority).to.equal('senate')
+    expect(merged.market.payoutSplit).to.deep.equal({ capability: 0.3, flight: 0.7 })
+    expect(merged.market.budgetGate).to.equal('flight-demo quote <= prize-pool TWAP')
+    expect(merged.market.status).to.equal('live')
+  })
+
+  it('ignores a non-finite fieldOdds rather than writing NaN into the bars', () => {
+    const merged = mergeLiveMarket(goal(), { ...liveOdds, fieldOdds: NaN })
+    expect(merged.market?.impliedOdds).to.not.have.property(OPEN_FIELD_PROJECT_ID)
+  })
+})
+
+describe('mergeLiveMarketInto', () => {
+  const goals: MergeableGoal[] = [goal(), { id: 'shared-habitat', market: { status: 'planned' } }]
+
+  it('merges only the mounted race and preserves identity elsewhere', () => {
+    const next = mergeLiveMarketInto(goals, 'shared-fission-power', liveOdds)
+    expect(next[0].market?.status).to.equal('live')
+    expect(next[1]).to.equal(goals[1])
+  })
+
+  it('returns the same array when nothing merged, so memos do not recompute', () => {
+    expect(mergeLiveMarketInto(goals, undefined, liveOdds)).to.equal(goals)
+    expect(mergeLiveMarketInto(goals, 'shared-fission-power', undefined)).to.equal(goals)
+    expect(
+      mergeLiveMarketInto(goals, 'shared-fission-power', { ...liveOdds, status: 'planned' })
+    ).to.equal(goals)
+    expect(mergeLiveMarketInto(goals, 'shared-nonexistent', liveOdds)).to.equal(goals)
+  })
+})

--- a/ui/docs/DEPRIZE_TERMS_AND_CONDITIONS.md
+++ b/ui/docs/DEPRIZE_TERMS_AND_CONDITIONS.md
@@ -134,6 +134,29 @@ refund-terminal state); on a successful prize payout they do not redeem against
 the pool. A superseded market's price may diverge from the live generation's
 odds — treat it as an exit quote, not the race's official odds.
 
+### 5.3 Named competitors and no endorsement
+
+Competitors are named at **MoonDAO's editorial discretion**, based on publicly
+available information about who is credibly pursuing the capability. Being listed
+as an outcome **does not mean** the organization has entered the DePrize,
+registered, agreed to participate, endorsed MoonDAO, or is affiliated with,
+sponsored by, or partnered with MoonDAO or this prize in any way. No listed
+organization is required to do anything, and none receives an entry obligation by
+being named.
+
+Your bet is on an **outcome** — whether that organization achieves the capability
+first as judged under Section 5 — and **not** on any affiliation, partnership, or
+endorsement. Organization names and marks are the property of their respective
+owners and are used only to identify the subject of an outcome (nominative use).
+Logos and brand styling are shown **only** for competitors that have claimed their
+listing; unclaimed competitors are displayed with a neutral placeholder mark.
+
+If you are an organization named in a DePrize and want your listing corrected,
+rebranded, or removed from future generations, contact MoonDAO using Section 15.
+An entrant who is verifiably ineligible to win may be dropped from the next
+generation's roster under Section 5.2; a live generation's outcome set cannot be
+edited.
+
 ## 6. Cancellation, no winner, and the equal-payout refund
 
 A DePrize may end in a **refund-terminal** state — **cancelled**, **no eligible

--- a/ui/lib/deprize/competitions.ts
+++ b/ui/lib/deprize/competitions.ts
@@ -37,8 +37,10 @@ export type DePrizeRaceOutcome = {
    */
   teamId?: number
   /**
-   * Competitor consent for public markets. Outside sepolia, every non-field
-   * outcome must be consented before the bridge reports status `live`.
+   * True once the organization has claimed its listing. Gates BRANDING ONLY
+   * (logo + brand color); it never gates market visibility. See
+   * {@link isCompetitorClaimed}. Distinct from the atlas `RosterStatus`, which
+   * stays editorial metadata for panel copy — do not cross-wire them.
    */
   consented?: boolean
   /**
@@ -69,7 +71,7 @@ export type DePrizeCompetition = {
   raceLabel?: string
   /**
    * CTF outcome index → atlas competitor. Order MUST match registry teamIds.
-   * `teamId` is the alignment checksum; `consented` gates public markets.
+   * `teamId` is the alignment checksum; `consented` gates branding only.
    */
   outcomes?: DePrizeRaceOutcome[]
   /** Prior generation this entry superseded (off-chain lineage mirror). */
@@ -311,19 +313,18 @@ export function findDePrizeIdForGoal(
 }
 
 /**
- * Pure consent check on an outcomes array.
- * Sepolia is always publishable (QA). Elsewhere every non-field outcome must
- * have `consented: true`. Field slots are not competitors and are skipped.
+ * A binding is usable when it names at least one real competitor. This is a
+ * completeness check, NOT a consent check: listing a public company as a market
+ * outcome does not require its permission, and hiding a bound market behind an
+ * all-or-nothing consent flag was stricter than the disclosure it stood in for.
+ * Implied endorsement is handled by the roster disclaimer plus withholding
+ * trademarks until a competitor claims — see {@link isCompetitorClaimed}.
  */
-export function areRaceOutcomesPublishable(
-  chainSlug: string,
+export function isRaceBindingComplete(
   outcomes: readonly DePrizeRaceOutcome[] | undefined
 ): boolean {
   if (!outcomes?.length) return false
-  if (chainSlug === 'sepolia') return true
-  const competitors = outcomes.filter((o) => !o.field)
-  if (!competitors.length) return false
-  return competitors.every((o) => o.consented === true)
+  return outcomes.some((o) => !o.field)
 }
 
 /** True when this outcome is the Open Field slot. */
@@ -334,10 +335,30 @@ export function isOpenFieldOutcome(
 }
 
 /**
- * Consent gate for reporting a race market as live.
- * Unbound goals are not publishable. See {@link areRaceOutcomesPublishable}.
+ * Has this competitor claimed its listing? Gates BRANDING ONLY (logo, brand
+ * color) — never market visibility. Unclaimed competitors still render their
+ * name and link, just with a neutral monogram instead of their mark.
  */
-export function isDePrizeGoalMarketPublishable(
+export function isCompetitorClaimed(
+  outcome: DePrizeRaceOutcome | undefined
+): boolean {
+  return outcome?.consented === true
+}
+
+/**
+ * Shown wherever named competitors appear next to a market. This is the control
+ * that replaced the consent gate, so it must render on any surface that lists
+ * outcomes: the DePrize detail roster and the Moon Base Zero race panel.
+ * Mirrors section 5.3 of the Terms.
+ */
+export const ROSTER_DISCLAIMER =
+  'Competitors are listed at MoonDAO’s editorial discretion. Listing does not mean the organization has entered, endorsed, or is affiliated with this prize. Bets are on outcomes, not on any affiliation.'
+
+/**
+ * True when a race is bound to an on-chain DePrize with a usable roster, so the
+ * bridge may report live odds. Unbound goals keep their curator priors.
+ */
+export function isDePrizeGoalMarketBound(
   chainSlug: string,
   sharedGoalId: string | undefined
 ): boolean {
@@ -345,7 +366,7 @@ export function isDePrizeGoalMarketPublishable(
   const deprizeId = findDePrizeIdForGoal(chainSlug, sharedGoalId)
   if (deprizeId === undefined) return false
   const binding = getDePrizeRaceBinding(chainSlug, deprizeId)
-  return areRaceOutcomesPublishable(chainSlug, binding?.outcomes)
+  return isRaceBindingComplete(binding?.outcomes)
 }
 
 export type DePrizeIndexRaceGroup = {

--- a/ui/lib/deprize/goal-market.ts
+++ b/ui/lib/deprize/goal-market.ts
@@ -1,0 +1,99 @@
+/**
+ * Merge live DePrize odds into a Moon Base Zero shared goal.
+ *
+ * Deliberately NOT typed against `@/lib/lunar-atlas` — those types ship with the
+ * Moon Base Zero branch, and this module has to build and unit test without them.
+ * The structural types below are a subset that the atlas `SharedGoal` already
+ * satisfies, so the page can call this with its concrete type and get it back
+ * unchanged.
+ *
+ * Keep dependency-free for yarn test:deprize.
+ */
+
+import { OPEN_FIELD_PROJECT_ID } from './competitions'
+
+/** Subset of the atlas `MarketStatus` union. */
+export type MergeableMarketStatus = 'none' | 'planned' | 'live' | 'resolved'
+
+/** Subset of the atlas `SharedGoalMarket`. */
+export type MergeableMarket = {
+  status: MergeableMarketStatus
+  /** Fractions of 1 keyed by atlas projectId. */
+  impliedOdds?: Record<string, number>
+}
+
+/** Subset of the atlas `SharedGoal`. */
+export type MergeableGoal = {
+  id: string
+  market?: MergeableMarket
+}
+
+/** What the goal-odds bridge produces for one race. */
+export type LiveGoalOdds = {
+  deprizeId: number | undefined
+  oddsByProjectId: Record<string, number> | undefined
+  fieldOdds: number | undefined
+  status: 'live' | 'resolved' | 'planned'
+}
+
+/**
+ * Swap a goal's curator priors for live market-implied odds.
+ *
+ * Returns the goal untouched when there is nothing trustworthy to show: no bound
+ * DePrize, a `planned` bridge status (unbound, superseded, or still loading), or
+ * an empty odds map. Curator priors are better than a blank market, so a partial
+ * result must never overwrite them.
+ *
+ * Open Field mass is carried under {@link OPEN_FIELD_PROJECT_ID} so the rendered
+ * bars still sum to ~1 rather than silently overstating the named competitors.
+ */
+export function mergeLiveMarket<T extends MergeableGoal>(
+  goal: T,
+  live: LiveGoalOdds | undefined
+): T {
+  if (!live || live.deprizeId === undefined) return goal
+  if (live.status === 'planned') return goal
+
+  const odds = live.oddsByProjectId
+  if (!odds || Object.keys(odds).length === 0) return goal
+
+  const impliedOdds: Record<string, number> = { ...odds }
+  if (live.fieldOdds !== undefined && Number.isFinite(live.fieldOdds)) {
+    impliedOdds[OPEN_FIELD_PROJECT_ID] = live.fieldOdds
+  }
+
+  return {
+    ...goal,
+    market: {
+      // A goal can be bound before a curator ever wrote a market block.
+      ...(goal.market ?? { status: 'planned' as MergeableMarketStatus }),
+      status: live.status,
+      impliedOdds,
+    },
+  }
+}
+
+/**
+ * Merge live odds into whichever goal in the list the bridge was mounted for.
+ * Every other goal is returned by reference so downstream memos that key on
+ * identity (buildTechTrees, the races memo) only recompute when they must.
+ *
+ * Takes and returns a mutable array on purpose: `buildTechTrees(projects,
+ * sharedGoals: SharedGoal[])` rejects `readonly`, and copying the result to
+ * satisfy that would defeat the identity preservation above.
+ */
+export function mergeLiveMarketInto<T extends MergeableGoal>(
+  goals: T[],
+  sharedGoalId: string | undefined,
+  live: LiveGoalOdds | undefined
+): T[] {
+  if (!sharedGoalId || !live) return goals
+  let changed = false
+  const next = goals.map((g) => {
+    if (g.id !== sharedGoalId) return g
+    const merged = mergeLiveMarket(g, live)
+    if (merged !== g) changed = true
+    return merged
+  })
+  return changed ? next : goals
+}

--- a/ui/lib/deprize/useDePrizeGoalOdds.tsx
+++ b/ui/lib/deprize/useDePrizeGoalOdds.tsx
@@ -3,7 +3,7 @@ import type { Chain } from 'thirdweb'
 import {
   findDePrizeIdForGoal,
   getDePrizeRaceBinding,
-  isDePrizeGoalMarketPublishable,
+  isDePrizeGoalMarketBound,
 } from './competitions'
 import { DePrizeState } from './constants'
 import { mapOutcomeOddsToProjectIds } from './goal-odds'
@@ -26,10 +26,10 @@ export type UseDePrizeGoalOddsResult = {
 
 function deriveGoalMarketStatus(
   registryState: DePrizeState | undefined,
-  publishable: boolean,
+  bound: boolean,
 ): DePrizeGoalMarketStatus {
-  // Consent gate: never surface live (or resolved) without publishable roster.
-  if (!publishable) return 'planned'
+  // An unbound race has no on-chain market to report; it keeps curator priors.
+  if (!bound) return 'planned'
   if (registryState === undefined) return 'planned'
 
   // Superseded generations are not the live race — treat as planned so the
@@ -72,7 +72,7 @@ export function useDePrizeGoalOdds(
   const chainSlug = getChainSlug(chain)
   const deprizeId = findDePrizeIdForGoal(chainSlug, sharedGoalId)
   const binding = getDePrizeRaceBinding(chainSlug, deprizeId)
-  const publishable = isDePrizeGoalMarketPublishable(chainSlug, sharedGoalId)
+  const bound = isDePrizeGoalMarketBound(chainSlug, sharedGoalId)
 
   const { deprize, loading: registryLoading } = useDePrize(deprizeId, chain)
   const numOutcomes = deprize?.teamIds.length ?? 0
@@ -86,18 +86,19 @@ export function useDePrizeGoalOdds(
   })
 
   const mapped = useMemo(() => {
-    // Consent gate: do not expose live LMSR fractions for non-public races.
-    if (!publishable) return undefined
+    if (!bound) return undefined
     if (!binding?.outcomes.length || !deprize?.teamIds.length) return undefined
+    // Alignment guard (correctness, not policy): a roster whose length has
+    // drifted from the market would attribute odds to the wrong competitor.
     if (market.outcomes.length !== binding.outcomes.length) return undefined
     return mapOutcomeOddsToProjectIds({
       outcomes: binding.outcomes,
       teamIds: deprize.teamIds,
       probabilities: market.outcomes.map((o) => o.probability),
     })
-  }, [binding, deprize?.teamIds, market.outcomes, publishable])
+  }, [binding, deprize?.teamIds, market.outcomes, bound])
 
-  const status = deriveGoalMarketStatus(deprize?.state, publishable)
+  const status = deriveGoalMarketStatus(deprize?.state, bound)
 
   return {
     deprizeId,

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -15,10 +15,12 @@ import { getContract } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import { eth_getBalance, getRpcClient } from 'thirdweb/rpc'
 import {
+  ROSTER_DISCLAIMER,
   getDePrizeCompetition,
   getDePrizeGenerationNumber,
   getDePrizeRaceBinding,
   isKnownDePrizeCompetition,
+  isRaceBindingComplete,
 } from '@/lib/deprize/competitions'
 import {
   DePrizeState,
@@ -652,6 +654,11 @@ function DePrizeDetailContent() {
         {numOutcomes > 0 && (
           <div className="flex flex-col gap-3">
             <h3 className="title-text-colors text-lg font-GoodTimes">Providers</h3>
+            {isRaceBindingComplete(raceBinding?.outcomes) && (
+              <p className="text-gray-500 text-xs leading-relaxed max-w-3xl">
+                {ROSTER_DISCLAIMER}
+              </p>
+            )}
             {market.outcomes.map((o) => {
               const teamId = deprize?.teamIds[o.index] ?? 0n
               const invested = costBasis[o.index] ?? 0
@@ -689,6 +696,11 @@ function DePrizeDetailContent() {
                   onCashOut={(i) => setExitIndex(i)}
                   isField={isField}
                   withdrawn={!!withdrawnByTeamId[teamId.toString()]}
+                  hrefOverride={
+                    outcomeBinding?.projectId
+                      ? `/moonbase/${outcomeBinding.projectId}`
+                      : undefined
+                  }
                 />
               )
             })}


### PR DESCRIPTION
## Summary

- Retires the B1 consent visibility gate in favor of disclaimer-first markets: bound races report live odds regardless of `consented`, which now gates branding only via `isCompetitorClaimed`. Alignment guards (`teamId` checksum, roster length) stay.
- Adds pure `mergeLiveMarket` / `mergeLiveMarketInto` in `ui/lib/deprize/goal-market.ts` (structural types, no atlas import) so Wave 2 can drop live LMSR odds into Moon Base Zero once #1405 lands. Open Field mass is carried under `OPEN_FIELD_PROJECT_ID`.
- Ships roster disclosure on DePrize detail (`ROSTER_DISCLAIMER`) and Terms §5.3; `hrefOverride` / `unclaimed` passthroughs on team cards; bound competitors link to `/moonbase/{projectId}`.

Stacked on #1500 (roster / Open Field). Wave 2 (page merge, SharedGoalPanel, deep links, atlas identity) remains blocked on #1405.

## Test plan

- [x] `yarn test:deprize` — 91 passing (includes new merge-helper + binding/claim tests)
- [x] `npx tsc --noEmit` clean in `ui/`
- [x] ESLint clean on touched files
- [x] Verified merge helper compiles against real `SharedGoal` / `buildTechTrees` signatures from `feat/lunar-simulator`
- [ ] Smoke `/deprize/9` on Sepolia: roster disclaimer visible; competitor links target `/moonbase/{projectId}` (route lands with #1405)
- [ ] Confirm no production race is seeded with `projectId`s until `/moonbase/[projectId]` is live

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes product/legal posture (named competitors and live odds visibility) and market display semantics; core trading paths are mostly pure helpers and gating renames with tests, but reviewers should treat disclaimer and branding behavior as user-facing compliance surface.
> 
> **Overview**
> **Phase B2 Wave 1** shifts DePrize from hiding live odds behind roster consent to **disclosure + claim-gated branding**. Bound races can report live market data on every chain; `consented` now only drives `isCompetitorClaimed` (logo/color), not visibility.
> 
> In `competitions.ts`, `areRaceOutcomesPublishable` / `isDePrizeGoalMarketPublishable` become **`isRaceBindingComplete`** and **`isDePrizeGoalMarketBound`** (at least one non–Open Field competitor). **`ROSTER_DISCLAIMER`** is added; **`useDePrizeGoalOdds`** uses the bound check instead of redacting odds while keeping roster alignment guards.
> 
> New **`goal-market.ts`** exposes **`mergeLiveMarket`** / **`mergeLiveMarketInto`** so Wave 2 can swap curator priors for live LMSR odds once (including Open Field mass under `OPEN_FIELD_PROJECT_ID`), with mocha coverage in `goal-market.cy.ts`.
> 
> **UI:** DePrize detail shows the disclaimer when the binding is complete; bound competitors link to `/moonbase/{projectId}`. **`DePrizeTeamLink`** / **`DePrizeTeamCard`** gain **`unclaimed`** and identity override passthroughs. Docs add **`DEPRIZE_PHASE_B2.md`** and Terms **§5.3**; B1 docs note B2 supersession.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca8ba048b991d3b72fa7baef5453bd762998b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->