### PR TITLE
Lock project-budget script prices to the first of the quarter

### DIFF
--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -778,33 +778,33 @@ export interface ProjectCycleConfig {
 }
 
 export const PROJECT_CYCLE: ProjectCycleConfig = {
-  // Deploy-time fallback after Q3 Member Vote + Q2 Retro wrap-up.
-  // Live phase is flipped to idle via Operator Panel → Wrap Up Cycle
-  // (Upstash KV override); this keeps post-redeploy UI consistent if
-  // the override is cleared.
-  phase: 'idle',
-  quarter: 3,
+  // Q4 2026 Senate Vote. If a leftover Upstash override from Q3 Wrap Up
+  // is still `idle`, clear `moondao:operator:cycle_phase` so this default
+  // takes effect after deploy.
+  phase: 'senate',
+  quarter: 4,
   year: 2026,
   memberVoteSubmissionsOpen: false,
   memberVoteExcludedAddresses: [],
-  // Q3 2026 deadlines.
-  submissionDeadline: 'July 9, 2026',
-  editingDeadline: 'July 14, 2026',
-  votingDate: 'July 16, 2026',
-  // Q3 2026: $24,310 → per-proposal max $4,862 (posted in the Senate review pack).
-  budgetUSD: 24310,
+  // Q4 2026 deadlines (second Thursday / 48h before third Thursday / third Thursday).
+  submissionDeadline: 'October 8, 2026',
+  editingDeadline: 'October 13, 2026',
+  votingDate: 'October 15, 2026',
+  // Q4 2026: $20,029 = 5% of NMA at 2026-07-01 00:00 UTC (ETH $1,569.94).
+  // Per-proposal max $4,006. From `scripts/calculate-budget.mjs`.
+  budgetUSD: 20029,
   retro: {
-    // Q2 2026 retroactives (the cohort paid out this cycle), USDC-paid:
-    //   - $5,629.26 for projects = ($23,409 * 0.9) - $15,438.84 upfront to the
-    //     4 Member-Vote winners (MDP-240 $3,955 + MDP-235 $3,600 +
-    //     MDP-245 $3,233.84 + MDP-237 $4,650).
-    //   - $2,340.90 community circle = 10% of Q2's $23,409 budget (pinned to
-    //     the cohort's own quarter, NOT the current $24,310 budget).
+    // Q3 2026 retroactives (the cohort paid out this cycle), USDC-paid:
+    //   - $4,427 for projects = ($24,310 * 0.9) - $17,452 upfront to the
+    //     5 Member-Vote winners (MDP-260 $4,640 + MDP-265 $1,100 +
+    //     MDP-259 $2,430 + MDP-262 $4,600 + MDP-258 $4,682).
+    //   - $2,431 community circle = 10% of Q3's $24,310 budget (pinned to
+    //     the cohort's own quarter, NOT the current $20,029 budget).
     // The prior ETH cycle (Q1 2026) kept 2.215 ETH here for reference.
     payoutToken: 'USDC',
-    usdBudget: 5629.26,
+    usdBudget: 4427,
     ethBudget: 2.215,
-    communityCirclePrimary: 2340.9,
+    communityCirclePrimary: 2431,
   },
 }
 

--- a/ui/scripts/calculate-budget.mjs
+++ b/ui/scripts/calculate-budget.mjs
@@ -1,15 +1,29 @@
 /**
- * Calculate Q2 2026 quarterly budget for MoonDAO projects.
- * 
- * Budget = 5% of liquid non-MOONEY assets (in ETH)
- * MOONEY budget decays geometrically from 15M at 5% per quarter starting Q4 2022
- * 
- * Fetches data from Safe Global API for all treasury chains:
+ * Calculate the quarterly project budget for MoonDAO.
+ *
+ * Budget = 5% of liquid non-MOONEY assets (NMA), rounded to the nearest USD.
+ * MOONEY budget decays geometrically from 15M at 5% per quarter starting Q4 2022.
+ *
+ * USD prices lock at 00:00 UTC on the first day of the quarter (see
+ * ProjectRewards.tsx and docs Projects/Project-System). Live CoinGecko prints
+ * are not used — that would make the budget drift with the market.
+ *
+ * Default run (no flags): upcoming quarter's budget, priced at the last
+ * quarter-start that has already occurred. Example: in August 2026 this is
+ * the Q4 2026 budget at 2026-07-01 00:00 UTC. Once the target quarter has
+ * started, the lock date is the first day of that quarter.
+ *
+ * Usage:
+ *   node scripts/calculate-budget.mjs
+ *   node scripts/calculate-budget.mjs --year 2026 --quarter 4
+ *   node scripts/calculate-budget.mjs --price-date 2026-07-01
+ *   node scripts/calculate-budget.mjs --live          # unofficial, current prints
+ *
+ * Treasuries (home-chain Safes only) + Kiln-staked ETH:
  *   - Ethereum mainnet
  *   - Arbitrum
  *   - Polygon
  *   - Base
- * Plus staked ETH from the beacon chain deposit contract.
  */
 
 const MAINNET_TREASURY = '0xce4a1E86a5c47CD677338f53DA22A91d85cab2c9'
@@ -18,178 +32,372 @@ const POLYGON_TREASURY = '0x8C0252c3232A2c7379DDC2E44214697ae8fF097a'
 const BASE_TREASURY = '0x871e232Eb935E54Eb90B812cf6fe0934D45e7354'
 const STAKED_ETH_ADDRESS = '0xbbb56e071f33e020daEB0A1dD2249B8Bbdb69fB8'
 
-// Using Safe Transaction Service API (the client API returns 403)
-const MAINNET_URL = `https://safe-transaction-mainnet.safe.global/api/v1/safes/${MAINNET_TREASURY}/balances/?trusted=true`
-const ARBITRUM_URL = `https://safe-transaction-arbitrum.safe.global/api/v1/safes/${ARBITRUM_TREASURY}/balances/?trusted=true`
-const POLYGON_URL = `https://safe-transaction-polygon.safe.global/api/v1/safes/${POLYGON_TREASURY}/balances/?trusted=true`
-const BASE_URL = `https://safe-transaction-base.safe.global/api/v1/safes/${BASE_TREASURY}/balances/?trusted=true`
+// Known Kiln stake (3 deposits × 32 ETH) used when Etherscan is unavailable.
+const KNOWN_STAKED_ETH = 96
 
-// Etherscan API for staked ETH (beacon chain deposits)
-// Set ETHERSCAN_API_KEY or NEXT_PUBLIC_ETHERSCAN_API_KEY in your environment
-const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY || process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY
-if (!ETHERSCAN_API_KEY) {
-  console.error('❌ Missing ETHERSCAN_API_KEY env var. Set it in .env.local or export it before running.')
-  process.exit(1)
+const SAFES = [
+  { name: 'Ethereum Mainnet', chainId: 1, address: MAINNET_TREASURY },
+  { name: 'Arbitrum', chainId: 42161, address: ARBITRUM_TREASURY },
+  { name: 'Polygon', chainId: 137, address: POLYGON_TREASURY },
+  { name: 'Base', chainId: 8453, address: BASE_TREASURY },
+]
+
+const SAFE_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+  Accept: 'application/json',
+  Origin: 'https://app.safe.global',
+  Referer: 'https://app.safe.global/',
 }
 
-// Current quarter: Q2 2026
-const YEAR = 2026
-const QUARTER = 2
-const NUM_QUARTERS_PAST_Q4_2022 = (YEAR - 2023) * 4 + QUARTER // = 14
+// DefiLlama / CoinGecko ids for every non-MOONEY asset the treasuries hold.
+const TOKEN_PRICE_IDS = {
+  ETH: { llama: 'coingecko:ethereum', gecko: 'ethereum' },
+  WETH: { llama: 'coingecko:weth', gecko: 'weth' },
+  DAI: { llama: 'coingecko:dai', gecko: 'dai' },
+  USDC: { llama: 'coingecko:usd-coin', gecko: 'usd-coin' },
+  USDT: { llama: 'coingecko:tether', gecko: 'tether' },
+  USDTB: { llama: 'coingecko:usdtb', gecko: 'usdtb' },
+  WBTC: { llama: 'coingecko:wrapped-bitcoin', gecko: 'wrapped-bitcoin' },
+  SAFE: { llama: 'coingecko:safe', gecko: 'safe' },
+  GIV: { llama: 'coingecko:giveth', gecko: 'giveth' },
+}
 
-async function getETHPrice() {
-  try {
-    const res = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd')
-    const data = await res.json()
-    return data.ethereum.usd
-  } catch {
-    // Fallback: use CoinGecko alternative
-    try {
-      const res = await fetch('https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD')
-      const data = await res.json()
-      return data.USD
-    } catch {
-      return 0
+const STABLECOINS = new Set(['DAI', 'USDC', 'USDT', 'USDTB'])
+
+function parseArgs(argv) {
+  const args = {
+    year: null,
+    quarter: null,
+    priceDate: null,
+    live: false,
+    help: false,
+    stakedEth: null,
+  }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--year') args.year = Number(argv[++i])
+    else if (a === '--quarter') args.quarter = Number(argv[++i])
+    else if (a === '--price-date') args.priceDate = argv[++i]
+    else if (a === '--staked-eth') args.stakedEth = Number(argv[++i])
+    else if (a === '--live') args.live = true
+    else if (a === '--help' || a === '-h') args.help = true
+    else {
+      console.error(`Unknown argument: ${a}`)
+      process.exit(1)
     }
+  }
+  if (args.year != null && (args.year < 2022 || !Number.isInteger(args.year))) {
+    console.error('--year must be an integer ≥ 2022')
+    process.exit(1)
+  }
+  if (args.quarter != null && ![1, 2, 3, 4].includes(args.quarter)) {
+    console.error('--quarter must be 1, 2, 3, or 4')
+    process.exit(1)
+  }
+  if ((args.year == null) !== (args.quarter == null)) {
+    console.error('--year and --quarter must be passed together')
+    process.exit(1)
+  }
+  if (args.priceDate && !/^\d{4}-\d{2}-\d{2}$/.test(args.priceDate)) {
+    console.error('--price-date must be YYYY-MM-DD (UTC)')
+    process.exit(1)
+  }
+  if (args.live && args.priceDate) {
+    console.error('Use either --live or --price-date, not both')
+    process.exit(1)
+  }
+  return args
+}
+
+function getCalendarQuarter(date) {
+  return {
+    year: date.getUTCFullYear(),
+    quarter: Math.floor(date.getUTCMonth() / 3) + 1,
   }
 }
 
-// Token prices for non-ETH tokens (CoinGecko IDs)
-const TOKEN_COINGECKO_IDS = {
-  'DAI': 'dai',
-  'USDC': 'usd-coin',
-  'USDT': 'tether',
-  'WBTC': 'wrapped-bitcoin',
-  'WETH': 'weth',
-  'SAFE': 'safe',
-  'GIV': 'giveth',
-  'USDTB': 'usdtb',
+function addQuarter({ year, quarter }, delta) {
+  const abs = year * 4 + (quarter - 1) + delta
+  return { year: Math.floor(abs / 4), quarter: (abs % 4) + 1 }
 }
 
-async function getTokenPrices() {
-  const ids = Object.values(TOKEN_COINGECKO_IDS).join(',')
-  try {
-    const res = await fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${ids}&vs_currencies=usd`)
-    const data = await res.json()
-    const prices = {}
-    for (const [symbol, id] of Object.entries(TOKEN_COINGECKO_IDS)) {
-      prices[symbol] = data[id]?.usd || 0
+function quarterStartUtc({ year, quarter }) {
+  return new Date(Date.UTC(year, (quarter - 1) * 3, 1, 0, 0, 0))
+}
+
+function formatYmd(date) {
+  return date.toISOString().slice(0, 10)
+}
+
+/**
+ * Target quarter + the UTC midnight used to lock USD prices.
+ *
+ * Default target is the upcoming quarter (this script writes
+ * PROJECT_CYCLE.budgetUSD for the next Senate Vote). Prices lock to the
+ * first day of that quarter once it has started; before then they lock to
+ * the first day of the current quarter so the print is already finalized.
+ */
+function resolveTargetAndPriceLock(args, now = new Date()) {
+  const target =
+    args.year != null
+      ? { year: args.year, quarter: args.quarter }
+      : addQuarter(getCalendarQuarter(now), 1)
+
+  if (args.live) {
+    return {
+      target,
+      priceLock: null,
+      priceLockNote: 'LIVE market prices (unofficial — not a quarter-start lock)',
     }
-    return prices
-  } catch {
-    return {}
+  }
+
+  if (args.priceDate) {
+    const priceLock = new Date(`${args.priceDate}T00:00:00.000Z`)
+    if (Number.isNaN(priceLock.getTime())) {
+      console.error(`Invalid --price-date: ${args.priceDate}`)
+      process.exit(1)
+    }
+    return {
+      target,
+      priceLock,
+      priceLockNote: `override via --price-date (${formatYmd(priceLock)} 00:00 UTC)`,
+    }
+  }
+
+  const targetStart = quarterStartUtc(target)
+  if (targetStart.getTime() <= now.getTime()) {
+    return {
+      target,
+      priceLock: targetStart,
+      priceLockNote: `first day of Q${target.quarter} ${target.year} (00:00 UTC)`,
+    }
+  }
+
+  const prior = addQuarter(target, -1)
+  const priceLock = quarterStartUtc(prior)
+  return {
+    target,
+    priceLock,
+    priceLockNote:
+      `first day of Q${prior.quarter} ${prior.year} (00:00 UTC); ` +
+      `Q${target.quarter} ${target.year} has not started yet`,
   }
 }
 
-async function fetchAssets(url, chainName, retries = 3) {
+function numQuartersPastQ4Y2022({ year, quarter }) {
+  return (year - 2023) * 4 + quarter
+}
+
+async function fetchJson(url, opts = {}, retries = 3) {
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
       const res = await fetch(url, {
-        headers: {
-          'Accept': 'application/json',
-          'User-Agent': 'Mozilla/5.0',
-        },
+        redirect: 'follow',
+        ...opts,
+        headers: { Accept: 'application/json', ...(opts.headers || {}) },
       })
       if (!res.ok) {
         const body = await res.text().catch(() => '')
         if (attempt < retries && (res.status === 429 || res.status >= 500)) {
-          const wait = attempt * 3000
-          console.log(`  ⏳ ${chainName}: HTTP ${res.status}, retrying in ${wait/1000}s... (attempt ${attempt}/${retries})`)
-          await new Promise(r => setTimeout(r, wait))
+          await new Promise((r) => setTimeout(r, attempt * 1500))
           continue
         }
-        console.error(`  ❌ ${chainName}: HTTP ${res.status} - ${body.slice(0, 200)}`)
+        throw new Error(`HTTP ${res.status} ${body.slice(0, 160)}`)
+      }
+      return await res.json()
+    } catch (err) {
+      if (attempt >= retries) throw err
+      await new Promise((r) => setTimeout(r, attempt * 1500))
+    }
+  }
+  return null
+}
+
+async function getLivePrices() {
+  const geckoIds = Object.values(TOKEN_PRICE_IDS)
+    .map((t) => t.gecko)
+    .join(',')
+  const data = await fetchJson(
+    `https://api.coingecko.com/api/v3/simple/price?ids=${geckoIds}&vs_currencies=usd`
+  )
+  const prices = {}
+  for (const [symbol, ids] of Object.entries(TOKEN_PRICE_IDS)) {
+    prices[symbol] = data?.[ids.gecko]?.usd || 0
+  }
+  return prices
+}
+
+async function getHistoricalPrices(priceLock) {
+  const timestamp = Math.floor(priceLock.getTime() / 1000)
+  const llamaCoins = Object.values(TOKEN_PRICE_IDS)
+    .map((t) => t.llama)
+    .join(',')
+  const prices = {}
+
+  try {
+    const data = await fetchJson(
+      `https://coins.llama.fi/prices/historical/${timestamp}/${llamaCoins}`
+    )
+    for (const [symbol, ids] of Object.entries(TOKEN_PRICE_IDS)) {
+      prices[symbol] = data?.coins?.[ids.llama]?.price || 0
+    }
+  } catch (err) {
+    console.warn(`  ⚠️  DefiLlama historical failed: ${err.message}`)
+  }
+
+  const missing = Object.entries(TOKEN_PRICE_IDS).filter(
+    ([symbol]) => !prices[symbol]
+  )
+  if (missing.length === 0) return prices
+
+  // CoinGecko /history uses dd-mm-yyyy and returns that calendar day's print.
+  const [year, month, day] = formatYmd(priceLock).split('-')
+  const geckoDate = `${day}-${month}-${year}`
+  for (const [symbol, ids] of missing) {
+    try {
+      const data = await fetchJson(
+        `https://api.coingecko.com/api/v3/coins/${ids.gecko}/history?date=${geckoDate}&localization=false`
+      )
+      prices[symbol] = data?.market_data?.current_price?.usd || 0
+    } catch (err) {
+      console.warn(`  ⚠️  CoinGecko history failed for ${symbol}: ${err.message}`)
+      prices[symbol] = 0
+    }
+  }
+  return prices
+}
+
+function buildPriceMap(rawPrices) {
+  const eth = rawPrices.ETH || 0
+  const map = {
+    ETH: eth,
+    // Safe Client labels native ETH on Arbitrum as AETH.
+    AETH: eth,
+    WETH: rawPrices.WETH || eth,
+    stETH: eth,
+    DAI: rawPrices.DAI || 1,
+    USDC: rawPrices.USDC || 1,
+    USDT: rawPrices.USDT || 1,
+    USDTB: rawPrices.USDTB || 1,
+    WBTC: rawPrices.WBTC || 0,
+    SAFE: rawPrices.SAFE || 0,
+    GIV: rawPrices.GIV || 0,
+  }
+  for (const symbol of STABLECOINS) {
+    if (!map[symbol]) map[symbol] = 1
+  }
+  return map
+}
+
+async function fetchAssets(safe, retries = 3) {
+  const url =
+    `https://safe-client.safe.global/v1/chains/${safe.chainId}` +
+    `/safes/${safe.address}/balances/usd?trusted=true`
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: SAFE_HEADERS,
+        redirect: 'follow',
+      })
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        if (attempt < retries && (res.status === 429 || res.status >= 500 || res.status === 403)) {
+          const wait = attempt * 3000
+          console.log(
+            `  ⏳ ${safe.name}: HTTP ${res.status}, retrying in ${wait / 1000}s... (attempt ${attempt}/${retries})`
+          )
+          await new Promise((r) => setTimeout(r, wait))
+          continue
+        }
+        console.error(`  ❌ ${safe.name}: HTTP ${res.status} - ${body.slice(0, 200)}`)
         return []
       }
       const data = await res.json()
-      const tokens = data.map((item) => {
-        const decimals = item.token ? item.token.decimals : 18
-        const symbol = item.token ? item.token.symbol : 'ETH'
+      const items = Array.isArray(data?.items) ? data.items : []
+      const tokens = items.map((item) => {
+        const info = item.tokenInfo || {}
+        const decimals = info.decimals ?? 18
+        const isNative = info.type === 'NATIVE_TOKEN' || !info.address
+        const symbol = (info.symbol || (isNative ? 'ETH' : '?')).trim()
         const balance = parseFloat(item.balance) / Math.pow(10, decimals)
         return {
           balance,
           symbol,
-          address: item.tokenAddress || 'native',
+          address: isNative ? 'native' : info.address,
         }
       })
-      console.log(`  ✅ ${chainName}: ${tokens.length} tokens found`)
+      console.log(`  ✅ ${safe.name}: ${tokens.length} tokens found`)
       return tokens
     } catch (err) {
       if (attempt < retries) {
         const wait = attempt * 3000
-        console.log(`  ⏳ ${chainName}: ${err.message}, retrying in ${wait/1000}s... (attempt ${attempt}/${retries})`)
-        await new Promise(r => setTimeout(r, wait))
+        console.log(
+          `  ⏳ ${safe.name}: ${err.message}, retrying in ${wait / 1000}s... (attempt ${attempt}/${retries})`
+        )
+        await new Promise((r) => setTimeout(r, wait))
         continue
       }
-      console.error(`  ❌ ${chainName}: ${err.message}`)
+      console.error(`  ❌ ${safe.name}: ${err.message}`)
       return []
     }
   }
   return []
 }
 
-async function fetchStakedEth() {
-  // MoonDAO staked ETH via Kiln staking contract
-  // We count Deposit events where the withdrawer is the MoonDAO treasury,
-  // then check each validator's withdrawal status via getWithdrawnFromPublicKeyRoot
-  // to mirror the app's useStakedEth hook logic.
-  const DEPOSIT_EVENT_TOPIC = '0xac1020908b5f7134d59c1580838eba6fc42dd8c28bae65bf345676bba1913f8e'
-  const MOONDAO_TREASURY_TOPIC = '0x000000000000000000000000ce4a1e86a5c47cd677338f53da22a91d85cab2c9'
+async function fetchStakedEth(apiKey) {
+  // MoonDAO staked ETH via Kiln staking contract.
+  // Count Deposit events where the withdrawer is the MoonDAO treasury,
+  // then subtract any 32-ETH internals back to the treasury.
+  const DEPOSIT_EVENT_TOPIC =
+    '0xac1020908b5f7134d59c1580838eba6fc42dd8c28bae65bf345676bba1913f8e'
+  const MOONDAO_TREASURY_TOPIC =
+    '0x000000000000000000000000ce4a1e86a5c47cd677338f53da22a91d85cab2c9'
   const INITIAL_STAKE_BLOCK = 21839730
   const ETH_PER_DEPOSIT = 32
 
-  // keccak256 helper using the Web Crypto API (no dependencies)
-  async function keccak256(hexData) {
-    // We need actual keccak256, not SHA-3. Use a minimal pure-JS implementation.
-    // For simplicity, use etherscan's eth_call to check withdrawal status directly.
-    // The function selector for getWithdrawnFromPublicKeyRoot(bytes32) is the first 4 bytes of keccak256("getWithdrawnFromPublicKeyRoot(bytes32)")
-    return null // handled below via contract call
+  if (!apiKey) {
+    console.warn(
+      `  ⚠️  No ETHERSCAN_API_KEY — using known stake of ${KNOWN_STAKED_ETH} ETH (3 × 32)`
+    )
+    return KNOWN_STAKED_ETH
   }
 
   try {
-    // Step 1: Get deposit events
-    const url = `https://api.etherscan.io/v2/api?chainid=1&module=logs&action=getLogs&address=${STAKED_ETH_ADDRESS}&fromBlock=${INITIAL_STAKE_BLOCK}&toBlock=99999999&topic0=${DEPOSIT_EVENT_TOPIC}&topic2=${MOONDAO_TREASURY_TOPIC}&topic0_2_opr=and&apikey=${ETHERSCAN_API_KEY}`
+    const url =
+      `https://api.etherscan.io/v2/api?chainid=1&module=logs&action=getLogs` +
+      `&address=${STAKED_ETH_ADDRESS}&fromBlock=${INITIAL_STAKE_BLOCK}&toBlock=99999999` +
+      `&topic0=${DEPOSIT_EVENT_TOPIC}&topic2=${MOONDAO_TREASURY_TOPIC}&topic0_2_opr=and` +
+      `&apikey=${apiKey}`
     const res = await fetch(url)
     const data = await res.json()
     if (data.status !== '1' || !Array.isArray(data.result)) {
-      console.warn('  ⚠️  Could not fetch staked ETH deposit events, using 0')
-      return 0
+      console.warn(
+        `  ⚠️  Could not fetch staked ETH deposit events, using known ${KNOWN_STAKED_ETH} ETH`
+      )
+      return KNOWN_STAKED_ETH
     }
 
     const numDeposits = data.result.length
     console.log(`   Found ${numDeposits} deposit events`)
 
-    // Step 2: Extract public keys and check withdrawal status
-    // The Deposit event data contains: publicKey (bytes) and signature (bytes), ABI-encoded
-    // We need to decode the pubkey, compute its keccak256 root, then call getWithdrawnFromPublicKeyRoot
-    // Function selector: 0x9a498a07 = getWithdrawnFromPublicKeyRoot(bytes32)
-    const GET_WITHDRAWN_SELECTOR = '0x9a498a07'
-
     let withdrawnCount = 0
-    for (const event of data.result) {
-      // ABI decode: data is offset(pubkey) + offset(sig) + len(pubkey) + pubkey + len(sig) + sig
-      // The pubkey is a 48-byte BLS key. The publicKeyRoot is keccak256(pubkey padded to 64 bytes)
-      // For keccak256 without ethers, we use Etherscan's proxy API to call the contract
-      // which already stores the mapping — we just need to derive the root.
-
-      // Actually, the simplest approach: extract pubkey from event data, then call the contract
-      // via eth_call with the pubkey root. But computing keccak256 in pure JS without deps is complex.
-      // 
-      // Pragmatic approach: just call eth_call for each deposit's toggleWithdrawnFromPublicKeyRoot
-      // No — let's just check if any ETH was returned to the treasury from the staking contract.
-    }
-
-    // Simpler withdrawal check: look for any ETH transfers from staking contract back to MoonDAO treasury
-    const withdrawalUrl = `https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlistinternal&address=${STAKED_ETH_ADDRESS}&startblock=${INITIAL_STAKE_BLOCK}&endblock=99999999&sort=asc&apikey=${ETHERSCAN_API_KEY}`
+    const withdrawalUrl =
+      `https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlistinternal` +
+      `&address=${STAKED_ETH_ADDRESS}&startblock=${INITIAL_STAKE_BLOCK}&endblock=99999999` +
+      `&sort=asc&apikey=${apiKey}`
     const wRes = await fetch(withdrawalUrl)
     const wData = await wRes.json()
 
     if (wData.status === '1' && Array.isArray(wData.result)) {
-      const MOONDAO_TREASURY_LOWER = MAINNET_TREASURY.toLowerCase()
-      const STAKING_LOWER = STAKED_ETH_ADDRESS.toLowerCase()
-
+      const treasuryLower = MAINNET_TREASURY.toLowerCase()
+      const stakingLower = STAKED_ETH_ADDRESS.toLowerCase()
       for (const tx of wData.result) {
-        if (tx.from.toLowerCase() === STAKING_LOWER && tx.to.toLowerCase() === MOONDAO_TREASURY_LOWER) {
+        if (
+          tx.from.toLowerCase() === stakingLower &&
+          tx.to.toLowerCase() === treasuryLower
+        ) {
           const ethReturned = parseInt(tx.value) / 1e18
           if (ethReturned >= 32) {
             withdrawnCount += Math.round(ethReturned / 32)
@@ -201,53 +409,99 @@ async function fetchStakedEth() {
     const stillStaked = numDeposits - withdrawnCount
     const totalStaked = stillStaked * ETH_PER_DEPOSIT
     if (withdrawnCount > 0) {
-      console.log(`   ${withdrawnCount} validator(s) withdrawn, ${stillStaked} still staked`)
+      console.log(
+        `   ${withdrawnCount} validator(s) withdrawn, ${stillStaked} still staked`
+      )
     }
-    console.log(`   ${stillStaked} validators × ${ETH_PER_DEPOSIT} ETH = ${totalStaked} ETH`)
+    console.log(
+      `   ${stillStaked} validators × ${ETH_PER_DEPOSIT} ETH = ${totalStaked} ETH`
+    )
     return totalStaked
   } catch (err) {
-    console.warn(`  ⚠️  Staked ETH fetch failed: ${err.message}`)
-    return 0
+    console.warn(
+      `  ⚠️  Staked ETH fetch failed (${err.message}), using known ${KNOWN_STAKED_ETH} ETH`
+    )
+    return KNOWN_STAKED_ETH
   }
 }
 
+function printHelp() {
+  console.log(`MoonDAO quarterly project-budget calculator
+
+USD prices lock at 00:00 UTC on the first day of the quarter.
+
+Usage:
+  node scripts/calculate-budget.mjs [options]
+
+Options:
+  --year YYYY --quarter N   Budget quarter (default: upcoming calendar quarter)
+  --price-date YYYY-MM-DD   Override the UTC midnight used for historical prices
+  --live                    Use current market prices (unofficial)
+  --staked-eth N            Override Kiln-staked ETH instead of querying Etherscan
+  -h, --help                Show this help
+
+Environment:
+  ETHERSCAN_API_KEY         Optional. Without it the script uses the known 96 ETH stake.
+`)
+}
+
 async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) {
+    printHelp()
+    return
+  }
+
+  const { target, priceLock, priceLockNote } = resolveTargetAndPriceLock(args)
+  const quartersPast = numQuartersPastQ4Y2022(target)
+  const etherscanKey =
+    process.env.ETHERSCAN_API_KEY || process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY
+
   console.log('╔═══════════════════════════════════════════════════════════════╗')
-  console.log('║        MoonDAO Q2 2026 Budget Calculator                     ║')
+  console.log(
+    `║        MoonDAO Q${target.quarter} ${target.year} Budget Calculator`.padEnd(64) + '║'
+  )
   console.log('╚═══════════════════════════════════════════════════════════════╝')
+  console.log()
+  console.log(`🔒 Price lock: ${priceLockNote}`)
+  if (priceLock) {
+    console.log(`   timestamp: ${Math.floor(priceLock.getTime() / 1000)} (${priceLock.toISOString()})`)
+  }
   console.log()
 
   console.log('📡 Fetching treasury balances from all chains...')
 
   const delay = (ms) => new Promise((r) => setTimeout(r, ms))
+  const allTokens = []
+  for (let i = 0; i < SAFES.length; i++) {
+    const tokens = await fetchAssets(SAFES[i])
+    allTokens.push(...tokens)
+    if (i < SAFES.length - 1) await delay(3000)
+  }
 
-  // Fetch sequentially with delays to avoid Safe API rate limiting (429/504)
-  const mainnetTokens = await fetchAssets(MAINNET_URL, 'Ethereum Mainnet')
-  await delay(3000)
-  const arbitrumTokens = await fetchAssets(ARBITRUM_URL, 'Arbitrum')
-  await delay(3000)
-  const polygonTokens = await fetchAssets(POLYGON_URL, 'Polygon')
-  await delay(3000)
-  const baseTokens = await fetchAssets(BASE_URL, 'Base')
+  console.log()
+  console.log(priceLock ? '💱 Fetching quarter-start historical prices...' : '💱 Fetching live prices...')
+  const rawPrices = priceLock
+    ? await getHistoricalPrices(priceLock)
+    : await getLivePrices()
+  const priceMap = buildPriceMap(rawPrices)
+  const ethPrice = priceMap.ETH
 
-  const [ethPrice, tokenPrices] = await Promise.all([
-    getETHPrice(),
-    getTokenPrices(),
-  ])
-
-  if (ethPrice === 0) {
+  if (!ethPrice) {
     console.error('❌ Could not fetch ETH price. Aborting.')
     process.exit(1)
   }
 
-  console.log()
   console.log(`💰 ETH Price: $${ethPrice.toFixed(2)}`)
+  if (priceLock) {
+    for (const [symbol, price] of Object.entries(priceMap)) {
+      if (symbol === 'ETH' || symbol === 'stETH' || !price) continue
+      if (STABLECOINS.has(symbol) && Math.abs(price - 1) < 0.01) continue
+      console.log(`   ${symbol}: $${price}`)
+    }
+  }
   console.log()
 
-  // Combine all tokens
-  const allTokens = [...mainnetTokens, ...arbitrumTokens, ...polygonTokens, ...baseTokens]
-
-  // Aggregate by symbol
   const aggregated = {}
   for (const t of allTokens) {
     if (!aggregated[t.symbol]) {
@@ -256,31 +510,21 @@ async function main() {
     aggregated[t.symbol].balance += t.balance
   }
 
-  // Fetch staked ETH
   console.log('🔒 Fetching staked ETH...')
-  const stakedEth = await fetchStakedEth()
-  console.log(`   Staked ETH: ${stakedEth.toFixed(4)} ETH ($${(stakedEth * ethPrice).toFixed(2)})`)
+  const stakedEth =
+    args.stakedEth != null ? args.stakedEth : await fetchStakedEth(etherscanKey)
+  if (args.stakedEth != null) {
+    console.log(`   Using --staked-eth override: ${stakedEth} ETH`)
+  }
+  console.log(
+    `   Staked ETH: ${stakedEth.toFixed(4)} ETH ($${(stakedEth * ethPrice).toFixed(2)})`
+  )
   console.log()
 
-  // Add staked ETH
   if (!aggregated['stETH']) {
     aggregated['stETH'] = { symbol: 'stETH', balance: 0 }
   }
   aggregated['stETH'].balance += stakedEth
-
-  // Calculate USD values for each token
-  const priceMap = {
-    'ETH': ethPrice,
-    'WETH': ethPrice,
-    'stETH': ethPrice,
-    'DAI': tokenPrices['DAI'] || 1,
-    'USDC': tokenPrices['USDC'] || 1,
-    'USDT': tokenPrices['USDT'] || 1,
-    'USDTB': tokenPrices['USDTB'] || 1,
-    'WBTC': tokenPrices['WBTC'] || 0,
-    'SAFE': tokenPrices['SAFE'] || 0,
-    'GIV': tokenPrices['GIV'] || 0,
-  }
 
   console.log('📊 Token Breakdown (non-MOONEY):')
   console.log('─'.repeat(70))
@@ -304,46 +548,86 @@ async function main() {
   }
 
   console.log('─'.repeat(70))
-  console.log(`  ${'TOTAL'.padEnd(12)} ${''.padStart(15)}              ${'$' + totalUSD.toFixed(2).padStart(11)}`)
+  console.log(
+    `  ${'TOTAL'.padEnd(12)} ${''.padStart(15)}              ${'$' + totalUSD.toFixed(2).padStart(11)}`
+  )
   console.log()
 
   // Budget = 5% of liquid non-MOONEY assets in USD (stablecoins)
   // See: https://docs.moondao.com/Projects/Project-System#quarterly-rewards
   const usdBudget = Math.round(totalUSD * 0.05)
-
-  // Max per project = 1/5 of total quarterly budget (per docs)
   const maxPerProject = Math.round(usdBudget / 5)
+  const approvalCap = Math.round((usdBudget * 3) / 4)
 
-  // Approval cap: cumulative approved budgets can't exceed 3/4 of quarterly budget
-  // (enforced in getApprovedProjects during vote tally)
-  const approvalCap = Math.round(usdBudget * 3 / 4)
-
-  // MOONEY budget with geometric decay
   const MOONEY_INITIAL_BUDGET = 15_000_000
   const MOONEY_DECAY_RATE = 0.95
-  const mooneyBudget = MOONEY_INITIAL_BUDGET * Math.pow(MOONEY_DECAY_RATE, NUM_QUARTERS_PAST_Q4_2022)
+  const mooneyBudget = MOONEY_INITIAL_BUDGET * Math.pow(MOONEY_DECAY_RATE, quartersPast)
+  const mooneyFormatted = mooneyBudget
+    .toFixed(0)
+    .replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 
+  const label = `Q${target.quarter} ${target.year}`
   console.log('╔═══════════════════════════════════════════════════════════════╗')
-  console.log('║  Q2 2026 BUDGET RESULTS                                     ║')
+  console.log(`║  ${label} BUDGET RESULTS`.padEnd(64) + '║')
   console.log('╠═══════════════════════════════════════════════════════════════╣')
-  console.log(`║  Total Assets (non-MOONEY):  $${totalUSD.toFixed(0).padStart(10)}`.padEnd(64) + '║')
-  console.log(`║  ETH Price:                  $${ethPrice.toFixed(2).padStart(10)}`.padEnd(64) + '║')
+  console.log(
+    `║  Total Assets (non-MOONEY):  $${totalUSD.toFixed(0).padStart(10)}`.padEnd(64) + '║'
+  )
+  console.log(
+    `║  ETH Price:                  $${ethPrice.toFixed(2).padStart(10)}`.padEnd(64) + '║'
+  )
+  if (priceLock) {
+    console.log(
+      `║  Price lock (UTC):           ${formatYmd(priceLock)}`.padEnd(64) + '║'
+    )
+  }
   console.log('║                                                              ║')
-  console.log(`║  📌 NEXT_QUARTER_BUDGET_USD:  $${usdBudget.toLocaleString()}`.padEnd(64) + '║')
-  console.log(`║     (5% of liquid non-MOONEY assets)`.padEnd(64) + '║')
+  console.log(
+    `║  📌 PROJECT_CYCLE.budgetUSD:  $${usdBudget.toLocaleString()}`.padEnd(64) + '║'
+  )
+  console.log('║     (5% of liquid non-MOONEY assets)                         ║')
   console.log('║                                                              ║')
-  console.log(`║  Max per Project (1/5):       $${maxPerProject.toLocaleString()}`.padEnd(64) + '║')
-  console.log(`║  Approval Cap (3/4):          $${approvalCap.toLocaleString()}`.padEnd(64) + '║')
+  console.log(
+    `║  Max per Project (1/5):       $${maxPerProject.toLocaleString()}`.padEnd(64) + '║'
+  )
+  console.log(
+    `║  Approval Cap (3/4):          $${approvalCap.toLocaleString()}`.padEnd(64) + '║'
+  )
   console.log('║                                                              ║')
-  console.log(`║  Retroactive Rewards:         $${usdBudget.toLocaleString()} - project budgets`.padEnd(64) + '║')
-  console.log(`║    10% of rewards → Community Circle`.padEnd(64) + '║')
+  console.log(
+    `║  Retroactive Rewards:         $${usdBudget.toLocaleString()} - project budgets`.padEnd(64) +
+      '║'
+  )
+  console.log('║    10% of rewards → Community Circle                         ║')
   console.log('║                                                              ║')
-  console.log(`║  vMOONEY Budget:              ${mooneyBudget.toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ',')} vMOONEY`.padEnd(64) + '║')
-  console.log(`║  (15M * 0.95^${NUM_QUARTERS_PAST_Q4_2022})`.padEnd(64) + '║')
+  console.log(
+    `║  vMOONEY Budget:              ${mooneyFormatted} vMOONEY`.padEnd(64) + '║'
+  )
+  console.log(`║  (15M * 0.95^${quartersPast})`.padEnd(64) + '║')
   console.log('╚═══════════════════════════════════════════════════════════════╝')
   console.log()
-  console.log(`👉 Update ui/const/config.ts:`)
-  console.log(`   export const NEXT_QUARTER_BUDGET_USD = ${usdBudget}`)
+  console.log('👉 Update ui/const/config.ts PROJECT_CYCLE:')
+  console.log(`   budgetUSD: ${usdBudget}`)
 }
 
-main().catch(console.error)
+// Exported for the inline self-check when run as `node --input-type=module`
+// against this file; the CLI always calls main().
+export {
+  addQuarter,
+  getCalendarQuarter,
+  numQuartersPastQ4Y2022,
+  quarterStartUtc,
+  resolveTargetAndPriceLock,
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  (process.argv[1].endsWith('calculate-budget.mjs') ||
+    process.argv[1].endsWith('calculate-budget.js'))
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/ui/scripts/calculate-budget.mjs
+++ b/ui/scripts/calculate-budget.mjs
@@ -61,6 +61,7 @@ const TOKEN_PRICE_IDS = {
   WBTC: { llama: 'coingecko:wrapped-bitcoin', gecko: 'wrapped-bitcoin' },
   SAFE: { llama: 'coingecko:safe', gecko: 'safe' },
   GIV: { llama: 'coingecko:giveth', gecko: 'giveth' },
+  POL: { llama: 'coingecko:polygon-ecosystem-token', gecko: 'polygon-ecosystem-token' },
 }
 
 const STABLECOINS = new Set(['DAI', 'USDC', 'USDT', 'USDTB'])
@@ -174,13 +175,13 @@ function resolveTargetAndPriceLock(args, now = new Date()) {
     }
   }
 
-  const prior = addQuarter(target, -1)
-  const priceLock = quarterStartUtc(prior)
+  const current = getCalendarQuarter(now)
+  const priceLock = quarterStartUtc(current)
   return {
     target,
     priceLock,
     priceLockNote:
-      `first day of Q${prior.quarter} ${prior.year} (00:00 UTC); ` +
+      `first day of Q${current.quarter} ${current.year} (00:00 UTC); ` +
       `Q${target.quarter} ${target.year} has not started yet`,
   }
 }
@@ -270,6 +271,7 @@ async function getHistoricalPrices(priceLock) {
 
 function buildPriceMap(rawPrices) {
   const eth = rawPrices.ETH || 0
+  const pol = rawPrices.POL || 0
   const map = {
     ETH: eth,
     // Safe Client labels native ETH on Arbitrum as AETH.
@@ -283,6 +285,9 @@ function buildPriceMap(rawPrices) {
     WBTC: rawPrices.WBTC || 0,
     SAFE: rawPrices.SAFE || 0,
     GIV: rawPrices.GIV || 0,
+    POL: pol,
+    // Safe Client may still label Polygon native as MATIC.
+    MATIC: pol,
   }
   for (const symbol of STABLECOINS) {
     if (!map[symbol]) map[symbol] = 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The operator script `ui/scripts/calculate-budget.mjs` was valuing NMA at **live** CoinGecko prices. The project system locks USD prices at **00:00 UTC on the first day of the quarter**, then hardcodes `PROJECT_CYCLE.budgetUSD`. Live prints make the 5% budget drift with the market.

This PR also rolls `PROJECT_CYCLE` forward to **Q4 2026** using that locked number.

## Script

- Historical prices from DefiLlama (`coins.llama.fi/prices/historical/{unix}/…`), with CoinGecko `/history` as fallback.
- Default run = **upcoming quarter**. If that quarter has not started, the lock date is the first day of the current quarter (the last quarter-start that has already occurred). Once the target quarter has started, the lock date is that quarter’s first day.
- Quarter / vMOONEY decay index are derived instead of being hardcoded to Q2 2026 (`15M × 0.95^16` = 6,601,900 for Q4 2026).
- Balances come from the Safe Client API (the tx-service URLs 308). Arbitrum native `AETH` is priced as ETH.
- `ETHERSCAN_API_KEY` is optional; without it the script uses the known 96 ETH Kiln stake.

```bash
cd ui
node scripts/calculate-budget.mjs
```

## Q4 2026 cycle (`PROJECT_CYCLE`)

| | |
|---|---|
| Phase | `senate` |
| Quarter | Q4 2026 |
| Price lock | 2026-07-01 00:00 UTC (ETH $1,569.94) |
| NMA | $400,582 |
| **budgetUSD** | **$20,029** |
| Max / approval cap | $4,006 / $15,022 |
| Deadlines | Oct 8 submit · Oct 13 edit · Oct 15 vote |
| vMOONEY | 6,601,900 |
| Q3 retro (projects) | $4,427 = ($24,310 × 0.9) − $17,452 upfront |
| Q3 community circle | $2,431 (10% of Q3’s $24,310) |

Q3 Member-Vote winners used for the retro remainder: MDP-260 $4,640, MDP-265 $1,100, MDP-259 $2,430, MDP-262 $4,600, MDP-258 $4,682.

After deploy, if a leftover Upstash override from Q3 Wrap Up is still `idle`, clear `moondao:operator:cycle_phase` so the new `phase: 'senate'` default takes effect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffdc1-3f42-7c3d-a924-9c1759ff4d70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffdc1-3f42-7c3d-a924-9c1759ff4d70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

