### PR TITLE
fix(onramp): replace deprecated Coinbase guest checkout fallback with MoonPay option

### DIFF
--- a/ui/components/coinbase/CBHeadlessOnramp.tsx
+++ b/ui/components/coinbase/CBHeadlessOnramp.tsx
@@ -45,11 +45,14 @@ interface CBHeadlessOnrampProps {
    *  screen and hand off to the parent (which polls for the balance and shows
    *  its own action) instead of reloading. Keeps the whole flow on one screen. */
   waitForFundsInApp?: boolean
-  /** Called when the device doesn't support Apple Pay or Google Pay so the
-   *  parent can fall back to MoonPay automatically. */
+  /** Called when the device doesn't support Apple Pay or Google Pay, or when
+   *  the user manually says they don't have it set up, so the parent can fall
+   *  back to MoonPay (Coinbase's guest/debit-card checkout was deprecated, so
+   *  MoonPay is the only no-Coinbase-account card option left). */
   onUnsupported?: () => void
-  /** Launches the hosted Coinbase flow (account / card / bank). Surfaced on the
-   *  QR screen for desktop users who don't have an iPhone to scan with. */
+  /** Launches the hosted Coinbase flow to sign into an existing account.
+   *  Coinbase's guest checkout (card without an account) was deprecated, so
+   *  this path now requires the user to already have a Coinbase account. */
   onUseAccountFlow?: () => void | Promise<void>
 }
 
@@ -608,40 +611,19 @@ export function CBHeadlessOnramp({
                 ? 'Press the Google Pay button above to complete your purchase securely with Coinbase.'
                 : 'Scan the QR code above with your iPhone to complete your purchase securely with Apple Pay.'}
           </p>
-          {/* Not everyone has Apple/Google Pay set up (or an iPhone to scan the
-              QR with) — always offer the hosted Coinbase flow (guest
-              debit/credit card checkout or an existing account) as a way out.
-              Previously this only showed on desktop browsers without native
-              Apple/Google Pay, which left Safari and Android users with no
-              visible alternative at all. */}
-          {onUseAccountFlow && (
-            <div className="pt-1 text-center">
-              <p className="text-gray-500 text-xs mb-2">
-                {nativeApplePay
-                  ? "Apple Pay not set up on this device?"
-                  : useGooglePay
-                    ? 'Google Pay not set up on this device?'
-                    : 'No iPhone to scan with?'}
-              </p>
-              <button
-                type="button"
-                disabled={accountFlowLoading}
-                onClick={async () => {
-                  setAccountFlowLoading(true)
-                  try {
-                    await onUseAccountFlow()
-                  } finally {
-                    setAccountFlowLoading(false)
-                  }
-                }}
-                className="text-sm font-semibold text-blue-300 hover:text-blue-200 underline disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {accountFlowLoading
-                  ? 'Opening Coinbase…'
-                  : 'Pay with a debit/credit card or Coinbase account instead'}
-              </button>
-            </div>
-          )}
+          {/* Coinbase's guest/debit-card checkout was deprecated, so someone
+              without Apple/Google Pay set up (or no iPhone to scan the QR
+              with) has exactly two ways forward: sign into an existing
+              Coinbase account, or use MoonPay instead, which still takes a
+              card without a Coinbase account. */}
+          <FallbackOptions
+            payLabel={payLabel}
+            onUseAccountFlow={onUseAccountFlow}
+            accountFlowLoading={accountFlowLoading}
+            setAccountFlowLoading={setAccountFlowLoading}
+            onUnsupported={onUnsupported}
+            className="pt-1"
+          />
         </div>
       </div>
     )
@@ -826,29 +808,14 @@ export function CBHeadlessOnramp({
         {/* Surfaced here too (not just after a failed attempt) so users who
             already know they don't have Apple/Google Pay set up don't have to
             verify phone/email and agree to terms first just to find an
-            alternative. Still Coinbase — guest card checkout or an existing
-            account — never MoonPay, which requires an SSN for US persons. */}
-        {onUseAccountFlow && (
-          <div className="text-center">
-            <button
-              type="button"
-              disabled={accountFlowLoading}
-              onClick={async () => {
-                setAccountFlowLoading(true)
-                try {
-                  await onUseAccountFlow()
-                } finally {
-                  setAccountFlowLoading(false)
-                }
-              }}
-              className="text-xs font-semibold text-blue-300 hover:text-blue-200 underline disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {accountFlowLoading
-                ? 'Opening Coinbase…'
-                : `Don't have ${payLabel} set up? Pay with a debit/credit card or Coinbase account instead`}
-            </button>
-          </div>
-        )}
+            alternative. */}
+        <FallbackOptions
+          payLabel={payLabel}
+          onUseAccountFlow={onUseAccountFlow}
+          accountFlowLoading={accountFlowLoading}
+          setAccountFlowLoading={setAccountFlowLoading}
+          onUnsupported={onUnsupported}
+        />
 
         {/* Secured footer */}
         <div className="bg-black/10 rounded-lg p-4 border border-white/5">
@@ -862,6 +829,63 @@ export function CBHeadlessOnramp({
             Pay with {payLabel} without leaving this page. Funds typically arrive within a few minutes.
           </p>
         </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Coinbase's guest/debit-card checkout was deprecated — someone who can't use
+ * Apple/Google Pay now has exactly two ways forward: sign into an existing
+ * Coinbase account, or pay by card via MoonPay (no Coinbase account needed).
+ */
+function FallbackOptions({
+  payLabel,
+  onUseAccountFlow,
+  accountFlowLoading,
+  setAccountFlowLoading,
+  onUnsupported,
+  className = '',
+}: {
+  payLabel: string
+  onUseAccountFlow?: () => void | Promise<void>
+  accountFlowLoading: boolean
+  setAccountFlowLoading: (loading: boolean) => void
+  onUnsupported?: () => void
+  className?: string
+}) {
+  if (!onUseAccountFlow && !onUnsupported) return null
+
+  return (
+    <div className={`text-center space-y-2 ${className}`}>
+      <p className="text-gray-500 text-xs">Can&apos;t use {payLabel}?</p>
+      <div className="flex flex-col items-center gap-1.5">
+        {onUseAccountFlow && (
+          <button
+            type="button"
+            disabled={accountFlowLoading}
+            onClick={async () => {
+              setAccountFlowLoading(true)
+              try {
+                await onUseAccountFlow()
+              } finally {
+                setAccountFlowLoading(false)
+              }
+            }}
+            className="text-sm font-semibold text-blue-300 hover:text-blue-200 underline disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {accountFlowLoading ? 'Opening Coinbase…' : 'Use your Coinbase account'}
+          </button>
+        )}
+        {onUnsupported && (
+          <button
+            type="button"
+            onClick={onUnsupported}
+            className="text-sm font-semibold text-blue-300 hover:text-blue-200 underline"
+          >
+            {`Don't have ${payLabel}? Use a debit card on MoonPay`}
+          </button>
+        )}
       </div>
     </div>
   )

--- a/ui/components/coinbase/CBOnramp.tsx
+++ b/ui/components/coinbase/CBOnramp.tsx
@@ -56,7 +56,6 @@ interface CBOnrampProps {
   onHeadlessSuccessInApp?: () => void
 }
 
-const GUEST_CHECKOUT_LIMIT = 500
 const MOCK_ONRAMP = process.env.NEXT_PUBLIC_MOCK_ONRAMP === 'true'
 
 export const CBOnramp: React.FC<CBOnrampProps> = ({
@@ -128,8 +127,6 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
   const [isLoadingQuote, setIsLoadingQuote] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [showExchangeFundingGuide, setShowExchangeFundingGuide] = useState(false)
-  const [showLimits, setShowLimits] = useState(false)
-  const [hasShownLimitsForExcess, setHasShownLimitsForExcess] = useState(false)
   const [quoteData, setQuoteData] = useState<{
     ethAmount: number
     purchaseAmount: number
@@ -152,11 +149,6 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
     }
   }, [ethAmount, allowAmountInput])
 
-  // Guest checkout limit
-  const exceedsGuestLimit = quoteData?.purchaseAmount
-    ? quoteData.purchaseAmount > GUEST_CHECKOUT_LIMIT
-    : false
-
   // Check if current chain is Arbitrum
   const isArbitrum = useMemo(
     () => selectedChain === arbitrum || selectedChain?.id === 42161 || selectedChain?.id === 421614,
@@ -174,14 +166,6 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
 
     return () => clearTimeout(timeoutId)
   }, [effectiveAmount])
-
-  // Auto-expand limits section when amount exceeds guest limit
-  useEffect(() => {
-    if (exceedsGuestLimit && !hasShownLimitsForExcess) {
-      setShowLimits(true)
-      setHasShownLimitsForExcess(true)
-    }
-  }, [exceedsGuestLimit, hasShownLimitsForExcess])
 
   // Fetch quote on component load and calculate fees
   useEffect(() => {
@@ -911,26 +895,38 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
           </div>
         </div>
 
-        {/* Guest limit warning */}
-        {exceedsGuestLimit && (
-          <div className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-4">
-            <div className="flex items-start gap-3">
-              <div className="flex-shrink-0 w-6 h-6 bg-orange-500/20 rounded-full flex items-center justify-center mt-0.5">
-                <span className="text-orange-400 text-sm">⚠️</span>
-              </div>
-              <div className="flex-1">
-                <p className="text-orange-300 font-semibold text-sm mb-1">
-                  Coinbase Account Required
-                </p>
-                <p className="text-orange-200/90 text-xs leading-relaxed">
-                  This purchase (${quoteData?.purchaseAmount.toFixed(2)}) exceeds the $500 guest
-                  checkout limit. You'll need to sign in with a Coinbase account to complete this
-                  purchase.
-                </p>
-              </div>
+        {/* Coinbase deprecated Guest Checkout on this hosted widget (June 30,
+            2026) — it's now account-login only, at any amount, not just above
+            the old $500 guest limit. */}
+        <div className="bg-orange-500/10 border border-orange-500/30 rounded-lg p-4">
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0 w-6 h-6 bg-orange-500/20 rounded-full flex items-center justify-center mt-0.5">
+              <span className="text-orange-400 text-sm">⚠️</span>
+            </div>
+            <div className="flex-1">
+              <p className="text-orange-300 font-semibold text-sm mb-1">
+                Coinbase account required
+              </p>
+              <p className="text-orange-200/90 text-xs leading-relaxed">
+                You&apos;ll need to sign in with a Coinbase account to complete this purchase.
+                {onUnsupported && (
+                  <>
+                    {' '}
+                    No account?{' '}
+                    <button
+                      type="button"
+                      onClick={onUnsupported}
+                      className="underline font-semibold text-orange-100 hover:text-white"
+                    >
+                      Use MoonPay instead
+                    </button>
+                    .
+                  </>
+                )}
+              </p>
             </div>
           </div>
-        )}
+        </div>
 
         {quoteData?.purchaseAmount &&
           quoteData.purchaseAmount > LARGE_ONRAMP_FIAT_THRESHOLD_USD && (

--- a/ui/components/coinbase/CBOnramp.tsx
+++ b/ui/components/coinbase/CBOnramp.tsx
@@ -41,8 +41,10 @@ interface CBOnrampProps {
   embedded?: boolean
   /** Optional content rendered just beneath the "Fund" header */
   headerSlot?: React.ReactNode
-  /** Called when the device doesn't support Apple/Google Pay so the parent
-   *  can fall back to MoonPay automatically. */
+  /** Called when the device doesn't support Apple/Google Pay, or the user
+   *  manually says they don't have it set up, so the parent can fall back to
+   *  MoonPay (Coinbase's guest/debit-card checkout was deprecated, leaving
+   *  MoonPay as the only no-account card option). */
   onUnsupported?: () => void
   /** Region already resolved by a parent (e.g. FundOnramp). When provided,
    *  skips the duplicate /api/coinbase/region request. */
@@ -500,9 +502,10 @@ export const CBOnramp: React.FC<CBOnrampProps> = ({
   }, [address, selectedChain, asset])
 
   // Hosted Coinbase flow for US users who can't use Apple/Google Pay (e.g.
-  // desktop, no iPhone to scan the QR). Supports signing into an existing
-  // Coinbase account or paying by card/bank. Presets the crypto amount so we
-  // don't depend on the headless quote (which isn't fetched for US users).
+  // desktop, no iPhone to scan the QR). Coinbase's guest/debit-card checkout
+  // was deprecated, so this now requires signing into an existing Coinbase
+  // account. Presets the crypto amount so we don't depend on the headless
+  // quote (which isn't fetched for US users).
   const handleHostedFallback = useCallback(async () => {
     if (!address) return
 

--- a/ui/components/onramp/FundOnramp.tsx
+++ b/ui/components/onramp/FundOnramp.tsx
@@ -154,11 +154,11 @@ export function FundOnramp({
 
   // Rendered just beneath the embedded provider's "Fund Wallet" header so the
   // user picks how to pay after they see what they're funding. US users only
-  // get Coinbase (Apple/Google Pay) — MoonPay's KYC requires an SSN for US
-  // persons, which we intentionally never ask for anywhere in the app — so we
-  // don't surface MoonPay or a provider toggle for them, just an informational
-  // line. The Coinbase-hosted guest/account fallback (card, no SSN needed
-  // under its guest-checkout limit) is surfaced inside CBHeadlessOnramp.
+  // get Coinbase (Apple/Google Pay) by default — no upfront provider toggle,
+  // just an informational line. Coinbase's guest/debit-card checkout was
+  // deprecated, so anyone who can't use Apple/Google Pay is offered two ways
+  // out inside CBHeadlessOnramp itself: sign into an existing Coinbase
+  // account, or switch to MoonPay (below) for a card without an account.
   const providerSelector = isUS ? (
     <div
       data-testid="onramp-provider-select"
@@ -242,6 +242,7 @@ export function FundOnramp({
           onBeforeNavigate={onCoinbaseBeforeNavigate}
           onHeadlessSuccessInApp={onCoinbaseSuccessInApp}
           redirectUrl={coinbaseRedirectUrl}
+          onUnsupported={() => handleSetProvider('moonpay')}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Coinbase deprecated guest checkout, so the "Pay with a debit/credit card or Coinbase account instead" fallback (added for US Apple Pay onboarding) no longer offers a card option — it now silently routes people into full Coinbase account signup, which is what's stranding citizens without Apple/Google Pay set up.
- Removed that stale card-on-Coinbase verbiage everywhere it appeared (config screen and payment/QR screen).
- Replaced it with two explicit options surfaced together: **"Use your Coinbase account"** (sign in) or **"Don't have Apple Pay? Use a debit card on MoonPay"** (switches the shared onramp to MoonPay for that purchase).
- Wired `onUnsupported` back through `FundOnramp` → `CBOnramp` → `CBHeadlessOnramp` so this also fires automatically when Coinbase reports Apple/Google Pay isn't set up on the device, not just on manual click.

## Test plan
- [ ] As a US user without Apple/Google Pay set up, open the fund flow and confirm both "Use your Coinbase account" and "Use a debit card on MoonPay" are visible before starting checkout (not just after a failed attempt)
- [ ] Click "Use your Coinbase account" and confirm it opens Coinbase's hosted sign-in page
- [ ] Click "Use a debit card on MoonPay" and confirm the flow switches to MoonPay in place, without a page reload
- [ ] Confirm the same two options appear on the QR/payment screen for browsers that fall back to the Apple Pay QR code
- [ ] Confirm non-US users and users who do have Apple/Google Pay set up see no change in behavior

Made with [Cursor](https://cursor.com)