### PR TITLE
Hide public project budget announcements

### DIFF
--- a/ui/components/home/SignedInDashboard.tsx
+++ b/ui/components/home/SignedInDashboard.tsx
@@ -48,6 +48,7 @@ import {
   MISSION_TABLE_ADDRESSES,
   TEAM_ADDRESSES,
   USD_BUDGET,
+  ANNOUNCE_PROJECT_BUDGET,
 } from 'const/config'
 import { BLOCKED_MDPS, BLOCKED_PROJECTS } from 'const/whitelist'
 import {
@@ -1228,7 +1229,7 @@ export default function SignedInDashboard({
         <DashboardActiveProjects
           currentProjects={currentProjects}
           usdBudget={USD_BUDGET}
-          showBudget={true}
+          showBudget={ANNOUNCE_PROJECT_BUDGET}
           maxProjects={6}
         />
 

--- a/ui/components/layout/ProjectBanner.tsx
+++ b/ui/components/layout/ProjectBanner.tsx
@@ -1,4 +1,9 @@
-import { PROJECT_SYSTEM_CONFIG, NEXT_QUARTER_BUDGET_USD, MAX_BUDGET_USD } from 'const/config'
+import {
+  ANNOUNCE_PROJECT_BUDGET,
+  PROJECT_SYSTEM_CONFIG,
+  NEXT_QUARTER_BUDGET_USD,
+  MAX_BUDGET_USD,
+} from 'const/config'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -24,7 +29,13 @@ export default function ProjectBanner() {
   // Hide banner if submission deadline has passed
   const isDeadlinePassed = new Date() > SUBMISSION_DEADLINE
 
-  if (!isVisible || isOnProjectPage || isDeadlinePassed || process.env.NEXT_PUBLIC_HIDE_PROJECT_BANNER === 'true') {
+  if (
+    !ANNOUNCE_PROJECT_BUDGET ||
+    !isVisible ||
+    isOnProjectPage ||
+    isDeadlinePassed ||
+    process.env.NEXT_PUBLIC_HIDE_PROJECT_BANNER === 'true'
+  ) {
     return null
   }
 

--- a/ui/components/nance/ProjectRewards.tsx
+++ b/ui/components/nance/ProjectRewards.tsx
@@ -15,6 +15,7 @@ import {
   POLYGON_ASSETS_URL,
   BASE_ASSETS_URL,
   USD_BUDGET,
+  ANNOUNCE_PROJECT_BUDGET,
   RETRO_PAYOUT_TOKEN,
   RETRO_ETH_BUDGET,
   RETRO_USD_BUDGET,
@@ -1654,14 +1655,20 @@ export function ProjectRewards({
                       <span className="leading-none">Create Project</span>
                     </button>
                   </div>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-1.5 sm:gap-4">
-                    <div className="bg-black/20 rounded-lg p-2 sm:p-3 border border-white/10">
-                      <RewardAsset
-                        name="USDC"
-                        value={`$${USD_BUDGET.toLocaleString()}`}
-                        usdValue={USD_BUDGET.toFixed(2)}
-                      />
-                    </div>
+                  <div
+                    className={`grid grid-cols-1 gap-1.5 sm:gap-4 ${
+                      ANNOUNCE_PROJECT_BUDGET ? 'md:grid-cols-2' : ''
+                    }`}
+                  >
+                    {ANNOUNCE_PROJECT_BUDGET && (
+                      <div className="bg-black/20 rounded-lg p-2 sm:p-3 border border-white/10">
+                        <RewardAsset
+                          name="USDC"
+                          value={`$${USD_BUDGET.toLocaleString()}`}
+                          usdValue={USD_BUDGET.toFixed(2)}
+                        />
+                      </div>
+                    )}
                     <div className="bg-black/20 rounded-lg p-2 sm:p-3 border border-white/10">
                       <RewardAsset
                         name="MOONEY"

--- a/ui/components/project/DashboardActiveProjects.tsx
+++ b/ui/components/project/DashboardActiveProjects.tsx
@@ -14,7 +14,7 @@ type DashboardActiveProjectsProps = {
 export default function DashboardActiveProjects({
   currentProjects,
   usdBudget,
-  showBudget = true,
+  showBudget = false,
   maxProjects = 6,
 }: DashboardActiveProjectsProps) {
   const { quarter, year } = getRelativeQuarter(0)

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -850,6 +850,10 @@ export const USD_BUDGET = NEXT_QUARTER_BUDGET_USD
 // total quarterly rewards."
 export const MAX_BUDGET_USD = Math.round(NEXT_QUARTER_BUDGET_USD / 5)
 
+// Public UI that prints NEXT_QUARTER_BUDGET_USD / MAX_BUDGET_USD. Off until
+// the next-quarter figure is confirmed so we don't advertise a stale pool.
+export const ANNOUNCE_PROJECT_BUDGET = false
+
 // Addresses that have manager-level access on ALL teams (can add jobs and
 // marketplace listings on behalf of any team). Lowercase for comparison.
 export const SUPER_MANAGERS: string[] = [

--- a/ui/cypress/integration/layout/project-banner.cy.tsx
+++ b/ui/cypress/integration/layout/project-banner.cy.tsx
@@ -1,10 +1,13 @@
-import { PROJECT_SYSTEM_CONFIG } from 'const/config'
+import { ANNOUNCE_PROJECT_BUDGET, PROJECT_SYSTEM_CONFIG } from 'const/config'
 import ProjectBanner from '@/components/layout/ProjectBanner'
 
 describe('<ProjectBanner />', () => {
   beforeEach(() => {
     cy.mountNextRouter('/')
   })
+
+  const hideBanner =
+    !ANNOUNCE_PROJECT_BUDGET || process.env.NEXT_PUBLIC_HIDE_PROJECT_BANNER === 'true'
 
   it('Renders when deadline has not passed', () => {
     // Set clock to a date before the deadline
@@ -14,8 +17,9 @@ describe('<ProjectBanner />', () => {
 
     cy.mount(<ProjectBanner />)
 
-    // Banner should be visible when deadline has not passed (unless env var hides it)
-    if (process.env.NEXT_PUBLIC_HIDE_PROJECT_BANNER === 'true') {
+    // Banner should be visible when deadline has not passed (unless budget
+    // announcements or the env var hide it)
+    if (hideBanner) {
       cy.get('div').contains('Project Proposals Open').should('not.exist')
     } else {
       cy.get('div').contains('Project Proposals Open').should('be.visible')
@@ -43,7 +47,7 @@ describe('<ProjectBanner />', () => {
     cy.clock(beforeDeadline)
 
     const projectPages = ['/projects-overview', '/projects', '/proposals', '/submit']
-    
+
     projectPages.forEach((page) => {
       cy.mountNextRouter(page)
       cy.mount(<ProjectBanner />)
@@ -58,7 +62,7 @@ describe('<ProjectBanner />', () => {
     cy.clock(beforeDeadline)
 
     // Only test close button if banner would be visible
-    if (process.env.NEXT_PUBLIC_HIDE_PROJECT_BANNER !== 'true') {
+    if (!hideBanner) {
       cy.mount(<ProjectBanner />)
 
       cy.get('div').contains('Project Proposals Open').should('be.visible')
@@ -67,7 +71,7 @@ describe('<ProjectBanner />', () => {
 
       cy.get('div').contains('Project Proposals Open').should('not.exist')
     } else {
-      cy.log('Skipping test: Banner is hidden by environment variable')
+      cy.log('Skipping test: Banner is hidden by budget-announce flag or environment variable')
     }
   })
 
@@ -77,12 +81,10 @@ describe('<ProjectBanner />', () => {
     beforeDeadline.setDate(beforeDeadline.getDate() - 1)
     cy.clock(beforeDeadline)
 
-    const hideBanner = process.env.NEXT_PUBLIC_HIDE_PROJECT_BANNER === 'true'
-
     cy.mount(<ProjectBanner />)
 
     if (hideBanner) {
-      // Banner should be hidden when environment variable is set to 'true'
+      // Banner should be hidden when budget announcements are off or the env var is set
       cy.get('div').contains('Project Proposals Open').should('not.exist')
     } else {
       // Banner should be visible when environment variable is not set to 'true'
@@ -97,12 +99,23 @@ describe('<ProjectBanner />', () => {
     cy.clock(beforeDeadline)
 
     // Only test deadline display if banner would be visible
-    if (process.env.NEXT_PUBLIC_HIDE_PROJECT_BANNER !== 'true') {
+    if (!hideBanner) {
       cy.mount(<ProjectBanner />)
 
       cy.contains(`Deadline: ${PROJECT_SYSTEM_CONFIG.submissionDeadline}`).should('be.visible')
     } else {
-      cy.log('Skipping test: Banner is hidden by environment variable')
+      cy.log('Skipping test: Banner is hidden by budget-announce flag or environment variable')
     }
+  })
+
+  it('Does not announce quarterly budget figures while announcements are off', () => {
+    const beforeDeadline = new Date(PROJECT_SYSTEM_CONFIG.submissionDeadline)
+    beforeDeadline.setDate(beforeDeadline.getDate() - 1)
+    cy.clock(beforeDeadline)
+
+    cy.mount(<ProjectBanner />)
+
+    cy.contains('Total Budget').should('not.exist')
+    cy.contains('Max per project').should('not.exist')
   })
 })

--- a/ui/cypress/integration/layout/project-banner.cy.tsx
+++ b/ui/cypress/integration/layout/project-banner.cy.tsx
@@ -115,7 +115,12 @@ describe('<ProjectBanner />', () => {
 
     cy.mount(<ProjectBanner />)
 
-    cy.contains('Total Budget').should('not.exist')
-    cy.contains('Max per project').should('not.exist')
+    if (hideBanner) {
+      cy.contains('Total Budget').should('not.exist')
+      cy.contains('Max per project').should('not.exist')
+    } else {
+      cy.contains('Total Budget').should('be.visible')
+      cy.contains('Max per project').should('be.visible')
+    }
   })
 })

--- a/ui/lib/nance/index.ts
+++ b/ui/lib/nance/index.ts
@@ -1,4 +1,4 @@
-import { MAX_BUDGET_USD, MOONDAO_ARBITRUM_TREASURY, MOONDAO_TREASURY } from 'const/config'
+import { ANNOUNCE_PROJECT_BUDGET, MAX_BUDGET_USD, MOONDAO_ARBITRUM_TREASURY, MOONDAO_TREASURY } from 'const/config'
 
 export function formatNumberUSStyle(n: string | number | bigint, compact: boolean = false) {
   return new Intl.NumberFormat('en-US', {
@@ -10,6 +10,15 @@ export function formatNumberUSStyle(n: string | number | bigint, compact: boolea
 /** Markdown project proposal template shown to authors and used as the canonical form. */
 export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): string {
   const maxFormatted = maxBudgetUsd.toLocaleString('en-US')
+  const maxAskBlurb = ANNOUNCE_PROJECT_BUDGET
+    ? `*Total ask must be ≤ **$${maxFormatted}** (1/5 of this quarter’s project budget — confirm the live figure on moondao.com/propose). Classify every dollar.*`
+    : `*Total ask must be ≤ the posted quarterly max (1/5 of this quarter’s project budget). Classify every dollar.*`
+  const maxTotalCell = ANNOUNCE_PROJECT_BUDGET
+    ? `*≤ $${maxFormatted}*`
+    : `*≤ posted quarterly max*`
+  const maxChecklist = ANNOUNCE_PROJECT_BUDGET
+    ? `- [ ] Ask ≤ posted quarterly max ($${maxFormatted})`
+    : `- [ ] Ask ≤ posted quarterly max`
 
   return `\n*Note: Please remove the italicized instructions before submitting. Incomplete Key Results, missing Novelty & Prior Art, or asks above the quarterly max will be returned for rewrite.*\n
 
@@ -132,7 +141,7 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 
 # Budget (Table C)
 
-*Total ask must be ≤ **$${maxFormatted}** (1/5 of this quarter’s project budget — confirm the live figure on moondao.com/propose). Classify every dollar.*
+${maxAskBlurb}
 
 **What MoonDAO funds:** labor for inspectable deliverables, and specialized equipment/services the work uniquely needs (with ownership/access terms).
 
@@ -145,7 +154,7 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 | *Foundational PC / home office* | *C — not allowed* | *$0* | *Remove* |
 | *Entity formation / tax / bailout* | *D — not allowed* | *$0* | *Remove* |
 | *Other overhead* | *E* | *$* | *Scrutinize* |
-| **Total** |  | *≤ $${maxFormatted}* |  |
+| **Total** |  | ${maxTotalCell} |  |
 
 *If success depends on a university, launch provider, or other partner: attach LOI, quote, or access MOU before the vote.*
 
@@ -159,7 +168,7 @@ export function getProposalTemplate(maxBudgetUsd: number = MAX_BUDGET_USD): stri
 
 # Pre-submit checklist
 
-- [ ] Ask ≤ posted quarterly max ($${maxFormatted})
+${maxChecklist}
 - [ ] All required sections completed; italicized instructions removed
 - [ ] Key Results are non-empty and testable
 - [ ] Budget justified and within allowed categories

--- a/ui/pages/projects-overview.tsx
+++ b/ui/pages/projects-overview.tsx
@@ -1,4 +1,5 @@
 import {
+  ANNOUNCE_PROJECT_BUDGET,
   ARBITRUM_ASSETS_URL,
   POLYGON_ASSETS_URL,
   MAX_BUDGET_USD,
@@ -102,7 +103,7 @@ const ProjectsOverview: React.FC<{
 }> = ({ currentProjects }) => {
   const title = 'MoonDAO Project System'
   const description =
-    "Quarterly grants for lunar-settlement work. See this quarter's max, what we fund, and how to submit a strong proposal."
+    'Quarterly grants for lunar-settlement work. See what we fund and how to submit a strong proposal.'
 
   const { quarter, year } = getRelativeQuarter(0)
   const reduceMotion = useReducedMotion()
@@ -244,16 +245,22 @@ const ProjectsOverview: React.FC<{
           {/* Quarter facts — single strip */}
           <section className="border-y border-white/10 bg-[#050810] px-4 py-12 md:px-8">
             <Reveal>
-              <div className="mx-auto grid max-w-6xl gap-10 md:grid-cols-3">
-                <div>
-                  <p className="text-xs uppercase tracking-[0.2em] text-white/45">
-                    Max per project · Q{quarter} {year}
-                  </p>
-                  <p className="mt-2 font-GoodTimes text-4xl text-white md:text-5xl">
-                    ${MAX_BUDGET_USD.toLocaleString()}
-                  </p>
-                  <p className="mt-2 text-sm text-white/45">1/5 of the quarterly project budget</p>
-                </div>
+              <div
+                className={`mx-auto grid max-w-6xl gap-10 ${
+                  ANNOUNCE_PROJECT_BUDGET ? 'md:grid-cols-3' : 'md:grid-cols-2'
+                }`}
+              >
+                {ANNOUNCE_PROJECT_BUDGET && (
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.2em] text-white/45">
+                      Max per project · Q{quarter} {year}
+                    </p>
+                    <p className="mt-2 font-GoodTimes text-4xl text-white md:text-5xl">
+                      ${MAX_BUDGET_USD.toLocaleString()}
+                    </p>
+                    <p className="mt-2 text-sm text-white/45">1/5 of the quarterly project budget</p>
+                  </div>
+                )}
                 <div>
                   <p className="text-xs uppercase tracking-[0.2em] text-white/45">Submit by</p>
                   <p className="mt-2 font-GoodTimes text-2xl text-white md:text-3xl">
@@ -401,14 +408,16 @@ const ProjectsOverview: React.FC<{
                   completed work sit alongside that pool.
                 </p>
                 <div className="mt-10 space-y-8">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.2em] text-white/45">
-                      Stablecoin retro pool
-                    </p>
-                    <p className="mt-2 font-GoodTimes text-4xl text-white">
-                      ${NEXT_QUARTER_BUDGET_USD.toLocaleString()}
-                    </p>
-                  </div>
+                  {ANNOUNCE_PROJECT_BUDGET && (
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.2em] text-white/45">
+                        Stablecoin retro pool
+                      </p>
+                      <p className="mt-2 font-GoodTimes text-4xl text-white">
+                        ${NEXT_QUARTER_BUDGET_USD.toLocaleString()}
+                      </p>
+                    </div>
+                  )}
                   <div>
                     <p className="text-xs uppercase tracking-[0.2em] text-white/45">
                       vMOONEY retro pool
@@ -503,7 +512,7 @@ const ProjectsOverview: React.FC<{
               <DashboardActiveProjects
                 currentProjects={currentProjects}
                 usdBudget={usdBudget}
-                showBudget={true}
+                showBudget={ANNOUNCE_PROJECT_BUDGET}
                 maxProjects={6}
               />
             </div>{' '}
@@ -517,8 +526,8 @@ const ProjectsOverview: React.FC<{
                 Bring a lunar-ready idea
               </h2>
               <p className="mx-auto mt-6 max-w-xl text-lg text-gray-300">
-                Start from the template, keep the ask under ${MAX_BUDGET_USD.toLocaleString()}, cite
-                prior art, and show the lunar bridge.
+                Start from the template, keep the ask under the quarterly max, cite prior art, and
+                show the lunar bridge.
               </p>
               <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
                 <StandardButton

--- a/ui/pages/proposal-template.tsx
+++ b/ui/pages/proposal-template.tsx
@@ -1,4 +1,4 @@
-import { MAX_BUDGET_USD } from 'const/config'
+import { ANNOUNCE_PROJECT_BUDGET, MAX_BUDGET_USD } from 'const/config'
 import { useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import ReactMarkdown from 'react-markdown'
@@ -53,11 +53,17 @@ export default function ProposalTemplatePage() {
               Copy this markdown into a Google Doc or editor, fill every required section, then
               import it on the propose page. Includes Novelty &amp; Prior Art, Lunar Bridge,
               Community Standing, budget classes, IP, COTS (for hardware), and a pre-submit
-              checklist. Current max ask:{' '}
-              <span className="font-semibold text-white">
-                ${MAX_BUDGET_USD.toLocaleString()}
-              </span>
-              .
+              checklist.
+              {ANNOUNCE_PROJECT_BUDGET && (
+                <>
+                  {' '}
+                  Current max ask:{' '}
+                  <span className="font-semibold text-white">
+                    ${MAX_BUDGET_USD.toLocaleString()}
+                  </span>
+                  .
+                </>
+              )}
             </p>
 
             <div className="mb-8 flex flex-col gap-3 sm:flex-row">

--- a/ui/pages/proposals.tsx
+++ b/ui/pages/proposals.tsx
@@ -1,5 +1,5 @@
 import { NanceProvider } from '@nance/nance-hooks'
-import { PROJECT_TABLE_NAMES, DEFAULT_CHAIN_V5, NEXT_QUARTER_BUDGET_USD, MAX_BUDGET_USD } from 'const/config'
+import { PROJECT_TABLE_NAMES, DEFAULT_CHAIN_V5, NEXT_QUARTER_BUDGET_USD, MAX_BUDGET_USD, ANNOUNCE_PROJECT_BUDGET } from 'const/config'
 import Image from 'next/image'
 import Link from 'next/link'
 import { GetServerSideProps } from 'next'
@@ -48,27 +48,28 @@ export default function ProposalsPage({ project }: { project: Project }) {
             {/* Main Content Area */}
             <div className="flex flex-col gap-5 md:gap-8 max-w-[1200px] md:mb-[5vw] 2xl:mb-[2vw]">
               
-              {/* Budget Info - At the top */}
-              <div className="bg-black/20 rounded-xl p-3 md:p-4 border border-white/10">
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
-                  <div className="bg-black/20 rounded-lg p-2 md:p-3 border border-white/10">
-                    <h2 className="font-GoodTimes text-white/80 text-xs md:text-sm mb-1">Total Quarter Budget</h2>
-                    <RewardAsset
-                      name="USDC"
-                      value={`$${NEXT_QUARTER_BUDGET_USD.toLocaleString()}`}
-                      usdValue={NEXT_QUARTER_BUDGET_USD}
-                    />
-                  </div>
-                  <div className="bg-black/20 rounded-lg p-2 md:p-3 border border-white/10">
-                    <h2 className="font-GoodTimes text-white/80 text-xs md:text-sm mb-1">Max Project Budget</h2>
-                    <RewardAsset
-                      name="USDC"
-                      value={`$${MAX_BUDGET_USD.toLocaleString()}`}
-                      usdValue={MAX_BUDGET_USD}
-                    />
+              {ANNOUNCE_PROJECT_BUDGET && (
+                <div className="bg-black/20 rounded-xl p-3 md:p-4 border border-white/10">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
+                    <div className="bg-black/20 rounded-lg p-2 md:p-3 border border-white/10">
+                      <h2 className="font-GoodTimes text-white/80 text-xs md:text-sm mb-1">Total Quarter Budget</h2>
+                      <RewardAsset
+                        name="USDC"
+                        value={`$${NEXT_QUARTER_BUDGET_USD.toLocaleString()}`}
+                        usdValue={NEXT_QUARTER_BUDGET_USD}
+                      />
+                    </div>
+                    <div className="bg-black/20 rounded-lg p-2 md:p-3 border border-white/10">
+                      <h2 className="font-GoodTimes text-white/80 text-xs md:text-sm mb-1">Max Project Budget</h2>
+                      <RewardAsset
+                        name="USDC"
+                        value={`$${MAX_BUDGET_USD.toLocaleString()}`}
+                        usdValue={MAX_BUDGET_USD}
+                      />
+                    </div>
                   </div>
                 </div>
-              </div>
+              )}
 
               {/* Step 1: Get the Template - Most Prominent */}
               <div className="bg-gradient-to-br from-slate-900/80 via-blue-950/40 to-slate-900/80 backdrop-blur-xl border border-blue-500/25 rounded-2xl p-4 md:p-8 shadow-xl">
@@ -80,7 +81,7 @@ export default function ProposalsPage({ project }: { project: Project }) {
                     <h2 className="text-xl md:text-2xl font-bold text-white mb-2">Get the Proposal Template</h2>
                     <p className="text-gray-300">
                       Use the canonical markdown template (novelty &amp; prior art, lunar bridge, budget
-                      classes, IP, checklist). Ask must be ≤ ${MAX_BUDGET_USD.toLocaleString()}.
+                      classes, IP, checklist). Ask must stay within the posted quarterly max.
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The next-quarter project budget is being revised, so the app was still advertising a stale pool. This turns off those public figures until the number is confirmed.

**What was announcing the budget**
- Site-wide project banner (`Total Budget` / `Max per project`)
- `/projects-overview` (max per project, stablecoin pool, CTA copy)
- `/proposals` (quarter + max project budget cards)
- `/proposal-template` (current max ask)
- Signed-in dashboard and `/projects` USDC pool card
- Proposal markdown template dollar amounts

**What this does**
Adds `ANNOUNCE_PROJECT_BUDGET = false` in `ui/const/config.ts` and gates those surfaces on it. Vote tallying, AI review, and form max constraints still use the configured budget; they just are not advertised.

Set `ANNOUNCE_PROJECT_BUDGET` back to `true` when the next-quarter figure is ready.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4f3d8da-ab68-4610-98b5-7834930afe97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4f3d8da-ab68-4610-98b5-7834930afe97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

