### PR TITLE
fix(projects): hide Oscar O'Farrill's MDP-244 project

### DIFF
--- a/ui/const/whitelist.ts
+++ b/ui/const/whitelist.ts
@@ -14,7 +14,7 @@ export const BLOCKED_PROJECTS: any = new Set(
 )
 export const BLOCKED_MDPS: any = new Set(
   process.env.NEXT_PUBLIC_CHAIN === 'mainnet'
-    ? [229, 243, 246, 247, 252, 253, 256, 257, 263]
+    ? [229, 243, 244, 246, 247, 252, 253, 256, 257, 263]
     : []
 )
 export const BLOCKED_PROPOSALS: any = new Set([221])


### PR DESCRIPTION
## Summary
- Oscar Iván O'Farrill Cobo (MoonDAO citizen #169, wallet `0x0E92E0e2FB6624e64Ae9d0283aA3FB76972cae7a`) emailed Pablo asking that his project be removed from the MoonDAO platform / taken out of public view, after multiple unanswered attempts to reach Ryan and `info@`.
- I identified his citizen record via a Tableland name search, then confirmed his single matching project by checking `authorAddress` in each project's IPFS proposal JSON on-chain (Tableland `PROJECT_42161_122`): **MDP 244 / project id 126**, "MLAATA — Mexico and Latin America Astronaut Training Agency / Lunar Readiness Gateway Pilot" (`https://moondao.com/project/244`).
- No other projects on the table matched his wallet address, so this is his only public project.
- Added `244` to `BLOCKED_MDPS` in `ui/const/whitelist.ts`, following the existing pattern used to hide other projects. This filters it out of `/projects`, `/project/[tokenId]`, and `/governance-proposals` without needing an on-chain transaction.

## Test plan
- [ ] Deploy/preview and confirm `/project/244` returns a 404/not-found.
- [ ] Confirm the project no longer appears in the `/projects` listing or `/governance-proposals`.
- [ ] Confirm other projects/proposals are unaffected.

Made with [Cursor](https://cursor.com)