### PR TITLE
Fix truncated marketplace listing text

### DIFF
--- a/ui/components/dashboard/calendar/DiscordEvent.tsx
+++ b/ui/components/dashboard/calendar/DiscordEvent.tsx
@@ -2,6 +2,7 @@
 import { parseISO } from 'date-fns'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
+import ExpandableText from '@/components/layout/ExpandableText'
 
 export function DiscordEvent({ discordEvent }: any) {
   const [formattedDate, setFormattedDate] = useState('')
@@ -64,9 +65,11 @@ export function DiscordEvent({ discordEvent }: any) {
         
         {/* Event Description */}
         {discordEvent.description && (
-          <p className="text-white/70 text-sm flex-1 line-clamp-3 leading-relaxed">
-            {discordEvent.description}
-          </p>
+          <div className="flex-1">
+            <ExpandableText className="text-white/70 text-sm leading-relaxed" lines={3}>
+              {discordEvent.description}
+            </ExpandableText>
+          </div>
         )}
       </div>
     </div>

--- a/ui/components/home/DiscordAnnouncements.tsx
+++ b/ui/components/home/DiscordAnnouncements.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import { useMemo } from 'react'
 import { useAnnouncements } from '@/lib/dashboard/hooks/useAnnouncements'
 import { renderDiscordMessageContent } from '@/lib/discord/formatDiscordMessage'
+import ExpandableText from '@/components/layout/ExpandableText'
 
 function relativeTime(iso: string): string {
   const ms = new Date(iso).getTime()
@@ -95,9 +96,14 @@ export default function DiscordAnnouncements({
                   {relativeTime(message.timestamp)}
                 </span>
               </div>
-              <p className="text-white/70 text-sm leading-relaxed mt-0.5 line-clamp-4 whitespace-pre-line">
-                {renderDiscordMessageContent(message.content, message.mentions)}
-              </p>
+              <div className="mt-0.5">
+                <ExpandableText
+                  className="text-white/70 text-sm leading-relaxed whitespace-pre-line"
+                  lines={4}
+                >
+                  {renderDiscordMessageContent(message.content, message.mentions)}
+                </ExpandableText>
+              </div>
             </div>
           </div>
         )

--- a/ui/components/jobs/Job.tsx
+++ b/ui/components/jobs/Job.tsx
@@ -6,6 +6,7 @@ import { getNFT } from 'thirdweb/extensions/erc721'
 import { useActiveAccount, useReadContract } from 'thirdweb/react'
 import useCurrUnixTime from '@/lib/utils/hooks/useCurrUnixTime'
 import { daysSinceTimestamp } from '@/lib/utils/timestamp'
+import ExpandableText from '../layout/ExpandableText'
 import Frame from '../layout/Frame'
 import { LoadingSpinner } from '../layout/LoadingSpinner'
 import StandardButton from '../layout/StandardButton'
@@ -51,8 +52,6 @@ export default function Job({
   const [isDeleting, setIsDeleting] = useState(false)
   const [isActive, setIsActive] = useState(false)
   const [isExpired, setIsExpired] = useState(false)
-  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
-
   const [teamNFT, setTeamNFT] = useState<any>()
 
   const currTime = useCurrUnixTime()
@@ -188,20 +187,9 @@ export default function Job({
 
         {/* Description */}
         <div className="flex-1 mb-4">
-          <p className={`text-sm text-slate-300 leading-relaxed ${isDescriptionExpanded ? '' : 'line-clamp-3'}`}>
+          <ExpandableText className="text-sm text-slate-300 leading-relaxed" lines={3}>
             {job.description}
-          </p>
-          {job.description && job.description.length > 150 && (
-            <button
-              className="text-xs text-blue-400 hover:text-blue-300 mt-1 transition-colors"
-              onClick={(e) => {
-                e.stopPropagation()
-                setIsDescriptionExpanded(!isDescriptionExpanded)
-              }}
-            >
-              {isDescriptionExpanded ? 'Show less' : 'Read more'}
-            </button>
-          )}
+          </ExpandableText>
         </div>
 
         {/* Metadata (compensation, location) */}

--- a/ui/components/layout/ExpandableText.tsx
+++ b/ui/components/layout/ExpandableText.tsx
@@ -1,11 +1,4 @@
-import {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react'
+import { ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 const LINE_CLAMP_CLASS: Record<number, string> = {
   1: 'line-clamp-1',
@@ -16,8 +9,7 @@ const LINE_CLAMP_CLASS: Record<number, string> = {
   6: 'line-clamp-6',
 }
 
-const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 type ExpandableTextProps = {
   children: ReactNode
@@ -29,10 +21,24 @@ type ExpandableTextProps = {
   id?: string
 }
 
+function applyClamp(el: HTMLElement, lines: number) {
+  el.style.display = '-webkit-box'
+  el.style.setProperty('-webkit-box-orient', 'vertical')
+  el.style.setProperty('-webkit-line-clamp', String(lines))
+  el.style.overflow = 'hidden'
+}
+
+function clearClamp(el: HTMLElement) {
+  el.style.display = ''
+  el.style.removeProperty('-webkit-box-orient')
+  el.style.removeProperty('-webkit-line-clamp')
+  el.style.overflow = ''
+}
+
 /**
  * Clamps body copy to a fixed number of lines and reveals a Read more control
- * only when the text actually overflows at the current width. This keeps card
- * previews compact without hiding content on smaller screens.
+ * only when the text actually overflows at the current width. Clamp styles are
+ * applied inline so overflow detection does not depend on Tailwind being loaded.
  */
 export default function ExpandableText({
   children,
@@ -50,18 +56,25 @@ export default function ExpandableText({
   const measure = useCallback(() => {
     const el = textRef.current
     if (!el || expanded) return
+    applyClamp(el, lines)
     setOverflows(el.scrollHeight > el.clientHeight + 1)
-  }, [expanded])
+  }, [expanded, lines])
 
   useIsomorphicLayoutEffect(() => {
-    measure()
     const el = textRef.current
-    if (!el || typeof ResizeObserver === 'undefined') return
+    if (!el) return
 
+    if (expanded) {
+      clearClamp(el)
+    } else {
+      measure()
+    }
+
+    if (typeof ResizeObserver === 'undefined') return
     const observer = new ResizeObserver(() => measure())
     observer.observe(el)
     return () => observer.disconnect()
-  }, [measure, children, lines])
+  }, [measure, children, lines, expanded])
 
   if (children == null || children === '') return null
 

--- a/ui/components/layout/ExpandableText.tsx
+++ b/ui/components/layout/ExpandableText.tsx
@@ -102,6 +102,9 @@ export default function ExpandableText({
             e.stopPropagation()
             setExpanded((isExpanded) => !isExpanded)
           }}
+          onKeyDown={(e) => {
+            e.stopPropagation()
+          }}
         >
           {expanded ? lessLabel : moreLabel}
         </button>

--- a/ui/components/layout/ExpandableText.tsx
+++ b/ui/components/layout/ExpandableText.tsx
@@ -1,0 +1,98 @@
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+
+const LINE_CLAMP_CLASS: Record<number, string> = {
+  1: 'line-clamp-1',
+  2: 'line-clamp-2',
+  3: 'line-clamp-3',
+  4: 'line-clamp-4',
+  5: 'line-clamp-5',
+  6: 'line-clamp-6',
+}
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+type ExpandableTextProps = {
+  children: ReactNode
+  className?: string
+  lines?: number
+  buttonClassName?: string
+  moreLabel?: string
+  lessLabel?: string
+  id?: string
+}
+
+/**
+ * Clamps body copy to a fixed number of lines and reveals a Read more control
+ * only when the text actually overflows at the current width. This keeps card
+ * previews compact without hiding content on smaller screens.
+ */
+export default function ExpandableText({
+  children,
+  className = '',
+  lines = 2,
+  buttonClassName = 'mt-1 text-xs font-medium text-blue-400 hover:text-blue-300 transition-colors',
+  moreLabel = 'Read more',
+  lessLabel = 'Show less',
+  id,
+}: ExpandableTextProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [overflows, setOverflows] = useState(false)
+  const textRef = useRef<HTMLDivElement>(null)
+
+  const measure = useCallback(() => {
+    const el = textRef.current
+    if (!el || expanded) return
+    setOverflows(el.scrollHeight > el.clientHeight + 1)
+  }, [expanded])
+
+  useIsomorphicLayoutEffect(() => {
+    measure()
+    const el = textRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(() => measure())
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [measure, children, lines])
+
+  if (children == null || children === '') return null
+
+  const clampClass = expanded ? '' : LINE_CLAMP_CLASS[lines] || 'line-clamp-2'
+
+  return (
+    <div className="min-w-0">
+      <div
+        id={id}
+        ref={textRef}
+        data-testid="expandable-text"
+        data-expanded={expanded ? 'true' : 'false'}
+        className={`${className} break-words ${clampClass}`.trim()}
+      >
+        {children}
+      </div>
+      {(overflows || expanded) && (
+        <button
+          type="button"
+          data-testid="expandable-text-toggle"
+          aria-expanded={expanded}
+          className={buttonClassName}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setExpanded((isExpanded) => !isExpanded)
+          }}
+        >
+          {expanded ? lessLabel : moreLabel}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/ui/components/marketplace/MarketplaceListing.tsx
+++ b/ui/components/marketplace/MarketplaceListing.tsx
@@ -5,6 +5,7 @@ import CitizenContext from '@/lib/citizen/citizen-context'
 import { generatePrettyLink } from '@/lib/subscription/pretty-links'
 import { truncateTokenValue } from '@/lib/utils/numbers'
 import AdaptiveImage from '@/components/layout/AdaptiveImage'
+import ExpandableText from '@/components/layout/ExpandableText'
 import BuyTeamListingModal from '@/components/subscription/BuyTeamListingModal'
 import { TeamListing } from '@/components/subscription/TeamListing'
 
@@ -119,9 +120,14 @@ export default function MarketplaceListing({
             >
               {listing.teamName || `Team ${listing.teamId}`}
             </button>
-            <p className="mt-1.5 text-sm leading-relaxed text-slate-300/80 break-words line-clamp-2">
-              {listing.description}
-            </p>
+            <div className="mt-1.5">
+              <ExpandableText
+                className="text-sm leading-relaxed text-slate-300/80"
+                lines={2}
+              >
+                {listing.description}
+              </ExpandableText>
+            </div>
             <div className="mt-auto flex flex-wrap items-center gap-2 pt-3">
               <p className="font-GoodTimes text-base text-white">{displayPrice}</p>
               {citizen ? (

--- a/ui/components/marketplace/MarketplaceListing.tsx
+++ b/ui/components/marketplace/MarketplaceListing.tsx
@@ -68,15 +68,13 @@ export default function MarketplaceListing({
 
   const handleTeamClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    router.push(
-      `/team/${
-        listing.teamName ? generatePrettyLink(listing.teamName) : listing.teamId
-      }`
-    )
+    router.push(`/team/${listing.teamName ? generatePrettyLink(listing.teamName) : listing.teamId}`)
   }
 
   const numericPrice = parseFloat(listing.price.replace(/,/g, ''))
-  const fullPrice = `${truncateTokenValue(numericPrice * 1.1, listing.currency)} ${listing.currency}`
+  const fullPrice = `${truncateTokenValue(numericPrice * 1.1, listing.currency)} ${
+    listing.currency
+  }`
   const displayPrice = citizen
     ? `${truncateTokenValue(listing.price, listing.currency)} ${listing.currency}`
     : fullPrice
@@ -121,10 +119,7 @@ export default function MarketplaceListing({
               {listing.teamName || `Team ${listing.teamId}`}
             </button>
             <div className="mt-1.5">
-              <ExpandableText
-                className="text-sm leading-relaxed text-slate-300/80"
-                lines={2}
-              >
+              <ExpandableText className="text-sm leading-relaxed text-slate-300/80" lines={2}>
                 {listing.description}
               </ExpandableText>
             </div>

--- a/ui/components/subscription/BuyTeamListingModal.tsx
+++ b/ui/components/subscription/BuyTeamListingModal.tsx
@@ -32,6 +32,7 @@ import useContract from '@/lib/thirdweb/hooks/useContract'
 import { truncateTokenValue } from '@/lib/utils/numbers'
 import { FundOnramp } from '@/components/onramp/FundOnramp'
 import { TeamListing } from '@/components/subscription/TeamListing'
+import ExpandableText from '../layout/ExpandableText'
 import IPFSRenderer from '../layout/IPFSRenderer'
 import Input from '../layout/Input'
 import Modal from '../layout/Modal'
@@ -411,10 +412,15 @@ export default function BuyTeamListingModal({
             </div>
           )}
           <div className="flex min-w-0 flex-1 flex-col gap-1">
-            <h3 className="font-GoodTimes text-base leading-tight text-white">{listing.title}</h3>
-            <p className="text-xs leading-snug text-white/60 line-clamp-2">
+            <h3 className="font-GoodTimes text-base leading-tight text-white break-words">
+              {listing.title}
+            </h3>
+            <ExpandableText
+              className="text-xs leading-snug text-white/60"
+              lines={4}
+            >
               {listing.description}
-            </p>
+            </ExpandableText>
             <div className="mt-auto flex flex-wrap items-center gap-2">
               <p id="listing-price" className="font-GoodTimes text-lg text-white">{`${
                 truncateTokenValue(purchasePrice, listing.currency)

--- a/ui/components/subscription/TeamListing.tsx
+++ b/ui/components/subscription/TeamListing.tsx
@@ -13,8 +13,9 @@ import { addNetworkToWallet } from '@/lib/thirdweb/addNetworkToWallet'
 import useCurrUnixTime from '@/lib/utils/hooks/useCurrUnixTime'
 import { truncateTokenValue } from '@/lib/utils/numbers'
 import { daysUntilTimestamp } from '@/lib/utils/timestamp'
-import { LoadingSpinner } from '../layout/LoadingSpinner'
+import ExpandableText from '../layout/ExpandableText'
 import IPFSRenderer from '../layout/IPFSRenderer'
+import { LoadingSpinner } from '../layout/LoadingSpinner'
 import BuyTeamListingModal from './BuyTeamListingModal'
 import TeamMarketplaceListingModal from './TeamMarketplaceListingModal'
 
@@ -189,11 +190,13 @@ export default function TeamListing({
           <h4 id="main-header" className="text-white font-semibold text-sm leading-tight line-clamp-2">
             {listing?.title}
           </h4>
-          {listing?.description && (
-            <p className="text-white/40 text-xs leading-relaxed line-clamp-2">
-              {listing.description}
-            </p>
-          )}
+          <ExpandableText
+            className="text-white/40 text-xs leading-relaxed"
+            lines={2}
+            buttonClassName="mt-0.5 text-[11px] font-medium text-white/50 hover:text-white/80 transition-colors"
+          >
+            {listing?.description}
+          </ExpandableText>
 
           {/* Footer: price + actions */}
           <div className="mt-auto pt-2 flex items-center justify-between gap-2">

--- a/ui/cypress/integration/layout/expandable-text.cy.tsx
+++ b/ui/cypress/integration/layout/expandable-text.cy.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ExpandableText from '../../../components/layout/ExpandableText'
 
 const LONG_TEXT =
-  'Join Loretta Hidalgo Whitesides on an 8-week Hero\'s Journey to help you take on the next level of your life. Level up your leadership, communication, and presence with weekly training, coaching, and community. This program is designed to meet you where you are and take you further than you thought possible.'
+  "Join Loretta Hidalgo Whitesides on an 8-week Hero's Journey to help you take on the next level of your life. Level up your leadership, communication, and presence with weekly training, coaching, and community. This program is designed to meet you where you are and take you further than you thought possible."
 
 describe('<ExpandableText />', () => {
   it('Does not show a Read more control for short text', () => {
@@ -34,9 +34,7 @@ describe('<ExpandableText />', () => {
 
     cy.get('[data-testid="expandable-text"]').should('have.attr', 'data-expanded', 'true')
     cy.get('[data-testid="expandable-text"]').should('not.have.class', 'line-clamp-2')
-    cy.get('[data-testid="expandable-text-toggle"]')
-      .should('have.text', 'Show less')
-      .click()
+    cy.get('[data-testid="expandable-text-toggle"]').should('have.text', 'Show less').click()
 
     cy.get('[data-testid="expandable-text"]').should('have.attr', 'data-expanded', 'false')
     cy.get('[data-testid="expandable-text"]').should('have.class', 'line-clamp-2')

--- a/ui/cypress/integration/layout/expandable-text.cy.tsx
+++ b/ui/cypress/integration/layout/expandable-text.cy.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import ExpandableText from '../../../components/layout/ExpandableText'
+
+const LONG_TEXT =
+  'Join Loretta Hidalgo Whitesides on an 8-week Hero\'s Journey to help you take on the next level of your life. Level up your leadership, communication, and presence with weekly training, coaching, and community. This program is designed to meet you where you are and take you further than you thought possible.'
+
+describe('<ExpandableText />', () => {
+  it('Does not show a Read more control for short text', () => {
+    cy.mount(
+      <div className="w-[360px]">
+        <ExpandableText className="text-sm">Short description</ExpandableText>
+      </div>
+    )
+
+    cy.get('[data-testid="expandable-text"]').should('contain', 'Short description')
+    cy.get('[data-testid="expandable-text-toggle"]').should('not.exist')
+  })
+
+  it('Reveals the full text when it overflows the clamp', () => {
+    cy.viewport(375, 667)
+    cy.mount(
+      <div className="w-[280px]">
+        <ExpandableText className="text-sm leading-relaxed" lines={2}>
+          {LONG_TEXT}
+        </ExpandableText>
+      </div>
+    )
+
+    cy.get('[data-testid="expandable-text"]').should('have.class', 'line-clamp-2')
+    cy.get('[data-testid="expandable-text-toggle"]')
+      .should('be.visible')
+      .and('have.text', 'Read more')
+      .click()
+
+    cy.get('[data-testid="expandable-text"]').should('have.attr', 'data-expanded', 'true')
+    cy.get('[data-testid="expandable-text"]').should('not.have.class', 'line-clamp-2')
+    cy.get('[data-testid="expandable-text-toggle"]')
+      .should('have.text', 'Show less')
+      .click()
+
+    cy.get('[data-testid="expandable-text"]').should('have.attr', 'data-expanded', 'false')
+    cy.get('[data-testid="expandable-text"]').should('have.class', 'line-clamp-2')
+  })
+
+  it('Does not bubble the toggle click to a parent handler', () => {
+    const onParentClick = cy.stub().as('parentClick')
+
+    cy.viewport(375, 667)
+    cy.mount(
+      <div className="w-[280px]" onClick={onParentClick} role="button" tabIndex={0}>
+        <ExpandableText className="text-sm leading-relaxed" lines={2}>
+          {LONG_TEXT}
+        </ExpandableText>
+      </div>
+    )
+
+    cy.get('[data-testid="expandable-text-toggle"]').click()
+    cy.get('@parentClick').should('not.have.been.called')
+  })
+})

--- a/ui/cypress/integration/lib/deprize/lifecycle.cy.ts
+++ b/ui/cypress/integration/lib/deprize/lifecycle.cy.ts
@@ -222,6 +222,8 @@ describe('deprize lifecycle derivations', () => {
     })
 
     it('rejects an unsettled tip', () => {
+      // Cypress's .throw() treats a RegExp as the expected thrown *value*,
+      // not a message matcher, so a string substring is the reliable check.
       expect(() =>
         buildSupersededPayouts({
           teamIds: roster,
@@ -229,7 +231,7 @@ describe('deprize lifecycle derivations', () => {
           tipWinningTeamId: 301n,
           openFieldTeamId: FIELD,
         })
-      ).to.throw(/unresolved/i)
+      ).to.throw('unresolved')
     })
   })
 

--- a/ui/cypress/integration/subscription/buy-team-listing-modal.cy.tsx
+++ b/ui/cypress/integration/subscription/buy-team-listing-modal.cy.tsx
@@ -50,23 +50,17 @@ describe('<BuyTeamListingModal />', () => {
       </TestnetProviders>
     )
 
-    cy.get('#listing-price').should(
-      'have.text',
-      `${listing.price} ${listing.currency}`
-    )
+    cy.get('#listing-price').should('have.text', `${listing.price} ${listing.currency}`)
   })
 
   it('Lets the buyer read a long listing description in full', () => {
     const longDescription =
-      'Join Loretta Hidalgo Whitesides on an 8-week Hero\'s Journey to help you take on the next level of your life. Level up your leadership, communication, and presence with weekly training, coaching, and community. This program is designed to meet you where you are and take you further than you thought possible.'
+      "Join Loretta Hidalgo Whitesides on an 8-week Hero's Journey to help you take on the next level of your life. Level up your leadership, communication, and presence with weekly training, coaching, and community. This program is designed to meet you where you are and take you further than you thought possible."
 
     cy.viewport(375, 667)
     cy.mount(
       <TestnetProviders>
-        <BuyTeamListingModal
-          {...props}
-          listing={{ ...listing, description: longDescription }}
-        />
+        <BuyTeamListingModal {...props} listing={{ ...listing, description: longDescription }} />
       </TestnetProviders>
     )
 

--- a/ui/cypress/integration/subscription/buy-team-listing-modal.cy.tsx
+++ b/ui/cypress/integration/subscription/buy-team-listing-modal.cy.tsx
@@ -55,4 +55,27 @@ describe('<BuyTeamListingModal />', () => {
       `${listing.price} ${listing.currency}`
     )
   })
+
+  it('Lets the buyer read a long listing description in full', () => {
+    const longDescription =
+      'Join Loretta Hidalgo Whitesides on an 8-week Hero\'s Journey to help you take on the next level of your life. Level up your leadership, communication, and presence with weekly training, coaching, and community. This program is designed to meet you where you are and take you further than you thought possible.'
+
+    cy.viewport(375, 667)
+    cy.mount(
+      <TestnetProviders>
+        <BuyTeamListingModal
+          {...props}
+          listing={{ ...listing, description: longDescription }}
+        />
+      </TestnetProviders>
+    )
+
+    cy.contains(longDescription).should('exist')
+    cy.get('[data-testid="expandable-text-toggle"]')
+      .should('be.visible')
+      .and('have.text', 'Read more')
+      .click()
+    cy.get('[data-testid="expandable-text"]').should('have.attr', 'data-expanded', 'true')
+    cy.get('[data-testid="expandable-text-toggle"]').should('have.text', 'Show less')
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/Official-MoonDao/MoonDAO/issues/1515

Marketplace listing descriptions were clamped to two lines in the buy modal with no way to read the rest, which was especially noticeable on narrower screens.

## Changes
- Add a shared `ExpandableText` component that clamps body copy and shows **Read more** only when the text actually overflows at the current width (instead of guessing from character count).
- Clamp with inline styles so overflow detection works even when Tailwind utilities are not loaded.
- Use it in the listing buy modal, marketplace cards, team listing cards, job posts, Discord announcements, and calendar event descriptions so similar truncation no longer hides content with no expansion path.
- Toggle clicks and keyboard events stop propagating, so expanding text on a listing card does not open the purchase modal.

## Tests
- Component tests for `ExpandableText` (short text, overflow expand/collapse, click isolation)
- Buy-modal coverage that a long listing description can be fully revealed
- Cypress `lifecycle.cy.ts` unsettled-tip assertion now uses a string matcher (Cypress `.throw()` does not treat a RegExp as a message matcher)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffd47-0c29-74ab-a60a-2e7a8a4ab302?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffd47-0c29-74ab-a60a-2e7a8a4ab302&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

