### PR TITLE
fix: responsive layout issues across nav, dashboard, treasury, marketplace, moonbase

### DIFF
--- a/ui/components/dashboard/treasury/TreasuryPage.tsx
+++ b/ui/components/dashboard/treasury/TreasuryPage.tsx
@@ -45,7 +45,7 @@ export default function TreasuryPage() {
       {/*Assets Section*/}
       <section className="flex flex-col h-full">
         <div className="flex-shrink-0">
-          <h2 className="text-white text-3xl lg:text-4xl font-GoodTimes">Treasury</h2>
+          <h2 className="text-white text-2xl sm:text-3xl lg:text-4xl font-GoodTimes">Treasury</h2>
           <div className="mt-4 h-[1px] bg-white/20 w-full"></div>
         </div>
         
@@ -77,7 +77,7 @@ export default function TreasuryPage() {
       {/*Transactions Section*/}
       <section className="flex flex-col h-full">
         <div className="flex-shrink-0">
-          <h2 className="text-white text-3xl lg:text-4xl font-GoodTimes">
+          <h2 className="text-white text-2xl sm:text-3xl lg:text-4xl font-GoodTimes">
             Transactions
           </h2>
           <div className="mt-4 h-[1px] bg-white/20 w-full"></div>

--- a/ui/components/dashboard/treasury/balance/Asset.tsx
+++ b/ui/components/dashboard/treasury/balance/Asset.tsx
@@ -45,9 +45,9 @@ const Asset = ({ name, amount, usd, address, loading }: AssetProps) => {
         </a>
       </div>
 
-      <div className="text-right">
+      <div className="text-right min-w-0 ml-3">
         <p
-          className={`font-semibold text-lg ${
+          className={`font-semibold text-lg break-all ${
             loading ? 'bg-white/20 text-transparent rounded' : 'text-white'
           }`}
         >

--- a/ui/components/dashboard/treasury/balance/TreasuryBalance.tsx
+++ b/ui/components/dashboard/treasury/balance/TreasuryBalance.tsx
@@ -7,7 +7,7 @@ const TreasuryBalance = ({ balance, loading }: any) => {
     <div className="bg-gradient-to-b from-slate-700/20 to-slate-800/30 backdrop-blur-xl border border-white/10 rounded-xl p-6 mt-4">
       <div className="flex flex-col font-RobotoMono">
         <h2
-          className={`text-white text-4xl xl:text-5xl font-bold ${
+          className={`text-white text-3xl sm:text-4xl xl:text-5xl font-bold break-all ${
             loading && 'animate-pulse bg-white/20 text-transparent rounded'
           }`}
         >

--- a/ui/components/home/SignedInDashboard.tsx
+++ b/ui/components/home/SignedInDashboard.tsx
@@ -533,7 +533,7 @@ export default function SignedInDashboard({
       <div className="max-w-7xl mx-auto px-4 py-4">
 
         {/* ── Mobile-only hero bar ─────────────────────────── */}
-        <div className="lg:hidden flex items-center gap-3 mb-4 bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4">
+        <div className="lg:hidden flex flex-wrap items-center gap-3 mb-4 bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4">
           {/* Avatar */}
           <div className="w-12 h-12 rounded-xl overflow-hidden flex-shrink-0">
             {citizen?.metadata?.image ? (
@@ -551,7 +551,7 @@ export default function SignedInDashboard({
             )}
           </div>
           {/* Name + greeting */}
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-[140px]">
             <p className="text-white font-semibold truncate">
               {citizen?.metadata?.name || 'Welcome back'}
             </p>
@@ -568,7 +568,7 @@ export default function SignedInDashboard({
             )}
           </div>
           {/* Edit profile link */}
-          <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-2 flex-shrink-0 ml-[60px] sm:ml-0">
             <Link
               href={
                 citizen?.metadata?.name && (citizen?.metadata?.id ?? citizen?.id)
@@ -715,7 +715,7 @@ export default function SignedInDashboard({
           {/* MIDDLE — Recent Activity (6 cols) */}
           <div className="lg:col-span-6 order-2 lg:order-2 flex flex-col gap-4">
             {/* Contribution CTA */}
-            <div className="flex items-center justify-between gap-4 bg-white/[0.04] border border-white/10 rounded-2xl px-5 py-3.5">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 bg-white/[0.04] border border-white/10 rounded-2xl px-5 py-3.5">
               <div>
                 <p className="text-white text-sm font-semibold">What did you get done this week?</p>
                 <p className="text-white/40 text-xs mt-0.5">Earn ETH & vMOONEY rewards each quarter.</p>
@@ -724,7 +724,7 @@ export default function SignedInDashboard({
                 href="https://docs.google.com/forms/d/e/1FAIpQLSdtHRzqDAAe1TOZ7Bp03TKVbxLFZzJeeKSUDQ-BpIZtDPxJWw/viewform"
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-400 hover:to-purple-400 text-white text-sm font-bold rounded-xl shadow-lg shadow-blue-500/30 transition-all whitespace-nowrap flex-shrink-0"
+                className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-400 hover:to-purple-400 text-white text-sm font-bold rounded-xl shadow-lg shadow-blue-500/30 transition-all whitespace-nowrap flex-shrink-0 sm:self-auto"
               >
                 <TrophyIcon className="w-4 h-4" />
                 Submit Contribution

--- a/ui/components/layout/ChartModal.tsx
+++ b/ui/components/layout/ChartModal.tsx
@@ -26,7 +26,7 @@ export default function ChartModal({
         topRight="0px"
         topLeft="10px"
       >
-        <div className="bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 p-4 md:p-6 w-[95vw] md:min-w-[800px] max-w-[95vw] md:max-w-[90vw]">
+        <div className="bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 backdrop-blur-xl border border-white/10 p-4 md:p-6 w-[95vw] max-w-[800px]">
           <div className="flex items-center justify-between mb-6">
             <h2 className="text-2xl font-GoodTimes text-white">{chartTitle}</h2>
             <button

--- a/ui/components/layout/TopNavBar.tsx
+++ b/ui/components/layout/TopNavBar.tsx
@@ -84,20 +84,20 @@ const TopNavBar = ({
       <nav className={`fixed top-0 left-0 right-0 z-[9999] bg-gradient-to-r from-gray-900/95 via-blue-900/80 to-purple-900/70 backdrop-blur-xl border-b border-white/20 shadow-2xl transition-transform duration-300 ease-in-out ${
         isVisible ? 'translate-y-0' : '-translate-y-full'
       }`}>
-      <div className="max-w-full mx-auto px-2 lg:px-4 xl:px-6">
+      <div className="max-w-full mx-auto px-2 lg:px-3 xl:px-4 2xl:px-6">
         <div className="flex items-center justify-between h-16 lg:h-18 min-w-0">
           <NavLink
             href="/"
-            className="flex-shrink-0 ml-2 md:ml-4 mr-4 lg:mr-6 xl:mr-8 cursor-pointer"
+            className="flex-shrink-0 ml-2 md:ml-4 mr-3 lg:mr-4 xl:mr-5 2xl:mr-8 cursor-pointer"
           >
             <div className="flex items-center">
-              <div className="w-24 md:w-28 lg:w-32 xl:w-36 hover:scale-105 transition-transform duration-200">
+              <div className="w-24 md:w-28 lg:w-28 xl:w-32 2xl:w-36 hover:scale-105 transition-transform duration-200">
                 <LogoSidebar />
               </div>
             </div>
           </NavLink>
 
-          <div className="hidden lg:flex items-center gap-1 xl:gap-2 flex-1 justify-center max-w-[1024px] mx-auto">
+          <div className="hidden lg:flex items-center gap-0.5 xl:gap-1 2xl:gap-2 flex-1 justify-center max-w-[1024px] mx-auto">
             {navigation.map((item, i) => {
               if (!item) return null
               const hasDropdown = item.children || item.dynamicChildren
@@ -139,27 +139,27 @@ const TopNavBar = ({
                         }
                       }}
                       title={item.href ? 'Single click: open menu. Double click: go to page.' : 'Click to open menu'}
-                      className={`flex items-center px-2 lg:px-3 py-2 text-sm font-medium transition-all duration-200 whitespace-nowrap rounded-lg w-full text-left cursor-pointer
+                      className={`flex items-center px-1.5 xl:px-2 2xl:px-3 py-2 text-[13px] 2xl:text-sm font-medium transition-all duration-200 whitespace-nowrap rounded-lg w-full text-left cursor-pointer
                         border
                         ${isActive
                           ? 'bg-gradient-to-r from-blue-500/20 to-purple-500/20 text-white border-white/30'
                           : 'text-gray-300 hover:text-white hover:bg-white/10 hover:border-white/20 border-transparent'
                         }`}
                     >
-                      <item.icon className="w-4 h-4 mr-2" />
+                      <item.icon className="w-4 h-4 mr-1 2xl:mr-2" />
                       {t(item.name)}
                       <ChevronDownIcon className={`w-3 h-3 ml-1 transition-transform duration-200 ${openDropdown === item.name ? 'rotate-180' : ''}`} />
                     </button>
                   ) : (
                     <NavLink
                       href={item.href}
-                      className={`flex items-center px-2 lg:px-3 py-2 text-sm font-medium transition-all duration-200 whitespace-nowrap rounded-lg cursor-pointer border border-transparent hover:border-white/20 ${
+                      className={`flex items-center px-1.5 xl:px-2 2xl:px-3 py-2 text-[13px] 2xl:text-sm font-medium transition-all duration-200 whitespace-nowrap rounded-lg cursor-pointer border border-transparent hover:border-white/20 ${
                         isActive
                           ? 'bg-gradient-to-r from-blue-500/20 to-purple-500/20 text-white border-white/30'
                           : 'text-gray-300 hover:text-white hover:bg-white/10'
                       }`}
                     >
-                      <item.icon className="w-4 h-4 mr-2" />
+                      <item.icon className="w-4 h-4 mr-1 2xl:mr-2" />
                       {t(item.name)}
                     </NavLink>
                   )}
@@ -231,20 +231,20 @@ const TopNavBar = ({
             })}
           </div>
 
-          <div className="flex items-center space-x-2 lg:space-x-3 xl:space-x-4 flex-shrink-0">
-            <div className="flex items-center space-x-4 lg:space-x-6">
-              <div className="max-w-[200px] overflow-hidden scale-90 lg:scale-100 xl:scale-105 min-w-0 [&>*]:max-w-full [&>*]:overflow-hidden [&>*]:text-ellipsis [&>*]:whitespace-nowrap [&>button]:max-w-[200px]">
+          <div className="flex items-center space-x-1 xl:space-x-2 2xl:space-x-4 flex-shrink-0">
+            <div className="flex items-center space-x-2 xl:space-x-3 2xl:space-x-6">
+              <div className="max-w-[160px] 2xl:max-w-[200px] overflow-hidden scale-100 2xl:scale-105 min-w-0 [&>*]:max-w-full [&>*]:overflow-hidden [&>*]:text-ellipsis [&>*]:whitespace-nowrap [&>button]:max-w-[160px] 2xl:[&>button]:max-w-[200px]">
                 <PrivyConnectWallet
                   type="desktop"
                   citizenContract={citizenContract}
                 />
               </div>
-              <div className="scale-90 lg:scale-100 xl:scale-105 flex-shrink-0 flex items-center justify-center">
+              <div className="scale-100 2xl:scale-105 flex-shrink-0 flex items-center justify-center">
                 <CitizenProfileLink />
               </div>
             </div>
             
-            <div className="scale-90 lg:scale-100 xl:scale-105">
+            <div className="scale-100 2xl:scale-105">
               <LanguageChange />
             </div>
           </div>

--- a/ui/components/layout/TopNavBar.tsx
+++ b/ui/components/layout/TopNavBar.tsx
@@ -233,7 +233,7 @@ const TopNavBar = ({
 
           <div className="flex items-center space-x-1 xl:space-x-2 2xl:space-x-4 flex-shrink-0">
             <div className="flex items-center space-x-2 xl:space-x-3 2xl:space-x-6">
-              <div className="max-w-[160px] 2xl:max-w-[200px] overflow-hidden scale-100 2xl:scale-105 min-w-0 [&>*]:max-w-full [&>*]:overflow-hidden [&>*]:text-ellipsis [&>*]:whitespace-nowrap [&>button]:max-w-[160px] 2xl:[&>button]:max-w-[200px]">
+              <div className="max-w-[180px] 2xl:max-w-[200px] overflow-hidden scale-100 2xl:scale-105 min-w-0 flex-shrink-0 [&>*]:max-w-full [&>*]:overflow-hidden [&>*]:text-ellipsis [&>*]:whitespace-nowrap">
                 <PrivyConnectWallet
                   type="desktop"
                   citizenContract={citizenContract}

--- a/ui/components/lunar-atlas/Legend.tsx
+++ b/ui/components/lunar-atlas/Legend.tsx
@@ -54,7 +54,7 @@ export default function Legend({
   const countForOrg = (id: string) => projects.filter((p) => p.orgId === id).length
 
   return (
-    <div className="pointer-events-auto w-64 rounded-2xl border border-white/10 bg-black/50 backdrop-blur-md">
+    <div className="pointer-events-auto w-full sm:w-64 rounded-2xl border border-white/10 bg-black/50 backdrop-blur-md">
       <button
         onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center justify-between px-4 py-3 text-left"

--- a/ui/components/lunar-atlas/Legend.tsx
+++ b/ui/components/lunar-atlas/Legend.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 import { AdjustmentsHorizontalIcon } from '@heroicons/react/24/outline'
 import { PROJECT_TYPE_GLYPH, orgColor } from '@/lib/lunar-atlas/display'
 import type {
@@ -50,6 +50,17 @@ export default function Legend({
   const [open, setOpen] = useState(true)
   const [orgsOpen, setOrgsOpen] = useState(false)
   const hasFilter = selectedOrgIds.length > 0
+
+  // On mobile the info card and this legend stack (rather than sit side by
+  // side), so an expanded-by-default race list — fine on desktop, where the
+  // globe has room to spare — ends up covering the whole viewport and leaves
+  // nothing to pan/look around on. Collapse it by default below `sm`; a tap
+  // on "Show" still opens it. useLayoutEffect (not a lazy useState initializer)
+  // so the collapse happens before paint without disagreeing with the SSR
+  // markup and tripping a hydration mismatch.
+  useLayoutEffect(() => {
+    if (window.matchMedia('(max-width: 639px)').matches) setOpen(false)
+  }, [])
 
   const countForOrg = (id: string) => projects.filter((p) => p.orgId === id).length
 

--- a/ui/components/nance/VotingResults.tsx
+++ b/ui/components/nance/VotingResults.tsx
@@ -71,7 +71,7 @@ export default function VotingResults({
         </div>
 
         {/* Summary Stats - Moved to top */}
-        <div className="grid grid-cols-3 gap-4 mb-6 p-4 bg-white/5 rounded-lg">
+        <div className="grid grid-cols-2 gap-4 mb-6 p-4 bg-white/5 rounded-lg">
           <div className="text-center">
             <p className="text-2xl font-bold text-white">{votes?.length || 0}</p>
             <p className="text-xs text-gray-400 uppercase tracking-wide">Total Voters</p>

--- a/ui/components/privy/PrivyConnectWallet.tsx
+++ b/ui/components/privy/PrivyConnectWallet.tsx
@@ -789,7 +789,7 @@ export function PrivyConnectWallet({ citizenContract, type }: PrivyConnectWallet
             createPortal(
               <div
                 id="privy-connect-wallet-dropdown"
-                className="fixed top-20 right-4 w-[360px] text-sm rounded-xl animate-fadeIn p-6 flex flex-col bg-gradient-to-br from-gray-900/98 via-blue-900/95 to-purple-900/90 backdrop-blur-xl border border-white/30 shadow-2xl text-white z-[9999] max-h-[80vh] overflow-y-auto scrollbar-hide"
+                className="fixed top-20 left-4 right-4 w-auto sm:left-auto sm:w-[360px] text-sm rounded-xl animate-fadeIn p-6 flex flex-col bg-gradient-to-br from-gray-900/98 via-blue-900/95 to-purple-900/90 backdrop-blur-xl border border-white/30 shadow-2xl text-white z-[9999] max-h-[80vh] overflow-y-auto scrollbar-hide"
               >
                 {sendModalEnabled && (
                   <SendModal

--- a/ui/pages/get-mooney.tsx
+++ b/ui/pages/get-mooney.tsx
@@ -40,7 +40,7 @@ export default function GetMooney() {
             />
           }
         >
-          <div className="max-w-2xl mx-auto w-full">
+          <div className="max-w-2xl mx-auto w-full px-4 sm:px-5 md:px-0">
             {/* Swap Tokens */}
             <div className="mb-4 sm:mb-6">
               <NativeToMooney selectedChain={selectedChain} />

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -304,7 +304,7 @@ export default function Lock() {
             />
           }
         >
-          <div className="max-w-2xl mx-auto w-full">
+          <div className="max-w-2xl mx-auto w-full px-4 sm:px-5 md:px-0">
 
               {/* vMOONEY Withdraw Section */}
               <div className="mb-4 sm:mb-6">

--- a/ui/pages/marketplace/index.tsx
+++ b/ui/pages/marketplace/index.tsx
@@ -134,7 +134,7 @@ export default function Marketplace({ listings }: MarketplaceProps) {
         <div className="flex w-full md:w-5/6 flex-col min-[1200px]:flex-row md:gap-2">
           <div className="w-full flex flex-row min-[800px]:flex-row gap-2 sm:gap-4 items-center">
             {/* Search Bar */}
-            <div className="w-fit max-w-[260px] bg-black/20 backdrop-blur-sm border border-white/10 rounded-xl px-3 py-1">
+            <div className="w-full min-w-0 max-w-[260px] bg-black/20 backdrop-blur-sm border border-white/10 rounded-xl px-3 py-1">
               <Search
                 className="w-full flex-grow"
                 input={input}
@@ -143,7 +143,7 @@ export default function Marketplace({ listings }: MarketplaceProps) {
               />
             </div>
             {/* Team filter dropdown */}
-            <div className="relative w-[10rem] sm:w-[12rem]">
+            <div className="relative w-[10rem] sm:w-[12rem] flex-shrink-0">
               <select
                 value={selectedTeam}
                 onChange={(e) => setSelectedTeam(e.target.value)}

--- a/ui/pages/moonbase/index.tsx
+++ b/ui/pages/moonbase/index.tsx
@@ -603,9 +603,10 @@ export default function MoonBaseZeroIndex() {
 
         {/* Overlay HUD */}
         <div className="pointer-events-none absolute inset-0 flex flex-col">
-          {/* Top row */}
-          <div className="flex items-start justify-between gap-4 p-4 sm:p-6">
-            <div className="pointer-events-auto max-w-sm rounded-2xl border border-white/10 bg-black/40 px-5 py-4 backdrop-blur-md">
+          {/* Top row: stacked on mobile so the info card and race legend never
+              have to squeeze into half the viewport each (see mobile audit). */}
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4 p-4 sm:p-6">
+            <div className="pointer-events-auto w-full sm:max-w-sm rounded-2xl border border-white/10 bg-black/40 px-5 py-4 backdrop-blur-md">
               <div className="flex items-center gap-2">
                 <GlobeAltIcon className="h-5 w-5 text-cyan-300" />
                 <h1 className="text-lg font-semibold text-white">Moon Base Zero</h1>


### PR DESCRIPTION
## Summary

Full responsive UI audit across mobile/tablet/desktop viewports, fixing overflow, clipping, and overlap bugs found via browser testing (Playwright) at widths from 320px to 1440px.

- **`TopNavBar`**: fixed clipping between 1280–1360px by deferring scale/spacing to the `2xl` breakpoint and constraining wallet/profile widths
- **`SignedInDashboard`**: fixed overlapping text/buttons in the mobile hero bar and contribution CTA at 320px
- **`TreasuryPage` / `TreasuryBalance` / `Asset`**: responsive font sizes + `break-all` to prevent heading and balance clipping/overflow on mobile
- **`VotingResults`**: fixed `grid-cols-3` layout that only rendered 2 children, leaving an unbalanced empty column
- **`ChartModal`**: removed contradictory min/max width constraints causing overflow at tablet sizes
- **`PrivyConnectWallet`**: fixed wallet dropdown overflowing the left edge on screens narrower than 376px
- **`marketplace`**: fixed team filter dropdown being squeezed/truncated by the search bar at 320px
- **`moonbase`**: info card and capability-race legend now stack vertically on mobile instead of overlapping

## Test plan

- [x] Browser-verified each fix at the original breaking width + neighboring widths (320/375/768/1024/1280/1440px)
- [x] Regression-tested other consumers of changed shared components (`ChartModal`, `VotingResults`, `TopNavBar`)
- [x] Final full-matrix pass across nav, homepage, dashboard, treasury, marketplace, moonbase, deprize, profile pages, and modals
- [ ] Review Vercel preview deployment across breakpoints

Made with [Cursor](https://cursor.com)