### PR TITLE
feat: footer Report a Bug link to public GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a bug you found on the MoonDAO site
+title: '[Bug]: '
+labels: ['bug', 'user-report']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Issues are **public** — do not include wallet
+        addresses, private keys, emails, or other personal information.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: I clicked X and then Y happened...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See error
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL
+      description: The page where you found the bug. Prefills automatically from the site.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser and device information. Prefills automatically from the site.
+      render: shell
+  - type: checkboxes
+    id: public-acknowledgement
+    attributes:
+      label: Public disclosure
+      description: GitHub issues are public. Do not include wallet addresses, emails, private keys, or other personal information.
+      options:
+        - label: I understand this issue will be public and I have not included private information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Support and general questions
+    url: https://moondao.com/discord
+    about: For help using MoonDAO, ask in the Discord support channel.

--- a/ui/components/docs/DocsLayout.tsx
+++ b/ui/components/docs/DocsLayout.tsx
@@ -1,4 +1,5 @@
 import type { DocsPageProps } from '@/lib/docs/types'
+import ReportBugButton from '@/components/layout/ReportBugButton'
 import DocMarkdown from './DocMarkdown'
 import DocsBacklinks from './DocsBacklinks'
 import DocsBreadcrumbs from './DocsBreadcrumbs'
@@ -47,6 +48,9 @@ export default function DocsLayout({ page }: { page: DocsPageProps }) {
             )}
             <DocMarkdown body={page.body} />
             <DocsBacklinks items={page.backlinks} />
+            <div className="mt-10 pt-6 border-t border-white/10">
+              <ReportBugButton />
+            </div>
           </main>
 
           <aside className="hidden xl:block w-56 shrink-0 px-4 py-8 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto">

--- a/ui/components/layout/ExpandedFooter.tsx
+++ b/ui/components/layout/ExpandedFooter.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/assets'
 import Disclaimer from './Disclaimer'
 import LegalLinks from './LegalLinks'
+import ReportBugButton from './ReportBugButton'
 
 type SocialLink = {
   href: string
@@ -295,6 +296,9 @@ export function ExpandedFooter({
                     {link.icon}
                   </Link>
                 ))}
+              </div>
+              <div className="mb-6">
+                <ReportBugButton />
               </div>
               <div className="flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm text-gray-400 mb-4">
                 <Link href="/docs" className="hover:text-white transition-colors">

--- a/ui/components/layout/ExpandedFooter.tsx
+++ b/ui/components/layout/ExpandedFooter.tsx
@@ -271,9 +271,7 @@ export function ExpandedFooter({
           {/* Social Links */}
           <div className="container mx-auto px-[5vw] xl:px-[2vw] max-w-[1200px] w-full">
             <div className="flex flex-col items-center border-t border-white/10 mt-6 pt-6">
-              <h3 className="text-sm font-medium text-gray-400 uppercase mb-4">
-                Follow Us
-              </h3>
+              <h3 className="text-sm font-medium text-gray-400 uppercase mb-4">Follow Us</h3>
               {/*
                 7 social icons at 40px + a 16px gap was overflowing on
                 ~360–390px viewports (the row needs ~376px but the

--- a/ui/components/layout/ReportBugButton.tsx
+++ b/ui/components/layout/ReportBugButton.tsx
@@ -1,0 +1,52 @@
+import { BugAntIcon } from '@heroicons/react/24/outline'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import {
+  buildBugReportHref,
+  formatBugReportEnvironment,
+} from '@/lib/github/bugReport'
+
+type ReportBugButtonProps = {
+  className?: string
+}
+
+export default function ReportBugButton({ className = '' }: ReportBugButtonProps) {
+  const router = useRouter()
+  const chain = process.env.NEXT_PUBLIC_CHAIN || 'unknown'
+  const asPath = router.asPath || '/'
+
+  const [href, setHref] = useState(() =>
+    buildBugReportHref({
+      pageUrl: asPath,
+      environment: formatBugReportEnvironment({ chain }),
+    })
+  )
+
+  useEffect(() => {
+    setHref(
+      buildBugReportHref({
+        pageUrl: window.location.href,
+        environment: formatBugReportEnvironment({
+          chain,
+          viewport: `${window.innerWidth}x${window.innerHeight}`,
+          userAgent: navigator.userAgent,
+        }),
+      })
+    )
+  }, [asPath, chain])
+
+  return (
+    <Link
+      id="report-bug-button"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Report a bug on GitHub"
+      className={`inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-white hover:border-white/40 hover:bg-white/10 transition-all duration-300 ${className}`}
+    >
+      <BugAntIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>Report a Bug</span>
+    </Link>
+  )
+}

--- a/ui/components/layout/ReportBugButton.tsx
+++ b/ui/components/layout/ReportBugButton.tsx
@@ -2,10 +2,7 @@ import { BugAntIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import {
-  buildBugReportHref,
-  formatBugReportEnvironment,
-} from '@/lib/github/bugReport'
+import { buildBugReportHref, formatBugReportEnvironment } from '@/lib/github/bugReport'
 
 type ReportBugButtonProps = {
   className?: string

--- a/ui/cypress/integration/layout/report-bug-button.cy.tsx
+++ b/ui/cypress/integration/layout/report-bug-button.cy.tsx
@@ -1,0 +1,70 @@
+import * as NextRouter from 'next/router'
+import {
+  BUG_REPORT_REPO_URL,
+  buildBugReportHref,
+  formatBugReportEnvironment,
+} from '@/lib/github/bugReport'
+import ReportBugButton from '@/components/layout/ReportBugButton'
+
+describe('buildBugReportHref', () => {
+  it('uses issue-form field ids as query keys', () => {
+    const href = buildBugReportHref({
+      pageUrl: 'https://moondao.com/lock',
+      environment: formatBugReportEnvironment({
+        chain: 'mainnet',
+        viewport: '1440x900',
+        userAgent: 'Mozilla/5.0',
+      }),
+    })
+    const url = new URL(href)
+
+    expect(url.origin + url.pathname).to.eq(BUG_REPORT_REPO_URL)
+    expect(url.searchParams.get('template')).to.eq('bug_report.yml')
+    expect(url.searchParams.get('title')).to.eq('[Bug]: ')
+    expect(url.searchParams.get('page-url')).to.eq('https://moondao.com/lock')
+    expect(url.searchParams.get('environment')).to.eq(
+      'Network: mainnet\nViewport: 1440x900\nUser agent: Mozilla/5.0'
+    )
+  })
+})
+
+describe('<ReportBugButton />', () => {
+  beforeEach(() => {
+    const useRouter = NextRouter.useRouter as any
+    if (useRouter && typeof useRouter.restore === 'function') {
+      useRouter.restore()
+    }
+
+    cy.stub(NextRouter, 'useRouter').returns({
+      pathname: '/lock',
+      asPath: '/lock',
+      query: {},
+      push: cy.stub().resolves(),
+      replace: cy.stub().resolves(),
+    })
+
+    cy.mount(<ReportBugButton />)
+  })
+
+  it('renders a pill that opens the public GitHub bug form', () => {
+    cy.get('#report-bug-button')
+      .should('be.visible')
+      .and('contain.text', 'Report a Bug')
+      .and('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer')
+      .and('have.attr', 'aria-label', 'Report a bug on GitHub')
+  })
+
+  it('links to the prefilled issue form with page and environment fields', () => {
+    cy.get('#report-bug-button')
+      .should('have.attr', 'href')
+      .then((href) => {
+        const url = new URL(href as unknown as string)
+        expect(url.origin + url.pathname).to.eq(BUG_REPORT_REPO_URL)
+        expect(url.searchParams.get('template')).to.eq('bug_report.yml')
+        expect(url.searchParams.get('title')).to.eq('[Bug]: ')
+        expect(url.searchParams.get('page-url')).to.include('/lock')
+        expect(url.searchParams.get('environment')).to.include('Network:')
+      })
+  })
+})

--- a/ui/cypress/integration/layout/report-bug-button.cy.tsx
+++ b/ui/cypress/integration/layout/report-bug-button.cy.tsx
@@ -3,6 +3,7 @@ import {
   BUG_REPORT_REPO_URL,
   buildBugReportHref,
   formatBugReportEnvironment,
+  stripBugReportPageUrl,
 } from '@/lib/github/bugReport'
 import ReportBugButton from '@/components/layout/ReportBugButton'
 
@@ -25,6 +26,16 @@ describe('buildBugReportHref', () => {
     expect(url.searchParams.get('environment')).to.eq(
       'Network: mainnet\nViewport: 1440x900\nUser agent: Mozilla/5.0'
     )
+  })
+
+  it('drops query strings and fragments so secrets are not published', () => {
+    const href = buildBugReportHref({
+      pageUrl: 'https://moondao.com/citizen?invite=secret-token#step-2',
+      environment: formatBugReportEnvironment({ chain: 'mainnet' }),
+    })
+
+    expect(new URL(href).searchParams.get('page-url')).to.eq('https://moondao.com/citizen')
+    expect(href).to.not.include('secret-token')
   })
 })
 
@@ -65,7 +76,7 @@ describe('<ReportBugButton />', () => {
         expect(url.searchParams.get('title')).to.eq('[Bug]: ')
         // After mount the href is enriched with window.location.href (the
         // Cypress iframe URL in component tests) plus viewport and UA.
-        expect(url.searchParams.get('page-url')).to.eq(window.location.href)
+        expect(url.searchParams.get('page-url')).to.eq(stripBugReportPageUrl(window.location.href))
         const environment = url.searchParams.get('environment') || ''
         expect(environment).to.include('Network:')
         expect(environment).to.include('Viewport:')

--- a/ui/cypress/integration/layout/report-bug-button.cy.tsx
+++ b/ui/cypress/integration/layout/report-bug-button.cy.tsx
@@ -63,8 +63,13 @@ describe('<ReportBugButton />', () => {
         expect(url.origin + url.pathname).to.eq(BUG_REPORT_REPO_URL)
         expect(url.searchParams.get('template')).to.eq('bug_report.yml')
         expect(url.searchParams.get('title')).to.eq('[Bug]: ')
-        expect(url.searchParams.get('page-url')).to.include('/lock')
-        expect(url.searchParams.get('environment')).to.include('Network:')
+        // After mount the href is enriched with window.location.href (the
+        // Cypress iframe URL in component tests) plus viewport and UA.
+        expect(url.searchParams.get('page-url')).to.eq(window.location.href)
+        const environment = url.searchParams.get('environment') || ''
+        expect(environment).to.include('Network:')
+        expect(environment).to.include('Viewport:')
+        expect(environment).to.include('User agent:')
       })
   })
 })

--- a/ui/lib/github/bugReport.ts
+++ b/ui/lib/github/bugReport.ts
@@ -1,0 +1,35 @@
+export const BUG_REPORT_REPO_URL =
+  'https://github.com/Official-MoonDao/MoonDAO/issues/new'
+
+export type BugReportContext = {
+  pageUrl: string
+  environment: string
+}
+
+export function buildBugReportHref({
+  pageUrl,
+  environment,
+}: BugReportContext): string {
+  const params = new URLSearchParams({
+    template: 'bug_report.yml',
+    title: '[Bug]: ',
+    'page-url': pageUrl,
+    environment,
+  })
+  return `${BUG_REPORT_REPO_URL}?${params.toString()}`
+}
+
+export function formatBugReportEnvironment({
+  chain,
+  viewport,
+  userAgent,
+}: {
+  chain: string
+  viewport?: string
+  userAgent?: string
+}): string {
+  const lines = [`Network: ${chain}`]
+  if (viewport) lines.push(`Viewport: ${viewport}`)
+  if (userAgent) lines.push(`User agent: ${userAgent}`)
+  return lines.join('\n')
+}

--- a/ui/lib/github/bugReport.ts
+++ b/ui/lib/github/bugReport.ts
@@ -1,15 +1,11 @@
-export const BUG_REPORT_REPO_URL =
-  'https://github.com/Official-MoonDao/MoonDAO/issues/new'
+export const BUG_REPORT_REPO_URL = 'https://github.com/Official-MoonDao/MoonDAO/issues/new'
 
 export type BugReportContext = {
   pageUrl: string
   environment: string
 }
 
-export function buildBugReportHref({
-  pageUrl,
-  environment,
-}: BugReportContext): string {
+export function buildBugReportHref({ pageUrl, environment }: BugReportContext): string {
   const params = new URLSearchParams({
     template: 'bug_report.yml',
     title: '[Bug]: ',

--- a/ui/lib/github/bugReport.ts
+++ b/ui/lib/github/bugReport.ts
@@ -5,11 +5,17 @@ export type BugReportContext = {
   environment: string
 }
 
+// Query strings and fragments can carry one-time secrets such as the citizen
+// invite token (`/citizen?invite=<token>`), which must never reach a public issue.
+export function stripBugReportPageUrl(pageUrl: string): string {
+  return pageUrl.split(/[?#]/)[0]
+}
+
 export function buildBugReportHref({ pageUrl, environment }: BugReportContext): string {
   const params = new URLSearchParams({
     template: 'bug_report.yml',
     title: '[Bug]: ',
-    'page-url': pageUrl,
+    'page-url': stripBugReportPageUrl(pageUrl),
     environment,
   })
   return `${BUG_REPORT_REPO_URL}?${params.toString()}`

--- a/ui/pages/404.tsx
+++ b/ui/pages/404.tsx
@@ -19,8 +19,8 @@ export default function FourOhFour() {
                   This page could not be found
                 </h1>
                 <p className="text-gray-300 text-sm leading-relaxed">
-                  The page you're looking for doesn't exist or has been moved.
-                  Check the URL or navigate back to our homepage.
+                  The page you're looking for doesn't exist or has been moved. Check the URL or
+                  navigate back to our homepage.
                 </p>
               </div>
             </div>

--- a/ui/pages/404.tsx
+++ b/ui/pages/404.tsx
@@ -1,6 +1,7 @@
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import Container from '@/components/layout/Container'
+import ReportBugButton from '@/components/layout/ReportBugButton'
 
 export default function FourOhFour() {
   return (
@@ -32,6 +33,9 @@ export default function FourOhFour() {
               >
                 <span>Go to Homepage</span>
               </Link>
+              <div className="flex justify-center">
+                <ReportBugButton />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a prominent **Report a Bug** control on every footer (plus docs pages and 404, which have no footer) that opens a prefilled, public GitHub issue form on `Official-MoonDao/MoonDAO`.

## What changed

- New `ReportBugButton` pill (`BugAntIcon` + “Report a Bug”) in [`ui/components/layout/ExpandedFooter.tsx`](ui/components/layout/ExpandedFooter.tsx), between the social icons and the utility links. The existing Discord **Submit a Ticket** link is unchanged.
- Same button at the bottom of docs articles ([`ui/components/docs/DocsLayout.tsx`](ui/components/docs/DocsLayout.tsx)) and as a secondary action on [`ui/pages/404.tsx`](ui/pages/404.tsx).
- The link goes to `https://github.com/Official-MoonDao/MoonDAO/issues/new` with `template=bug_report.yml`, a `[Bug]: ` title prefix, and prefilled `page-url` / `environment` fields.
- Prefill is SSR-safe (`router.asPath` on first render) then enriched after mount with `window.location.href`, user agent, viewport, and `NEXT_PUBLIC_CHAIN`. Wallet addresses, emails, and session identifiers are never included.
- New issue form [`.github/ISSUE_TEMPLATE/bug_report.yml`](.github/ISSUE_TEMPLATE/bug_report.yml) with required “what happened” + a public-disclosure checkbox. [`.github/ISSUE_TEMPLATE/config.yml`](.github/ISSUE_TEMPLATE/config.yml) routes general questions to Discord.

## Follow-ups for reviewers

1. **Create the `user-report` label** in repo settings. The template applies `bug` + `user-report`; `bug` already exists, `user-report` does not. Without it GitHub silently drops that label.
2. **The in-repo autofix workflow is not this flow.** [`.github/workflows/autofix.yml`](.github/workflows/autofix.yml) only runs on **PR** comments (`github.event.issue.pull_request != null`) and only runs ESLint/Prettier. Commenting on a bug issue will not trigger it. The “review then comment to auto-fix” automation needs to live in the Cursor dashboard (or a new workflow), gated on a maintainer comment (`OWNER` / `MEMBER` / `COLLABORATOR`) and ideally an explicit keyword. Agent PRs should stay drafts.
3. **XP quest side effect.** Footer-filed issues count toward the “Submit an Issue” quest (`author:<user> is:issue org:Official-MoonDao`). One-click reporting from every page makes that quest easier to farm. Flag to whoever owns XP.
4. **GitHub sign-in is required** to file. That matches the existing XP issue quest; we did not add a bot-token API proxy.

## Test plan

- [ ] `yarn lint` in `ui/`
- [ ] Cypress component spec `report-bug-button.cy.tsx`
- [ ] Click **Report a Bug** on a page with a footer and confirm the GitHub form prefills page URL + environment
- [ ] Confirm the same control appears on a docs page and on `/404`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0440a75-5b66-492f-a757-abefd733e574?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0440a75-5b66-492f-a757-abefd733e574&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

