### PR TITLE
docs(geo): clarify EU/EEA geoblock excludes Russia by design

### DIFF
--- a/ui/lib/geo/index.ts
+++ b/ui/lib/geo/index.ts
@@ -45,6 +45,14 @@ export function getCountryFromHeaders(req: NextApiRequest): string | null {
 // (Iceland, Liechtenstein, Norway), and the UK (which retains UK-GDPR
 // post-Brexit). These regions cannot permanently store personal data on chain,
 // so we let them browse the site but block on-chain profile creation.
+//
+// This list is deliberately scoped to actual EU/EEA/UK member states, not a
+// "Europe" continent grouping. Russia (RU) is intentionally NOT included here:
+// despite MaxMind-style geo databases sometimes bucketing Russia under a
+// broad "Europe" continent code, Russia is not in the EU/EEA and has no GDPR
+// obligation on our end. If Russian visitors are still seeing a geoblock, the
+// cause is not this in-repo list -- check the Vercel project's Firewall/WAF
+// rules in the dashboard for an overly broad continent-based rule.
 export const EU_EEA_COUNTRIES: ReadonlySet<string> = new Set([
   'AT', // Austria
   'BE', // Belgium


### PR DESCRIPTION
## Summary
- Investigated a teammate report that Russia is caught by "our Euro geoblock, although it shouldn't be, not from our end."
- Confirmed `EU_EEA_COUNTRIES` in `ui/lib/geo/index.ts` (the GDPR on-chain-write gate) already never included `RU` — it's scoped to actual EU member states + EEA (IS/LI/NO) + UK/crown dependencies, not a broad "Europe" continent bucket.
- Checked all other geo-aware code in the repo (Coinbase onramp region detection, cookie banner, citizen/team creation gates) — none of them reference Russia or a continent-level grouping either.
- No firewall/WAF config exists in this repo (`vercel.json` has none, no `firewall.json`). A prior commit (`21480de0`) confirms the *old* geoblock was "an external Vercel WAF rule" — i.e. configured in the Vercel dashboard, not in code.
- **Conclusion**: there's no in-repo bug to fix here. This PR adds a code comment documenting the investigation so the list isn't re-suspected next time, and points whoever owns the Vercel dashboard at the likely real cause (an overly broad continent-based Firewall rule that needs to be scoped to explicit EU/EEA/UK country codes instead of a "Europe" preset).

## Test plan
- [ ] No functional change — `isEUCountry('RU')` returns `false` before and after this PR.
- [ ] Whoever has Vercel dashboard access should check Project Settings → Firewall for a continent-based rule and narrow it to explicit country codes so Russia isn't caught.

Made with [Cursor](https://cursor.com)