### PR TITLE
fix(mission): allow anyone to contribute to MoonDAO missions

### DIFF
--- a/ui/components/mission/MissionContributeModal.tsx
+++ b/ui/components/mission/MissionContributeModal.tsx
@@ -292,22 +292,6 @@ export default function MissionContributeModal({
   const mockAddress = typeof window !== 'undefined' && (window as any).__CYPRESS_MOCK_ADDRESS__
   const address = account?.address || mockAddress
 
-  // Tracks whether the citizen check has had enough time to resolve so we
-  // don't flash the gate at citizens while the RPC call is in-flight.
-  const [citizenCheckDone, setCitizenCheckDone] = useState(false)
-  useEffect(() => {
-    if (!account) {
-      setCitizenCheckDone(false)
-      return
-    }
-    if (isCitizen) {
-      setCitizenCheckDone(true)
-      return
-    }
-    const timer = setTimeout(() => setCitizenCheckDone(true), 1500)
-    return () => clearTimeout(timer)
-  }, [account, isCitizen])
-
   const [input, setInput] = useState('')
   const [output, setOutput] = useState(0)
   const [message, setMessage] = useState(() => {
@@ -2180,39 +2164,6 @@ export default function MissionContributeModal({
               router={router}
               formatWithCommas={formatWithCommas}
             />
-          ) : account && !citizenCheckDone ? (
-            <div className="flex flex-col items-center justify-center py-12 px-6 space-y-4">
-              <div className="w-12 h-12 rounded-full border-2 border-blue-500/40 border-t-blue-400 animate-spin" />
-              <p className="text-gray-400 text-sm">Verifying citizenship…</p>
-            </div>
-          ) : account && citizenCheckDone && !isCitizen ? (
-            <div className="flex flex-col items-center justify-center py-10 px-6 space-y-6 text-center">
-              <div className="w-16 h-16 rounded-full bg-gradient-to-br from-yellow-500/20 to-amber-500/10 border border-yellow-500/30 flex items-center justify-center">
-                <span className="text-3xl">🌙</span>
-              </div>
-              <div className="space-y-2">
-                <h3 className="text-xl font-semibold text-white">Citizens Only</h3>
-                <p className="text-gray-400 text-sm max-w-sm leading-relaxed">
-                  Contributing to MoonDAO missions is reserved for Citizens of the Space
-                  Acceleration Network. Become a Citizen to participate.
-                </p>
-              </div>
-              <div className="flex flex-col sm:flex-row gap-3 w-full max-w-xs">
-                <Link
-                  href="/citizen"
-                  className="flex-1 flex justify-center items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 text-white font-semibold rounded-xl transition-all duration-300 text-sm"
-                >
-                  Become a Citizen
-                </Link>
-                <button
-                  type="button"
-                  onClick={handleModalClose}
-                  className="flex-1 px-6 py-3 bg-slate-800/60 hover:bg-slate-700/60 border border-white/10 text-white font-medium rounded-xl transition-all duration-300 text-sm"
-                >
-                  Close
-                </button>
-              </div>
-            </div>
           ) : (
             <>
               <MissionContributeStatusNotices


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Culprit

[#1460 feat(mission): gate contributions to citizens only](https://github.com/Official-MoonDao/MoonDAO/pull/1460) (merged Jul 15, 2026) added a citizens-only gate in `MissionContributeModal`. Connected wallets without a Citizen NFT saw a “Citizens Only / Become a Citizen” screen instead of the contribution form.

## Fix

Remove that gate so anyone can contribute to MoonDAO missions again.

`isCitizen` is still used after a successful payment to offer a free citizenship mint when the contributor is eligible — that path was already in place before #1460 and is unchanged.

Note: #1460 also gated Community Circle form submissions on `/contributions`. That is a different flow (quarterly work submissions, not Juicebox mission funding) and is left as-is.

## Test plan

- [ ] Connect a wallet **without** a Citizen NFT, open a mission contribute modal → contribution form appears (no “Citizens Only” screen, no “Verifying citizenship…” spinner)
- [ ] Connect a wallet **with** a Citizen NFT → contribution form appears as before
- [ ] Unauthenticated / no wallet → Privy connect prompt as before
- [ ] After a non-citizen contribution that meets the free-mint threshold, the free citizenship toast still appears

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42f5e9f4-d1ac-4806-baa8-5da6fa3c8da8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42f5e9f4-d1ac-4806-baa8-5da6fa3c8da8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

