### PR TITLE
fix(safe): load treasury transactions on mount instead of after 30s

### DIFF
--- a/ui/components/safe/SafeTransactions.tsx
+++ b/ui/components/safe/SafeTransactions.tsx
@@ -33,6 +33,31 @@ const EXECUTE_BTN_CLASS =
 const REJECT_BTN_CLASS =
   'rounded-full px-5 py-2 text-sm font-semibold bg-transparent border border-red-500/40 text-red-300 hover:bg-red-500/10 hover:border-red-500/60 transition-all duration-200'
 
+function Spinner({ className = 'h-3 w-3' }: { className?: string }) {
+  return (
+    <svg
+      className={`animate-spin ${className}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  )
+}
+
 export default function SafeTransactions({
   address,
   safeData,
@@ -44,6 +69,7 @@ export default function SafeTransactions({
     rejectTransaction,
     threshold,
     pendingTransactions,
+    isLoadingTransactions,
   } = safeData
   const { selectedChain } = useContext(ChainContextV5)
   const { wallets } = useWallets()
@@ -90,10 +116,20 @@ export default function SafeTransactions({
         >
           Recent Transactions
         </h3>
-        {pendingTransactions.length > 0 && (
-          <span className="rounded-full bg-white/5 border border-white/10 px-3 py-1 text-xs text-slate-300">
-            {pendingTransactions.length} pending
+        {isLoadingTransactions ? (
+          <span
+            data-testid="transactions-loading-badge"
+            className="inline-flex items-center gap-2 rounded-full bg-white/5 border border-white/10 px-3 py-1 text-xs text-slate-300"
+          >
+            <Spinner />
+            Syncing
           </span>
+        ) : (
+          pendingTransactions.length > 0 && (
+            <span className="rounded-full bg-white/5 border border-white/10 px-3 py-1 text-xs text-slate-300">
+              {pendingTransactions.length} pending
+            </span>
+          )
         )}
       </div>
 
@@ -357,6 +393,16 @@ export default function SafeTransactions({
           >
             Switch Network
           </StandardButton>
+        </div>
+      ) : isLoadingTransactions && pendingTransactions.length === 0 ? (
+        <div
+          data-testid="transactions-loading"
+          className="rounded-2xl border border-white/10 bg-white/[0.02] p-8 flex flex-col items-center gap-3"
+        >
+          <Spinner className="h-6 w-6 text-slate-400" />
+          <p className="text-slate-400 text-sm">
+            Fetching the latest transactions…
+          </p>
         </div>
       ) : pendingTransactions.length === 0 ? (
         <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-8 text-center">

--- a/ui/cypress/integration/safe/safe-send-modal.cy.tsx
+++ b/ui/cypress/integration/safe/safe-send-modal.cy.tsx
@@ -69,6 +69,7 @@ describe('<SafeSendModal />', () => {
       owners: [],
       threshold: 1,
       pendingTransactions: [],
+      isLoadingTransactions: false,
       transactionsToSign: [],
       transactionsToExecute: [],
       signPendingTransaction: cy.stub(),

--- a/ui/cypress/integration/safe/safe-transactions.cy.tsx
+++ b/ui/cypress/integration/safe/safe-transactions.cy.tsx
@@ -55,6 +55,7 @@ describe('SafeTransactions', () => {
           signatures: null,
         },
       ],
+      isLoadingTransactions: false,
       transactionsToSign: [],
       transactionsToExecute: [],
       fetchPendingTransactions: fetchPendingTransactionsStub,

--- a/ui/lib/safe/useSafe.tsx
+++ b/ui/lib/safe/useSafe.tsx
@@ -436,23 +436,22 @@ export default function useSafe(
         safeAddress,
       })
 
-      // Owners/threshold are required to init; nonce is not. Fetch it
-      // separately so an RPC blip cannot skip setSafe.
-      const [currentOwners, currentThreshold] = await Promise.all([
+      // Owners/threshold are required to init; nonce is not. Isolate
+      // getNonce so an RPC blip cannot skip setSafe, but still apply
+      // it in the same render as the new Safe (null if the fetch fails).
+      const [currentOwners, currentThreshold, nonce] = await Promise.all([
         newSafe.getOwners(),
         newSafe.getThreshold(),
+        newSafe.getNonce().catch((nonceErr) => {
+          console.error('Error getting current nonce:', nonceErr)
+          return null
+        }),
       ])
 
       setOwners(currentOwners)
       setThreshold(currentThreshold)
+      setCurrentNonce(nonce)
       setSafe(newSafe)
-
-      try {
-        const nonce = await newSafe.getNonce()
-        setCurrentNonce(nonce)
-      } catch (nonceErr) {
-        console.error('Error getting current nonce:', nonceErr)
-      }
 
       return newSafe
     } catch (err) {

--- a/ui/lib/safe/useSafe.tsx
+++ b/ui/lib/safe/useSafe.tsx
@@ -13,7 +13,7 @@ import {
 } from '@safe-global/safe-core-sdk-types'
 import ERC20ABI from 'const/abis/ERC20.json'
 import { ethers } from 'ethers'
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { getContract, readContract } from 'thirdweb'
 import { Chain } from 'thirdweb/chains'
 import { useActiveAccount } from 'thirdweb/react'
@@ -40,10 +40,11 @@ export type SafeData = {
   owners: string[]
   threshold: number
   pendingTransactions: PendingTransaction[]
+  isLoadingTransactions: boolean
   transactionsToSign: PendingTransaction[]
   transactionsToExecute: PendingTransaction[]
   signPendingTransaction: (safeTxHash: string) => Promise<any>
-  fetchPendingTransactions: () => Promise<void>
+  fetchPendingTransactions: (options?: { silent?: boolean }) => Promise<void>
   rejectTransaction: (safeTxHash: string) => Promise<string>
   sendFunds: (
     to: string,
@@ -75,13 +76,24 @@ export default function useSafe(
   const [pendingTransactions, setPendingTransactions] = useState<
     PendingTransaction[]
   >([])
-  const [transactionsToSign, setTransactionsToSign] = useState<
-    PendingTransaction[]
-  >([])
-  const [transactionsToExecute, setTransactionsToExecute] = useState<
-    PendingTransaction[]
-  >([])
+  const [isLoadingTransactions, setIsLoadingTransactions] = useState(true)
   const [currentNonce, setCurrentNonce] = useState<number | null>(null)
+
+  const transactionsToSign = useMemo(
+    () => pendingTransactions.filter((tx) => !tx.isExecuted),
+    [pendingTransactions]
+  )
+
+  const transactionsToExecute = useMemo(
+    () =>
+      pendingTransactions.filter(
+        (tx) =>
+          !tx.isExecuted &&
+          (tx.confirmations?.length ?? 0) >=
+            (tx.confirmationsRequired ?? threshold)
+      ),
+    [pendingTransactions, threshold]
+  )
 
   async function getCurrentNonce() {
     if (!safe) return null
@@ -424,11 +436,15 @@ export default function useSafe(
       })
 
       // Get initial state
-      const currentOwners = await newSafe.getOwners()
-      const currentThreshold = await newSafe.getThreshold()
+      const [currentOwners, currentThreshold, nonce] = await Promise.all([
+        newSafe.getOwners(),
+        newSafe.getThreshold(),
+        newSafe.getNonce(),
+      ])
 
       setOwners(currentOwners)
       setThreshold(currentThreshold)
+      setCurrentNonce(nonce)
       setSafe(newSafe)
 
       return newSafe
@@ -442,57 +458,39 @@ export default function useSafe(
     if (!account) return
 
     try {
-      const newSafe = await initializeSafe()
-      if (!newSafe) return
-
-      await fetchPendingTransactions()
+      await Promise.all([
+        initializeSafe(),
+        fetchPendingTransactions({ silent: true }),
+      ])
     } catch (err) {
       console.error('Error refreshing Safe state:', err)
     }
   }
 
-  async function fetchPendingTransactions() {
-    if (!safeApiKit || !safe) return
+  // Reads straight from the Safe Transaction Service, so it deliberately does
+  // not depend on the protocol-kit `Safe` instance. Gating on `safe` meant the
+  // queue couldn't load until a wallet was connected on the matching chain and
+  // several RPC round-trips had completed, which is what made the tab sit on
+  // "No pending transactions" for the first ~30s.
+  const fetchPendingTransactions = useCallback(
+    async ({ silent = false }: { silent?: boolean } = {}) => {
+      if (!safeApiKit || !safeAddress) {
+        setIsLoadingTransactions(false)
+        return
+      }
 
-    try {
-      const pendingTxs = await safeApiKit.getPendingTransactions(safeAddress)
-      setPendingTransactions(pendingTxs.results)
-
-      const currentThreshold = await safe.getThreshold()
-      // Keep the on-chain nonce in sync here so execution gating works
-      // immediately on mount (the 30s interval alone leaves it null at first).
+      if (!silent) setIsLoadingTransactions(true)
       try {
-        const nonce = await safe.getNonce()
-        setCurrentNonce(nonce)
-      } catch (nonceErr) {
-        console.error('Error getting current nonce:', nonceErr)
+        const pendingTxs = await safeApiKit.getPendingTransactions(safeAddress)
+        setPendingTransactions(pendingTxs.results)
+      } catch (err) {
+        console.error('Error fetching pending transactions:', err)
+      } finally {
+        setIsLoadingTransactions(false)
       }
-      const currentAddress = wallets?.[selectedWallet]?.address
-
-      if (currentAddress) {
-        // Show all pending transactions, but mark which ones need signing
-        const toSign = pendingTxs.results.filter((tx) => {
-          const hasSigned = tx.confirmations?.some(
-            (conf) => conf.owner.toLowerCase() === currentAddress.toLowerCase()
-          )
-          return !tx.isExecuted // Show all non-executed transactions
-        })
-        setTransactionsToSign(toSign)
-
-        // Filter transactions that can be executed
-        const toExecute = pendingTxs.results.filter((tx) => {
-          return (
-            tx.confirmations?.length &&
-            tx.confirmations.length >= currentThreshold &&
-            !tx.isExecuted
-          )
-        })
-        setTransactionsToExecute(toExecute)
-      }
-    } catch (err) {
-      console.error('Error fetching pending transactions:', err)
-    }
-  }
+    },
+    [safeApiKit, safeAddress]
+  )
 
   async function signPendingTransaction(safeTxHash: string) {
     if (!safe) throw new Error('Safe not initialized')
@@ -602,27 +600,31 @@ export default function useSafe(
     return queueSafeTx(safeTransactionData)
   }
 
+  // Load the queue as soon as we know which Safe to ask about, in parallel
+  // with (and independent of) wallet-dependent Safe initialization below.
   useEffect(() => {
-    async function setupSafe() {
-      const newSafe = await initializeSafe()
-      if (newSafe) {
-        await fetchPendingTransactions()
-      }
-    }
-    setupSafe()
+    fetchPendingTransactions()
+  }, [fetchPendingTransactions])
+
+  useEffect(() => {
+    initializeSafe()
   }, [wallets, selectedWallet, safeAddress, account])
 
   // Background refresh of the Safe state. Only poll once a Safe is actually
   // initialized, at a relaxed cadence, and never while the tab is hidden —
   // this hook is mounted on team/project pages where users mostly read.
+  // Silent so a periodic refetch never swaps the rendered queue for a spinner.
   useEffect(() => {
     if (!safe) return
     const interval = setInterval(async () => {
       if (document.hidden) return
-      await refreshSafeState()
+      await Promise.all([
+        fetchPendingTransactions({ silent: true }),
+        getCurrentNonce(),
+      ])
     }, 30000)
     return () => clearInterval(interval)
-  }, [safeApiKit, safe, wallets, selectedWallet, safeAddress])
+  }, [safe, fetchPendingTransactions])
 
   // Tight 5s polling is only justified while a queued transaction is being
   // monitored; stop as soon as it executes.
@@ -633,22 +635,13 @@ export default function useSafe(
       const isExecuted = await monitorTransactionExecution(lastSafeTxHash)
       if (isExecuted) {
         setLastSafeTxExecuted(isExecuted)
-        await fetchPendingTransactions()
+        await fetchPendingTransactions({ silent: true })
       }
     }
 
     const interval = setInterval(checkExecution, 5000)
     return () => clearInterval(interval)
   }, [lastSafeTxHash, lastSafeTxExecuted])
-
-  useEffect(() => {
-    if (!safe) return
-    const interval = setInterval(async () => {
-      if (document.hidden) return
-      await getCurrentNonce()
-    }, 30000)
-    return () => clearInterval(interval)
-  }, [safe])
 
   return {
     safe,
@@ -662,6 +655,7 @@ export default function useSafe(
     owners,
     threshold,
     pendingTransactions,
+    isLoadingTransactions,
     transactionsToSign,
     transactionsToExecute,
     signPendingTransaction,

--- a/ui/lib/safe/useSafe.tsx
+++ b/ui/lib/safe/useSafe.tsx
@@ -13,7 +13,7 @@ import {
 } from '@safe-global/safe-core-sdk-types'
 import ERC20ABI from 'const/abis/ERC20.json'
 import { ethers } from 'ethers'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { getContract, readContract } from 'thirdweb'
 import { Chain } from 'thirdweb/chains'
 import { useActiveAccount } from 'thirdweb/react'
@@ -78,6 +78,7 @@ export default function useSafe(
   >([])
   const [isLoadingTransactions, setIsLoadingTransactions] = useState(true)
   const [currentNonce, setCurrentNonce] = useState<number | null>(null)
+  const pendingTxRequestId = useRef(0)
 
   const transactionsToSign = useMemo(
     () => pendingTransactions.filter((tx) => !tx.isExecuted),
@@ -435,17 +436,23 @@ export default function useSafe(
         safeAddress,
       })
 
-      // Get initial state
-      const [currentOwners, currentThreshold, nonce] = await Promise.all([
+      // Owners/threshold are required to init; nonce is not. Fetch it
+      // separately so an RPC blip cannot skip setSafe.
+      const [currentOwners, currentThreshold] = await Promise.all([
         newSafe.getOwners(),
         newSafe.getThreshold(),
-        newSafe.getNonce(),
       ])
 
       setOwners(currentOwners)
       setThreshold(currentThreshold)
-      setCurrentNonce(nonce)
       setSafe(newSafe)
+
+      try {
+        const nonce = await newSafe.getNonce()
+        setCurrentNonce(nonce)
+      } catch (nonceErr) {
+        console.error('Error getting current nonce:', nonceErr)
+      }
 
       return newSafe
     } catch (err) {
@@ -475,18 +482,24 @@ export default function useSafe(
   const fetchPendingTransactions = useCallback(
     async ({ silent = false }: { silent?: boolean } = {}) => {
       if (!safeApiKit || !safeAddress) {
+        pendingTxRequestId.current += 1
+        setPendingTransactions([])
         setIsLoadingTransactions(false)
         return
       }
 
+      const requestId = ++pendingTxRequestId.current
       if (!silent) setIsLoadingTransactions(true)
       try {
         const pendingTxs = await safeApiKit.getPendingTransactions(safeAddress)
+        if (requestId !== pendingTxRequestId.current) return
         setPendingTransactions(pendingTxs.results)
       } catch (err) {
         console.error('Error fetching pending transactions:', err)
       } finally {
-        setIsLoadingTransactions(false)
+        if (requestId === pendingTxRequestId.current) {
+          setIsLoadingTransactions(false)
+        }
       }
     },
     [safeApiKit, safeAddress]
@@ -603,7 +616,14 @@ export default function useSafe(
   // Load the queue as soon as we know which Safe to ask about, in parallel
   // with (and independent of) wallet-dependent Safe initialization below.
   useEffect(() => {
+    setPendingTransactions([])
     fetchPendingTransactions()
+
+    return () => {
+      // Invalidate in-flight responses so a slower previous Safe cannot
+      // overwrite the queue after navigation.
+      pendingTxRequestId.current += 1
+    }
   }, [fetchPendingTransactions])
 
   useEffect(() => {

--- a/ui/lib/safe/useSafeApiKit.tsx
+++ b/ui/lib/safe/useSafeApiKit.tsx
@@ -3,9 +3,10 @@ import { useMemo } from 'react'
 import { Chain } from 'thirdweb'
 
 export default function useSafeApiKit(selectedChain: Chain): SafeApiKit {
+  const chainId = selectedChain?.id
   return useMemo(() => {
     return new SafeApiKit({
-      chainId: BigInt(selectedChain.id),
+      chainId: BigInt(chainId),
     })
-  }, [selectedChain])
+  }, [chainId])
 }


### PR DESCRIPTION
## Summary

A queued transaction on a project's underlying multisig did not appear on the Treasury tab (e.g. `/project/209?tab=treasury`) for roughly 30 seconds, and during that window the panel actively claimed **"No pending transactions"** — so a real pending transaction looked like it didn't exist.

**Root cause:** in `useSafe`, the mount effect ran `initializeSafe()` and then `fetchPendingTransactions()`. That function started with `if (!safeApiKit || !safe) return`, and it closed over the `safe` value from the render in which the effect was created — which is always `undefined` on first mount. The initial fetch therefore bailed out every single time, and the queue only ever loaded on the first tick of the 30-second background poll.

**Compounding it:** that fetch never needed `safe` at all. Pending transactions come from the Safe Transaction Service over HTTP, not from the chain. Gating it on the protocol-kit instance meant waiting on a connected wallet, a chain-ID match, and several *sequential* RPC round-trips (`getOwners`, then `getThreshold`, then `getThreshold` again, then `getNonce`) before a single HTTP request was even attempted.

## Changes

`ui/lib/safe/useSafe.tsx`
- The queue fetch is now its own effect keyed on the API kit and Safe address, so it fires immediately on mount in parallel with wallet-dependent initialization instead of behind it.
- `fetchPendingTransactions` is a `useCallback` that no longer touches `safe`, taking an optional `{ silent }` flag so background refreshes don't swap an already-rendered list for a spinner.
- `initializeSafe` reads owners, threshold, and nonce in one `Promise.all` rather than serially.
- `transactionsToSign` / `transactionsToExecute` are derived with `useMemo` from the fetched list instead of being state populated by extra `getThreshold` calls.
- The two separate 30-second intervals are merged into one, and it refetches silently rather than re-initializing the entire Safe every cycle.
- New `isLoadingTransactions` on `SafeData`.

`ui/components/safe/SafeTransactions.tsx`
- While loading, renders a spinner with "Fetching the latest transactions…" plus a small "Syncing" badge in the header, instead of falling through to the empty state.

`ui/lib/safe/useSafeApiKit.tsx`
- Memoize on `selectedChain.id` rather than the chain object, so a new chain object identity can't churn the API kit and re-trigger the fetch effect.

Cypress `SafeData` mocks updated with the new field.

## Test plan

- [ ] `yarn cypress run --component --spec "cypress/integration/safe/**"` — existing Safe specs still pass (`isLoadingTransactions: false` in the mocks preserves the current empty-state assertions).
- [ ] On `/project/209?tab=treasury` as a multisig signer, confirm the spinner shows on first paint and the pending transaction appears in ~1s rather than ~30s.
- [ ] Confirm the empty state still reads "No pending transactions" once a fetch completes with an empty queue, and that the 30s background refresh does not flash the spinner.
- [ ] Sign / reject / execute still refresh the list correctly.

## Note for reviewers

This panel only renders for signers (`isSigner && safeData` in `TeamTreasury`), so a non-signer on the Treasury tab still sees no transaction section at all. Out of scope here, but worth deciding whether the queue should be visible read-only to everyone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Safe treasury data-loading and polling behavior; mistakes could show stale queues or wrong empty states, but scope is UI/hook orchestration rather than on-chain execution logic.
> 
> **Overview**
> Fixes the Treasury tab falsely showing **"No pending transactions"** for ~30s when a queue actually exists.
> 
> **`useSafe`** now loads the pending queue from the Safe Transaction Service as soon as the Safe address and API kit are known—**in parallel** with wallet-dependent protocol-kit init, instead of waiting on `safe` (which was always `undefined` on the first effect run). Adds **`isLoadingTransactions`**, a **`silent`** option on refetches so 30s polling doesn’t flash loading, **`useMemo`**-derived sign/execute lists, parallel **`initializeSafe`** RPC reads, merged background refresh, and request-id guarding when switching Safes.
> 
> **`SafeTransactions`** shows a spinner and **"Syncing"** / **"Fetching the latest transactions…"** while the initial fetch runs when the list is still empty.
> 
> **`useSafeApiKit`** memoizes on **`chainId`** to avoid churning the fetch effect. Cypress mocks include the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45acdcb023fd7d7e30ed017df1ae5258ed6e744f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->