### PR TITLE
fix(onramp): surface Coinbase card fallback for all US users

### DIFF
--- a/ui/components/coinbase/CBHeadlessOnramp.tsx
+++ b/ui/components/coinbase/CBHeadlessOnramp.tsx
@@ -608,11 +608,21 @@ export function CBHeadlessOnramp({
                 ? 'Press the Google Pay button above to complete your purchase securely with Coinbase.'
                 : 'Scan the QR code above with your iPhone to complete your purchase securely with Apple Pay.'}
           </p>
-          {/* Desktop users without an iPhone can't scan the Apple Pay QR — offer
-              the hosted Coinbase flow (account / card / bank) as an alternative. */}
-          {!nativeApplePay && !useGooglePay && onUseAccountFlow && (
+          {/* Not everyone has Apple/Google Pay set up (or an iPhone to scan the
+              QR with) — always offer the hosted Coinbase flow (guest
+              debit/credit card checkout or an existing account) as a way out.
+              Previously this only showed on desktop browsers without native
+              Apple/Google Pay, which left Safari and Android users with no
+              visible alternative at all. */}
+          {onUseAccountFlow && (
             <div className="pt-1 text-center">
-              <p className="text-gray-500 text-xs mb-2">No iPhone to scan with?</p>
+              <p className="text-gray-500 text-xs mb-2">
+                {nativeApplePay
+                  ? "Apple Pay not set up on this device?"
+                  : useGooglePay
+                    ? 'Google Pay not set up on this device?'
+                    : 'No iPhone to scan with?'}
+              </p>
               <button
                 type="button"
                 disabled={accountFlowLoading}
@@ -628,7 +638,7 @@ export function CBHeadlessOnramp({
               >
                 {accountFlowLoading
                   ? 'Opening Coinbase…'
-                  : 'Pay with a Coinbase account or card instead'}
+                  : 'Pay with a debit/credit card or Coinbase account instead'}
               </button>
             </div>
           )}
@@ -812,6 +822,33 @@ export function CBHeadlessOnramp({
             effectiveEthAmount <= 0
           }
         />
+
+        {/* Surfaced here too (not just after a failed attempt) so users who
+            already know they don't have Apple/Google Pay set up don't have to
+            verify phone/email and agree to terms first just to find an
+            alternative. Still Coinbase — guest card checkout or an existing
+            account — never MoonPay, which requires an SSN for US persons. */}
+        {onUseAccountFlow && (
+          <div className="text-center">
+            <button
+              type="button"
+              disabled={accountFlowLoading}
+              onClick={async () => {
+                setAccountFlowLoading(true)
+                try {
+                  await onUseAccountFlow()
+                } finally {
+                  setAccountFlowLoading(false)
+                }
+              }}
+              className="text-xs font-semibold text-blue-300 hover:text-blue-200 underline disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {accountFlowLoading
+                ? 'Opening Coinbase…'
+                : `Don't have ${payLabel} set up? Pay with a debit/credit card or Coinbase account instead`}
+            </button>
+          </div>
+        )}
 
         {/* Secured footer */}
         <div className="bg-black/10 rounded-lg p-4 border border-white/5">

--- a/ui/components/onramp/FundOnramp.tsx
+++ b/ui/components/onramp/FundOnramp.tsx
@@ -154,8 +154,11 @@ export function FundOnramp({
 
   // Rendered just beneath the embedded provider's "Fund Wallet" header so the
   // user picks how to pay after they see what they're funding. US users only
-  // get Coinbase (Apple/Google Pay), so we don't surface MoonPay or a provider
-  // toggle for them — just an informational line.
+  // get Coinbase (Apple/Google Pay) — MoonPay's KYC requires an SSN for US
+  // persons, which we intentionally never ask for anywhere in the app — so we
+  // don't surface MoonPay or a provider toggle for them, just an informational
+  // line. The Coinbase-hosted guest/account fallback (card, no SSN needed
+  // under its guest-checkout limit) is surfaced inside CBHeadlessOnramp.
   const providerSelector = isUS ? (
     <div
       data-testid="onramp-provider-select"


### PR DESCRIPTION
## Summary
- Show Coinbase's hosted debit-card / account fallback on the initial fund screen and payment screen for all US users, not only desktop Chrome/Firefox
- Clarify in code comments that US users stay on Coinbase only (MoonPay requires SSN for US persons)

## Context
Citizens reported onboarding looked Apple Pay-only with no guest checkout path. The fallback already existed but was gated behind a device check that hid it from Safari and Android users — the people most likely to lack Apple/Google Pay set up.

## Test plan
- [ ] As a US user on Safari (no Apple Pay card configured), open citizen onboarding fund modal and confirm "Pay with a debit/credit card or Coinbase account instead" is visible before phone/email verification
- [ ] As a US user on Android, confirm the same link appears on both the initial and payment screens
- [ ] Click the fallback link and confirm it opens Coinbase hosted checkout (guest card or account sign-in)
- [ ] Confirm non-US users still see MoonPay/Coinbase provider toggle unchanged
- [ ] Confirm MoonPay is not offered to US users anywhere in the flow


Made with [Cursor](https://cursor.com)