### PR TITLE
Add telecommunications and satellites resource to /resources

### DIFF
--- a/ui/cypress/integration/lib/deprize/lifecycle.cy.ts
+++ b/ui/cypress/integration/lib/deprize/lifecycle.cy.ts
@@ -229,7 +229,7 @@ describe('deprize lifecycle derivations', () => {
           tipWinningTeamId: 301n,
           openFieldTeamId: FIELD,
         })
-      ).to.throw(/unresolved/i)
+      ).to.throw('unresolved')
     })
   })
 

--- a/ui/pages/resources.tsx
+++ b/ui/pages/resources.tsx
@@ -278,6 +278,11 @@ const resourceCategories = [
         name: 'Karman Project',
         url: 'https://www.karmanproject.org/',
         description: 'Educational initiative promoting space exploration and STEM education through innovative programs.'
+      },
+      {
+        name: 'Telecommunications, Satellites, and Space Exploration',
+        url: 'https://www.ooma.com/blog/telecommunications-satellites-and-space-exploration/',
+        description: 'Overview of how satellite technology supports communication, research, and our understanding of Earth and the environment.'
       }
     ]
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a community-suggested educational article to the MoonDAO resources page.

**Resource:** [Telecommunications, Satellites, and Space Exploration](https://www.ooma.com/blog/telecommunications-satellites-and-space-exploration/)

Placed under **Community & Learning**, matching the other educational materials. The description follows the existing card style and highlights how satellite technology supports communication, research, and Earth observation.

Suggested by a student (Hannah) who found it useful alongside the other materials on [moondao.com/resources](https://www.moondao.com/resources).

---

**CI fix:** `component-tests (2)` was failing on a pre-existing assertion in `lib/deprize/lifecycle.cy.ts`. Cypress Chai does not match `.to.throw(/regex/)` against the error message, so `rejects an unsettled tip` failed even though `buildSupersededPayouts` correctly throws `Settling generation unresolved (state 2)`. Switched to a string include match, which is the pattern used by the other Cypress specs in this repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffd72-cf6a-72bb-a68a-c7f40907d3c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffd72-cf6a-72bb-a68a-c7f40907d3c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

