### PR TITLE
fix(gate): password-only moonbase and DePrize on production

### DIFF
--- a/ui/const/flags.ts
+++ b/ui/const/flags.ts
@@ -14,7 +14,9 @@ const PRODUCTION_HOSTS = new Set(['moondao.com', 'www.moondao.com'])
 
 // Routes that exist in main but aren't public yet. `router.pathname` is the
 // matched route pattern, so a dynamic child appears here in its bracket form.
-const UNRELEASED_PATHS = ['/moonbase', '/moonbase/[projectId]']
+// Moonbase and DePrize used to live here; they are password-gated now (see
+// lib/gate/access.ts) and reachable on production, so they are not listed.
+const UNRELEASED_PATHS: string[] = []
 
 // Bare hostname, no port, lower-cased. Accepts either a `Host` header value or
 // a `window.location.host`.
@@ -58,7 +60,8 @@ export function FlagProvider({ children }: { children: React.ReactNode }) {
 // — no hydration mismatch — then settles to the real answer after mount. The
 // routes themselves are gated server-side regardless, so the brief pre-mount
 // visibility of a link on the production site is harmless: following it just
-// lands on /coming-soon.
+// lands on /coming-soon. Password-gated pages (moonbase, DePrize) should not
+// use this hook — they are meant to be visible, then locked by /gate.
 export function useHiddenOnProduction(): boolean {
   const [hidden, setHidden] = useState(false)
   useEffect(() => {

--- a/ui/cypress/integration/unit/access-gate.cy.ts
+++ b/ui/cypress/integration/unit/access-gate.cy.ts
@@ -57,10 +57,17 @@ describe('access gate', () => {
     // (what middleware.ts must declare). If they drift, a prefix is "gated" in
     // the app but never actually matched by middleware.
     it('keeps the middleware matcher in step with the prefix list', () => {
-      const base = (route: string) => route.replace(/\/:path\*$/, '')
-      expect(GATED_MIDDLEWARE_MATCHERS.map(base).sort()).to.deep.equal([...GATED_PREFIXES].sort())
+      // Every prefix must be matched as itself (the typed URL) and, when it
+      // has children, as `${prefix}/:path*`. Dedup so `/deprize-play` (no
+      // children) still counts once.
+      const covered = new Set(
+        GATED_MIDDLEWARE_MATCHERS.map((route) => route.replace(/\/:path\*$/, ''))
+      )
+      expect([...covered].sort()).to.deep.equal([...GATED_PREFIXES].sort())
       expect(GATED_MIDDLEWARE_MATCHERS).to.deep.equal([
+        '/moonbase',
         '/moonbase/:path*',
+        '/deprize',
         '/deprize/:path*',
         '/deprize-play',
       ])

--- a/ui/docs/ACCESS_GATE.md
+++ b/ui/docs/ACCESS_GATE.md
@@ -76,14 +76,17 @@ than returning early, so a rejection does not time out the length of the secret.
   directly. If the concern is that real money should not be at stake yet, that
   has to be settled on-chain, not here.
 - **Anything already public.** Routes outside the three prefixes are untouched.
-  Navigation still links to the gated pages; visitors reach the password form
-  rather than a 404.
+  The production nav links to the gated pages; visitors reach the password form
+  rather than a 404 or `/coming-soon`. The old host-based coming-soon lock on
+  `/moonbase` is gone — the password is the only gate.
 - **Sharing.** One password among several people is exactly as private as the
   least careful of them.
 
 ## Adding a route to the gate
 
 Add the prefix to `GATED_PREFIXES` in `ui/lib/gate/access.ts` **and** to the
-`matcher` in `ui/middleware.ts`. Next requires that matcher to be a static
-literal it can read at build time, so it cannot import the list. A unit test in
+`matcher` in `ui/middleware.ts` — the bare path (`/foo`) plus `/foo/:path*`
+if it has children. Next's `:path*` matcher does not reliably fire on the
+typed URL alone. The matcher must be a static literal Next can read at
+build time, so it cannot import the list. A unit test in
 `cypress/integration/unit/access-gate.cy.ts` fails if the two drift apart.

--- a/ui/lib/gate/access.ts
+++ b/ui/lib/gate/access.ts
@@ -44,7 +44,16 @@ export const GATED_PREFIXES = ['/moonbase', '/deprize', '/deprize-play']
 // Exact strings that must appear in middleware.ts `config.matcher`. Kept here
 // so the Cypress unit suite can assert the pairing without reading the file
 // (the browser bundle has no Node `fs`).
-export const GATED_MIDDLEWARE_MATCHERS = ['/moonbase/:path*', '/deprize/:path*', '/deprize-play']
+// Next's `:path*` matcher does not reliably fire on the bare prefix
+// (`/deprize` vs `/deprize/1`). List both so a typed URL is gated the same
+// way as a deep link.
+export const GATED_MIDDLEWARE_MATCHERS = [
+  '/moonbase',
+  '/moonbase/:path*',
+  '/deprize',
+  '/deprize/:path*',
+  '/deprize-play',
+]
 
 // Where the gate form lives, and the query parameter holding the route the
 // visitor was trying to reach.

--- a/ui/lib/navigation/useNavigation.tsx
+++ b/ui/lib/navigation/useNavigation.tsx
@@ -10,14 +10,10 @@ import {
   WrenchScrewdriverIcon,
 } from '@heroicons/react/24/outline'
 import { useMemo } from 'react'
-import { useHiddenOnProduction } from 'const/flags'
 import IconOrg from '@/components/assets/IconOrg'
 import { generatePrettyLinkWithId } from '@/lib/subscription/pretty-links'
 
 export default function useNavigation(citizen: any) {
-  // Moon Base Zero is merged to main but not public yet, so its entry drops out
-  // on the live production site while staying present everywhere we develop.
-  const hideUnreleased = useHiddenOnProduction()
   return useMemo(() => {
     const isCitizen = !!citizen?.metadata?.name
     const citizenshipChildren = [
@@ -61,20 +57,16 @@ export default function useNavigation(citizen: any) {
         href: '/projects',
         dynamicChildren: 'Projects' as const,
       },
-      ...(!hideUnreleased
-        ? [
-            {
-              name: 'Moon Base Zero',
-              icon: MoonIcon,
-              href: '/moonbase',
-            },
-            {
-              name: 'DePrize',
-              icon: TrophyIcon,
-              href: '/deprize',
-            },
-          ]
-        : []),
+      {
+        name: 'Moon Base Zero',
+        icon: MoonIcon,
+        href: '/moonbase',
+      },
+      {
+        name: 'DePrize',
+        icon: TrophyIcon,
+        href: '/deprize',
+      },
       {
         name: '$MOONEY',
         icon: CircleStackIcon,
@@ -117,5 +109,5 @@ export default function useNavigation(citizen: any) {
         ],
       },
     ]
-  }, [citizen, hideUnreleased])
+  }, [citizen])
 }

--- a/ui/middleware.ts
+++ b/ui/middleware.ts
@@ -16,7 +16,13 @@ import {
 // lib/gate/access.ts. Keep these strings identical to GATED_MIDDLEWARE_MATCHERS
 // in that file; the access-gate unit test pins the pairing.
 export const config = {
-  matcher: ['/moonbase/:path*', '/deprize/:path*', '/deprize-play'],
+  matcher: [
+    '/moonbase',
+    '/moonbase/:path*',
+    '/deprize',
+    '/deprize/:path*',
+    '/deprize-play',
+  ],
 }
 
 export function middleware(req: NextRequest) {

--- a/ui/pages/moonbase/[projectId].tsx
+++ b/ui/pages/moonbase/[projectId].tsx
@@ -1,5 +1,3 @@
 // Deep link into Moon Base Zero with a project pre-selected.
 // Shares the index page component; `/moonbase/[projectId]` is read there.
-// Re-exports the index's server gate too, so this route is hidden on the public
-// production site exactly like `/moonbase` (see const/flags).
-export { default, getServerSideProps } from './index'
+export { default } from './index'

--- a/ui/pages/moonbase/index.tsx
+++ b/ui/pages/moonbase/index.tsx
@@ -1,11 +1,9 @@
 import { CameraIcon, GlobeAltIcon } from '@heroicons/react/24/outline'
 import { useLogin } from '@privy-io/react-auth'
-import type { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useActiveAccount } from 'thirdweb/react'
 import { eth_getBalance, getRpcClient } from 'thirdweb/rpc'
-import { isPublicProductionHost } from 'const/flags'
 import { isCompetitiveRace } from '@/lib/deprize/competitions'
 import { MarketStage, UNIT } from '@/lib/deprize/constants'
 import { fmtPrizeEth } from '@/lib/deprize/format'
@@ -890,22 +888,4 @@ export default function MoonBaseZeroIndex() {
       </div>
     </>
   )
-}
-
-// Moon Base Zero lives in main but isn't public yet. Hide it on the live
-// production site (moondao.com) while leaving it fully usable everywhere we
-// develop — local, Vercel previews off any branch, staging. The gate is the
-// request host, since our env vars are pulled from prod and can't tell those
-// apart (see const/flags). Runs for both `/moonbase` and `/moonbase/[projectId]`
-// (that route re-exports this).
-export const getServerSideProps: GetServerSideProps = async ({ req }) => {
-  const forwarded = req.headers['x-forwarded-host']
-  const host =
-    (Array.isArray(forwarded) ? forwarded[0] : forwarded) ?? req.headers.host
-  if (isPublicProductionHost(host)) {
-    return {
-      redirect: { destination: '/coming-soon?from=moonbase', permanent: false },
-    }
-  }
-  return { props: {} }
 }


### PR DESCRIPTION
## Summary
- Password is now the only lock: moonbase no longer redirects to `/coming-soon` on moondao.com after a successful login (removed the host-based GSSP + `UNRELEASED_PATHS` bounce).
- Middleware now matches the bare `/moonbase` and `/deprize` URLs, so `/deprize` requires the password the same way `/moonbase` does.
- Moon Base Zero and DePrize stay in the production nav; visitors hit `/gate`, not a 404.

## Test plan
- [ ] On production (or a preview pointed at a production host), open `/moonbase`, enter the password, and land on the moonbase — not `/coming-soon`.
- [ ] Open `/deprize` in a fresh session (no gate cookie) and get the password form.
- [ ] After entering the password, `/deprize` and `/deprize-play` load.
- [ ] Confirm Moon Base Zero and DePrize appear in the nav on moondao.com.
- [ ] Confirm other routes (`/`, `/projects`, etc.) are still ungated.


Made with [Cursor](https://cursor.com)