### PR TITLE
fix(jobs): stop showing the authoring table as raw markdown

### DIFF
--- a/docs/JOB_SOCIAL_MEDIA_MANAGER.md
+++ b/docs/JOB_SOCIAL_MEDIA_MANAGER.md
@@ -1,8 +1,10 @@
 # Social Media Manager (X) — public posting
 
-Ready to paste into the jobs board authoring form. The values under
-[Structured fields](#structured-fields) map 1:1 to the fields in the new form; the
-[Body](#body-markdown) section is the markdown body.
+Ready to paste into the jobs board authoring form. Map
+[Structured fields](#structured-fields) onto the matching form inputs. Paste
+**only** the [Body](#body-markdown) section into Full description — not this
+whole file, and not the fields table. The live page already renders those facts
+from the form; pasting the table shows up as raw `| Title | ... |` markdown.
 
 Compensation reasoning and negotiation guidance live in
 [`JOB_SOCIAL_MEDIA_MANAGER_COMP.md`](./JOB_SOCIAL_MEDIA_MANAGER_COMP.md) and are deliberately

--- a/ui/components/subscription/TeamJobModal.tsx
+++ b/ui/components/subscription/TeamJobModal.tsx
@@ -658,7 +658,7 @@ export default function TeamJobModal({
           <Field
             id="job-body-input"
             label="Full description"
-            hint="Markdown supported: headings, lists, links and tables. No length limit — this is stored on IPFS and rendered on the role's own page."
+            hint="Markdown supported: headings, lists, links and tables. Paste the public description only — not the structured-fields table; those already have their own inputs above and below."
           >
             <textarea
               id="job-body-input"

--- a/ui/cypress/integration/unit/job-metadata.cy.ts
+++ b/ui/cypress/integration/unit/job-metadata.cy.ts
@@ -1,6 +1,7 @@
 import {
   MAX_METADATA_BYTES,
   buildJobMetadata,
+  extractPublicJobBody,
   formatCommitment,
   formatCompensation,
   formatDeadlineCountdown,
@@ -164,6 +165,68 @@ describe('buildJobMetadata', () => {
   })
 })
 
+describe('extractPublicJobBody', () => {
+  const pitch = '### The pitch\n\nMoonDAO has already put civilians in space.'
+  const processTable = [
+    '### Hiring process',
+    '',
+    '| Stage | What happens |',
+    '|---|---|',
+    '| Interview | A conversation about prior results. |',
+  ].join('\n')
+
+  it('leaves a normal posting untouched', () => {
+    const body = `${pitch}\n\n${processTable}`
+    expect(extractPublicJobBody(body)).to.equal(body)
+  })
+
+  it('keeps a real table that is not the authoring cheat sheet', () => {
+    expect(extractPublicJobBody(processTable)).to.equal(processTable)
+  })
+
+  it('takes the public section out of an authoring paste', () => {
+    const pasted = [
+      '|---|---|',
+      '| Title | Social Media Manager — X (Twitter) |',
+      '| Category | Marketing |',
+      '| Summary | Own @OfficialMoonDAO and grow it. |',
+      '| Compensation | $2,000–$2,800 / month |',
+      '',
+      '---',
+      '',
+      '## Body (markdown)',
+      '',
+      pitch,
+      '',
+      processTable,
+      '',
+      '## Notes on what changed from the original draft, and why',
+      '',
+      'Internal: this must never ship on the public page.',
+    ].join('\n')
+
+    const extracted = extractPublicJobBody(pasted)
+    expect(extracted).to.equal(`${pitch}\n\n${processTable}`)
+    expect(extracted).to.not.include('| Title |')
+    expect(extracted).to.not.include('Body (markdown)')
+    expect(extracted).to.not.include('Notes on what changed')
+    expect(extracted).to.not.include('must never ship')
+  })
+
+  it('drops a leading structured-fields table even without a Body heading', () => {
+    const pasted = [
+      '| Field | Value |',
+      '|---|---|',
+      '| Title | Social Media Manager — X (Twitter) |',
+      '| Category | Marketing |',
+      '',
+      pitch,
+    ].join('\n')
+
+    expect(extractPublicJobBody(pasted)).to.equal(pitch)
+  })
+})
+
 describe('normalizeJobPostingDoc', () => {
   it('returns null when there is no content', () => {
     expect(normalizeJobPostingDoc({})).to.equal(null)
@@ -182,6 +245,24 @@ describe('normalizeJobPostingDoc', () => {
     expect(doc?.requirements).to.deep.equal(['Proven growth', 'Crypto fluency'])
     expect(doc?.hiringProcess).to.deep.equal([{ label: 'Interview', detail: '30 minutes' }])
     expect(doc?.links).to.deep.equal([{ label: 'https://moondao.com', url: 'https://moondao.com' }])
+  })
+
+  it('strips authoring scaffolding from the stored body', () => {
+    const doc = normalizeJobPostingDoc({
+      body: [
+        '|---|---|',
+        '| Title | Social Media Manager — X (Twitter) |',
+        '| Category | Marketing |',
+        '',
+        '## Body (markdown)',
+        '',
+        '### The pitch',
+        '',
+        'Own the account.',
+      ].join('\n'),
+    })
+
+    expect(doc?.body).to.equal('### The pitch\n\nOwn the account.')
   })
 })
 

--- a/ui/lib/jobs/jobMetadata.ts
+++ b/ui/lib/jobs/jobMetadata.ts
@@ -359,6 +359,61 @@ export function buildJobMetadata(doc: JobPostingDoc, cid?: string): JobMetadataE
   }) as JobMetadataEnvelope
 }
 
+/**
+ * The authoring doc for a role is easy to paste whole: a structured-fields
+ * table, a `## Body (markdown)` heading, then the public posting, then internal
+ * notes. The live page only wants the public posting. This pulls that out and
+ * leaves a normal markdown body untouched.
+ */
+const BODY_SECTION_HEADING = /^#{1,3}\s+body(?:\s*\(.*\))?\s*$/i
+const INTERNAL_NOTES_HEADING = /^#{1,3}\s+notes on what changed\b/i
+const TABLE_ROW = /^\s*\|.+\|\s*$/
+const AUTHORING_TABLE_FIELD = /^\s*\|\s*(Title|Category|Summary|Compensation|Commitment|Location|Seniority|Application deadline|Apply URL|Skills)\s*\|/i
+
+export function extractPublicJobBody(markdown: string): string {
+  if (!markdown || !markdown.trim()) return ''
+
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n')
+
+  let start = 0
+  for (let i = 0; i < lines.length; i++) {
+    if (BODY_SECTION_HEADING.test(lines[i].trim())) {
+      start = i + 1
+      break
+    }
+  }
+
+  let end = lines.length
+  for (let i = start; i < lines.length; i++) {
+    if (INTERNAL_NOTES_HEADING.test(lines[i].trim())) {
+      end = i
+      break
+    }
+  }
+
+  return stripLeadingAuthoringTable(lines.slice(start, end).join('\n'))
+}
+
+function stripLeadingAuthoringTable(markdown: string): string {
+  const lines = markdown.split('\n')
+  let i = 0
+  while (i < lines.length && lines[i].trim() === '') i++
+  if (i >= lines.length || !TABLE_ROW.test(lines[i])) return markdown.trim()
+
+  const tableStart = i
+  while (i < lines.length && (TABLE_ROW.test(lines[i]) || lines[i].trim() === '')) {
+    if (lines[i].trim() === '' && i + 1 < lines.length && !TABLE_ROW.test(lines[i + 1])) break
+    i++
+  }
+
+  const tableBlock = lines.slice(tableStart, i).join('\n')
+  const fieldHits = tableBlock.split('\n').filter((line) => AUTHORING_TABLE_FIELD.test(line))
+  if (fieldHits.length < 2) return markdown.trim()
+
+  while (i < lines.length && (/^\s*-{3,}\s*$/.test(lines[i]) || lines[i].trim() === '')) i++
+  return lines.slice(i).join('\n').trim()
+}
+
 /** Normalize an IPFS document, discarding anything that isn't the expected shape. */
 export function normalizeJobPostingDoc(raw: any): JobPostingDoc | null {
   if (!isPlainObject(raw)) return null
@@ -409,7 +464,10 @@ export function normalizeJobPostingDoc(raw: any): JobPostingDoc | null {
   const doc = compact({
     v: cleanNumber(raw.v) ?? JOB_METADATA_VERSION,
     summary: cleanString(raw.summary),
-    body: typeof raw.body === 'string' && raw.body.trim() !== '' ? raw.body : undefined,
+    body:
+      typeof raw.body === 'string' && raw.body.trim() !== ''
+        ? extractPublicJobBody(raw.body) || undefined
+        : undefined,
     responsibilities: cleanStringArray(raw.responsibilities),
     requirements: cleanStringArray(raw.requirements),
     niceToHave: cleanStringArray(raw.niceToHave),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The live Social Media Manager page (`/jobs/22`) was opening with a block of unformatted `| Title | ... |` markdown.

That text is not the job description. The IPFS document for job 22 stored the authoring cheat-sheet — a structured-fields table (missing its header row, so GFM cannot render it) plus a `## Body (markdown)` heading — in front of the actual posting.

This PR strips that scaffolding when a posting is loaded or saved:

- Keep everything after `## Body (markdown)`
- Drop a leading Title/Category/Summary table
- Drop the internal “Notes on what changed” section if it was pasted
- Leave a normal markdown body, including real tables like the hiring process, untouched

No on-chain rewrite is required. After deploy + ISR, `/jobs/22` should open on **The pitch**.

Also tightens the authoring-form hint and the paste instructions in the Social Media Manager doc so this is harder to repeat.

## Testing

- Mocha unit suite for `extractPublicJobBody` / `normalizeJobPostingDoc`: passing
- Ran the extractor against the live CID `Qmb4SknAG3eNGxQmKbUiJ4RVSRA7qdWuW53nb4XTuNmpWd`: stored body starts with `|---|---|` / `| Title |`; normalized body starts at `### The pitch` and keeps the hiring-process table
- Production `/jobs/22` still shows the raw table today (expected until this ships)

[Live /jobs/22 showing the raw authoring table](https://cursor.com/agents/bc-548d78c6-fd9a-491b-a144-858dd94cac08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjobs_22_live_raw_markdown.webp)
[Extracted body starts at The pitch](https://cursor.com/agents/bc-548d78c6-fd9a-491b-a144-858dd94cac08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjobs_22_body_starts_at_pitch.webp)
[Hiring process table rendered as a real table](https://cursor.com/agents/bc-548d78c6-fd9a-491b-a144-858dd94cac08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjobs_22_hiring_table_rendered.webp)
[job-22-structured-body.mp4](https://cursor.com/agents/bc-548d78c6-fd9a-491b-a144-858dd94cac08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjob-22-structured-body.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-548d78c6-fd9a-491b-a144-858dd94cac08?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-548d78c6-fd9a-491b-a144-858dd94cac08&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

