### PR TITLE
Fix job pages dropping the full description

### DIFF
--- a/ui/components/jobs/Job.tsx
+++ b/ui/components/jobs/Job.tsx
@@ -24,7 +24,8 @@ export type Job = {
   endTime: number
   timestamp: number
   tag: string
-  metadata: string
+  /** JSON string or already-parsed object — Tableland returns TEXT JSON as either. */
+  metadata: string | Record<string, unknown>
   contactInfo: string
 }
 
@@ -213,8 +214,8 @@ export default function Job({
                 {daysSincePosting === 0
                   ? 'Posted today'
                   : daysSincePosting === 1
-                  ? '1 day ago'
-                  : `${daysSincePosting} days ago`}
+                    ? '1 day ago'
+                    : `${daysSincePosting} days ago`}
               </span>
               {countdown && !isExpired && (
                 <span className="ml-2 text-slate-400">· {countdown}</span>

--- a/ui/cypress/integration/unit/job-metadata.cy.ts
+++ b/ui/cypress/integration/unit/job-metadata.cy.ts
@@ -25,9 +25,20 @@ describe('parseJobMetadata', () => {
     expect(parseJobMetadata('"a string"')).to.deep.equal({ v: 0 })
   })
 
+  it('accepts an already-parsed object from Tableland', () => {
+    const parsed = parseJobMetadata({
+      v: 1,
+      cid: 'Qmb4SknAG3eNGxQmKbUiJ4RVSRA7qdWuW53nb4XTuNmpWd',
+      deadline: 1791342000,
+    })
+    expect(parsed.cid).to.equal('Qmb4SknAG3eNGxQmKbUiJ4RVSRA7qdWuW53nb4XTuNmpWd')
+    expect(parsed.deadline).to.equal(1791342000)
+    expect(parsed.v).to.equal(1)
+  })
+
   it('still reads the legacy { compensation, location } shape', () => {
     const parsed = parseJobMetadata(
-      JSON.stringify({ compensation: '$2,000 / month', location: 'Remote' })
+      JSON.stringify({ compensation: '$2,000 / month', location: 'Remote' }),
     )
     expect(parsed.compensation).to.equal('$2,000 / month')
     expect(parsed.location).to.equal('Remote')
@@ -53,7 +64,7 @@ describe('parseJobMetadata', () => {
 
   it('drops enum values it does not recognize', () => {
     const parsed = parseJobMetadata(
-      JSON.stringify({ v: 1, commitmentType: 'indentured', locationType: 'lunar' })
+      JSON.stringify({ v: 1, commitmentType: 'indentured', locationType: 'lunar' }),
     )
     expect(parsed.commitmentType).to.equal(undefined)
     expect(parsed.locationType).to.equal(undefined)
@@ -92,19 +103,19 @@ describe('serializeJobMetadata', () => {
 describe('formatters', () => {
   it('formats a compensation range', () => {
     expect(formatCompensation({ min: 3000, max: 4500, currency: 'USD', period: 'month' })).to.equal(
-      '$3,000–$4,500 / month'
+      '$3,000–$4,500 / month',
     )
   })
 
   it('formats a single compensation figure', () => {
     expect(formatCompensation({ min: 100, currency: 'USD', period: 'hour' })).to.equal(
-      '$100 / hour'
+      '$100 / hour',
     )
   })
 
   it('prefers an author-written display string', () => {
     expect(formatCompensation({ min: 1, max: 2, display: 'Bounty, negotiable' })).to.equal(
-      'Bounty, negotiable'
+      'Bounty, negotiable',
     )
   })
 
@@ -116,7 +127,7 @@ describe('formatters', () => {
   it('formats location and commitment summaries', () => {
     expect(formatLocation({ type: 'remote', region: 'Worldwide' })).to.equal('Remote · Worldwide')
     expect(formatCommitment({ type: 'part-time', hoursPerWeek: 10 })).to.equal(
-      'Part-time · ≤10 hrs/week'
+      'Part-time · ≤10 hrs/week',
     )
   })
 })
@@ -133,7 +144,7 @@ describe('buildJobMetadata', () => {
         applicationDeadline: 1800000000,
         skills: ['X growth'],
       },
-      'bafytestcid'
+      'bafytestcid',
     )
 
     expect(envelope).to.deep.equal({

--- a/ui/lib/jobs/jobMetadata.ts
+++ b/ui/lib/jobs/jobMetadata.ts
@@ -55,12 +55,7 @@ export type JobLocation = {
 }
 
 export type JobCommitmentType =
-  | 'full-time'
-  | 'part-time'
-  | 'contract'
-  | 'internship'
-  | 'bounty'
-  | 'volunteer'
+  'full-time' | 'part-time' | 'contract' | 'internship' | 'bounty' | 'volunteer'
 
 export type JobCommitment = {
   type?: JobCommitmentType
@@ -269,17 +264,26 @@ export function isPaidRole(compensation?: JobCompensation): boolean | undefined 
 }
 
 /**
- * Parse the on-chain `metadata` column. Accepts the v1 envelope, the legacy
- * `{ compensation, location }` object, and anything unrecognizable (which
- * degrades to "no metadata" rather than throwing on a job page).
+ * Parse the on-chain `metadata` column. Accepts a JSON string, an already-parsed
+ * object (Tableland's HTTP/SDK validators return TEXT JSON as an object — the
+ * same way citizen `location` comes back), the legacy `{ compensation, location }`
+ * shape, and anything unrecognizable (which degrades to "no metadata" rather
+ * than throwing on a job page).
  */
-export function parseJobMetadata(raw?: string | null): JobMetadataEnvelope {
-  if (!raw || typeof raw !== 'string' || raw.trim() === '') return EMPTY_JOB_METADATA
+export function parseJobMetadata(raw?: unknown): JobMetadataEnvelope {
+  if (raw == null || raw === '') return EMPTY_JOB_METADATA
 
   let parsed: any
-  try {
-    parsed = JSON.parse(raw)
-  } catch {
+  if (typeof raw === 'string') {
+    if (raw.trim() === '') return EMPTY_JOB_METADATA
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return EMPTY_JOB_METADATA
+    }
+  } else if (isPlainObject(raw)) {
+    parsed = raw
+  } else {
     return EMPTY_JOB_METADATA
   }
   if (!isPlainObject(parsed)) return EMPTY_JOB_METADATA
@@ -398,7 +402,7 @@ export function normalizeJobPostingDoc(raw: any): JobPostingDoc | null {
     ? raw.links
         .filter((link: any) => isPlainObject(link) && cleanString(link.url))
         .map((link: any) =>
-          compact({ label: cleanString(link.label) || link.url.trim(), url: link.url.trim() })
+          compact({ label: cleanString(link.label) || link.url.trim(), url: link.url.trim() }),
         )
     : undefined
 
@@ -440,7 +444,7 @@ export function getJobHref(job: { id: number | string }): string {
 /** The date applications close: an explicit deadline, else the listing's expiry. */
 export function getApplicationDeadline(
   envelope: JobMetadataEnvelope,
-  endTime?: number
+  endTime?: number,
 ): number | undefined {
   if (envelope.deadline) return envelope.deadline
   return endTime && endTime > 0 ? endTime : undefined
@@ -462,7 +466,7 @@ export function daysUntil(timestamp?: number, now = Math.floor(Date.now() / 1000
 
 export function formatDeadlineCountdown(
   timestamp?: number,
-  now = Math.floor(Date.now() / 1000)
+  now = Math.floor(Date.now() / 1000),
 ): string | null {
   const days = daysUntil(timestamp, now)
   if (days === null) return null

--- a/ui/pages/jobs/[id].tsx
+++ b/ui/pages/jobs/[id].tsx
@@ -66,7 +66,21 @@ export default function JobDetail({
   useChainDefault()
 
   const isGated = !JOB_DETAIL_PUBLIC && !citizen
-  const posting = isGated ? null : doc
+  const [clientDoc, setClientDoc] = useState<JobPostingDoc | null>(null)
+  const posting = isGated ? null : doc || clientDoc
+
+  // ISR can ship without the IPFS body (slow gateway). Retry in the browser
+  // whenever the on-chain envelope has a CID but the server did not load it.
+  useEffect(() => {
+    if (doc || !metadata.cid || isGated) return
+    let cancelled = false
+    fetchJobPostingDoc(metadata.cid).then((loaded) => {
+      if (!cancelled && loaded) setClientDoc(loaded)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [doc, metadata.cid, isGated])
 
   const teamContract = useContract({
     chain: selectedChain,

--- a/ui/pages/jobs/[id].tsx
+++ b/ui/pages/jobs/[id].tsx
@@ -66,16 +66,20 @@ export default function JobDetail({
   useChainDefault()
 
   const isGated = !JOB_DETAIL_PUBLIC && !citizen
-  const [clientDoc, setClientDoc] = useState<JobPostingDoc | null>(null)
-  const posting = isGated ? null : doc || clientDoc
+  // Pages Router reuses this component across /jobs/[id] navigations, so a
+  // fetched doc is tagged with its CID and ignored once the route moves on.
+  const [clientDoc, setClientDoc] = useState<{ cid: string; doc: JobPostingDoc } | null>(null)
+  const fetchedDoc = clientDoc && clientDoc.cid === metadata.cid ? clientDoc.doc : null
+  const posting = isGated ? null : doc || fetchedDoc
 
   // ISR can ship without the IPFS body (slow gateway). Retry in the browser
   // whenever the on-chain envelope has a CID but the server did not load it.
   useEffect(() => {
-    if (doc || !metadata.cid || isGated) return
+    const cid = metadata.cid
+    if (doc || !cid || isGated) return
     let cancelled = false
-    fetchJobPostingDoc(metadata.cid).then((loaded) => {
-      if (!cancelled && loaded) setClientDoc(loaded)
+    fetchJobPostingDoc(cid).then((loaded) => {
+      if (!cancelled && loaded) setClientDoc({ cid, doc: loaded })
     })
     return () => {
       cancelled = true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
https://www.moondao.com/jobs/22 is live but only shows the 280-character summary. The full posting is on IPFS (`Qmb4SknAG3eNGxQmKbUiJ4RVSRA7qdWuW53nb4XTuNmpWd`) and the Tableland row has the CID — the page never read it.

**Cause.** Tableland returns TEXT JSON as an already-parsed object (the same way citizen `location` comes back). `parseJobMetadata` only accepted a string, so it treated the envelope as empty, dropped the CID, skipped the IPFS fetch, and fell back to `job.description`.

Confirmed against the live row:

```json
"metadata": {
  "v": 1,
  "cid": "Qmb4SknAG3eNGxQmKbUiJ4RVSRA7qdWuW53nb4XTuNmpWd",
  "deadline": 1791342000
}
```

The Pinata document is valid JSON with a `body` field; the dedicated gateway returns it in under a second.

**Fix.** Accept string or object in `parseJobMetadata`. If ISR still ships without the body (slow gateway), the job page retries the IPFS fetch in the browser.

After this merges, `/jobs/22` should revalidate within 60 seconds and show the full markdown.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-548d78c6-fd9a-491b-a144-858dd94cac08?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-548d78c6-fd9a-491b-a144-858dd94cac08&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

