### PR TITLE
fix(citizen): deliver completed AI portraits instead of raw photos

### DIFF
--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -85,6 +85,8 @@ import {
   getReviewPreviewFile,
   hasAiPortraitImage,
   isAiPortraitReady,
+  isGeneratedAiPortraitFile,
+  isUsableAiPortrait,
 } from '@/lib/image-generator/citizenOnboardingImage'
 import NetworkSelector from '@/components/thirdweb/NetworkSelector'
 import CitizenABI from '../../const/abis/Citizen.json'
@@ -552,7 +554,11 @@ export default function CreateCitizen({
     }
   }, [imageGenProgress, isRegenerating, regenPhase, regenElapsedMs])
 
-  const hasAiPortrait = hasAiPortraitImage(citizenImage, croppedInputImage) && isAiPortraitReady()
+  const hasAiPortrait = isUsableAiPortrait(
+    citizenImage,
+    croppedInputImage,
+    isAiPortraitReady(),
+  )
 
   const isAwaitingAiPortrait = isImageGenerating || hasPendingImageJob
 
@@ -1124,8 +1130,15 @@ export default function CreateCitizen({
     if (formData.citizenImage && isSerializedFile(formData.citizenImage)) {
       const restoredCitizenImage = base64ToFile(formData.citizenImage)
       setCitizenImage(restoredCitizenImage)
-      // If citizenImage differs from croppedInputImage, it's an AI portrait - mark it ready
-      if (!cropped || restoredCitizenImage !== cropped) {
+      // File object identity is meaningless after base64 restore — compare
+      // serialized bytes / generated filename so a cropped fallback is not
+      // marked as the AI portrait (which would skip resume-polling).
+      const looksLikeAi =
+        isGeneratedAiPortraitFile(restoredCitizenImage) ||
+        !formData.croppedInputImage ||
+        !isSerializedFile(formData.croppedInputImage) ||
+        formData.citizenImage.dataURL !== formData.croppedInputImage.dataURL
+      if (looksLikeAi) {
         markAiPortraitReady()
       }
     }
@@ -1265,8 +1278,9 @@ export default function CreateCitizen({
         formData.citizenImage &&
         isSerializedFile(formData.citizenImage)
       ) {
-        // Compare serialized data to determine if it's an AI portrait
+        const restored = base64ToFile(formData.citizenImage)
         if (
+          isGeneratedAiPortraitFile(restored) ||
           !formData.croppedInputImage ||
           !isSerializedFile(formData.croppedInputImage) ||
           formData.citizenImage.dataURL !== formData.croppedInputImage.dataURL
@@ -2032,7 +2046,8 @@ export default function CreateCitizen({
         inputImage,
         isImageGenerating,
         hasPendingImageJob,
-        aiPortraitReady: isAiPortraitReady(),
+        aiPortraitReady:
+          isAiPortraitReady() || isGeneratedAiPortraitFile(citizenImage),
       }),
     [citizenImage, croppedInputImage, inputImage, isImageGenerating, hasPendingImageJob],
   )

--- a/ui/components/onboarding/CreateCitizen.tsx
+++ b/ui/components/onboarding/CreateCitizen.tsx
@@ -87,6 +87,7 @@ import {
   isAiPortraitReady,
   isGeneratedAiPortraitFile,
   isUsableAiPortrait,
+  restoredCitizenImageLooksLikeAi,
 } from '@/lib/image-generator/citizenOnboardingImage'
 import NetworkSelector from '@/components/thirdweb/NetworkSelector'
 import CitizenABI from '../../const/abis/Citizen.json'
@@ -1130,15 +1131,12 @@ export default function CreateCitizen({
     if (formData.citizenImage && isSerializedFile(formData.citizenImage)) {
       const restoredCitizenImage = base64ToFile(formData.citizenImage)
       setCitizenImage(restoredCitizenImage)
-      // File object identity is meaningless after base64 restore — compare
-      // serialized bytes / generated filename so a cropped fallback is not
-      // marked as the AI portrait (which would skip resume-polling).
-      const looksLikeAi =
-        isGeneratedAiPortraitFile(restoredCitizenImage) ||
-        !formData.croppedInputImage ||
-        !isSerializedFile(formData.croppedInputImage) ||
-        formData.citizenImage.dataURL !== formData.croppedInputImage.dataURL
-      if (looksLikeAi) {
+      // File object identity is meaningless after base64 restore — only a
+      // Comfy job filename (not the crop's own name/bytes) is a finished portrait.
+      const crop = isSerializedFile(formData.croppedInputImage)
+        ? formData.croppedInputImage
+        : undefined
+      if (restoredCitizenImageLooksLikeAi(formData.citizenImage, crop)) {
         markAiPortraitReady()
       }
     }
@@ -1272,19 +1270,17 @@ export default function CreateCitizen({
         setCitizenImage,
         'citizen image',
       )
-      // If citizenImage was restored and differs from croppedInputImage, it's an AI portrait
+      // If citizenImage was restored and is a Comfy download (not the crop),
+      // it's an AI portrait. SerializedFile stores bytes on `data`, not dataURL.
       if (
         citizenImageRestored &&
         formData.citizenImage &&
         isSerializedFile(formData.citizenImage)
       ) {
-        const restored = base64ToFile(formData.citizenImage)
-        if (
-          isGeneratedAiPortraitFile(restored) ||
-          !formData.croppedInputImage ||
-          !isSerializedFile(formData.croppedInputImage) ||
-          formData.citizenImage.dataURL !== formData.croppedInputImage.dataURL
-        ) {
+        const crop = isSerializedFile(formData.croppedInputImage)
+          ? formData.croppedInputImage
+          : undefined
+        if (restoredCitizenImageLooksLikeAi(formData.citizenImage, crop)) {
           markAiPortraitReady()
         }
       }

--- a/ui/lib/image-generator/citizenOnboardingImage.ts
+++ b/ui/lib/image-generator/citizenOnboardingImage.ts
@@ -36,6 +36,27 @@ export function hasAiPortraitImage(
 }
 
 /**
+ * Comfy downloads are named `image_<jobId>.png`. Storage restore re-encodes
+ * that file as `image_<jobId>.jpg`. Fitted / cropped fallbacks keep the user's
+ * original filename, so this is a reliable discriminator even when the
+ * sessionStorage "AI ready" flag was lost (quota) or never written.
+ */
+export function isGeneratedAiPortraitFile(file?: File | null): boolean {
+  return !!file?.name && /^image_[A-Za-z0-9_-]+\.(png|jpe?g)$/i.test(file.name)
+}
+
+export function isUsableAiPortrait(
+  citizenImage: File | undefined,
+  croppedInputImage: File | undefined,
+  aiPortraitReady: boolean
+): boolean {
+  if (!hasAiPortraitImage(citizenImage, croppedInputImage) || !citizenImage) {
+    return false
+  }
+  return aiPortraitReady || isGeneratedAiPortraitFile(citizenImage)
+}
+
+/**
  * Image used to (re)start comfy.icu — must be the face crop, never the full upload.
  */
 export function getGenerationSourceImage(
@@ -108,7 +129,7 @@ export function getReviewPreviewFile({
   hasPendingImageJob,
   aiPortraitReady,
 }: ReviewPreviewInput): File | null {
-  const hasAi = hasAiPortraitImage(citizenImage, croppedInputImage) && aiPortraitReady
+  const hasAi = isUsableAiPortrait(citizenImage, croppedInputImage, aiPortraitReady)
 
   if (hasAi && citizenImage) {
     return citizenImage

--- a/ui/lib/image-generator/citizenOnboardingImage.ts
+++ b/ui/lib/image-generator/citizenOnboardingImage.ts
@@ -37,12 +37,27 @@ export function hasAiPortraitImage(
 
 /**
  * Comfy downloads are named `image_<jobId>.png`. Storage restore re-encodes
- * that file as `image_<jobId>.jpg`. Fitted / cropped fallbacks keep the user's
- * original filename, so this is a reliable discriminator even when the
- * sessionStorage "AI ready" flag was lost (quota) or never written.
+ * that file as `image_<jobId>.jpg`. Job ids are 21-char nanoids
+ * (`VE52rnl_BVdbgou9tQbEF`, `3AIdyeK1zmdW9NaWw-46u`) — not `image_1234.jpg`.
+ * Crop / fitImage keep the upload filename, so a short `image_*` name is a
+ * user photo, not a finished portrait.
  */
+const COMFY_PORTRAIT_FILENAME_RE = /^image_[A-Za-z0-9_-]{21}\.(png|jpe?g)$/i
+
 export function isGeneratedAiPortraitFile(file?: File | null): boolean {
-  return !!file?.name && /^image_[A-Za-z0-9_-]+\.(png|jpe?g)$/i.test(file.name)
+  return !!file?.name && COMFY_PORTRAIT_FILENAME_RE.test(file.name)
+}
+
+/** Restore-time check: Comfy filename, and not the same payload as the crop. */
+export function restoredCitizenImageLooksLikeAi(
+  citizen: { name: string; data: string },
+  cropped?: { name: string; data: string } | null
+): boolean {
+  if (!COMFY_PORTRAIT_FILENAME_RE.test(citizen.name)) return false
+  if (cropped && cropped.name === citizen.name && cropped.data === citizen.data) {
+    return false
+  }
+  return true
 }
 
 export function isUsableAiPortrait(
@@ -53,7 +68,10 @@ export function isUsableAiPortrait(
   if (!hasAiPortraitImage(citizenImage, croppedInputImage) || !citizenImage) {
     return false
   }
-  return aiPortraitReady || isGeneratedAiPortraitFile(citizenImage)
+  if (aiPortraitReady) return true
+  if (!isGeneratedAiPortraitFile(citizenImage)) return false
+  // Same name as the crop means this is the upload / fitted fallback, not Comfy.
+  return !croppedInputImage || citizenImage.name !== croppedInputImage.name
 }
 
 /**

--- a/ui/lib/image-generator/pollComfyImageJob.ts
+++ b/ui/lib/image-generator/pollComfyImageJob.ts
@@ -51,16 +51,32 @@ async function deleteFromGoogleStorage(filename: string) {
   }
 }
 
+export function comfyJobStatusUrl(generateApiRoute: string, jobId: string): string {
+  const separator = generateApiRoute.includes('?') ? '&' : '?'
+  return `${generateApiRoute}${separator}id=${encodeURIComponent(jobId)}`
+}
+
+/** Normalize a single-run or legacy list response into the matching job. */
+export function parseComfyJobStatus(payload: unknown, jobId: string): any | undefined {
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    const job = payload as { id?: string }
+    if (job.id && job.id !== jobId) {
+      throw new Error('Job status response did not match the requested job')
+    }
+    return payload
+  }
+  if (Array.isArray(payload)) {
+    return payload.find((j: any) => j?.id === jobId)
+  }
+  throw new Error('Unexpected job status response shape')
+}
+
 async function fetchJob(generateApiRoute: string, jobId: string): Promise<any> {
-  const res = await fetchWithTimeout(generateApiRoute, {}, 20_000)
+  const res = await fetchWithTimeout(comfyJobStatusUrl(generateApiRoute, jobId), {}, 20_000)
   if (!res.ok) {
     throw new Error(`Job status request failed (${res.status})`)
   }
-  const jobs = await res.json()
-  if (!Array.isArray(jobs)) {
-    throw new Error('Unexpected job status response shape')
-  }
-  return jobs.find((j: any) => j?.id === jobId)
+  return parseComfyJobStatus(await res.json(), jobId)
 }
 
 export type PollComfyJobCallbacks = {

--- a/ui/pages/api/image-gen/citizen-image.ts
+++ b/ui/pages/api/image-gen/citizen-image.ts
@@ -2,8 +2,11 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { v4 } from 'uuid'
 import { enforceRegionNotRestricted } from '@/lib/geo'
 
-const COMFY_WORKFLOW_URL =
-  'https://comfy.icu/api/v1/workflows/8BYQ3mpiFVlTjWOatIUAc/runs'
+const COMFY_WORKFLOW_ID = '8BYQ3mpiFVlTjWOatIUAc'
+const COMFY_WORKFLOW_URL = `https://comfy.icu/api/v1/workflows/${COMFY_WORKFLOW_ID}/runs`
+
+// Comfy.icu run ids look like `VE52rnl_BVdbgou9tQbEF` / `3AIdyeK1zmdW9NaWw-46u`.
+const COMFY_RUN_ID_RE = /^[A-Za-z0-9_-]{8,64}$/
 
 // Comfy.icu's API can occasionally take a while to accept a job, so give it
 // plenty of time before we abort the request.
@@ -19,22 +22,23 @@ const JUGGERNAUT_CHECKPOINT_URL =
   'https://huggingface.co/RunDiffusion/Juggernaut-XL-Lightning/resolve/main/Juggernaut_RunDiffusionPhoto2_Lightning_4Steps.safetensors?download=true'
 
 async function fetchComfy(
-  init: RequestInit & { method: 'POST' | 'GET' }
+  init: RequestInit & { method: 'POST' | 'GET'; url?: string }
 ): Promise<Response> {
+  const { url, ...requestInit } = init
   const controller = new AbortController()
   const timeoutId = setTimeout(
     () => controller.abort(),
     COMFY_REQUEST_TIMEOUT_MS
   )
   try {
-    return await fetch(COMFY_WORKFLOW_URL, {
-      ...init,
+    return await fetch(url || COMFY_WORKFLOW_URL, {
+      ...requestInit,
       signal: controller.signal,
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
         authorization: `Bearer ${process.env.COMFYICU_API_KEY}`,
-        ...(init.headers || {}),
+        ...(requestInit.headers || {}),
       },
     })
   } finally {
@@ -178,25 +182,36 @@ export default async function handler(
         .json({ error: 'Failed to create comfy.icu job' })
     }
   } else if (req.method === 'GET') {
+    // Poll one run. The collection endpoint is capped at ~300 rows and is the
+    // wrong API for status checks — official docs are GET /runs/:id.
+    const runId = typeof req.query.id === 'string' ? req.query.id : ''
+    if (!COMFY_RUN_ID_RE.test(runId)) {
+      return res.status(400).json({ error: 'Missing or invalid job id' })
+    }
+
     try {
-      const comfyRes = await fetchComfy({ method: 'GET' })
+      res.setHeader('Cache-Control', 'no-store')
+      const comfyRes = await fetchComfy({
+        method: 'GET',
+        url: `${COMFY_WORKFLOW_URL}/${encodeURIComponent(runId)}`,
+      })
       if (!comfyRes.ok) {
         const body = await comfyRes.text().catch(() => '')
         console.error(
-          `Comfy.icu list runs failed: ${comfyRes.status} ${body}`
+          `Comfy.icu get run failed: ${comfyRes.status} ${body}`
         )
         return res
           .status(comfyRes.status >= 500 ? 502 : comfyRes.status)
-          .json({ error: 'Failed to fetch comfy.icu jobs' })
+          .json({ error: 'Failed to fetch comfy.icu job' })
       }
-      const jobs = await comfyRes.json()
-      return res.status(200).json(jobs)
+      const job = await comfyRes.json()
+      return res.status(200).json(job)
     } catch (err: any) {
       const isAbort = err?.name === 'AbortError'
-      console.error('Comfy.icu list runs error:', err)
+      console.error('Comfy.icu get run error:', err)
       return res
         .status(isAbort ? 504 : 502)
-        .json({ error: 'Failed to fetch comfy.icu jobs' })
+        .json({ error: 'Failed to fetch comfy.icu job' })
     }
   } else {
     return res.status(405).json({ error: 'Method not allowed' })

--- a/ui/scripts/citizen-onboarding-image.test.ts
+++ b/ui/scripts/citizen-onboarding-image.test.ts
@@ -6,10 +6,7 @@ import {
   isGeneratedAiPortraitFile,
   isUsableAiPortrait,
 } from '../lib/image-generator/citizenOnboardingImage'
-import {
-  comfyJobStatusUrl,
-  parseComfyJobStatus,
-} from '../lib/image-generator/pollComfyImageJob'
+import { comfyJobStatusUrl, parseComfyJobStatus } from '../lib/image-generator/pollComfyImageJob'
 
 function mockFile(name: string): File {
   return new File(['x'], name, { type: 'image/png' })
@@ -129,7 +126,7 @@ describe('citizenOnboardingImage', () => {
         hasSourceImage: true,
       }),
       'restart-generation',
-      'uploading + source restarts',
+      'uploading + source restarts'
     )
     expectEqual(
       decideImageResumeAction({
@@ -139,7 +136,7 @@ describe('citizenOnboardingImage', () => {
         hasSourceImage: false,
       }),
       'none',
-      'uploading without source cannot restart',
+      'uploading without source cannot restart'
     )
   })
 
@@ -169,7 +166,7 @@ describe('citizenOnboardingImage', () => {
         hasSourceImage: true,
       }),
       'none',
-      'stale uploading job ignored (no jobId to recover)',
+      'stale uploading job ignored (no jobId to recover)'
     )
     expectEqual(
       decideImageResumeAction({
@@ -179,7 +176,7 @@ describe('citizenOnboardingImage', () => {
         hasSourceImage: true,
       }),
       'none',
-      'already have AI portrait',
+      'already have AI portrait'
     )
     expectEqual(
       decideImageResumeAction({
@@ -189,7 +186,7 @@ describe('citizenOnboardingImage', () => {
         hasSourceImage: true,
       }),
       'none',
-      'no job',
+      'no job'
     )
   })
 
@@ -213,7 +210,10 @@ describe('citizenOnboardingImage', () => {
     const crop = mockFile('face-crop.jpg')
     const ai = mockFile('image_VE52rnl_BVdbgou9tQbEF.png')
     expectTruthy(isGeneratedAiPortraitFile(ai), 'png job filename')
-    expectTruthy(isGeneratedAiPortraitFile(mockFile('image_VE52rnl_BVdbgou9tQbEF.jpg')), 'restored jpeg')
+    expectTruthy(
+      isGeneratedAiPortraitFile(mockFile('image_VE52rnl_BVdbgou9tQbEF.jpg')),
+      'restored jpeg'
+    )
     expectFalsy(isGeneratedAiPortraitFile(crop), 'user crop filename')
     expectTruthy(isUsableAiPortrait(ai, crop, false), 'usable without session flag')
 
@@ -238,14 +238,14 @@ describe('citizenOnboardingImage', () => {
     expectEqual(
       comfyJobStatusUrl('/api/image-gen/citizen-image', 'VE52rnl_BVdbgou9tQbEF'),
       '/api/image-gen/citizen-image?id=VE52rnl_BVdbgou9tQbEF',
-      'status url',
+      'status url'
     )
     const job = { id: 'VE52rnl_BVdbgou9tQbEF', status: 'COMPLETED' }
     expectEqual(parseComfyJobStatus(job, 'VE52rnl_BVdbgou9tQbEF'), job, 'single-run payload')
     expectEqual(
       parseComfyJobStatus([job, { id: 'other' }], 'VE52rnl_BVdbgou9tQbEF'),
       job,
-      'legacy list payload',
+      'legacy list payload'
     )
     try {
       parseComfyJobStatus({ id: 'other' }, 'VE52rnl_BVdbgou9tQbEF')

--- a/ui/scripts/citizen-onboarding-image.test.ts
+++ b/ui/scripts/citizen-onboarding-image.test.ts
@@ -5,6 +5,7 @@ import {
   hasAiPortraitImage,
   isGeneratedAiPortraitFile,
   isUsableAiPortrait,
+  restoredCitizenImageLooksLikeAi,
 } from '../lib/image-generator/citizenOnboardingImage'
 import { comfyJobStatusUrl, parseComfyJobStatus } from '../lib/image-generator/pollComfyImageJob'
 
@@ -215,7 +216,19 @@ describe('citizenOnboardingImage', () => {
       'restored jpeg'
     )
     expectFalsy(isGeneratedAiPortraitFile(crop), 'user crop filename')
+    expectFalsy(
+      isGeneratedAiPortraitFile(mockFile('image_1234.jpg')),
+      'common camera/upload name is not a Comfy job id'
+    )
+    expectFalsy(
+      isGeneratedAiPortraitFile(mockFile('image_20240115.png')),
+      'date-stamped upload is not a Comfy job id'
+    )
     expectTruthy(isUsableAiPortrait(ai, crop, false), 'usable without session flag')
+    expectFalsy(
+      isUsableAiPortrait(mockFile('image_1234.jpg'), mockFile('image_1234.jpg'), false),
+      'same-name user upload is not usable AI'
+    )
 
     const preview = getReviewPreviewFile({
       citizenImage: ai,
@@ -225,6 +238,31 @@ describe('citizenOnboardingImage', () => {
       aiPortraitReady: false,
     })
     expectEqual(preview, ai, 'AI file wins without session flag')
+  })
+
+  it('restore does not treat image_* user photos as AI via filename or dataURL', () => {
+    const userPhoto = {
+      name: 'image_1234.jpg',
+      data: 'data:image/jpeg;base64,AAA',
+    }
+    const crop = { name: 'image_1234.jpg', data: 'data:image/jpeg;base64,AAA' }
+    expectFalsy(restoredCitizenImageLooksLikeAi(userPhoto, crop), 'same-name user upload is not AI')
+    expectFalsy(
+      restoredCitizenImageLooksLikeAi(userPhoto, undefined),
+      'user image_* name alone is not AI'
+    )
+    const ai = {
+      name: 'image_VE52rnl_BVdbgou9tQbEF.jpg',
+      data: 'data:image/jpeg;base64,BBB',
+    }
+    expectTruthy(
+      restoredCitizenImageLooksLikeAi(ai, crop),
+      'Comfy filename with different bytes is AI'
+    )
+    expectTruthy(
+      restoredCitizenImageLooksLikeAi(ai, undefined),
+      'Comfy filename without crop is AI'
+    )
   })
 
   it('does not treat a fitted fallback as AI just because it is a different File', () => {

--- a/ui/scripts/citizen-onboarding-image.test.ts
+++ b/ui/scripts/citizen-onboarding-image.test.ts
@@ -3,7 +3,13 @@ import {
   getGenerationSourceImage,
   getReviewPreviewFile,
   hasAiPortraitImage,
+  isGeneratedAiPortraitFile,
+  isUsableAiPortrait,
 } from '../lib/image-generator/citizenOnboardingImage'
+import {
+  comfyJobStatusUrl,
+  parseComfyJobStatus,
+} from '../lib/image-generator/pollComfyImageJob'
 
 function mockFile(name: string): File {
   return new File(['x'], name, { type: 'image/png' })
@@ -203,6 +209,54 @@ describe('citizenOnboardingImage', () => {
 
   // Regression: after Privy return, cache often had full input + stale fitted citizenImage
   // but not aiPortraitReady — old UI showed the full upload on Review.
+  it('treats comfy download filenames as AI even when the session flag is missing', () => {
+    const crop = mockFile('face-crop.jpg')
+    const ai = mockFile('image_VE52rnl_BVdbgou9tQbEF.png')
+    expectTruthy(isGeneratedAiPortraitFile(ai), 'png job filename')
+    expectTruthy(isGeneratedAiPortraitFile(mockFile('image_VE52rnl_BVdbgou9tQbEF.jpg')), 'restored jpeg')
+    expectFalsy(isGeneratedAiPortraitFile(crop), 'user crop filename')
+    expectTruthy(isUsableAiPortrait(ai, crop, false), 'usable without session flag')
+
+    const preview = getReviewPreviewFile({
+      citizenImage: ai,
+      croppedInputImage: crop,
+      isImageGenerating: false,
+      hasPendingImageJob: false,
+      aiPortraitReady: false,
+    })
+    expectEqual(preview, ai, 'AI file wins without session flag')
+  })
+
+  it('does not treat a fitted fallback as AI just because it is a different File', () => {
+    const crop = mockFile('face-crop.jpg')
+    const fitted = mockFile('face-crop.jpg')
+    expectFalsy(isGeneratedAiPortraitFile(fitted), 'fallback keeps user filename')
+    expectFalsy(isUsableAiPortrait(fitted, crop, false), 'fallback is not AI without flag')
+  })
+
+  it('polls a single comfy run by id instead of listing every job', () => {
+    expectEqual(
+      comfyJobStatusUrl('/api/image-gen/citizen-image', 'VE52rnl_BVdbgou9tQbEF'),
+      '/api/image-gen/citizen-image?id=VE52rnl_BVdbgou9tQbEF',
+      'status url',
+    )
+    const job = { id: 'VE52rnl_BVdbgou9tQbEF', status: 'COMPLETED' }
+    expectEqual(parseComfyJobStatus(job, 'VE52rnl_BVdbgou9tQbEF'), job, 'single-run payload')
+    expectEqual(
+      parseComfyJobStatus([job, { id: 'other' }], 'VE52rnl_BVdbgou9tQbEF'),
+      job,
+      'legacy list payload',
+    )
+    try {
+      parseComfyJobStatus({ id: 'other' }, 'VE52rnl_BVdbgou9tQbEF')
+      throw new Error('expected mismatched id to throw')
+    } catch (err: any) {
+      if (!String(err?.message).includes('did not match')) {
+        throw err
+      }
+    }
+  })
+
   it('Privy-return regression: stale full-size citizenImage must not win over crop', () => {
     const full = mockFile('vacation-full.jpg')
     const crop = mockFile('face-crop.jpg')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The citizen image generator is completing on comfy.icu, but people are still minting with their raw uploaded photo.

I confirmed this against live data:
- Production `GET /api/image-gen/citizen-image` returns exactly **300** runs (the list cap), almost all `COMPLETED`, including jobs from Aug 22–24.
- Recent citizens (#239–#243) minted with regular photos, not the MoonDAO astronaut portrait — the same class of bug as #1535 (citizens #228–#240).

**Root causes**
1. Status polling listed every workflow run instead of fetching `GET /workflows/{id}/runs/{run_id}` (the official ComfyICU API). A capped/stale list means the client never sees the job it just created, times out, and falls back to the crop.
2. Review + mint treated a portrait as AI only when a sessionStorage flag was set. If that write failed (quota) or the memo didn’t refresh, a completed `image_<jobId>.png` was ignored and the cropped upload was minted instead.

**Fix**
- Poll a single run by id; stop exposing the public 300-job list (that also leaked other users’ output URLs).
- Treat `image_<jobId>.png` / restored `image_<jobId>.jpg` as the AI portrait even without the session flag.
- When restoring cached images, don’t mark a cropped fallback as AI just because two `File` objects aren’t the same reference.

## Test plan
- [x] Unit tests for filename detection, review preview without the session flag, and single-run status parsing (`yarn test:onboarding-image` — 16 passing).
- [ ] After deploy: start a citizen AI generation, confirm Review shows the astronaut portrait (not the crop), and that mint uses that file.
- [ ] Resume after Privy / onramp: completed job should still be applied.
- [ ] `GET /api/image-gen/citizen-image` without `id` should 400; with a real job id should return that run.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30bfde96-374c-4dca-8bb0-2542a732500a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30bfde96-374c-4dca-8bb0-2542a732500a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

