### PR TITLE
Add a dedicated /press page

### DIFF
--- a/ui/components/layout/ExpandedFooter.tsx
+++ b/ui/components/layout/ExpandedFooter.tsx
@@ -186,6 +186,7 @@ export function ExpandedFooter({
 
   const learnLinks = [
     { text: 'News', href: '/news' },
+    { text: 'Press', href: '/press' },
     { text: 'Town Hall', href: '/townhall' },
     { text: 'Roadmap', href: '/roadmap' },
     { text: 'About', href: '/about' },

--- a/ui/components/layout/GlobalSearch.tsx
+++ b/ui/components/layout/GlobalSearch.tsx
@@ -289,11 +289,21 @@ const searchMappings = [
   {
     keywords: [
       'news', 'announcements', 'blog', 'articles', 'updates', 'latest news',
-      'recent updates', "what's new", 'press',
+      'recent updates', "what's new",
     ],
     title: 'News',
     description: 'Stay updated with the latest MoonDAO news and announcements',
     link: '/news',
+    category: 'Learn',
+  },
+  {
+    keywords: [
+      'press', 'press kit', 'media', 'media kit', 'press release', 'coverage',
+      'journalist', 'logo', 'brand assets', 'boilerplate', 'in the news', 'interview',
+    ],
+    title: 'Press',
+    description: 'Press releases, media coverage and downloadable press kit assets',
+    link: '/press',
     category: 'Learn',
   },
   {

--- a/ui/components/press/CoverageGrid.tsx
+++ b/ui/components/press/CoverageGrid.tsx
@@ -1,5 +1,4 @@
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
-import Image from 'next/image'
 import React from 'react'
 import formatPressDate, { pressYear } from '@/lib/press/formatPressDate'
 import type { CoverageItem } from '@/lib/press/press-data'
@@ -12,21 +11,11 @@ function CoverageCard({ item }: { item: CoverageItem }) {
       rel="noopener noreferrer"
       className="group flex flex-col rounded-xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5 transition-all duration-200 hover:border-slate-500/50"
     >
-      <div className="flex h-6 items-center justify-between gap-3">
-        {item.logo ? (
-          <Image
-            src={item.logo}
-            alt={item.outlet}
-            width={120}
-            height={24}
-            className="h-5 w-auto max-w-[120px] object-contain object-left opacity-70 brightness-0 invert transition-opacity group-hover:opacity-100"
-          />
-        ) : (
-          <span className="truncate font-RobotoMono text-xs uppercase tracking-[0.2em] text-slate-400">
-            {item.outlet}
-          </span>
-        )}
-        <ArrowTopRightOnSquareIcon className="h-4 w-4 flex-shrink-0 text-slate-500 transition-colors group-hover:text-slate-300" />
+      <div className="flex items-start justify-between gap-3">
+        <span className="font-RobotoMono text-xs uppercase leading-5 tracking-[0.2em] text-slate-400">
+          {item.outlet}
+        </span>
+        <ArrowTopRightOnSquareIcon className="mt-0.5 h-4 w-4 flex-shrink-0 text-slate-500 transition-colors group-hover:text-slate-300" />
       </div>
       <h3 className="mt-3 flex-1 font-semibold leading-snug text-white transition-colors group-hover:text-slate-200">
         {item.title}

--- a/ui/components/press/CoverageGrid.tsx
+++ b/ui/components/press/CoverageGrid.tsx
@@ -1,0 +1,60 @@
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import Image from 'next/image'
+import React from 'react'
+import formatPressDate, { pressYear } from '@/lib/press/formatPressDate'
+import type { CoverageItem } from '@/lib/press/press-data'
+
+function CoverageCard({ item }: { item: CoverageItem }) {
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col rounded-xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5 transition-all duration-200 hover:border-slate-500/50"
+    >
+      <div className="flex h-6 items-center justify-between gap-3">
+        {item.logo ? (
+          <Image
+            src={item.logo}
+            alt={item.outlet}
+            width={120}
+            height={24}
+            className="h-5 w-auto max-w-[120px] object-contain object-left opacity-70 brightness-0 invert transition-opacity group-hover:opacity-100"
+          />
+        ) : (
+          <span className="truncate font-RobotoMono text-xs uppercase tracking-[0.2em] text-slate-400">
+            {item.outlet}
+          </span>
+        )}
+        <ArrowTopRightOnSquareIcon className="h-4 w-4 flex-shrink-0 text-slate-500 transition-colors group-hover:text-slate-300" />
+      </div>
+      <h3 className="mt-3 flex-1 font-semibold leading-snug text-white transition-colors group-hover:text-slate-200">
+        {item.title}
+      </h3>
+      <time dateTime={item.date} className="mt-3 text-xs text-slate-400">
+        {formatPressDate(item.date)}
+      </time>
+    </a>
+  )
+}
+
+export default function CoverageGrid({ coverage }: { coverage: CoverageItem[] }) {
+  const years = Array.from(new Set(coverage.map((item) => pressYear(item.date))))
+
+  return (
+    <div className="flex flex-col gap-8">
+      {years.map((year) => (
+        <div key={year}>
+          <h3 className="mb-4 font-GoodTimes text-lg text-slate-400">{year}</h3>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {coverage
+              .filter((item) => pressYear(item.date) === year)
+              .map((item) => (
+                <CoverageCard key={item.url} item={item} />
+              ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/ui/components/press/CoverageGrid.tsx
+++ b/ui/components/press/CoverageGrid.tsx
@@ -28,7 +28,9 @@ function CoverageCard({ item }: { item: CoverageItem }) {
 }
 
 export default function CoverageGrid({ coverage }: { coverage: CoverageItem[] }) {
-  const years = Array.from(new Set(coverage.map((item) => pressYear(item.date))))
+  const years = Array.from(new Set(coverage.map((item) => pressYear(item.date)))).sort(
+    (a, b) => Number(b) - Number(a)
+  )
 
   return (
     <div className="flex flex-col gap-8">

--- a/ui/components/press/MediaAppearances.tsx
+++ b/ui/components/press/MediaAppearances.tsx
@@ -17,7 +17,7 @@ function AppearanceList({ title, appearances }: { title: string; appearances: Me
               className="group flex items-start justify-between gap-3 rounded-xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 px-4 py-3 transition-all duration-200 hover:border-slate-500/50"
             >
               <div className="min-w-0">
-                <span className="block truncate font-RobotoMono text-xs uppercase tracking-[0.2em] text-slate-400">
+                <span className="block font-RobotoMono text-xs uppercase leading-5 tracking-[0.2em] text-slate-400">
                   {appearance.program}
                 </span>
                 <span className="mt-1 block text-sm text-white transition-colors group-hover:text-slate-200">

--- a/ui/components/press/MediaAppearances.tsx
+++ b/ui/components/press/MediaAppearances.tsx
@@ -1,0 +1,54 @@
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import React from 'react'
+import formatPressDate from '@/lib/press/formatPressDate'
+import type { MediaAppearance } from '@/lib/press/press-data'
+
+function AppearanceList({ title, appearances }: { title: string; appearances: MediaAppearance[] }) {
+  return (
+    <div>
+      <h3 className="mb-4 font-GoodTimes text-lg text-slate-400">{title}</h3>
+      <ul className="flex flex-col gap-2">
+        {appearances.map((appearance) => (
+          <li key={appearance.url}>
+            <a
+              href={appearance.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex items-start justify-between gap-3 rounded-xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 px-4 py-3 transition-all duration-200 hover:border-slate-500/50"
+            >
+              <div className="min-w-0">
+                <span className="block truncate font-RobotoMono text-xs uppercase tracking-[0.2em] text-slate-400">
+                  {appearance.program}
+                </span>
+                <span className="mt-1 block text-sm text-white transition-colors group-hover:text-slate-200">
+                  {appearance.title}
+                </span>
+                {appearance.date && (
+                  <time dateTime={appearance.date} className="mt-1 block text-xs text-slate-500">
+                    {formatPressDate(appearance.date)}
+                  </time>
+                )}
+              </div>
+              <ArrowTopRightOnSquareIcon className="mt-1 h-4 w-4 flex-shrink-0 text-slate-500 transition-colors group-hover:text-slate-300" />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default function MediaAppearances({
+  podcasts,
+  videos,
+}: {
+  podcasts: MediaAppearance[]
+  videos: MediaAppearance[]
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+      <AppearanceList title="Podcasts" appearances={podcasts} />
+      <AppearanceList title="Video" appearances={videos} />
+    </div>
+  )
+}

--- a/ui/components/press/PressAbout.tsx
+++ b/ui/components/press/PressAbout.tsx
@@ -1,0 +1,52 @@
+import { ClipboardDocumentIcon } from '@heroicons/react/24/outline'
+import React from 'react'
+import toast from 'react-hot-toast'
+import type { Fact } from '@/lib/press/press-data'
+
+async function copyBoilerplate(boilerplate: string) {
+  try {
+    if (!navigator.clipboard?.writeText) {
+      throw new Error('Clipboard API unavailable')
+    }
+    await navigator.clipboard.writeText(boilerplate)
+    toast.success('Boilerplate copied to clipboard.')
+  } catch (err) {
+    toast.error('Could not copy. Please select the text and copy it manually.')
+  }
+}
+
+export default function PressAbout({
+  boilerplate,
+  facts,
+}: {
+  boilerplate: string
+  facts: Fact[]
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <div className="rounded-2xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5 lg:col-span-2">
+        <div className="flex items-start justify-between gap-4">
+          <h3 className="font-GoodTimes text-lg text-white">About MoonDAO</h3>
+          <button
+            type="button"
+            onClick={() => copyBoilerplate(boilerplate)}
+            className="inline-flex flex-shrink-0 items-center gap-2 rounded-lg border border-slate-500/40 px-3 py-1.5 text-xs font-medium text-slate-300 transition-colors hover:border-slate-400/60 hover:text-white"
+          >
+            <ClipboardDocumentIcon className="h-4 w-4" />
+            Copy
+          </button>
+        </div>
+        <p className="mt-3 text-sm leading-relaxed text-slate-300">{boilerplate}</p>
+      </div>
+      <dl className="flex flex-col gap-3 rounded-2xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5">
+        <h3 className="font-GoodTimes text-lg text-white">Fact sheet</h3>
+        {facts.map((fact) => (
+          <div key={fact.label} className="flex items-baseline justify-between gap-3">
+            <dt className="text-xs text-slate-400">{fact.label}</dt>
+            <dd className="text-right text-sm font-medium text-white">{fact.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  )
+}

--- a/ui/components/press/PressKit.tsx
+++ b/ui/components/press/PressKit.tsx
@@ -1,0 +1,127 @@
+import {
+  ArrowDownTrayIcon,
+  ArrowTopRightOnSquareIcon,
+  ClipboardDocumentIcon,
+} from '@heroicons/react/24/outline'
+import Image from 'next/image'
+import React from 'react'
+import toast from 'react-hot-toast'
+import type { BrandAsset, Fact } from '@/lib/press/press-data'
+
+async function copyBoilerplate(boilerplate: string) {
+  try {
+    if (!navigator.clipboard?.writeText) {
+      throw new Error('Clipboard API unavailable')
+    }
+    await navigator.clipboard.writeText(boilerplate)
+    toast.success('Boilerplate copied to clipboard.')
+  } catch (err) {
+    toast.error('Could not copy. Please select the text and copy it manually.')
+  }
+}
+
+function AssetLink({ asset }: { asset: BrandAsset }) {
+  return (
+    <a
+      href={asset.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      download={asset.external ? undefined : ''}
+      className="group flex items-start justify-between gap-3 rounded-xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-4 transition-all duration-200 hover:border-slate-500/50"
+    >
+      <div className="min-w-0">
+        <span className="block font-semibold text-white transition-colors group-hover:text-slate-200">
+          {asset.name}
+        </span>
+        <span className="mt-1 block text-xs leading-relaxed text-slate-400">
+          {asset.description}
+        </span>
+      </div>
+      {asset.external ? (
+        <ArrowTopRightOnSquareIcon className="mt-1 h-4 w-4 flex-shrink-0 text-slate-400 transition-colors group-hover:text-slate-300" />
+      ) : (
+        <ArrowDownTrayIcon className="mt-1 h-4 w-4 flex-shrink-0 text-slate-400 transition-colors group-hover:text-slate-300" />
+      )}
+    </a>
+  )
+}
+
+export default function PressKit({
+  boilerplate,
+  facts,
+  brandAssets,
+  imagery,
+}: {
+  boilerplate: string
+  facts: Fact[]
+  brandAssets: BrandAsset[]
+  imagery: BrandAsset[]
+}) {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="rounded-2xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5 lg:col-span-2">
+          <div className="flex items-start justify-between gap-4">
+            <h3 className="font-GoodTimes text-lg text-white">About MoonDAO</h3>
+            <button
+              type="button"
+              onClick={() => copyBoilerplate(boilerplate)}
+              className="inline-flex flex-shrink-0 items-center gap-2 rounded-lg border border-slate-500/40 px-3 py-1.5 text-xs font-medium text-slate-300 transition-colors hover:border-slate-400/60 hover:text-white"
+            >
+              <ClipboardDocumentIcon className="h-4 w-4" />
+              Copy
+            </button>
+          </div>
+          <p className="mt-3 text-sm leading-relaxed text-slate-300">{boilerplate}</p>
+        </div>
+        <dl className="flex flex-col gap-3 rounded-2xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5">
+          <h3 className="font-GoodTimes text-lg text-white">Fact sheet</h3>
+          {facts.map((fact) => (
+            <div key={fact.label} className="flex items-baseline justify-between gap-3">
+              <dt className="text-xs text-slate-400">{fact.label}</dt>
+              <dd className="text-right text-sm font-medium text-white">{fact.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      <div>
+        <h3 className="mb-4 font-GoodTimes text-lg text-slate-400">Logos &amp; brand assets</h3>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {brandAssets.map((asset) => (
+            <AssetLink key={asset.href} asset={asset} />
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="mb-4 font-GoodTimes text-lg text-slate-400">Approved imagery</h3>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {imagery.map((image) => (
+            <a
+              key={image.href}
+              href={image.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              download=""
+              className="group overflow-hidden rounded-xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 transition-all duration-200 hover:border-slate-500/50"
+            >
+              <div className="relative h-40 w-full bg-black/30">
+                <Image src={image.href} alt={image.name} fill className="object-contain p-3" />
+              </div>
+              <div className="flex items-start justify-between gap-3 p-4">
+                <div className="min-w-0">
+                  <span className="block font-semibold text-white transition-colors group-hover:text-slate-200">
+                    {image.name}
+                  </span>
+                  <span className="mt-1 block text-xs text-slate-400">{image.description}</span>
+                </div>
+                <ArrowDownTrayIcon className="mt-1 h-4 w-4 flex-shrink-0 text-slate-400 transition-colors group-hover:text-slate-300" />
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/components/press/PressKit.tsx
+++ b/ui/components/press/PressKit.tsx
@@ -1,24 +1,7 @@
-import {
-  ArrowDownTrayIcon,
-  ArrowTopRightOnSquareIcon,
-  ClipboardDocumentIcon,
-} from '@heroicons/react/24/outline'
+import { ArrowDownTrayIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import Image from 'next/image'
 import React from 'react'
-import toast from 'react-hot-toast'
-import type { BrandAsset, Fact } from '@/lib/press/press-data'
-
-async function copyBoilerplate(boilerplate: string) {
-  try {
-    if (!navigator.clipboard?.writeText) {
-      throw new Error('Clipboard API unavailable')
-    }
-    await navigator.clipboard.writeText(boilerplate)
-    toast.success('Boilerplate copied to clipboard.')
-  } catch (err) {
-    toast.error('Could not copy. Please select the text and copy it manually.')
-  }
-}
+import type { BrandAsset } from '@/lib/press/press-data'
 
 function AssetLink({ asset }: { asset: BrandAsset }) {
   return (
@@ -47,44 +30,14 @@ function AssetLink({ asset }: { asset: BrandAsset }) {
 }
 
 export default function PressKit({
-  boilerplate,
-  facts,
   brandAssets,
   imagery,
 }: {
-  boilerplate: string
-  facts: Fact[]
   brandAssets: BrandAsset[]
   imagery: BrandAsset[]
 }) {
   return (
     <div className="flex flex-col gap-8">
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-        <div className="rounded-2xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5 lg:col-span-2">
-          <div className="flex items-start justify-between gap-4">
-            <h3 className="font-GoodTimes text-lg text-white">About MoonDAO</h3>
-            <button
-              type="button"
-              onClick={() => copyBoilerplate(boilerplate)}
-              className="inline-flex flex-shrink-0 items-center gap-2 rounded-lg border border-slate-500/40 px-3 py-1.5 text-xs font-medium text-slate-300 transition-colors hover:border-slate-400/60 hover:text-white"
-            >
-              <ClipboardDocumentIcon className="h-4 w-4" />
-              Copy
-            </button>
-          </div>
-          <p className="mt-3 text-sm leading-relaxed text-slate-300">{boilerplate}</p>
-        </div>
-        <dl className="flex flex-col gap-3 rounded-2xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5">
-          <h3 className="font-GoodTimes text-lg text-white">Fact sheet</h3>
-          {facts.map((fact) => (
-            <div key={fact.label} className="flex items-baseline justify-between gap-3">
-              <dt className="text-xs text-slate-400">{fact.label}</dt>
-              <dd className="text-right text-sm font-medium text-white">{fact.value}</dd>
-            </div>
-          ))}
-        </dl>
-      </div>
-
       <div>
         <h3 className="mb-4 font-GoodTimes text-lg text-slate-400">Logos &amp; brand assets</h3>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/ui/components/press/PressReleaseList.tsx
+++ b/ui/components/press/PressReleaseList.tsx
@@ -1,0 +1,74 @@
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import React from 'react'
+import formatPressDate from '@/lib/press/formatPressDate'
+import type { PressRelease } from '@/lib/press/press-data'
+
+function ReleaseMeta({ release }: { release: PressRelease }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-RobotoMono text-xs uppercase tracking-[0.2em] text-slate-400">
+      <time dateTime={release.date}>{formatPressDate(release.date)}</time>
+      <span aria-hidden className="text-slate-600">
+        /
+      </span>
+      <span>{release.source}</span>
+    </div>
+  )
+}
+
+function FeaturedRelease({ release }: { release: PressRelease }) {
+  return (
+    <a
+      href={release.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block rounded-2xl border border-blue-500/30 bg-gradient-to-r from-blue-600/20 to-purple-600/20 p-6 transition-all duration-200 hover:border-blue-400/50 md:p-8"
+    >
+      <ReleaseMeta release={release} />
+      <h3 className="mt-3 font-GoodTimes text-xl leading-snug text-white transition-colors group-hover:text-slate-200 md:text-2xl">
+        {release.title}
+      </h3>
+      <p className="mt-3 max-w-3xl text-sm leading-relaxed text-slate-300">{release.summary}</p>
+      <span className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-blue-300 group-hover:text-blue-200">
+        Read more
+        <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+      </span>
+    </a>
+  )
+}
+
+function Release({ release }: { release: PressRelease }) {
+  return (
+    <a
+      href={release.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block rounded-xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5 transition-all duration-200 hover:border-slate-500/50"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <ReleaseMeta release={release} />
+          <h3 className="mt-2 font-semibold text-white transition-colors group-hover:text-slate-200">
+            {release.title}
+          </h3>
+          <p className="mt-2 text-xs leading-relaxed text-slate-400">{release.summary}</p>
+        </div>
+        <ArrowTopRightOnSquareIcon className="mt-1 h-4 w-4 flex-shrink-0 text-slate-400 transition-colors group-hover:text-slate-300" />
+      </div>
+    </a>
+  )
+}
+
+export default function PressReleaseList({ releases }: { releases: PressRelease[] }) {
+  const [featured, ...rest] = releases
+
+  return (
+    <div className="flex flex-col gap-4">
+      {featured && <FeaturedRelease release={featured} />}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {rest.map((release) => (
+          <Release key={release.url} release={release} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/ui/components/press/PressSection.tsx
+++ b/ui/components/press/PressSection.tsx
@@ -1,0 +1,32 @@
+import React, { ReactNode } from 'react'
+
+type PressSectionProps = {
+  id: string
+  title: string
+  description?: string
+  action?: ReactNode
+  children: ReactNode
+}
+
+export default function PressSection({
+  id,
+  title,
+  description,
+  action,
+  children,
+}: PressSectionProps) {
+  return (
+    <section id={id} className="scroll-mt-24">
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="font-GoodTimes text-2xl text-white">{title}</h2>
+          {description && (
+            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-slate-300">{description}</p>
+          )}
+        </div>
+        {action}
+      </div>
+      {children}
+    </section>
+  )
+}

--- a/ui/components/press/Spokespeople.tsx
+++ b/ui/components/press/Spokespeople.tsx
@@ -1,0 +1,27 @@
+import Image from 'next/image'
+import React from 'react'
+import type { Spokesperson } from '@/lib/press/press-data'
+
+export default function Spokespeople({ people }: { people: Spokesperson[] }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      {people.map((person) => (
+        <div
+          key={person.name}
+          className="flex flex-col rounded-xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5"
+        >
+          {person.image && (
+            <div className="relative mb-4 h-16 w-16 overflow-hidden rounded-full bg-black/30">
+              <Image src={person.image} alt={person.name} fill className="object-cover" />
+            </div>
+          )}
+          <h3 className="font-GoodTimes text-lg text-white">{person.name}</h3>
+          <p className="mt-1 font-RobotoMono text-xs uppercase tracking-[0.2em] text-slate-400">
+            {person.role}
+          </p>
+          <p className="mt-3 text-sm leading-relaxed text-slate-300">{person.bio}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/ui/components/press/Spokespeople.tsx
+++ b/ui/components/press/Spokespeople.tsx
@@ -2,6 +2,8 @@ import Image from 'next/image'
 import React from 'react'
 import type { Spokesperson } from '@/lib/press/press-data'
 
+const FALLBACK_AVATAR = '/assets/MoonDAO-Logo-White.svg'
+
 export default function Spokespeople({ people }: { people: Spokesperson[] }) {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
@@ -10,11 +12,14 @@ export default function Spokespeople({ people }: { people: Spokesperson[] }) {
           key={person.name}
           className="flex flex-col rounded-xl border border-slate-600/30 bg-gradient-to-b from-slate-700/20 to-slate-800/30 p-5"
         >
-          {person.image && (
-            <div className="relative mb-4 h-16 w-16 overflow-hidden rounded-full bg-black/30">
-              <Image src={person.image} alt={person.name} fill className="object-cover" />
-            </div>
-          )}
+          <div className="relative mb-4 h-16 w-16 overflow-hidden rounded-full bg-black/30">
+            <Image
+              src={person.image ?? FALLBACK_AVATAR}
+              alt={person.image ? person.name : ''}
+              fill
+              className={person.image ? 'object-cover' : 'object-contain p-3 opacity-60'}
+            />
+          </div>
           <h3 className="font-GoodTimes text-lg text-white">{person.name}</h3>
           <p className="mt-1 font-RobotoMono text-xs uppercase tracking-[0.2em] text-slate-400">
             {person.role}

--- a/ui/lib/navigation/useNavigation.tsx
+++ b/ui/lib/navigation/useNavigation.tsx
@@ -102,6 +102,7 @@ export default function useNavigation(citizen: any) {
         href: '/info',
         children: [
           { name: 'News', href: '/news' },
+          { name: 'Press', href: '/press' },
           { name: 'Town Hall', href: '/townhall' },
           { name: 'Roadmap', href: '/roadmap' },
           { name: 'About', href: '/about' },

--- a/ui/lib/press/formatPressDate.ts
+++ b/ui/lib/press/formatPressDate.ts
@@ -1,0 +1,31 @@
+import type { PressDate } from './press-data'
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+// Dates are stored at whatever precision we could verify, so a full Date parse would
+// both invent a day we don't have and shift it by the reader's timezone.
+export default function formatPressDate(date: PressDate) {
+  const [year, month, day] = date.split('-')
+  const monthName = month ? MONTHS[Number(month) - 1] : undefined
+
+  if (!monthName) return year
+  if (!day) return `${monthName} ${year}`
+  return `${monthName} ${Number(day)}, ${year}`
+}
+
+export function pressYear(date: PressDate) {
+  return date.slice(0, 4)
+}

--- a/ui/lib/press/press-data.ts
+++ b/ui/lib/press/press-data.ts
@@ -1,0 +1,483 @@
+// Curated press data. MoonDAO's newsletter host (Kit) exposes no feed and its public index
+// only ever returns the 10 most recent posts, so this list is maintained by hand.
+
+export type PressDate = string // 'YYYY', 'YYYY-MM' or 'YYYY-MM-DD'
+
+export type PressRelease = {
+  title: string
+  date: PressDate
+  url: string
+  source: string
+  summary: string
+}
+
+export type CoverageItem = {
+  outlet: string
+  title: string
+  date: PressDate
+  url: string
+  logo?: string
+}
+
+export type MediaAppearance = {
+  program: string
+  title: string
+  url: string
+  date?: PressDate
+}
+
+export type Spokesperson = {
+  name: string
+  role: string
+  bio: string
+  image?: string
+}
+
+export type BrandAsset = {
+  name: string
+  description: string
+  href: string
+  external?: boolean
+}
+
+export type Fact = {
+  label: string
+  value: string
+}
+
+export const PRESS_CONTACT_EMAIL = 'info@moondao.com'
+export const CAMPAIGN_PRESS_CONTACT_EMAIL = 'spaceteam@brodeur.com'
+
+export const PRESS_BOILERPLATE = `MoonDAO is the Internet's Space Program, a decentralized autonomous organization accelerating the development of a self-sustaining, self-governing settlement on the Moon. Founded in 2021, MoonDAO raised more than $8 million in ETH from over 2,600 people in a single month and used part of that treasury to buy two seats aboard Blue Origin's New Shepard rocket, becoming the first organization to crowdfund human spaceflight. MoonDAO has since flown two astronauts to space, delivered its Constitution of the Moon to the lunar surface, and funds open space projects through community governance with the $MOONEY token.`
+
+export const PRESS_FACTS: Fact[] = [
+  { label: 'Founded', value: '2021' },
+  { label: 'Raised in first month', value: '$8M+ in ETH' },
+  { label: 'Contributors to the raise', value: '2,600+' },
+  { label: 'Astronauts flown', value: '2' },
+  { label: 'Legal structure', value: 'Marshall Islands DAO LLC' },
+  { label: 'Governance token', value: '$MOONEY' },
+]
+
+// Major announcements only. The full newsletter archive lives at news.moondao.com.
+export const PRESS_RELEASES: PressRelease[] = [
+  {
+    title: 'Send Frank White to Space',
+    date: '2026-03-18',
+    url: 'https://news.moondao.com/posts/send-frank-white-to-space',
+    source: 'MoonDAO Newsletter',
+    summary:
+      'MoonDAO opens a community fundraise to fly Frank White, author of The Overview Effect, on a suborbital flight so he can experience first-hand the phenomenon he spent four decades documenting.',
+  },
+  {
+    title: 'Your Mission: Go to Space with Frank White',
+    date: '2026-03-13',
+    url: 'https://www.globenewswire.com/news-release/2026/03/13/3255658/0/en/your-mission-go-to-space-with-frank-white.html',
+    source: 'GlobeNewswire',
+    summary:
+      'Wire announcement of the Overview Effect campaign, in which any contributor can win a seat alongside Frank White.',
+  },
+  {
+    title: 'A New Era Begins: Decoding the Lunar Decade',
+    date: '2026-02-13',
+    url: 'https://news.moondao.com/posts/shifting-timelines-how-the-moon-became-the-priority',
+    source: 'MoonDAO Newsletter',
+    summary:
+      'MoonDAO lays out how national and commercial timelines converged on the Moon, and what that shift means for its settlement roadmap.',
+  },
+  {
+    title: '2025 Year in Review',
+    date: '2025-12-18',
+    url: 'https://news.moondao.com/posts/2025-year-in-review',
+    source: 'MoonDAO Newsletter',
+    summary:
+      "A full accounting of MoonDAO's 2025: projects funded, governance changes, the lunar bounty, and the launch of the Launchpad.",
+  },
+  {
+    title: 'Support the Inspiration4 Complex at Space Camp',
+    date: '2025-10-16',
+    url: 'https://news.moondao.com/posts/support-the-inspiration4-complex-at-space-camp',
+    source: 'MoonDAO Newsletter',
+    summary:
+      'The first mission to run on the MoonDAO Launchpad, raising funds for the Inspiration4 Complex at Space Camp.',
+  },
+  {
+    title: 'The Constitution of the Moon Reaches the Lunar Surface',
+    date: '2025-03-11',
+    url: 'https://news.moondao.com/posts/lunar-bounty-has-landed-on-moon',
+    source: 'MoonDAO Newsletter',
+    summary:
+      "MoonDAO's Constitution of the Moon and a lunar bounty wallet land in Mare Crisium aboard Firefly Aerospace's Blue Ghost, carried in the LifeShip payload.",
+  },
+  {
+    title: 'Launching Today: The Space Acceleration Network',
+    date: '2024-10-10',
+    url: 'https://news.moondao.com/posts/launching-today-the-space-acceleration-network',
+    source: 'MoonDAO Newsletter',
+    summary:
+      'MoonDAO launches the Space Acceleration Network, an open directory connecting space companies, teams, and citizens working off-world.',
+  },
+  {
+    title: 'We did it, MoonDAO!',
+    date: '2024-09-10',
+    url: 'https://news.moondao.com/posts/we-did-it-moondao',
+    source: 'MoonDAO Newsletter',
+    summary:
+      'Dr. Eiman Jahangir returns from New Shepard NS-26, making him the second astronaut sent to space by a decentralized community vote.',
+  },
+  {
+    title: "Back to Space: MoonDAO's 2nd Astronaut Takes Off This Week!",
+    date: '2024-08-27',
+    url: 'https://news.moondao.com/posts/back-to-space-moondao-s-2nd-astronaut-takes-off-this-week',
+    source: 'MoonDAO Newsletter',
+    summary:
+      'Announcement of Dr. Eiman Jahangir launching aboard Blue Origin New Shepard NS-26 on August 29, 2024.',
+  },
+  {
+    title: 'Prepare to Launch: The Ticket to Space Sweepstakes',
+    date: '2023-12-06',
+    url: 'https://news.moondao.com/posts/prepare-to-launch',
+    source: 'MoonDAO Newsletter',
+    summary:
+      "MoonDAO reopens the sweepstakes for its second Blue Origin seat, giving the community a free path to becoming MoonDAO's next astronaut.",
+  },
+  {
+    title: 'MoonDAO can send users to outer space with a free NFT collection',
+    date: '2022-06-01',
+    url: 'https://www.timesnewswire.com/pressrelease/moondao-announced-that-it-can-send-users-to-outer-space-with-a-free-nft-collection/',
+    source: 'Times Newswire',
+    summary:
+      'MoonDAO announces the Ticket to Space NFT, a free collection that entered holders into the draw for a seat aboard New Shepard.',
+  },
+]
+
+export const MEDIA_COVERAGE: CoverageItem[] = [
+  {
+    outlet: 'Business Insider',
+    title: 'Your Mission: Go to Space with Frank White',
+    date: '2026-03-13',
+    url: 'https://markets.businessinsider.com/news/currencies/your-mission-go-to-space-with-frank-white-1035925299',
+  },
+  {
+    outlet: 'Yahoo Finance',
+    title: 'Your Mission: Go to Space with Frank White',
+    date: '2026-03-13',
+    url: 'https://finance.yahoo.com/news/mission-space-frank-white-153700223.html',
+  },
+  {
+    outlet: 'Space.com',
+    title:
+      'Cardiologist rockets to the final frontier on Blue Origin suborbital spaceflight, thanks to MoonDAO',
+    date: '2024-09-29',
+    url: 'https://www.space.com/blue-origin-eiman-jahangir-suborbital-flight-moondao',
+    logo: '/assets/logo-spacedotcom.svg',
+  },
+  {
+    outlet: 'NewsChannel 5 Nashville',
+    title:
+      "'I've imagined being this person for a long time': Nashville doctor takes suborbital flight",
+    date: '2024-09-04',
+    url: 'https://www.newschannel5.com/news/ive-imagined-being-this-person-for-a-long-time-nashville-doctor-space-enthusiast-takes-suborbital-flight',
+  },
+  {
+    outlet: 'The Tennessean',
+    title: "Vanderbilt cardiologist on Blue Origin flight to space: 'It was incredible'",
+    date: '2024-08-29',
+    url: 'https://www.tennessean.com/story/news/local/2024/08/29/eiman-jahangir-vanderbilt-blue-origin-new-shepard-first-nashvillian-space/74996549007/',
+  },
+  {
+    outlet: 'WSMV 4 Nashville',
+    title: "Tennessee doctor among '6 people having their minds blown' during space launch",
+    date: '2024-08-29',
+    url: 'https://www.wsmv.com/2024/08/29/tn-doctor-among-6-people-having-their-minds-blown-during-space-launch/',
+  },
+  {
+    outlet: 'Vanderbilt University',
+    title: 'MPH Graduate Eiman Jahangir Heads to Space with Blue Origin Space Launch',
+    date: '2024-08-29',
+    url: 'https://medschool.vanderbilt.edu/2024/08/29/mph-graduate-eiman-jahangir-blue-origin-space-launch/',
+  },
+  {
+    outlet: 'MSN',
+    title:
+      'Representation matters: Vanderbilt doctor to become first Nashvillian to go to outer space',
+    date: '2024-08',
+    url: 'https://www.msn.com/en-us/money/other/representation-matters-vanderbilt-doctor-to-become-first-nashvillian-to-go-outer-space/ar-AA1oRGNM',
+    logo: '/assets/logo-msn.svg',
+  },
+  {
+    outlet: 'Space Impulse',
+    title: "Cardiologist's Dream Of Space Takes Flight With MoonDAO Selection",
+    date: '2024-07-08',
+    url: 'https://spaceimpulse.com/2024/07/08/cardiologists-dream-of-space-takes-flight-with-moondao-selection/',
+  },
+  {
+    outlet: 'Vanderbilt University Medical Center',
+    title:
+      'The stars look very different today: Eiman Jahangir to realize lifelong dream to fly to space',
+    date: '2024-04-24',
+    url: 'https://news.vumc.org/2024/04/24/eiman-jahangir-to-realize-lifelong-dream-to-fly-to-space/',
+  },
+  {
+    outlet: 'NewsNation',
+    title: 'Vanderbilt doctor to go to space on Blue Origin flight',
+    date: '2024',
+    url: 'https://www.newsnationnow.com/good-news/vanderbilt-doctor-to-go-to-space-on-blue-origin-flight/',
+  },
+  {
+    outlet: 'Cointelegraph',
+    title: "Lunar colony 'unlikely' by 2030, but that's not the point — MoonDAO",
+    date: '2024-01-23',
+    url: 'https://cointelegraph.com/news/moondao-crypto-space-moon-mission-funding-research',
+  },
+  {
+    outlet: 'Houston Chronicle',
+    title:
+      "Crypto in space? As markets overlap, some see blockchain's potential in growing off-planet economy",
+    date: '2023',
+    url: 'https://www.houstonchronicle.com/news/houston-texas/space/article/cryptocurrency-blockchain-space-overlap-17753964.php',
+    logo: '/assets/logo-houston-chronicle.svg',
+  },
+  {
+    outlet: 'Forbes',
+    title: "The Crypto Community That's Going To The Moon – Literally",
+    date: '2022-11-09',
+    url: 'https://www.forbes.com/sites/zengernews/2022/11/09/the-crypto-community-thats-going-to-the-moonliterally/',
+    logo: '/assets/logo-forbes.svg',
+  },
+  {
+    outlet: 'CoinDesk',
+    title: 'A DAO That Literally Wants to Party on the Moon Just Sent a Viral YouTuber to Space',
+    date: '2022-08-06',
+    url: 'https://www.coindesk.com/business/2022/08/06/a-dao-that-literally-wants-to-party-on-the-moon-just-sent-a-viral-youtuber-to-space',
+  },
+  {
+    outlet: 'Quartz',
+    title: "Space Business: MoonDAO's Golden Tickets",
+    date: '2022-08-04',
+    url: 'https://qz.com/emails/space-business/1849365590/space-business-moondaos-golden-tickets',
+  },
+  {
+    outlet: 'Space.com',
+    title: "Blue Origin launches 6 people on company's 6th space tourism mission",
+    date: '2022-08-04',
+    url: 'https://www.space.com/blue-origin-ns-22-space-tourist-flight-success',
+    logo: '/assets/logo-spacedotcom.svg',
+  },
+  {
+    outlet: 'Spaceflight Now',
+    title: 'Blue Origin launches six more passengers to suborbital space',
+    date: '2022-08-04',
+    url: 'https://spaceflightnow.com/2022/08/04/blue-origin-ns-22-live-coverage/',
+  },
+  {
+    outlet: 'Local Profile',
+    title: "Dude Perfect's Coby Cotton Flying To Space With Blue Origin",
+    date: '2022-08-04',
+    url: 'https://www.localprofile.com/news/dude-perfect-coby-cotton-flying-space-7505388',
+  },
+  {
+    outlet: 'SlashGear',
+    title: 'The Bizarre Story Of How Dude Perfect Got A Chance To Go To Space',
+    date: '2022-08-04',
+    url: 'https://www.slashgear.com/952622/the-bizarre-story-of-how-dude-perfect-got-a-chance-to-go-to-space/',
+  },
+  {
+    outlet: 'Dallas Morning News',
+    title: 'Co-founder of Frisco-based Dude Perfect is set to go to space',
+    date: '2022-08-01',
+    url: 'https://www.dallasnews.com/business/local-companies/2022/08/01/co-founder-of-frisco-based-dude-perfect-is-set-to-go-to-space/',
+  },
+  {
+    outlet: 'Phys.org',
+    title: 'Co-founder of Texas-based Dude Perfect is set to go to space',
+    date: '2022-08',
+    url: 'https://phys.org/news/2022-08-co-founder-texas-based-dude-space.html',
+    logo: '/assets/logo-phys.svg',
+  },
+  {
+    outlet: 'News18',
+    title: "'Dude Perfect' YouTuber Jets Off to Space With Free Ticket Aboard Blue Origin Flight",
+    date: '2022-08',
+    url: 'https://www.news18.com/news/buzz/dude-perfect-youtuber-jets-off-to-space-with-free-ticket-aboard-blue-origin-flight-6322909.html',
+  },
+  {
+    outlet: 'Space.com',
+    title: 'Blue Origin announces crew for 6th suborbital space tourism launch',
+    date: '2022-07-23',
+    url: 'https://www.space.com/blue-origin-crew-ns-22-announced',
+    logo: '/assets/logo-spacedotcom.svg',
+  },
+  {
+    outlet: 'CNET',
+    title: 'MoonDAO Will Pick 2 of the Next Blue Origin Astronauts With the Help of NFTs',
+    date: '2022-06-09',
+    url: 'https://www.cnet.com/science/space/moondao-will-pick-2-of-the-next-blue-origin-astronauts-with-the-help-of-nfts/',
+    logo: '/assets/logo-cnet.svg',
+  },
+  {
+    outlet: 'HackerNoon',
+    title: "On MoonDAO's Unending Ambition to Decentralize The Space Industry",
+    date: '2022-02-25',
+    url: 'https://hackernoon.com/on-moondaos-unending-ambition-to-decentralize-the-space-industry',
+  },
+  {
+    outlet: 'VICE',
+    title: "Investors in 'MoonDAO' Think They'll Go to Space on a Billionaire's Rocket",
+    date: '2022-01-26',
+    url: 'https://www.vice.com/en/article/4aw4wj/investors-in-moondao-think-theyll-go-to-space-on-a-billionaires-rocket',
+    logo: '/assets/logo-vice.svg',
+  },
+]
+
+export const PODCAST_APPEARANCES: MediaAppearance[] = [
+  {
+    program: 'The Space Show',
+    title: 'Frank White & Pablo Moncada-Larrotiz on decentralized funding for spaceflight',
+    date: '2026-03-28',
+    url: 'https://doctorspace.substack.com/p/the-space-show-presents-frank-white',
+  },
+  {
+    program: 'Space Café Podcast',
+    title: 'Beyond Billionaires: MoonDAO and the Radical Vision of a Decentralized Space Economy',
+    date: '2025-01-28',
+    url: 'https://www.buzzsprout.com/1915816/episodes/16529164-beyond-billionaires-moondao-and-the-radical-vision-of-a-decentralized-space-economy',
+  },
+  {
+    program: 'Space and Things',
+    title: 'Winning a Trip to Space with Dr. Eiman Jahangir',
+    date: '2024-05-23',
+    url: 'https://spaceandthingspodcast.com/podcast/stp195-winning-a-trip-to-space-with-dr-eiman-jahangir',
+  },
+  {
+    program: 'The Space Revolution with Rick Tumlinson',
+    title: 'Episode 21: Pablo Moncada-Larrotiz',
+    date: '2023-09-06',
+    url: 'https://podcasts.apple.com/gb/podcast/episode-21-pablo-moncada/id1659076624?i=1000626953339',
+  },
+  {
+    program: 'Astro Ben',
+    title: 'Pablo Moncada-Larrotiz, Co-founder of MoonDAO',
+    url: 'https://astroben.libsyn.com/pablo-moncada-larrotiz-co-founder-of-moondao',
+  },
+  {
+    program: 'Astro Ben',
+    title: 'Dr. Eiman Jahangir on going to space with MoonDAO',
+    url: 'https://astroben.libsyn.com/dr-eiman-jahangir-associate-professor-at-vanderbilt-university-and-the-director-of-the-sections-of-general-cardiology-and-cardio-oncology-hes-also-going-to-space-with-moondao',
+  },
+  {
+    program: 'The Interplanetary Podcast',
+    title: 'Dr. Eiman Jahangir on New Shepard',
+    url: 'https://soundcloud.com/matt-interplanetary/306-dr-eiman-jahangir-new-shepard',
+  },
+]
+
+export const VIDEO_APPEARANCES: MediaAppearance[] = [
+  {
+    program: 'Dude Perfect',
+    title: 'Dude Perfect goes to SPACE',
+    url: 'https://www.youtube.com/watch?v=YXXlSG-du7c',
+  },
+  {
+    program: 'Ellie in Space',
+    title: 'How Dude Perfect was Sent to Space',
+    url: 'https://www.youtube.com/watch?v=u0sUwRWWZe0',
+  },
+  {
+    program: 'WKRN Nashville',
+    title: 'Vanderbilt doctor prepares to be an astronaut',
+    url: 'https://www.youtube.com/watch?v=YsofvOAKG3E',
+  },
+  {
+    program: 'Foresight Institute',
+    title: 'Decentralized Approaches to Support Space Progress',
+    url: 'https://www.youtube.com/watch?v=huNZxzM5u3w',
+  },
+  {
+    program: 'DAO Denver',
+    title: 'MoonDAO, A Fireside Chat with Pablo Moncada',
+    url: 'https://www.youtube.com/watch?v=VYhZ6YeDP18',
+  },
+  {
+    program: 'Mars Society Convention',
+    title: 'Decentralized Funding for Public Access to Space',
+    url: 'https://www.youtube.com/watch?v=I4MIL6-7jEU',
+  },
+  {
+    program: 'New Worlds Conference',
+    title: 'MoonDAO at New Worlds',
+    url: 'https://www.youtube.com/watch?v=BGMq5V-BGnY',
+  },
+]
+
+export const SPOKESPEOPLE: Spokesperson[] = [
+  {
+    name: 'Pablo Moncada-Larrotiz',
+    role: 'Co-founder',
+    bio: "Pablo co-founded MoonDAO at the end of 2021 and served as its first elected Executive Lead. He previously worked at Waymo, Google's self-driving car division, and on YouTube VR, leaving big tech after concluding that centralized control over billions of lives was better answered by decentralization. He studied at the University of Michigan and grew up between Ann Arbor and Zaragoza, Spain.",
+  },
+  {
+    name: 'Dr. Eiman Jahangir',
+    role: "MoonDAO's second astronaut",
+    bio: 'A cardiologist and associate professor at Vanderbilt University Medical Center, Dr. Jahangir was selected by MoonDAO through an open sweepstakes and flew aboard Blue Origin New Shepard NS-26 on August 29, 2024, becoming the first Nashvillian in space after applying to NASA twice.',
+    image: '/assets/eiman-jahangir.png',
+  },
+  {
+    name: 'Coby Cotton',
+    role: "MoonDAO's first astronaut",
+    bio: 'Co-founder of the YouTube sports-entertainment group Dude Perfect, Coby was chosen by MoonDAO token holders to use the first of its two Blue Origin seats. He flew aboard New Shepard NS-22 on August 4, 2022, in the first human spaceflight ever crowdfunded by an online community.',
+    image: '/assets/coby-cotton.png',
+  },
+]
+
+export const BRAND_ASSETS: BrandAsset[] = [
+  {
+    name: 'Full logo pack',
+    description: 'High-resolution MoonDAO logos, wordmarks, and graphics.',
+    href: 'https://drive.google.com/drive/folders/1xFv7fFPVLUKWPhd9LKd7-PWYH28WyUGP',
+    external: true,
+  },
+  {
+    name: 'MoonDAO logo (color)',
+    description: 'Primary mark, SVG.',
+    href: '/assets/moondao-logo.svg',
+  },
+  {
+    name: 'MoonDAO logo (white)',
+    description: 'For dark backgrounds, SVG.',
+    href: '/assets/MoonDAO-Logo-White.svg',
+  },
+  {
+    name: 'Animated logo',
+    description: 'Animated mark for video and broadcast, SVG.',
+    href: '/assets/MoonDAO%20Animated%20Logo%20-%20Original.svg',
+  },
+  {
+    name: 'Space Acceleration Network logo',
+    description: 'Mark for the Space Acceleration Network, SVG.',
+    href: '/assets/logo-san-full.svg',
+  },
+  {
+    name: 'Launchpad logo',
+    description: 'Mark for the MoonDAO Launchpad, SVG.',
+    href: '/assets/MoonDAOLaunchpad.svg',
+  },
+]
+
+export const PRESS_IMAGERY: BrandAsset[] = [
+  {
+    name: 'Coby Cotton, NS-22',
+    description: "MoonDAO's first astronaut.",
+    href: '/assets/astronaut-coby.png',
+  },
+  {
+    name: 'Dr. Eiman Jahangir, NS-26',
+    description: "MoonDAO's second astronaut.",
+    href: '/assets/astronaut-eiman.png',
+  },
+  {
+    name: 'Both MoonDAO astronauts',
+    description: 'Coby Cotton and Dr. Eiman Jahangir.',
+    href: '/assets/Astronauts.png',
+  },
+]

--- a/ui/lib/press/press-data.ts
+++ b/ui/lib/press/press-data.ts
@@ -412,12 +412,6 @@ export const SPOKESPEOPLE: Spokesperson[] = [
     bio: 'A cardiologist and associate professor at Vanderbilt University Medical Center, Dr. Jahangir was selected by MoonDAO through an open sweepstakes and flew aboard Blue Origin New Shepard NS-26 on August 29, 2024, becoming the first Nashvillian in space after applying to NASA twice.',
     image: '/assets/eiman-jahangir.png',
   },
-  {
-    name: 'Coby Cotton',
-    role: "MoonDAO's first astronaut",
-    bio: 'Co-founder of the YouTube sports-entertainment group Dude Perfect, Coby was chosen by MoonDAO token holders to use the first of its two Blue Origin seats. He flew aboard New Shepard NS-22 on August 4, 2022, in the first human spaceflight ever crowdfunded by an online community.',
-    image: '/assets/coby-cotton.png',
-  },
 ]
 
 export const BRAND_ASSETS: BrandAsset[] = [

--- a/ui/lib/press/press-data.ts
+++ b/ui/lib/press/press-data.ts
@@ -16,7 +16,6 @@ export type CoverageItem = {
   title: string
   date: PressDate
   url: string
-  logo?: string
 }
 
 export type MediaAppearance = {
@@ -170,7 +169,6 @@ export const MEDIA_COVERAGE: CoverageItem[] = [
       'Cardiologist rockets to the final frontier on Blue Origin suborbital spaceflight, thanks to MoonDAO',
     date: '2024-09-29',
     url: 'https://www.space.com/blue-origin-eiman-jahangir-suborbital-flight-moondao',
-    logo: '/assets/logo-spacedotcom.svg',
   },
   {
     outlet: 'NewsChannel 5 Nashville',
@@ -203,7 +201,6 @@ export const MEDIA_COVERAGE: CoverageItem[] = [
       'Representation matters: Vanderbilt doctor to become first Nashvillian to go to outer space',
     date: '2024-08',
     url: 'https://www.msn.com/en-us/money/other/representation-matters-vanderbilt-doctor-to-become-first-nashvillian-to-go-outer-space/ar-AA1oRGNM',
-    logo: '/assets/logo-msn.svg',
   },
   {
     outlet: 'Space Impulse',
@@ -236,14 +233,12 @@ export const MEDIA_COVERAGE: CoverageItem[] = [
       "Crypto in space? As markets overlap, some see blockchain's potential in growing off-planet economy",
     date: '2023',
     url: 'https://www.houstonchronicle.com/news/houston-texas/space/article/cryptocurrency-blockchain-space-overlap-17753964.php',
-    logo: '/assets/logo-houston-chronicle.svg',
   },
   {
     outlet: 'Forbes',
     title: "The Crypto Community That's Going To The Moon – Literally",
     date: '2022-11-09',
     url: 'https://www.forbes.com/sites/zengernews/2022/11/09/the-crypto-community-thats-going-to-the-moonliterally/',
-    logo: '/assets/logo-forbes.svg',
   },
   {
     outlet: 'CoinDesk',
@@ -262,7 +257,6 @@ export const MEDIA_COVERAGE: CoverageItem[] = [
     title: "Blue Origin launches 6 people on company's 6th space tourism mission",
     date: '2022-08-04',
     url: 'https://www.space.com/blue-origin-ns-22-space-tourist-flight-success',
-    logo: '/assets/logo-spacedotcom.svg',
   },
   {
     outlet: 'Spaceflight Now',
@@ -293,7 +287,6 @@ export const MEDIA_COVERAGE: CoverageItem[] = [
     title: 'Co-founder of Texas-based Dude Perfect is set to go to space',
     date: '2022-08',
     url: 'https://phys.org/news/2022-08-co-founder-texas-based-dude-space.html',
-    logo: '/assets/logo-phys.svg',
   },
   {
     outlet: 'News18',
@@ -306,14 +299,12 @@ export const MEDIA_COVERAGE: CoverageItem[] = [
     title: 'Blue Origin announces crew for 6th suborbital space tourism launch',
     date: '2022-07-23',
     url: 'https://www.space.com/blue-origin-crew-ns-22-announced',
-    logo: '/assets/logo-spacedotcom.svg',
   },
   {
     outlet: 'CNET',
     title: 'MoonDAO Will Pick 2 of the Next Blue Origin Astronauts With the Help of NFTs',
     date: '2022-06-09',
     url: 'https://www.cnet.com/science/space/moondao-will-pick-2-of-the-next-blue-origin-astronauts-with-the-help-of-nfts/',
-    logo: '/assets/logo-cnet.svg',
   },
   {
     outlet: 'HackerNoon',
@@ -326,7 +317,6 @@ export const MEDIA_COVERAGE: CoverageItem[] = [
     title: "Investors in 'MoonDAO' Think They'll Go to Space on a Billionaire's Rocket",
     date: '2022-01-26',
     url: 'https://www.vice.com/en/article/4aw4wj/investors-in-moondao-think-theyll-go-to-space-on-a-billionaires-rocket',
-    logo: '/assets/logo-vice.svg',
   },
 ]
 

--- a/ui/pages/press.tsx
+++ b/ui/pages/press.tsx
@@ -1,0 +1,186 @@
+import { ArrowTopRightOnSquareIcon, EnvelopeIcon } from '@heroicons/react/24/outline'
+import React from 'react'
+import {
+  BRAND_ASSETS,
+  CAMPAIGN_PRESS_CONTACT_EMAIL,
+  MEDIA_COVERAGE,
+  PODCAST_APPEARANCES,
+  PRESS_BOILERPLATE,
+  PRESS_CONTACT_EMAIL,
+  PRESS_FACTS,
+  PRESS_IMAGERY,
+  PRESS_RELEASES,
+  SPOKESPEOPLE,
+  VIDEO_APPEARANCES,
+} from '@/lib/press/press-data'
+import { useChainDefault } from '@/lib/thirdweb/hooks/useChainDefault'
+import Container from '../components/layout/Container'
+import ContentLayout from '../components/layout/ContentLayout'
+import WebsiteHead from '../components/layout/Head'
+import { NoticeFooter } from '@/components/layout/NoticeFooter'
+import CoverageGrid from '@/components/press/CoverageGrid'
+import MediaAppearances from '@/components/press/MediaAppearances'
+import PressKit from '@/components/press/PressKit'
+import PressReleaseList from '@/components/press/PressReleaseList'
+import PressSection from '@/components/press/PressSection'
+import Spokespeople from '@/components/press/Spokespeople'
+
+const sections = [
+  { id: 'press-releases', label: 'Announcements' },
+  { id: 'coverage', label: 'In the news' },
+  { id: 'appearances', label: 'Podcasts & video' },
+  { id: 'press-kit', label: 'Press kit' },
+  { id: 'spokespeople', label: 'Spokespeople' },
+  { id: 'contact', label: 'Contact' },
+]
+
+export default function Press() {
+  useChainDefault()
+
+  return (
+    <>
+      <WebsiteHead
+        title="Press"
+        description="MoonDAO press releases, news coverage, and press kit. Logos, boilerplate, imagery, and media contacts for the Internet's Space Program."
+        image="/assets/moondao-og.jpg"
+      />
+      <section className="mt-5 flex w-[90vw] animate-fadeIn flex-col items-start justify-start px-5 md:w-full">
+        <Container>
+          <ContentLayout
+            header="Press"
+            headerSize="40px"
+            description={
+              <div className="text-lg leading-relaxed text-gray-300">
+                Announcements, media coverage, and downloadable assets for journalists writing about
+                MoonDAO. For interviews, imagery, or comment, email{' '}
+                <a
+                  href={`mailto:${PRESS_CONTACT_EMAIL}`}
+                  className="text-blue-300 underline underline-offset-4 hover:text-blue-200"
+                >
+                  {PRESS_CONTACT_EMAIL}
+                </a>
+                .
+              </div>
+            }
+            mainPadding
+            mode="compact"
+            isProfile={true}
+          >
+            <div className="flex max-w-[1200px] flex-col gap-10 rounded-2xl border border-white/10 bg-gradient-to-br from-gray-900 via-blue-900/30 to-purple-900/20 p-6 shadow-2xl backdrop-blur-xl md:mb-[5vw] md:p-8 2xl:mb-[2vw]">
+              <nav aria-label="Press page sections" className="flex flex-wrap gap-2">
+                {sections.map((section) => (
+                  <a
+                    key={section.id}
+                    href={`#${section.id}`}
+                    className="rounded-full border border-slate-600/40 px-4 py-1.5 text-xs font-medium text-slate-300 transition-colors hover:border-slate-400/60 hover:text-white"
+                  >
+                    {section.label}
+                  </a>
+                ))}
+              </nav>
+
+              <PressSection
+                id="press-releases"
+                title="Announcements & press releases"
+                description="Major announcements from MoonDAO. Weekly project updates and governance notices are published to the newsletter."
+                action={
+                  <a
+                    href="https://news.moondao.com/posts"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex flex-shrink-0 items-center gap-2 text-sm font-medium text-blue-300 hover:text-blue-200"
+                  >
+                    Full newsletter archive
+                    <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                  </a>
+                }
+              >
+                <PressReleaseList releases={PRESS_RELEASES} />
+              </PressSection>
+
+              <PressSection
+                id="coverage"
+                title="In the news"
+                description="Selected coverage of MoonDAO and its missions from outlets around the world."
+              >
+                <CoverageGrid coverage={MEDIA_COVERAGE} />
+              </PressSection>
+
+              <PressSection
+                id="appearances"
+                title="Podcasts & video"
+                description="Long-form interviews and talks featuring MoonDAO's team and astronauts."
+              >
+                <MediaAppearances podcasts={PODCAST_APPEARANCES} videos={VIDEO_APPEARANCES} />
+              </PressSection>
+
+              <PressSection
+                id="press-kit"
+                title="Press kit"
+                description="Boilerplate copy, key facts, logos, and imagery cleared for editorial use."
+              >
+                <PressKit
+                  boilerplate={PRESS_BOILERPLATE}
+                  facts={PRESS_FACTS}
+                  brandAssets={BRAND_ASSETS}
+                  imagery={PRESS_IMAGERY}
+                />
+              </PressSection>
+
+              <PressSection
+                id="spokespeople"
+                title="Spokespeople"
+                description="Available for interviews on decentralized space funding, lunar settlement, and citizen astronaut programs."
+              >
+                <Spokespeople people={SPOKESPEOPLE} />
+              </PressSection>
+
+              <section id="contact" className="scroll-mt-24">
+                <div className="rounded-2xl border border-blue-500/30 bg-gradient-to-r from-blue-600/20 to-purple-600/20 p-6">
+                  <h2 className="mb-3 font-GoodTimes text-xl text-white">Media enquiries</h2>
+                  <p className="mb-4 text-sm leading-relaxed text-slate-300">
+                    Looking to feature MoonDAO in an upcoming publication? Email{' '}
+                    <a
+                      href={`mailto:${PRESS_CONTACT_EMAIL}`}
+                      className="text-blue-300 underline underline-offset-4 hover:text-blue-200"
+                    >
+                      {PRESS_CONTACT_EMAIL}
+                    </a>{' '}
+                    with details of your story and deadline. For the Send Frank to Space campaign,
+                    contact Brodeur Partners at{' '}
+                    <a
+                      href={`mailto:${CAMPAIGN_PRESS_CONTACT_EMAIL}`}
+                      className="text-blue-300 underline underline-offset-4 hover:text-blue-200"
+                    >
+                      {CAMPAIGN_PRESS_CONTACT_EMAIL}
+                    </a>
+                    .
+                  </p>
+                  <a
+                    href={`mailto:${PRESS_CONTACT_EMAIL}`}
+                    className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-blue-500 to-purple-500 px-4 py-2 font-medium text-white transition-all duration-200 hover:scale-105 hover:from-blue-600 hover:to-purple-600"
+                  >
+                    <EnvelopeIcon className="h-4 w-4" />
+                    Contact the press team
+                  </a>
+                </div>
+              </section>
+            </div>
+          </ContentLayout>
+        </Container>
+      </section>
+      <NoticeFooter
+        defaultTitle="Media Enquiries"
+        defaultImage="../assets/MoonDAO-Logo-White.svg"
+        defaultDescription="Writing about MoonDAO? Reach out for interviews, imagery, or comment from the team."
+        defaultButtonText="Email the Press Team"
+        defaultButtonLink={`mailto:${PRESS_CONTACT_EMAIL}`}
+        citizenTitle="Media Enquiries"
+        citizenImage="../assets/MoonDAO-Logo-White.svg"
+        citizenDescription="Writing about MoonDAO? Reach out for interviews, imagery, or comment from the team."
+        citizenButtonText="Email the Press Team"
+        citizenButtonLink={`mailto:${PRESS_CONTACT_EMAIL}`}
+      />
+    </>
+  )
+}

--- a/ui/pages/press.tsx
+++ b/ui/pages/press.tsx
@@ -20,12 +20,14 @@ import WebsiteHead from '../components/layout/Head'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import CoverageGrid from '@/components/press/CoverageGrid'
 import MediaAppearances from '@/components/press/MediaAppearances'
+import PressAbout from '@/components/press/PressAbout'
 import PressKit from '@/components/press/PressKit'
 import PressReleaseList from '@/components/press/PressReleaseList'
 import PressSection from '@/components/press/PressSection'
 import Spokespeople from '@/components/press/Spokespeople'
 
 const sections = [
+  { id: 'about', label: 'About' },
   { id: 'press-releases', label: 'Announcements' },
   { id: 'coverage', label: 'In the news' },
   { id: 'appearances', label: 'Podcasts & video' },
@@ -80,6 +82,14 @@ export default function Press() {
               </nav>
 
               <PressSection
+                id="about"
+                title="About MoonDAO"
+                description="Boilerplate copy and key facts for journalists on deadline. Copy the boilerplate straight into your story."
+              >
+                <PressAbout boilerplate={PRESS_BOILERPLATE} facts={PRESS_FACTS} />
+              </PressSection>
+
+              <PressSection
                 id="press-releases"
                 title="Announcements & press releases"
                 description="Major announcements from MoonDAO. Weekly project updates and governance notices are published to the newsletter."
@@ -117,14 +127,9 @@ export default function Press() {
               <PressSection
                 id="press-kit"
                 title="Press kit"
-                description="Boilerplate copy, key facts, logos, and imagery cleared for editorial use."
+                description="Logos and imagery cleared for editorial use."
               >
-                <PressKit
-                  boilerplate={PRESS_BOILERPLATE}
-                  facts={PRESS_FACTS}
-                  brandAssets={BRAND_ASSETS}
-                  imagery={PRESS_IMAGERY}
-                />
+                <PressKit brandAssets={BRAND_ASSETS} imagery={PRESS_IMAGERY} />
               </PressSection>
 
               <PressSection


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `/press`, a single home for MoonDAO's announcements, news coverage, and press kit, modelled on the structure of [anoma.foundation/press](https://anoma.foundation/press).

## Why

Press material was scattered and none of it lived on moondao.com:

- `docs.moondao.com/Press/Press-Kit` and `/Press/Press-Coverage` hold a genuine curated kit and coverage list, but they sit in the Docusaurus docs site, the rendered pages strip their hyperlinks, and the coverage list stops in mid-2024.
- The homepage `PartnersMarquee` hardcodes seven "As Featured On" logos.
- `/news` is a Next.js route containing nothing but a full-viewport iframe of the ConvertKit newsletter.

There was no press kit on the site itself: no copy-pasteable boilerplate, no fact sheet, no logo downloads, no spokespeople bios beyond Pablo's.

## What's on the page

Announcements and press releases (featured item plus a grid), news coverage grouped by year, podcast and video appearances, a press kit (boilerplate with a copy button, fact sheet, logo and imagery downloads), spokespeople, and media contacts. In-page anchor pills jump between sections.

## Data

The list is a hand-maintained module at `lib/press/press-data.ts` rather than a live fetch. Kit (formerly ConvertKit), which hosts `news.moondao.com`, exposes no RSS, Atom, JSON feed, or sitemap, and its public index returns only the ten most recent posts regardless of the `?page` parameter — older posts are reachable solely by direct slug. There is no public source to pull from.

Every URL was checked and every date verified against the source rather than carried over from the docs list. Two corrections came out of that:

- The docs' DAO Times link is a hard 404 and was dropped.
- Dr. Eiman Jahangir flew on **NS-26 (August 29, 2024)**, not NS-25. NS-25 was the Ed Dwight flight and had no MoonDAO connection.

Roughly a dozen URLs return 403 or 429 to automated fetchers (CoinDesk, Quartz, Phys.org, News18, NewsNation, Space Impulse, The Tennessean). Those are anti-bot responses, not dead links; the pages resolve in a browser.

## Files

| Path | Purpose |
|---|---|
| `lib/press/press-data.ts` | Typed press data: releases, coverage, appearances, spokespeople, brand assets, facts |
| `lib/press/formatPressDate.ts` | Formats dates stored at whatever precision could be verified (`YYYY`, `YYYY-MM`, `YYYY-MM-DD`) |
| `pages/press.tsx` | The page, following the `info.tsx` / `resources.tsx` layout convention |
| `components/press/*.tsx` | Five presentational section components |

Registered in `useNavigation` and `ExpandedFooter` under **Learn**, and in `GlobalSearch`. The `press` keyword moved off the `/news` search entry onto the new one.

## Verification

Typecheck is clean (the two pre-existing `import.meta` errors in `scripts/verify-deprize-moonbase-sepolia.ts` are untouched) and the production build compiles. Prerender fails for all 45 pages in this environment on `Cannot initialize the Privy provider with an invalid Privy app ID`, which is a missing credential rather than anything in this change. `yarn lint` cannot run here at all: `eslint-config-next`'s `jsx-a11y` plugin fails to load under Node 22, on existing files too.

The page was reviewed in a browser at desktop and 390×844 mobile. Three visual issues found and fixed during that pass:

- Showing logos on the seven cards we had assets for, next to plain text on the other twenty, read as noise rather than branding. All outlets now use a uniform text label.
- The fixed-height label row truncated "Vanderbilt University Medical Center"; labels now wrap.
- Spokespeople without a photo left their card heading sitting higher than its neighbours'; those now fall back to the MoonDAO mark.

## Not included

I left `PartnersMarquee` alone. It duplicates its press links with the dead `PartnerSection` component, and both could source from `lib/press/press-data.ts` so the homepage and press page never drift — but that touches the homepage, so it's worth deciding separately.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3788788-dbe1-460d-b77b-d7075c37282d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3788788-dbe1-460d-b77b-d7075c37282d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

