### PR TITLE
fix(citizen): don't fail-closed the GDPR geoblock on a geo lookup error

### DIFF
--- a/ui/lib/geo/useRegionRestriction.ts
+++ b/ui/lib/geo/useRegionRestriction.ts
@@ -16,8 +16,12 @@ export type RegionRestriction = {
   // don't briefly flash a creation flow before discovering the user is in a
   // restricted region.
   isLoading: boolean
-  // True when geo resolution failed after retries. Callers gating personal-data
-  // creation flows should treat this as "unresolved" rather than "allowed".
+  // True when geo resolution failed after retries (network error, timeout,
+  // etc.) rather than resolving to a definite country. This is distinct from
+  // `isRestricted`, which is only ever true for a *confirmed* EU/EEA/UK
+  // country code -- an error here does not mean the visitor is restricted.
+  // Whether to treat an unresolved lookup as "allow" or "block" is a
+  // per-flow decision for the caller (see usage notes below).
   isError: boolean
 }
 
@@ -30,11 +34,19 @@ export type RegionRestriction = {
  * (citizen / team creation). Detection comes from Vercel/Cloudflare geo headers
  * via `/api/geo/country`.
  *
- * This client hook is only a UX gate; it retries on error (rather than silently
- * failing open after one failed fetch) and surfaces `isError` so creation pages
- * can avoid rendering the wizard on an unresolved region. The authoritative
+ * This client hook is only a UX gate; it retries on error rather than
+ * silently failing open after one failed fetch, and surfaces `isError` so
+ * callers can decide how to handle an unresolved lookup. The authoritative
  * GDPR block is enforced server-side in the data-persistence routes (see
- * `enforceRegionNotRestricted`), which return HTTP 451 regardless of the client.
+ * `enforceRegionNotRestricted`), which return HTTP 451 regardless of the
+ * client -- so it's safe for personal-data creation flows (citizen/team) to
+ * fail *open* on `isError` and let the visitor into the flow, rather than
+ * assuming an unresolved lookup means "restricted". Failing closed on error
+ * incorrectly blocked non-EU/EEA visitors (e.g. Russia) whenever their geo
+ * lookup happened to fail, even though they were never actually in a
+ * restricted region. Flows with additional non-GDPR regulatory concerns
+ * (e.g. DePrize betting, which also cares about unknown jurisdictions) may
+ * still choose to fail closed on `isError` -- that's a per-flow decision.
  */
 export default function useRegionRestriction(): RegionRestriction {
   const { data, error, isLoading } = useSWR<GeoCountryResponse>(

--- a/ui/pages/citizen/index.tsx
+++ b/ui/pages/citizen/index.tsx
@@ -12,15 +12,18 @@ export default function Join() {
   const router = useRouter()
 
   // EU/EEA visitors may browse the site but cannot permanently store personal
-  // data on chain (GDPR), so they don't get the citizen creation flow. If geo
-  // can't be resolved we fail closed (treat it as restricted) rather than risk
-  // showing the flow to a restricted visitor; the mint is also blocked
-  // server-side regardless.
-  const {
-    isRestricted,
-    isLoading: isResolvingRegion,
-    isError: regionError,
-  } = useRegionRestriction()
+  // data on chain (GDPR), so they don't get the citizen creation flow. We only
+  // gate on a *confirmed* restricted country here -- if the geo lookup errors
+  // out (timeout, flaky connection, etc.) we let the visitor through rather
+  // than assuming they're EU/EEA, since that previously misclassified
+  // non-EU/EEA visitors (e.g. Russia, which is not in EU_EEA_COUNTRIES) whose
+  // requests to /api/geo/country failed as "restricted" and blocked them from
+  // a flow that was never meant to apply to them. The GDPR gate is still
+  // enforced authoritatively server-side (see enforceRegionNotRestricted) at
+  // mint/image-generation time regardless of this client-side check, so
+  // actual EU/EEA visitors are never able to complete the flow even if their
+  // geo lookup happens to error out here.
+  const { isRestricted, isLoading: isResolvingRegion } = useRegionRestriction()
 
   useChainDefault()
 
@@ -54,7 +57,7 @@ export default function Join() {
       />
       {/* Wait until geo resolves so we never flash the creation flow to a
           restricted visitor. */}
-      {isResolvingRegion ? null : isRestricted || regionError ? (
+      {isResolvingRegion ? null : isRestricted ? (
         <RegionRestrictedNotice type="citizen" />
       ) : (
         <CreateCitizen


### PR DESCRIPTION
## Summary
- A Russian user trying to register as a Citizen was hitting the same "Not Available in Your Region" GDPR notice shown to EU/EEA visitors, even though Russia is not, and never was, in the `EU_EEA_COUNTRIES` allowlist (`ui/lib/geo/index.ts`).
- Root cause: the citizen page (`ui/pages/citizen/index.tsx`) blocked the creation flow whenever `isRestricted || regionError` was true. A geo lookup **error** (network hiccup, timeout, etc. calling `/api/geo/country`) was being treated identically to a **confirmed** EU/EEA country match, so any visitor whose geo lookup happened to fail — for any reason, not just actual EU/EEA location — got permanently shown the GDPR block screen instead of the creation wizard.
- Fix: the client now only blocks on a *confirmed* `isRestricted` (i.e. a real EU/EEA/UK country code came back). It no longer fails closed purely because the lookup errored. This is safe because the real GDPR enforcement already happens authoritatively server-side in `enforceRegionNotRestricted` (HTTP 451) at mint / citizen-image-generation time — so actual EU/EEA visitors are still blocked from completing the flow even if this client-side check lets them see the wizard.
- Left the DePrize betting gate (`ui/pages/deprize/[id].tsx`, `ui/components/deprize/DePrizeIndexContent.tsx`) unchanged — it intentionally fails closed on unknown/errored geo for separate wagering-jurisdiction reasons unrelated to GDPR, and that wasn't the flow reported as broken.

## Test plan
- [ ] Confirm the previously-affected Russian user can now load `/citizen` and see the creation wizard instead of the region-restricted notice.
- [ ] Confirm an actual EU/EEA visitor (e.g. via VPN) still sees the restricted notice when `/api/geo/country` resolves successfully.
- [ ] Confirm an EU/EEA visitor who somehow bypasses the client gate still gets rejected with HTTP 451 when attempting the sponsored mint / citizen image generation (server-side enforcement unchanged).

Made with [Cursor](https://cursor.com)