### PR TITLE
fix(citizen): resume stale AI portrait jobs instead of discarding them

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -1593,7 +1593,11 @@ export default function CreateCitizen({
       const sourceForGen = getGenerationSourceImage(cropped, undefined)
 
       const pendingJob = readPendingImageJob()
-      if (pendingJob && isPendingImageJobStale(pendingJob)) {
+      // Only eagerly clear stale 'uploading' jobs, which have no jobId to
+      // recover. A stale 'polling' job still has a real comfy.icu jobId that
+      // may already have a completed portrait waiting — decideImageResumeAction
+      // below will try to resume it rather than discard it.
+      if (pendingJob && isPendingImageJobStale(pendingJob) && pendingJob.status !== 'polling') {
         clearPendingImageJob()
       }
 

--- a/ui/lib/image-generator/citizenOnboardingImage.ts
+++ b/ui/lib/image-generator/citizenOnboardingImage.ts
@@ -63,6 +63,15 @@ export type ImageResumeInput = {
  * failures. So polling resumes even when the cropped image failed to persist.
  * Restarting an `uploading` job, by contrast, re-uploads and therefore needs the
  * cropped source image.
+ *
+ * Staleness (`jobStale`) only applies to `uploading` jobs, which have no jobId
+ * to fall back on. A `polling` job's jobId is real and comfy.icu keeps
+ * completed runs queryable for a long time (well beyond our local staleness
+ * window) — so even a "stale" polling job may already have a finished
+ * portrait waiting. Bug fix: this used to bail out to 'none' for any stale
+ * job, which silently discarded completed AI portraits for anyone who took a
+ * while to return (e.g. funding their wallet via onramp) and caused their
+ * mint to fall back to the raw uploaded photo instead.
  */
 export function decideImageResumeAction({
   job,
@@ -70,8 +79,9 @@ export function decideImageResumeAction({
   hasAiPortraitReady,
   hasSourceImage,
 }: ImageResumeInput): ImageResumeAction {
-  if (!job || jobStale || hasAiPortraitReady) return 'none'
+  if (!job || hasAiPortraitReady) return 'none'
   if (job.status === 'polling' && job.jobId) return 'resume-polling'
+  if (jobStale) return 'none'
   if (job.status === 'uploading') {
     return hasSourceImage ? 'restart-generation' : 'none'
   }

--- a/ui/lib/image-generator/pendingImageJob.ts
+++ b/ui/lib/image-generator/pendingImageJob.ts
@@ -1,6 +1,10 @@
 export const CITIZEN_PENDING_IMAGE_JOB_KEY = 'CreateCitizen_pendingImageJob'
 
-/** Max age before we stop resuming a job (slightly above client poll ceiling). */
+/**
+ * Max age before we stop resuming an 'uploading' job (slightly above client
+ * poll ceiling). Once a job reaches 'polling' it has a real comfy.icu jobId
+ * that stays resumable far longer than this — see decideImageResumeAction.
+ */
 export const PENDING_IMAGE_JOB_TTL_MS = 8 * 60 * 1000
 
 export type PendingImageJobStatus = 'uploading' | 'polling'

--- a/ui/scripts/citizen-onboarding-image.test.ts
+++ b/ui/scripts/citizen-onboarding-image.test.ts
@@ -137,16 +137,33 @@ describe('citizenOnboardingImage', () => {
     )
   })
 
-  it('does nothing for stale jobs or when AI portrait already ready', () => {
+  // The exact reported bug: comfy.icu jobs were completing successfully, but
+  // citizens who took a while to return (e.g. funding their wallet via
+  // onramp) had their local job timer exceed the staleness window, so a
+  // finished portrait was silently discarded and the mint fell back to the
+  // raw uploaded photo. A 'polling' job's jobId stays valid on comfy.icu far
+  // longer than the local staleness window, so staleness alone must not
+  // block resuming it.
+  it('resumes a stale polling job instead of discarding a finished portrait', () => {
+    const action = decideImageResumeAction({
+      job: { status: 'polling', jobId: 'x' },
+      jobStale: true,
+      hasAiPortraitReady: false,
+      hasSourceImage: true,
+    })
+    expectEqual(action, 'resume-polling', 'stale polling job still resumes')
+  })
+
+  it('does nothing for a stale uploading job or when AI portrait already ready', () => {
     expectEqual(
       decideImageResumeAction({
-        job: { status: 'polling', jobId: 'x' },
+        job: { status: 'uploading' },
         jobStale: true,
         hasAiPortraitReady: false,
         hasSourceImage: true,
       }),
       'none',
-      'stale job ignored',
+      'stale uploading job ignored (no jobId to recover)',
     )
     expectEqual(
       decideImageResumeAction({


### PR DESCRIPTION
## Summary
- Citizens who took a while to return from a full-page redirect (Privy login, onramp wallet funding) had their in-progress AI portrait job silently discarded once it crossed the local 8-minute staleness window — even though the comfy.icu job had already completed successfully.
- The mint then fell back to the raw uploaded photo instead of the AI astronaut portrait. I confirmed this against live data: citizens #228 through #240 (13 in a row) all minted with their raw photo instead of an AI portrait, while comfy.icu's own job history shows those generations were completing fine.
- Root cause: once a job reaches the `polling` stage it has a real comfy.icu jobId that stays resumable for a long time (confirmed comfy.icu retains completed jobs for well over a week), but the local "stale after 8 minutes" check discarded it anyway. Now, staleness only gates `uploading` jobs (which have no jobId to recover); `polling` jobs always attempt to resume and pick up the finished portrait.

## Test plan
- [x] `node node_modules/mocha/bin/mocha.js --require ts-node/register --require tsconfig-paths/register scripts/citizen-onboarding-image.test.ts` — new/updated `decideImageResumeAction` cases pass (pre-existing unrelated `File is not defined` failures in a few other tests are a local Node 18 test-env gap, not caused by this change).
- [ ] Manually verify: start citizen AI generation, wait >8 minutes (or simulate via devtools) before returning to the Review step, confirm the finished AI portrait is used at mint instead of the raw photo.

Made with [Cursor](https://cursor.com)