### PR TITLE
feat(dashboard): surface live Discord announcements on the homepage

### DIFF
--- a/ui/components/home/DiscordAnnouncements.tsx
+++ b/ui/components/home/DiscordAnnouncements.tsx
@@ -1,0 +1,107 @@
+import Image from 'next/image'
+import { useMemo } from 'react'
+import { useAnnouncements } from '@/lib/dashboard/hooks/useAnnouncements'
+import { renderDiscordMessageContent } from '@/lib/discord/formatDiscordMessage'
+
+function relativeTime(iso: string): string {
+  const ms = new Date(iso).getTime()
+  if (Number.isNaN(ms)) return ''
+  const diff = Date.now() - ms
+  const mins = Math.floor(diff / 60_000)
+  if (mins < 1) return 'Just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  if (days < 7) return `${days}d ago`
+  return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+function getAvatarUrl(author: any): string | null {
+  if (!author) return null
+  if (author.avatar) {
+    return `https://cdn.discordapp.com/avatars/${author.id}/${author.avatar}.png?size=64`
+  }
+  // Discord's default avatar bucket (5 options), keyed off the user id.
+  const defaultIndex = Number(BigInt(author.id ?? '0') % 5n)
+  return `https://cdn.discordapp.com/embed/avatars/${defaultIndex}.png`
+}
+
+type DiscordAnnouncementsProps = {
+  maxItems?: number
+}
+
+export default function DiscordAnnouncements({
+  maxItems = 5,
+}: DiscordAnnouncementsProps) {
+  const { announcements, isLoading, error } = useAnnouncements()
+
+  const messages = useMemo(
+    () => (Array.isArray(announcements) ? announcements.slice(0, maxItems) : []),
+    [announcements, maxItems]
+  )
+
+  if (isLoading && messages.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white/60" />
+      </div>
+    )
+  }
+
+  if (error || (!isLoading && messages.length === 0)) {
+    return (
+      <div className="flex items-center justify-center py-10 text-center">
+        <p className="text-white/50 text-sm">
+          Couldn&apos;t load the latest Discord announcements right now.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {messages.map((message: any) => {
+        const author = message.author
+        const displayName =
+          author?.global_name || author?.username || 'MoonDAO'
+        const avatarUrl = getAvatarUrl(author)
+
+        return (
+          <div
+            key={message.id}
+            className="flex gap-3 bg-black/20 hover:bg-black/30 border border-white/5 hover:border-white/10 rounded-xl p-3.5 transition-all"
+          >
+            <div className="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 ring-2 ring-white/10">
+              {avatarUrl ? (
+                <Image
+                  src={avatarUrl}
+                  alt={displayName}
+                  width={36}
+                  height={36}
+                  className="w-full h-full object-cover"
+                  unoptimized
+                />
+              ) : (
+                <div className="w-full h-full bg-gradient-to-br from-indigo-500 to-purple-600" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <p className="text-white text-sm font-semibold truncate">
+                  {displayName}
+                </p>
+                <span className="text-white/30 text-xs flex-shrink-0">
+                  {relativeTime(message.timestamp)}
+                </span>
+              </div>
+              <p className="text-white/70 text-sm leading-relaxed mt-0.5 line-clamp-4 whitespace-pre-line">
+                {renderDiscordMessageContent(message.content, message.mentions)}
+              </p>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/components/home/SignedInDashboard.tsx
+++ b/ui/components/home/SignedInDashboard.tsx
@@ -23,6 +23,7 @@ import {
   PencilSquareIcon,
   ExclamationTriangleIcon,
   XMarkIcon,
+  ChatBubbleLeftRightIcon,
 } from '@heroicons/react/24/outline'
 import { useFundWallet } from '@privy-io/react-auth'
 import HatsABI from 'const/abis/Hats.json'
@@ -92,6 +93,7 @@ import ProposalList from '../nance/ProposalList'
 import NewMarketplaceListings from '../subscription/NewMarketplaceListings'
 import DashboardActiveProjects from '../project/DashboardActiveProjects'
 import DashboardQuests from './DashboardQuests'
+import DiscordAnnouncements from './DiscordAnnouncements'
 import RecentActivity from './RecentActivity'
 import { useClaimableQuestsCount } from '@/lib/xp/useClaimableQuestsCount'
 import LazyEarth from '@/components/globe/LazyEarth'
@@ -962,6 +964,21 @@ export default function SignedInDashboard({
               </div>
             </div>
           </div>
+        </div>
+
+        {/* Live from Discord — surfaces the community's active conversation */}
+        <div className="bg-white/[0.03] backdrop-blur-xl border border-white/10 rounded-2xl p-5 sm:p-6 mt-6">
+          <SectionHeader
+            title="Live from Discord"
+            subtitle="Recent announcements from the MoonDAO community"
+            icon={<ChatBubbleLeftRightIcon className="w-6 h-6 text-indigo-400" />}
+            actions={
+              <SubtleButton color="indigo" link="https://moondao.com/discord">
+                Join the conversation
+              </SubtleButton>
+            }
+          />
+          <DiscordAnnouncements maxItems={5} />
         </div>
 
         {/* Launchpad Feature - Featured Mission */}

--- a/ui/lib/dashboard/hooks/useAnnouncements.ts
+++ b/ui/lib/dashboard/hooks/useAnnouncements.ts
@@ -7,15 +7,20 @@ export function useAnnouncements() {
 
   async function getAnnouncements(id?: string) {
     setIsLoading(true)
-    console.log('Fetching announcements...')
     try {
       const response = await fetch(
-        `/api/discord/announcements${id ? `?before=${id}` : ''}`
+        `/api/discord/messages?type=announcements${id ? `&before=${id}` : ''}`
       )
+      if (!response.ok) {
+        throw new Error('Failed to fetch announcements')
+      }
       const announcements = await response.json()
-      setAnnouncements((prev: any) => [...prev, ...announcements])
+      if (Array.isArray(announcements)) {
+        setAnnouncements((prev: any) => [...prev, ...announcements])
+      }
     } catch (error) {
       console.error('Error fetching announcements:', error)
+      setError(error)
     }
 
     setIsLoading(false)

--- a/ui/lib/discord/formatDiscordMessage.tsx
+++ b/ui/lib/discord/formatDiscordMessage.tsx
@@ -1,0 +1,147 @@
+import React from 'react'
+import {
+  discordChannelDictionary,
+  discordRoleDictionary,
+} from '@/lib/dashboard/dashboard-utils.ts/discord-config'
+
+// Matches Discord's raw mention/markdown syntax so announcement messages
+// pulled from the API render close to how they look in the Discord client,
+// instead of showing raw `<@&123>` / `**bold**` tokens.
+const TOKEN_REGEX =
+  /(<@&(\d+)>)|(<#(\d+)>)|(<@!?(\d+)>)|(\*\*([^*]+)\*\*)|(~~([^~]+)~~)|(`([^`]+)`)|(\[([^\]]+)\]\((https?:\/\/[^\s)]+)\))|(https?:\/\/[^\s<]+)|(\n)/g
+
+interface DiscordMention {
+  id: string
+  username?: string
+  global_name?: string
+}
+
+// Renders raw Discord message content (mentions + a small subset of
+// markdown) as React nodes. Not a full markdown parser — just enough to
+// make announcement messages readable outside of Discord itself.
+export function renderDiscordMessageContent(
+  content: string,
+  mentions: DiscordMention[] = []
+): React.ReactNode {
+  if (!content) return null
+
+  const mentionMap = new Map(
+    mentions.map((m) => [m.id, m.global_name || m.username || 'member'])
+  )
+
+  const nodes: React.ReactNode[] = []
+  let lastIndex = 0
+  let key = 0
+  let match: RegExpExecArray | null
+
+  TOKEN_REGEX.lastIndex = 0
+  while ((match = TOKEN_REGEX.exec(content))) {
+    if (match.index > lastIndex) {
+      nodes.push(content.slice(lastIndex, match.index))
+    }
+
+    const [
+      full,
+      ,
+      roleId,
+      ,
+      channelId,
+      ,
+      userId,
+      ,
+      boldText,
+      ,
+      strikeText,
+      ,
+      codeText,
+      ,
+      linkText,
+      linkUrl,
+      bareUrl,
+      newline,
+    ] = match
+
+    if (roleId) {
+      const [colorClass, name] = discordRoleDictionary[roleId] || [
+        'text-blue-400',
+        'role',
+      ]
+      nodes.push(
+        <span key={key++} className={`font-medium ${colorClass}`}>
+          @{name}
+        </span>
+      )
+    } else if (channelId) {
+      const [colorClass, name] = discordChannelDictionary[channelId] || [
+        'text-blue-400',
+        'channel',
+      ]
+      nodes.push(
+        <span key={key++} className={`font-medium ${colorClass}`}>
+          #{name}
+        </span>
+      )
+    } else if (userId) {
+      nodes.push(
+        <span key={key++} className="font-medium text-blue-400">
+          @{mentionMap.get(userId) || 'member'}
+        </span>
+      )
+    } else if (boldText !== undefined) {
+      nodes.push(
+        <strong key={key++} className="font-semibold text-white">
+          {boldText}
+        </strong>
+      )
+    } else if (strikeText !== undefined) {
+      nodes.push(
+        <span key={key++} className="line-through opacity-70">
+          {strikeText}
+        </span>
+      )
+    } else if (codeText !== undefined) {
+      nodes.push(
+        <code
+          key={key++}
+          className="px-1 py-0.5 rounded bg-white/10 text-xs font-RobotoMono"
+        >
+          {codeText}
+        </code>
+      )
+    } else if (linkUrl) {
+      nodes.push(
+        <a
+          key={key++}
+          href={linkUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-400 underline hover:text-blue-300"
+        >
+          {linkText}
+        </a>
+      )
+    } else if (bareUrl) {
+      nodes.push(
+        <a
+          key={key++}
+          href={bareUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-400 underline hover:text-blue-300 break-all"
+        >
+          {bareUrl}
+        </a>
+      )
+    } else if (newline) {
+      nodes.push(<br key={key++} />)
+    }
+
+    lastIndex = match.index + full.length
+  }
+
+  if (lastIndex < content.length) {
+    nodes.push(content.slice(lastIndex))
+  }
+
+  return nodes
+}


### PR DESCRIPTION
## Summary
- The community's real activity lives in Discord, but the signed-in dashboard only ever showed on-chain/Tableland activity (citizens, teams, jobs, proposals), so website-only users felt disconnected from what's actually happening.
- `useAnnouncements` was already wired up to pull Discord announcement messages, but it called a `/api/discord/announcements` route that was never implemented — it silently failed on every load. Fixed it to hit the existing `/api/discord/messages?type=announcements` handler instead.
- Added a Discord message renderer (`lib/discord/formatDiscordMessage.tsx`) that turns raw Discord content (role/channel/user mentions, bold, code, links) into readable, styled text using the channel/role color dictionaries that already existed in the codebase but had no consumer.
- Added a `DiscordAnnouncements` component and wired it into `SignedInDashboard` as a new "Live from Discord" section (with a "Join the conversation" CTA), so the homepage now reflects live community activity instead of just on-chain events.

## Test plan
- [ ] Confirm `DISCORD_BOT_TOKEN` is set in the deploy environment (existing requirement — the announcements channel API already depended on it).
- [ ] Load the signed-in home dashboard and verify the "Live from Discord" section shows the latest announcement messages with correct author, avatar, timestamp, and formatted mentions.
- [ ] Verify the section gracefully shows a fallback message if the Discord API call fails or returns no messages.
- [ ] Click "Join the conversation" and confirm it opens the Discord invite.

Made with [Cursor](https://cursor.com)