### PR TITLE
feat(lunar-atlas): add Queqiao-2 to the comms race, and seat districts by size

### DIFF
--- a/ui/components/lunar-atlas/ProjectModel.tsx
+++ b/ui/components/lunar-atlas/ProjectModel.tsx
@@ -154,6 +154,14 @@ const PROJECT_SIZE_M: Record<string, number> = {
   // at this case measured a true 0.79 m and read as basically invisible next
   // to its neighbors, so it was scaled up 2.5x (proportions unchanged).
   'crescent-parsec': 2.0,
+  // Grade to the rim of the tilted dish on the Queqiao user terminal — a
+  // tracking mount, so it stands taller than the other customer terminals
+  // while spreading no further across the ground than its tripod (0.9 m of
+  // radial reach against the 1.14 m the default footprint fraction reserves,
+  // so it needs no FOOTPRINT_FRACTION entry). Measured off the authored
+  // geometry rather than chosen, with scripts/tmp-queqiao-check.ts (deleted).
+  // QQ_TERM_M inverts this number.
+  'queqiao-2': 2.28,
   // Ground to the dish's tilted apex — taller than it is wide, unlike the
   // other three comms terminals, because the dish rides gimballed straight
   // on the equipment box's lid rather than on its own ground mount (see
@@ -6495,6 +6503,332 @@ export function Parsec({ accent }: { accent: string }) {
   )
 }
 
+// ---------------------------------------------------------------------------
+// Queqiao-2 — CNSA / CAST
+// ---------------------------------------------------------------------------
+//
+// The fourth orbiter here and the only one that is already working. It looks
+// nothing like the other three because it was not built to sell anything: IM,
+// ESA and Crescent are all pitching a service to whoever subscribes, while
+// Queqiao-2 was built to keep one programme alive on the far side, where a
+// lander has no line of sight to Earth at all and a relay is not a convenience
+// but the entire mission.
+//
+// That shows in the proportion anyone notices first, and it is the reason this
+// model is worth building rather than reskinning the relay above: the dish
+// aimed at the MOON is 4.2 m across and the one aimed at EARTH is 0.6 m. It
+// reads backwards — Earth is 380,000 km away and a lander a few hundred —
+// until you ask which end of each link owns the big antenna. Talking to Earth,
+// Queqiao-2 is speaking into a ground station tens of metres across and can
+// afford to whisper. Talking to a lander it is the only good antenna in the
+// conversation, so it carries the whole link budget itself. Both figures are
+// CNSA's own, and between them they invert the relay's layout completely.
+//
+// The 4.2 m reflector is a deployable gold MESH, not a solid shell, which is
+// what every published image of this spacecraft leads with and what the
+// wireframe cap below exists to draw.
+
+// Wingtip to wingtip, the same convention as RELAY_SPAN_M — and, as with
+// Pathfinder, CNSA publish the antennas but not a deployed array span, so this
+// is measured off the geometry rather than chosen first.
+export const QUEQIAO_SPAN_M = 5.34
+const QQ_M = UNIT_MAX_DIM / QUEQIAO_SPAN_M
+export const QUEQIAO_SCALE = (QUEQIAO_SPAN_M * M_TO_UNITS) / UNIT_MAX_DIM
+
+// Mesh gold, and a darker gold for the ribs behind it. Both are warmer and
+// far more saturated than SAT_FOIL's MLI trim: a mesh reflector is the one
+// place on a spacecraft where gold is the structure rather than a wrapper.
+const QQ_MESH = '#d6a63c'
+const QQ_RIB = '#7d5c1c'
+
+const QQ_BUS_W = 1.5 // across the wing axis (X)
+const QQ_BUS_H = 1.4
+const QQ_BUS_D = 1.3
+
+// Two panels a side rather than the relay's four. Queqiao-2 is a ~1.2 t
+// spacecraft against a TDRS-class bus, and the wings are sized to that: they
+// clear the reflector's 4.2 m by about half a metre a side, which is the whole
+// reason the span figure above is a wing measurement and not the dish.
+const QQ_YOKE = 0.32
+const QQ_PANEL_L = 0.8
+const QQ_PANEL_H = 1.25
+const QQ_PANELS = 2
+const QQ_WING_ROOT = QQ_BUS_W / 2 + QQ_YOKE
+// Wings ride above the bus centreline so the reflector hanging below them has
+// somewhere to go — see QQ_DISH_Y.
+const QQ_WING_Y = 0.35
+
+const QQ_DISH_D = 4.2
+const QQ_DISH_THETA = 0.72
+const QQ_DISH_R = QQ_DISH_D / 2 / Math.sin(QQ_DISH_THETA)
+const QQ_DISH_DEPTH = QQ_DISH_R * (1 - Math.cos(QQ_DISH_THETA))
+const QQ_DISH_FOCUS = QQ_DISH_R / 2
+// Radial ribs, counted off the published imagery rather than picked for looks.
+const QQ_RIBS = 24
+
+// How far the big reflector hangs below the bus. Driven by a collision, not by
+// taste: the rim swings up as the dish pitches down, and at the first pass
+// (vertex at -0.9 m) it came within 12 cm of the inboard solar panels. Dropped
+// until there is a third of a metre of daylight between the two.
+const QQ_DISH_Y = -1.4
+// Radians the reflector is pitched DOWN off horizontal, on the side away from
+// the Earth dish. Positive because a positive rotation about +X carries +Z
+// toward -Y (see the rotation-sign rule in docs/MOONBASE_MODEL_HANDOFF.md).
+//
+// It is deliberately NOT aimed at Moon Base Zero, and that is the honest
+// reading rather than a framing convenience. Queqiao-2's customers are
+// Chang'e landers — the far side, then the south pole — so at any given
+// moment its 4.2 m dish is pointed at somebody else's mission somewhere else
+// on the Moon. A relay in this scene that aimed its high-gain antenna at this
+// colony would be claiming a service the colony cannot actually buy, which is
+// exactly the thing keeping the only working relay in the race from being its
+// outright favourite.
+const QQ_DISH_PITCH = 0.84
+
+// The Earth link, and the one thing on this spacecraft that follows the relay's
+// own rule: from 89°S the Earth sits within a few degrees of the horizon, so
+// this dish is very nearly horizontal. It is a sixth the diameter of the one
+// pointed at the Moon.
+const QQ_EARTH_DISH_D = 0.6
+const QQ_EARTH_DISH_THETA = 0.9
+const QQ_EARTH_DISH_R = QQ_EARTH_DISH_D / 2 / Math.sin(QQ_EARTH_DISH_THETA)
+const QQ_EARTH_DISH_DEPTH =
+  QQ_EARTH_DISH_R * (1 - Math.cos(QQ_EARTH_DISH_THETA))
+
+function QueqiaoPanel({ x }: { x: number }) {
+  return (
+    <group position={[x, 0, 0]}>
+      <mesh>
+        <boxGeometry args={[QQ_PANEL_L, QQ_PANEL_H, 0.045]} />
+        <meshStandardMaterial color={PANEL} roughness={0.4} metalness={0.18} />
+      </mesh>
+      {/* Cell strings, standing proud so they don't strobe against the face */}
+      {Array.from({ length: 2 }, (_, i) => (
+        <mesh key={i} position={[QQ_PANEL_L * ((i + 1) / 3 - 0.5), 0, 0.035]}>
+          <boxGeometry args={[0.035, QQ_PANEL_H - 0.08, 0.02]} />
+          <meshStandardMaterial color={PANEL_EDGE} roughness={0.5} metalness={0.3} />
+        </mesh>
+      ))}
+      {[-1, 1].map((s) => (
+        <mesh key={s} position={[0, (s * QQ_PANEL_H) / 2, 0]}>
+          <boxGeometry args={[QQ_PANEL_L, 0.06, 0.08]} />
+          <meshStandardMaterial color={SAT_SHADE} roughness={0.5} metalness={0.4} />
+        </mesh>
+      ))}
+    </group>
+  )
+}
+
+function QueqiaoWing({ side }: { side: 1 | -1 }) {
+  return (
+    <group scale={[side, 1, 1]} position={[0, QQ_WING_Y, 0]}>
+      {/* Array drive. The wings turn about the wing axis to hold a sun that
+          circles low, which is also why the faces stand upright rather than
+          lying flat — the same argument every array on this base makes. */}
+      <mesh position={[QQ_BUS_W / 2 + 0.12, 0, 0]} rotation={[0, 0, Math.PI / 2]}>
+        <cylinderGeometry args={[0.24, 0.24, 0.24, 14]} />
+        <meshStandardMaterial color={SAT_TRIM} roughness={0.5} metalness={0.5} />
+      </mesh>
+      <mesh
+        position={[QQ_BUS_W / 2 + QQ_YOKE / 2, 0, 0]}
+        rotation={[0, 0, Math.PI / 2]}
+      >
+        <cylinderGeometry args={[0.09, 0.09, QQ_YOKE, 10]} />
+        <meshStandardMaterial color={SAT_SHADE} roughness={0.55} metalness={0.4} />
+      </mesh>
+      {Array.from({ length: QQ_PANELS }, (_, i) => (
+        <QueqiaoPanel key={i} x={QQ_WING_ROOT + QQ_PANEL_L * (i + 0.5)} />
+      ))}
+    </group>
+  )
+}
+
+// The 4.2 m deployable mesh reflector — the whole reason this spacecraft is
+// recognisable at a glance.
+//
+// The mesh is drawn as two caps rather than one textured surface: a solid gold
+// membrane, and a wireframe cap of the same profile set 2 cm INSIDE it. A
+// sphere's own wireframe is already a radial-and-hoop grid, which is exactly
+// what a rib-and-cord mesh antenna looks like, so QQ_RIBS segments of longitude
+// gives the 24 real ribs for free and the latitude rings read as the cords
+// between them. Inside rather than outside because the ribs show through from
+// the FRONT in every published image, and because a second cap resolved on the
+// same radius would z-fight the first across its whole area.
+function QueqiaoMeshDish({ accent }: { accent: string }) {
+  const rimR = QQ_DISH_D / 2
+  return (
+    <group>
+      <mesh position={[0, 0, QQ_DISH_R]} rotation={[-Math.PI / 2, 0, 0]}>
+        <sphereGeometry
+          args={[QQ_DISH_R, 40, 20, 0, Math.PI * 2, 0, QQ_DISH_THETA]}
+        />
+        <meshStandardMaterial
+          color={QQ_MESH}
+          side={THREE.DoubleSide}
+          roughness={0.44}
+          metalness={0.72}
+        />
+      </mesh>
+      <mesh position={[0, 0, QQ_DISH_R]} rotation={[-Math.PI / 2, 0, 0]}>
+        <sphereGeometry
+          args={[QQ_DISH_R - 0.02, QQ_RIBS, 7, 0, Math.PI * 2, 0, QQ_DISH_THETA]}
+        />
+        <meshBasicMaterial color={QQ_RIB} wireframe transparent opacity={0.6} />
+      </mesh>
+
+      {/* Rim hoop — the tensioned ring the mesh is strung from, and the one
+          part of a deployable antenna that is unambiguously structure. */}
+      <mesh position={[0, 0, QQ_DISH_DEPTH]}>
+        <torusGeometry args={[rimR, 0.05, 8, 48]} />
+        <meshStandardMaterial color={SAT_SHADE} roughness={0.45} metalness={0.5} />
+      </mesh>
+
+      {/* Deployment ribs on the BACK, where the real load path is. Eight of
+          the 24, because the back of the dish is mostly seen in silhouette and
+          all 24 as solid members reads as a plate rather than a truss. */}
+      {Array.from({ length: 8 }, (_, i) => {
+        const a = (i / 8) * Math.PI * 2
+        return (
+          <TaperedMast
+            key={i}
+            from={[0, 0, -0.12]}
+            to={[Math.cos(a) * rimR, Math.sin(a) * rimR, QQ_DISH_DEPTH - 0.03]}
+            r0={0.07}
+            r1={0.022}
+            color={QQ_RIB}
+          />
+        )
+      })}
+      {/* Hub the ribs fold out of */}
+      <mesh position={[0, 0, -0.14]}>
+        <cylinderGeometry args={[0.26, 0.3, 0.22, 16]} />
+        <meshStandardMaterial color={SAT_FOIL} roughness={0.4} metalness={0.6} />
+      </mesh>
+
+      {/* Feed at the focus on its tripod. Same reasoning as the relay's: the
+          tripod is what says "antenna" instead of "bowl". */}
+      {[0, (Math.PI * 2) / 3, (Math.PI * 4) / 3].map((a) => (
+        <Strut
+          key={a}
+          from={[
+            Math.cos(a) * rimR * 0.84,
+            Math.sin(a) * rimR * 0.84,
+            QQ_DISH_DEPTH * 0.8,
+          ]}
+          to={[0, 0, QQ_DISH_FOCUS]}
+          r={0.035}
+          color={SAT_TRIM}
+        />
+      ))}
+      <mesh position={[0, 0, QQ_DISH_FOCUS + 0.02]}>
+        <boxGeometry args={[0.34, 0.34, 0.4]} />
+        <meshStandardMaterial color={SAT_FOIL} roughness={0.4} metalness={0.6} />
+      </mesh>
+      <mesh position={[0, 0, QQ_DISH_FOCUS + 0.26]}>
+        <sphereGeometry args={[0.08, 10, 10]} />
+        <meshStandardMaterial
+          color={accent}
+          emissive={accent}
+          emissiveIntensity={1.4}
+          toneMapped={false}
+        />
+      </mesh>
+    </group>
+  )
+}
+
+// The 0.6 m Earth link, mounted on the bus roof and very nearly horizontal.
+function QueqiaoEarthDish() {
+  return (
+    <group position={[0, QQ_BUS_H / 2 + 0.28, QQ_BUS_D / 2 - 0.2]}>
+      <mesh position={[0, -0.2, 0]}>
+        <cylinderGeometry args={[0.09, 0.11, 0.4, 12]} />
+        <meshStandardMaterial color={SAT_TRIM} roughness={0.5} metalness={0.5} />
+      </mesh>
+      <group rotation={[-SAT_DISH_EL, 0, 0]}>
+        <mesh position={[0, 0, QQ_EARTH_DISH_R]} rotation={[-Math.PI / 2, 0, 0]}>
+          <sphereGeometry
+            args={[
+              QQ_EARTH_DISH_R,
+              20,
+              12,
+              0,
+              Math.PI * 2,
+              0,
+              QQ_EARTH_DISH_THETA,
+            ]}
+          />
+          <meshStandardMaterial
+            color={SAT_REFLECT}
+            side={THREE.DoubleSide}
+            roughness={0.32}
+            metalness={0.3}
+          />
+        </mesh>
+        <mesh position={[0, 0, QQ_EARTH_DISH_DEPTH]}>
+          <torusGeometry args={[QQ_EARTH_DISH_D / 2, 0.022, 6, 24]} />
+          <meshStandardMaterial color={SAT_SHADE} roughness={0.45} metalness={0.5} />
+        </mesh>
+        <mesh position={[0, 0, QQ_EARTH_DISH_R / 2]}>
+          <cylinderGeometry args={[0.045, 0.06, 0.14, 10]} />
+          <meshStandardMaterial color={SAT_FOIL} roughness={0.4} metalness={0.6} />
+        </mesh>
+      </group>
+    </group>
+  )
+}
+
+export function Queqiao({ accent }: { accent: string }) {
+  return (
+    <group scale={QQ_M}>
+      {/* Bus, in gold MLI rather than the relay's white blanket — CAST's own
+          renders and the CNSA release imagery both show a foiled bus. */}
+      <mesh>
+        <boxGeometry args={[QQ_BUS_W, QQ_BUS_H, QQ_BUS_D]} />
+        <meshStandardMaterial color={SAT_FOIL} roughness={0.44} metalness={0.62} />
+      </mesh>
+      {/* Corner longerons, so the bus reads as a built frame under its foil */}
+      {[-1, 1].map((sx) =>
+        [-1, 1].map((sz) => (
+          <mesh
+            key={`${sx}:${sz}`}
+            position={[(sx * QQ_BUS_W) / 2, 0, (sz * QQ_BUS_D) / 2]}
+          >
+            <boxGeometry args={[0.07, QQ_BUS_H + 0.02, 0.07]} />
+            <meshStandardMaterial color={SAT_TRIM} roughness={0.55} metalness={0.45} />
+          </mesh>
+        ))
+      )}
+      {/* Instrument deck on the shaded flank: the EUV camera and the neutral
+          atom imager Queqiao-2 carries alongside the relay payload. */}
+      <mesh position={[0, -0.1, -QQ_BUS_D / 2 - 0.14]}>
+        <boxGeometry args={[0.7, 0.5, 0.28]} />
+        <meshStandardMaterial color={SAT_MLI} roughness={0.6} metalness={0.24} />
+      </mesh>
+
+      <QueqiaoWing side={1} />
+      <QueqiaoWing side={-1} />
+      <QueqiaoEarthDish />
+
+      {/* The reflector, slung under the bus on a short yoke and pitched down
+          onto the surface. */}
+      <group position={[0, QQ_DISH_Y, 0]}>
+        <Strut
+          from={[0, QQ_BUS_H / 2 - QQ_DISH_Y - QQ_BUS_H, 0]}
+          to={[0, 0.1, 0]}
+          r={0.09}
+          color={SAT_TRIM}
+        />
+        <group rotation={[0, Math.PI, 0]}>
+          <group rotation={[QQ_DISH_PITCH, 0, 0]}>
+            <QueqiaoMeshDish accent={accent} />
+          </group>
+        </group>
+      </group>
+    </group>
+  )
+}
+
 // Which model, scale and span a flying project uses — keyed by project id,
 // exactly like PROJECT_MODEL for ground installations. SkyLayer looks these up
 // per station instead of assuming every satellite is the relay above.
@@ -6502,16 +6836,19 @@ export const SKY_SAT_MODEL: Record<string, ComponentType<{ accent: string }>> = 
   'im-near-space-network': RelaySat,
   'esa-lunar-pathfinder': Pathfinder,
   'crescent-parsec': Parsec,
+  'queqiao-2': Queqiao,
 }
 export const SKY_SAT_SCALE: Record<string, number> = {
   'im-near-space-network': RELAY_SCALE,
   'esa-lunar-pathfinder': PATHFINDER_SCALE,
   'crescent-parsec': PARSEC_SCALE,
+  'queqiao-2': QUEQIAO_SCALE,
 }
 export const SKY_SAT_SPAN_M: Record<string, number> = {
   'im-near-space-network': RELAY_SPAN_M,
   'esa-lunar-pathfinder': PATHFINDER_SPAN_M,
   'crescent-parsec': PARSEC_SPAN_M,
+  'queqiao-2': QUEQIAO_SPAN_M,
 }
 
 // ---------------------------------------------------------------------------
@@ -11036,6 +11373,157 @@ function ParsecTerminal({ accent }: { accent: string }) {
 }
 
 // ---------------------------------------------------------------------------
+// Queqiao-2 ground terminal
+// ---------------------------------------------------------------------------
+//
+// The one terminal in this district that has to TRACK, and that is the whole
+// design. Queqiao-2 is a single spacecraft in a 24-hour elliptical orbit, so
+// from the ground it is somewhere different every hour and gone entirely for
+// part of the day — a user needs a real dish on a real two-axis mount that
+// follows it across the sky. Crescent's terminal makes the opposite argument
+// with a fixed patch under a radome and no gimbal at all (see ParsecTerminal),
+// because a constellation means never having to point at one specific node.
+// Standing the two side by side in the same district is the clearest statement
+// this map makes about what a customer is actually buying.
+//
+// The reflector is a small gold mesh in the same livery as the orbiter's 4.2 m
+// antenna, because it is the same CAST hardware family scaled down — and
+// because a Queqiao user terminal reading as Queqiao hardware is the point:
+// this is the lot that says the incumbent relay comes with the incumbent's
+// standards attached.
+const QQ_TERM_M = UNIT_MAX_DIM / (PROJECT_SIZE_M['queqiao-2'] ?? 2.28)
+
+const QQ_TERM_HEAD_H = 1.7 // grade to the elevation trunnion
+const QQ_TERM_DISH_D = 1.1
+const QQ_TERM_DISH_THETA = 0.85
+const QQ_TERM_DISH_R = QQ_TERM_DISH_D / 2 / Math.sin(QQ_TERM_DISH_THETA)
+const QQ_TERM_DISH_DEPTH =
+  QQ_TERM_DISH_R * (1 - Math.cos(QQ_TERM_DISH_THETA))
+// Radians the dish is tilted UP. High rather than near-horizontal because
+// Queqiao-2 spends most of a 24-hour ellipse near apolune, well up the sky —
+// unlike every Earth-pointing antenna on this base, which lies nearly flat.
+const QQ_TERM_EL = 0.7
+const QQ_TERM_LEG_R = 0.9
+
+function QueqiaoTerminal({ accent }: { accent: string }) {
+  return (
+    <group scale={QQ_TERM_M}>
+      {/* Tripod, with the feet driven in below grade like every other footing
+          on this base. */}
+      {[0, 1, 2].map((i) => {
+        const a = (i / 3) * Math.PI * 2 + 0.5
+        const x = Math.cos(a) * QQ_TERM_LEG_R
+        const z = Math.sin(a) * QQ_TERM_LEG_R
+        return (
+          <group key={i}>
+            <Strut
+              from={[x, -0.07, z]}
+              to={[0, QQ_TERM_HEAD_H - 0.3, 0]}
+              r={0.038}
+              color={TERM_TRIM}
+            />
+            <mesh position={[x, -0.04, z]}>
+              <cylinderGeometry args={[0.11, 0.14, 0.12, 8]} />
+              <meshStandardMaterial color={HULL_DARK} roughness={0.85} metalness={0.15} />
+            </mesh>
+          </group>
+        )
+      })}
+
+      {/* Azimuth bearing, then the elevation trunnion above it — two axes,
+          which is the part Crescent's terminal deliberately does without. */}
+      <mesh position={[0, QQ_TERM_HEAD_H - 0.28, 0]}>
+        <cylinderGeometry args={[0.19, 0.22, 0.22, 16]} />
+        <meshStandardMaterial color={TERM_TRIM} roughness={0.5} metalness={0.5} />
+      </mesh>
+      <mesh position={[0, QQ_TERM_HEAD_H - 0.09, 0]} rotation={[0, 0, Math.PI / 2]}>
+        <cylinderGeometry args={[0.075, 0.075, 0.42, 12]} />
+        <meshStandardMaterial color={SAT_SHADE} roughness={0.5} metalness={0.45} />
+      </mesh>
+
+      <group position={[0, QQ_TERM_HEAD_H, 0]} rotation={[-QQ_TERM_EL, 0, 0]}>
+        <mesh position={[0, 0, QQ_TERM_DISH_R]} rotation={[-Math.PI / 2, 0, 0]}>
+          <sphereGeometry
+            args={[QQ_TERM_DISH_R, 32, 16, 0, Math.PI * 2, 0, QQ_TERM_DISH_THETA]}
+          />
+          <meshStandardMaterial
+            color={QQ_MESH}
+            side={THREE.DoubleSide}
+            roughness={0.44}
+            metalness={0.72}
+          />
+        </mesh>
+        {/* Same two-cap trick as the orbiter's reflector: a wireframe shell
+            just inside the membrane draws the ribs and cords. */}
+        <mesh position={[0, 0, QQ_TERM_DISH_R]} rotation={[-Math.PI / 2, 0, 0]}>
+          <sphereGeometry
+            args={[
+              QQ_TERM_DISH_R - 0.012,
+              16,
+              5,
+              0,
+              Math.PI * 2,
+              0,
+              QQ_TERM_DISH_THETA,
+            ]}
+          />
+          <meshBasicMaterial color={QQ_RIB} wireframe transparent opacity={0.6} />
+        </mesh>
+        <mesh position={[0, 0, QQ_TERM_DISH_DEPTH]}>
+          <torusGeometry args={[QQ_TERM_DISH_D / 2, 0.03, 6, 32]} />
+          <meshStandardMaterial color={SAT_SHADE} roughness={0.45} metalness={0.5} />
+        </mesh>
+        {/* Feed on a tripod at the focus */}
+        {[0, (Math.PI * 2) / 3, (Math.PI * 4) / 3].map((a) => (
+          <Strut
+            key={a}
+            from={[
+              (Math.cos(a) * QQ_TERM_DISH_D) / 2 * 0.82,
+              (Math.sin(a) * QQ_TERM_DISH_D) / 2 * 0.82,
+              QQ_TERM_DISH_DEPTH * 0.78,
+            ]}
+            to={[0, 0, QQ_TERM_DISH_R / 2]}
+            r={0.018}
+            color={TERM_TRIM}
+          />
+        ))}
+        <mesh position={[0, 0, QQ_TERM_DISH_R / 2 + 0.03]}>
+          <cylinderGeometry args={[0.06, 0.08, 0.16, 10]} />
+          <meshStandardMaterial color={SAT_FOIL} roughness={0.4} metalness={0.6} />
+        </mesh>
+        <mesh position={[0, 0, QQ_TERM_DISH_R / 2 + 0.15]}>
+          <sphereGeometry args={[0.045, 8, 8]} />
+          <meshStandardMaterial
+            color={accent}
+            emissive={accent}
+            emissiveIntensity={1.6}
+            toneMapped={false}
+          />
+        </mesh>
+      </group>
+
+      {/* Modem and drive electronics at the foot, bedded into the regolith */}
+      <mesh position={[0.5, 0.2, -0.14]}>
+        <boxGeometry args={[0.5, 0.42, 0.38]} />
+        <meshStandardMaterial color={TERM_SHELTER} roughness={0.6} metalness={0.2} />
+      </mesh>
+      <mesh position={[0.5, -0.02, -0.14]}>
+        <boxGeometry args={[0.54, 0.06, 0.42]} />
+        <meshStandardMaterial color={TERM_TRIM} roughness={0.7} metalness={0.3} />
+      </mesh>
+      {/* Cable run from the case up to the drive, so the mount is plainly
+          powered rather than decorative. */}
+      <Strut
+        from={[0.5, 0.38, -0.14]}
+        to={[0.08, QQ_TERM_HEAD_H - 0.34, -0.04]}
+        r={0.016}
+        color={HULL_DARK}
+      />
+    </group>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Buried habitats — cut-and-cover vaults under a regolith cover
 // ---------------------------------------------------------------------------
 //
@@ -12138,6 +12626,10 @@ const PROJECT_MODEL: Record<string, ComponentType<{ accent: string }>> = {
   // Crescent's ground lot, smaller again than ESA's: see ParsecTerminal.
   // Parsec itself flies as two satellites via SKY_STATIONS/SkyLayer.
   'crescent-parsec': ParsecTerminal,
+  // CNSA's ground lot: a two-axis tracking dish, the only one in the district,
+  // because a single satellite in a 24-hour ellipse has to be followed. The
+  // orbiter itself flies via SKY_STATIONS/SkyLayer.
+  'queqiao-2': QueqiaoTerminal,
   // IM's ground lot: a single sealed avionics package with its dish
   // gimballed onto the lid, not the generic CommsPnt mast-shelter-array site
   // Nokia still stands on. RelaySat flies via SKY_STATIONS/SkyLayer.

--- a/ui/cypress/integration/unit/lunar-atlas-baseplan.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-baseplan.cy.ts
@@ -103,11 +103,16 @@ const ROSTERS: Partial<Record<ProjectType, Plot[]>> = {
   // eVinci radiator wall, IX's radiator canopy, Lockheed's radiator mast — the
   // three fission bids, and three very different amounts of ground.
   power: plots(11, 6.5, 4),
-  // Blue Origin, Sierra, Lunar Resources — dataset order. Sierra's packaged
-  // skid (5.35) and Lunar Resources' single crucible (5.58) are each little
-  // more than half the generic field-plus-tower footprint (9.5) Blue Origin
-  // still stands on.
-  isru_plant: plots(9.5, 5.35, 5.58),
+  // Blue Origin, Sierra, Lunar Resources, Cislune — dataset order. Sierra's
+  // packaged skid (5.35) and Lunar Resources' single crucible (5.58) are each
+  // little more than half the generic field-plus-tower footprint (9.5) Blue
+  // Origin and Cislune both still stand on.
+  //
+  // Cislune was MISSING from this roster, and its absence is what let the
+  // second 9.5 m plot sit on the perimeter road unnoticed — a hand-mirrored
+  // roster that under-counts a district does not fail, it just quietly stops
+  // testing the case that breaks. See the seating comment in districtSlots.
+  isru_plant: plots(9.5, 5.35, 5.58, 9.5),
   rover: plots(2.3, 2.1, 2.2),
   // ICON, Redwire, Astroport, AI SpaceFactory, Astrobotic — five bids on the
   // same generic paving footprint, and the only district on main street that
@@ -125,7 +130,14 @@ const ROSTERS: Partial<Record<ProjectType, Plot[]>> = {
   // avionics package (1.13) sits between the two — it operates the network
   // rather than subscribing to one — but is a fraction of the generic
   // mast-shelter-array lot Nokia still stands on.
-  comms_pnt: plots(7.5, 1.04, 1.52, 1.13),
+  //
+  // Solstar (7.5, on the same generic terminal as Nokia) and CNSA's Queqiao-2
+  // tracking dish (1.14) were both missing here, the same under-count as the
+  // ISRU district above and with the same consequence — Solstar's lot was
+  // standing 1.4 m inside the perimeter road with no test to say so. Six
+  // competitors makes this the largest district on main street and the only
+  // one besides construction to exercise the second lane.
+  comms_pnt: plots(7.5, 1.04, 1.52, 1.13, 7.5, 1.14),
   // A single concept-study competitor, standing alone on its own corner lot.
   // The lot holds the launcher's BREACH WORKS only (BREACH_LOT_RADIUS_M) — the
   // 600 m guideway runs out of it and is checked as a corridor, further down,

--- a/ui/docs/MOONBASE_MODEL_HANDOFF.md
+++ b/ui/docs/MOONBASE_MODEL_HANDOFF.md
@@ -42,18 +42,34 @@ are each down to a single project (Nokia; Blue Origin) on the generic model,
 which is no longer duplication, just one competitor left where the generic
 model already happens to be that competitor's own concept:
 
-### Priority 1 — comms / PNT (1 of 4 still on the generic model)
+### Priority 1 — comms / PNT (2 of 6 still on the generic model)
 
 | Odds | Org | Project | id | Status |
 |---|---|---|---|---|
-| 30% | Nokia Bell Labs | Lunar Surface Communication System | `nokia-lunar-lte` | generic `CommsPnt` |
-| 28% | Intuitive Machines | Lunar Relay Satellites | `im-near-space-network` | **done** — `RelaySat` (orbit, ×3) + `RelayGroundTerminal` (ground) |
-| 24% | ESA | Lunar Pathfinder & Moonlight | `esa-lunar-pathfinder` | **done** — `Pathfinder` (orbit) + `PathfinderTerminal` (ground) |
-| 18% | Crescent Space Services | Parsec | `crescent-parsec` | **done** — `Parsec` (orbit, ×2) + `ParsecTerminal` (ground) |
+| 24% | CNSA / CAST | Queqiao-2 Relay | `queqiao-2` | **done** — `Queqiao` (orbit) + `QueqiaoTerminal` (ground) |
+| 21% | Modul8 (ex-Nokia Bell Labs) | Lunar Surface Communication System | `nokia-lunar-lte` | generic `CommsPnt` |
+| 20% | Intuitive Machines | Lunar Relay Satellites | `im-near-space-network` | **done** — `RelaySat` (orbit, ×3) + `RelayGroundTerminal` (ground) |
+| 18% | ESA | Lunar Pathfinder & Moonlight | `esa-lunar-pathfinder` | **done** — `Pathfinder` (orbit) + `PathfinderTerminal` (ground) |
+| 13% | Crescent Space Services | Parsec | `crescent-parsec` | **done** — `Parsec` (orbit, ×2) + `ParsecTerminal` (ground) |
+| 4% | Solstar Space | Lunar WiFi Access Point | `solstar-lunar-wifi` | generic `CommsPnt` |
 
-All four comms bids are now orbiter-plus-ground builds except Nokia, which has
-no orbital component to begin with, and each one answers "what's in orbit and
+This is the largest district on the map and every bid in it except Solstar and
+Modul8 is an orbiter-plus-ground build, each answering "what's in orbit and
 what's on the ground" differently on purpose:
+
+- **CNSA** (`Queqiao`, ×1 station + `QueqiaoTerminal`): the only relay in the
+  race that is already flying, and the only one built to serve a single
+  programme rather than a market. Its whole silhouette is one proportion: a
+  4.2 m gold mesh reflector pointed at the MOON and a 0.6 m dish pointed at
+  EARTH. That reads backwards until you ask which end of each link owns the
+  big antenna — into a ground station tens of metres across it can whisper;
+  to a lander it is the only good antenna in the conversation. The mesh is
+  drawn as a solid gold cap with a wireframe cap of the same profile 2 cm
+  inside it, since a sphere's own wireframe is already the radial-and-hoop
+  grid a rib-and-cord antenna is made of. Its ground lot is the district's
+  only two-axis TRACKING mount, which is the direct counter-argument to
+  Crescent's gimbal-less patch: one satellite in a 24-hour ellipse has to be
+  followed across the sky, a constellation never does.
 
 - **IM** (`RelaySat`, ×3 stations + `RelayGroundTerminal`): an operational
   TDRS-class bus, four-panel wings, a big Earth dish, overhead. On the ground,
@@ -83,14 +99,23 @@ what's on the ground" differently on purpose:
   point-mast does, so ESA keeps the smallest-footprint lot and Crescent the
   smallest model.
 
-All three orbiters are wired through the same generalized lookup —
+All four orbiters are wired through the same generalized lookup —
 `SKY_SAT_MODEL` / `SKY_SAT_SCALE` / `SKY_SAT_SPAN_M` in `ProjectModel.tsx`,
 keyed by project id and consumed by `SkyLayer.tsx` — and each gets its own
 entry in `SKY_STATIONS` (`skyplan.ts`): 3 stations for IM, 1 for Pathfinder, 2
-for Parsec, which is not a portrayal but each program's actual state (an
-operational fleet, a single precursor, and a network that starts at two and
-scales). Only Nokia's LTE network of small cells remains on the fully generic
-`CommsPnt` terminal — the last item in this district.
+for Parsec, 1 for Queqiao-2, which is not a portrayal but each program's actual
+state (an operational fleet, a single precursor, a network that starts at two
+and scales, and one working relay). Queqiao-2's station stands furthest out and
+lowest of the four — 430 m out at 240 m, where the others sit 150–360 m out and
+300–500 m up — to separate it from the three programs selling into the same
+Western market, and its bearing (40°) is set by the fact that its hero face is
+turned AWAY from the colony, so the sun ends up behind an eye standing off
+outward rather than in front of it.
+
+Modul8's LTE network of small cells and Solstar's access point are what remain
+on the fully generic `CommsPnt` terminal — and Solstar in particular should not
+stay there, because that generic model is a 15 m mast-shelter-array site
+standing in for what is really a single small radio (see the layout note in §4).
 
 ### Priority 2 — surface construction (4 competitors, 4× the same model)
 
@@ -261,6 +286,23 @@ going any further without `MAIN_LOOP_M` moving too (see the comment on
 These are all mistakes that were made and fixed in this scene. They are cheap to
 avoid up front and annoying to find later.
 
+- **A district seats its biggest plots on the OUTWARD corners, and an
+  under-counted test roster hides it when that goes wrong.** The four corner
+  seats of a crossroads alternate outward and inward of main street, and the
+  two are not equally deep — an inward lot reaches back toward the perimeter
+  road, so every extra metre of radius costs it two metres of clearance.
+  `districtSlots` used to seat plots strictly largest-first, which put the
+  *second* biggest plot on the first inward corner: Cislune's 9.5 m ISRU plant
+  ended up 5.4 m inside the ring road and Solstar's comms lot 1.4 m inside it.
+  Nothing failed, because `ROSTERS` in `lunar-atlas-baseplan.cy.ts` is mirrored
+  by hand and both projects were missing from it — a roster that under-counts
+  a district doesn't fail, it silently stops testing the case that breaks. The
+  seating is now size-aware (biggest onto the outward seats, smallest onto the
+  inward ones) and both rosters are at their true counts. The fill ORDER is
+  untouched, so a two-competitor race still gets one lot either side of both
+  streets. Worst margin on the map is now construction's 1.0 m, where all five
+  plots are the same 6.3 m and no seating choice can help. **When you add a
+  competitor, add it to `ROSTERS` in the same change.**
 - **Nothing floats, nothing hovers.** Bed every foot, pad and fitting a few
   centimetres *into* what it stands on. Footings should run below grade — a pad
   resolved exactly at `y = 0` lifts clear of any hollow it lands over. Bedding an

--- a/ui/lib/lunar-atlas/baseplan.ts
+++ b/ui/lib/lunar-atlas/baseplan.ts
@@ -317,11 +317,46 @@ export function districtSlots(plan: SitePlan, plots: Plot[]): Map<string, Slot> 
       // street, and the district's gap of untouched regolith separates the two
       // strips.
       const laneClearM = DISTRICT_GAP_M + 2 * SETBACK_M
+      // Which plot sits in which of the first four corner seats.
+      //
+      // The seats alternate OUTWARD and INWARD of main street (see CORNERS),
+      // and the two are not equally deep: an outward lot has the whole plain
+      // to grow into, while an inward one reaches back toward the perimeter
+      // road, its inner edge landing at `centre - frontage - radius` — so
+      // every extra metre of radius costs an inward lot two metres of
+      // clearance. Seating strictly largest-first therefore put the SECOND
+      // biggest plot on the first inward corner, which is exactly where the
+      // ground runs out: it is how Cislune's 9.5 m ISRU plant came to stand
+      // 5.4 m into the ring road and Solstar's comms lot 1.4 m into it, with
+      // nothing catching either because both projects were missing from the
+      // hand-mirrored roster in lunar-atlas-baseplan.cy.ts.
+      //
+      // So the biggest plots take the outward seats and the smallest take the
+      // inward ones. The fill ORDER is untouched — a two-competitor race still
+      // gets one lot either side of BOTH streets, which is the whole reason
+      // CORNERS fills diagonally — because with two seats there is one of each
+      // and the choice makes no difference. It only bites from three up, where
+      // there is a genuine choice to get wrong.
+      const seatCount = Math.min(order.length, 4)
+      const outwardSeats: number[] = []
+      const inwardSeats: number[] = []
+      for (let i = 0; i < seatCount; i++) {
+        ;(CORNERS[i][0] > 0 ? outwardSeats : inwardSeats).push(i)
+      }
+      const seated = [...order]
+      const corners = order.slice(0, seatCount)
+      outwardSeats.forEach((seat, k) => {
+        seated[seat] = corners[k]
+      })
+      inwardSeats.forEach((seat, k) => {
+        seated[seat] = corners[outwardSeats.length + k]
+      })
+
       // Angle about the base centre for each lot. Radius is fixed by the lot's
       // own setback off main street, so only the angle is free.
       const angle: number[] = []
       const radii: number[] = []
-      order.forEach((plot, i) => {
+      seated.forEach((plot, i) => {
         const [alongSign, acrossSign] = CORNERS[i % 4]
         const front = frontageM(plot.radiusM)
         const radius = centre + alongSign * front
@@ -338,7 +373,7 @@ export function districtSlots(plan: SitePlan, plots: Plot[]): Map<string, Slot> 
           angle[i] =
             bearing + acrossSign * Math.asin(Math.min(1, front / radius))
         } else {
-          const want = order[back].radiusM + plot.radiusM + laneClearM
+          const want = seated[back].radiusM + plot.radiusM + laneClearM
           const cos =
             (radii[back] ** 2 + radius ** 2 - want ** 2) /
             (2 * radii[back] * radius)

--- a/ui/lib/lunar-atlas/seed/atlas.dataset.json
+++ b/ui/lib/lunar-atlas/seed/atlas.dataset.json
@@ -343,6 +343,22 @@
       ]
     },
     {
+      "id": "cnsa",
+      "name": "CNSA / CAST",
+      "kind": "agency",
+      "country": "China",
+      "website": "https://www.cnsa.gov.cn/english/",
+      "brandColor": "#E4572E",
+      "summary": "China's National Space Administration and the China Academy of Space Technology, which built and operates the Queqiao relay satellites. Queqiao-2 is the only lunar communications relay in service today, and CNSA has said publicly it will carry other nations' missions as well as China's own.",
+      "sources": [
+        {
+          "label": "CNSA — China launches new relay satellite for Earth-Moon communications",
+          "url": "https://www.cnsa.gov.cn/english/n6465652/n6465653/c10489434/content.html",
+          "retrievedAt": "2026-08-28"
+        }
+      ]
+    },
+    {
       "id": "esa",
       "name": "European Space Agency",
       "kind": "international",
@@ -2590,6 +2606,101 @@
       "visibility": "public"
     },
     {
+      "id": "queqiao-2",
+      "orgId": "cnsa",
+      "name": "Queqiao-2 Relay",
+      "type": "comms_pnt",
+      "summary": "The only lunar communications relay actually in service. Queqiao-2 reached lunar orbit in March 2024 and has carried Chang'e-4 on the far side and Chang'e-6 through the first sample return ever flown from it, at downlink rates from 1 to 500 Mb/s. It is the incumbent every other bid in this race is trying to displace — with one caveat that keeps it from being the favourite outright: it answers to CNSA's own standards rather than the NASA/ESA LunaNet framework, so a Western mission cannot simply buy time on it.",
+      "location": {
+        "lat": -88.75,
+        "lon": 60
+      },
+      "locationPrecision": "region",
+      "regionLabel": "Lunar South Pole — service coverage area",
+      "milestones": [
+        {
+          "id": "queqiao2-launch",
+          "title": "Launched to lunar orbit on a Long March 8",
+          "targetDate": "2024-03",
+          "datePrecision": "month",
+          "status": "achieved",
+          "sources": [
+            {
+              "label": "CNSA — China launches new relay satellite for Earth-Moon communications",
+              "url": "https://www.cnsa.gov.cn/english/n6465652/n6465653/c10489434/content.html",
+              "retrievedAt": "2026-08-28"
+            }
+          ]
+        },
+        {
+          "id": "queqiao2-in-service",
+          "title": "In-orbit tests complete; relaying for Chang'e-4 on the far side",
+          "targetDate": "2024-04",
+          "datePrecision": "month",
+          "status": "achieved",
+          "sources": [
+            {
+              "label": "China Daily — Relay satellite ready for lunar mission service",
+              "url": "https://www.chinadaily.com.cn/a/202404/13/WS6619c67ea31082fc043c1be6.html",
+              "retrievedAt": "2026-08-28"
+            }
+          ]
+        },
+        {
+          "id": "queqiao2-change6",
+          "title": "Carried Chang'e-6 — first sample return from the lunar far side",
+          "targetDate": "2024-06",
+          "datePrecision": "month",
+          "status": "achieved",
+          "metrics": [
+            {
+              "label": "Downlink rate to Earth",
+              "value": 500,
+              "unit": "Mb/s"
+            }
+          ],
+          "sources": [
+            {
+              "label": "Journal of Deep Space Exploration — Queqiao-2 integrated data processing and transmission",
+              "url": "https://doi.org/10.3724/j.issn.2096-9287.2026.20250043",
+              "retrievedAt": "2026-08-28"
+            }
+          ]
+        },
+        {
+          "id": "queqiao2-change7",
+          "title": "Relay support for Chang'e-7 at the south pole",
+          "targetDate": "2026",
+          "datePrecision": "estimated",
+          "status": "planned",
+          "sources": [
+            {
+              "label": "CNSA — China launches new relay satellite for Earth-Moon communications",
+              "url": "https://www.cnsa.gov.cn/english/n6465652/n6465653/c10489434/content.html",
+              "retrievedAt": "2026-08-28"
+            }
+          ]
+        }
+      ],
+      "sharedGoalIds": [
+        "shared-lunar-comms"
+      ],
+      "rosterStatus": "listed",
+      "sources": [
+        {
+          "label": "China Daily — Relay satellite ready for lunar mission service",
+          "url": "https://www.chinadaily.com.cn/a/202404/13/WS6619c67ea31082fc043c1be6.html",
+          "retrievedAt": "2026-08-28"
+        },
+        {
+          "label": "CNSA — China launches new relay satellite for Earth-Moon communications",
+          "url": "https://www.cnsa.gov.cn/english/n6465652/n6465653/c10489434/content.html",
+          "retrievedAt": "2026-08-28"
+        }
+      ],
+      "visibility": "public"
+    },
+    {
       "id": "solstar-lunar-wifi",
       "orgId": "solstar-space",
       "name": "Lunar WiFi Access Point",
@@ -3122,13 +3233,14 @@
     {
       "id": "shared-lunar-comms",
       "title": "First operational lunar communications and navigation service",
-      "description": "Every mission today flies its own radio link back to Earth, which does not scale to a base. Five groups are trying to make connectivity something you buy: Modul8 — the Nokia Bell Labs venture that spun out in 2026 — has already run LTE on the surface, Intuitive Machines holds NASA's Near Space Network relay contract, ESA is procuring the Moonlight constellation behind its Lunar Pathfinder relay, Lockheed's Crescent Space is selling Parsec as a subscription, and Solstar — which flew the first commercial WiFi hotspot in space in 2018 — is adapting that same hardware into a lunar-rated access point under NASA SBIR funding. Coverage and interoperability decide who can sell a service at all; throughput decides whether it is worth buying, which is why bandwidth is a bar here and not a footnote.",
+      "description": "Every mission today flies its own radio link back to Earth, which does not scale to a base. One relay is already up and working — China's Queqiao-2 has been in lunar orbit since 2024 and carried Chang'e-6 through the first far-side sample return — so this race is really about who can sell that as a service to anyone who asks. Five others are trying: Modul8, the Nokia Bell Labs venture that spun out in 2026, has already run LTE on the surface; Intuitive Machines holds NASA's Near Space Network relay contract; ESA is procuring the Moonlight constellation behind its Lunar Pathfinder relay; Lockheed's Crescent Space is selling Parsec as a subscription; and Solstar — which flew the first commercial WiFi hotspot in space in 2018 — is adapting that hardware into a lunar-rated access point under NASA SBIR funding. Coverage and interoperability decide who can sell a service at all, which is where the incumbent is weakest; throughput decides whether it is worth buying, which is why bandwidth is a bar here and not a footnote.",
       "projectIds": [
         "nokia-lunar-lte",
         "im-near-space-network",
         "esa-lunar-pathfinder",
         "crescent-parsec",
-        "solstar-lunar-wifi"
+        "solstar-lunar-wifi",
+        "queqiao-2"
       ],
       "location": {
         "lat": -88.7,
@@ -3170,11 +3282,12 @@
         "status": "planned",
         "resolutionAuthority": "senate",
         "impliedOdds": {
-          "nokia-lunar-lte": 0.28,
-          "im-near-space-network": 0.26,
-          "esa-lunar-pathfinder": 0.23,
-          "crescent-parsec": 0.17,
-          "solstar-lunar-wifi": 0.06
+          "queqiao-2": 0.24,
+          "nokia-lunar-lte": 0.21,
+          "im-near-space-network": 0.2,
+          "esa-lunar-pathfinder": 0.18,
+          "crescent-parsec": 0.13,
+          "solstar-lunar-wifi": 0.04
         }
       },
       "sources": [

--- a/ui/lib/lunar-atlas/skyplan.ts
+++ b/ui/lib/lunar-atlas/skyplan.ts
@@ -99,6 +99,21 @@ export const SKY_STATIONS: Record<string, SkyStation[]> = {
     { bearingDeg: 20, ringM: 200, altM: 380, wingBearingDeg: 132 },
     { bearingDeg: 340, ringM: 150, altM: 300, wingBearingDeg: 148 },
   ],
+  // One station, for the one relay in this race that is already flying.
+  //
+  // It is the furthest out and the lowest of all four programs (430 m at 240 m
+  // altitude, where the American and European birds sit between 150 and 360 m
+  // out and 300 to 500 m up), which is not a ranking but a separation: three of
+  // these programs are selling into the same Western market and read as one
+  // cluster, and Queqiao-2 answers to nobody in it. Standing it off on its own
+  // arc says that before any panel does.
+  //
+  // Bearing 40° is the lighting choice. The 4.2 m reflector is pitched down
+  // and OUTWARD (see QQ_DISH_PITCH), so unlike the Earth-pointing relays the
+  // face worth seeing is the one turned away from the colony — which puts the
+  // sun, at bearing 50°, almost directly behind an eye standing off outward
+  // here. Bearings past about 95° swing that gold mesh into its own shadow.
+  'queqiao-2': [{ bearingDeg: 40, ringM: 430, altM: 240, wingBearingDeg: 134 }],
 }
 
 // Meters east and north of the ridge center.


### PR DESCRIPTION
> **Stacked on #1553.** Based on `fix/atlas-deloitte-corrections` because the
> `shared-lunar-comms` description edited here was introduced by that PR.
> GitHub retargets this to `main` automatically once #1553 merges. Review the
> [two-dot diff](https://github.com/Official-MoonDao/MoonDAO/compare/fix/atlas-deloitte-corrections...feat/atlas-queqiao-2) to see only this PR's changes.

## Why

The comms race was missing the only lunar relay that actually works. CNSA's
Queqiao-2 has been in lunar orbit since March 2024 and carried Chang'e-6
through the first sample return ever flown from the far side. Leaving it out
meant the race read as five bids competing for a job nobody had done yet.

It joins at **24%**, the highest in the field, with the other five rebalanced
to keep the odds summing to 1. High because it is the incumbent; not higher
still because it answers to CNSA's own standards rather than the NASA/ESA
LunaNet framework, so a Western mission cannot simply buy time on it. That
caveat is written into the project summary and the race description rather
than left implied.

## What's in it

**The competitor.** New `cnsa` org (CNSA / CAST) and a `queqiao-2` project
with four sourced milestones: the Long March 8 launch (2024-03), in-orbit
checkout and Chang'e-4 far-side service (2024-04), Chang'e-6 at 500 Mb/s
(2024-06), and Chang'e-7 support ahead (2026).

**Two models**, following the orbiter-plus-ground pattern the other three
relay bids already use.

The orbiter is built around the one proportion that makes it recognisable: a
4.2 m gold mesh reflector aimed at the **Moon** and a 0.6 m dish aimed at
**Earth**. That reads backwards until you ask which end of each link owns the
big antenna — into a ground station tens of metres across it can whisper,
while to a lander it is the only good antenna in the conversation and carries
the whole link budget itself. Both figures are CNSA's own. The mesh is drawn
as a solid gold cap with a wireframe cap of the same profile 2 cm inside it,
since a sphere's own wireframe is already the radial-and-hoop grid a
rib-and-cord antenna is made of — 24 ribs for one extra mesh instead of
ninety-six.

The ground lot is the district's only **two-axis tracking mount**, which is
the direct counter-argument to Crescent's gimbal-less patch a few lots away:
one satellite in a 24-hour ellipse has to be followed across the sky, a
constellation never does. Standing those two side by side is the clearest
statement the district makes about what a customer is buying.

The dish is deliberately **not** aimed at Moon Base Zero. Queqiao-2's
customers are Chang'e landers elsewhere on the Moon, so aiming it here would
claim a service the colony cannot actually buy.

## The layout bug this exposed

Adding a sixth competitor surfaced a live bug rather than causing one, and
this is the part worth reviewing closely.

The four corner seats of a crossroads alternate outward and inward of main
street, and they are not equally deep — an inward lot reaches back toward the
perimeter road, so every extra metre of radius costs it two metres of
clearance. `districtSlots` seated plots strictly largest-first, which put the
*second* biggest plot on the first inward corner every time:

| District | Plot | Before | After |
|---|---|---|---|
| `isru_plant` | Cislune (9.5 m) | **−5.4 m** (on the road) | +29.8 m |
| `comms_pnt` | Solstar (7.5 m) | **−1.4 m** (on the road) | +29.8 m |

Nothing failed, because `ROSTERS` in `lunar-atlas-baseplan.cy.ts` is mirrored
by hand and **both projects were missing from it**. An under-counted roster
does not fail — it quietly stops testing the case that breaks.

Seating is now size-aware: biggest onto the outward seats, smallest onto the
inward ones. The fill **order** is untouched, so a two-competitor race still
gets one lot either side of both streets (the reason `CORNERS` fills
diagonally). Worst margin on the map is now construction's +1.0 m, where all
five plots are an identical 6.3 m and no seating choice can help.

Both rosters are corrected to their true counts here, and "add a competitor to
`ROSTERS` in the same change" is now a house rule in the handoff doc.

⚠️ This does move some existing competitors between corners in the `power`
and `isru_plant` districts. Two alternatives were considered and rejected:
giving Cislune/Solstar smaller `PROJECT_SIZE_M` figures (would shrink a 15 m
site model to a doll's house) and pushing `MAIN_LOOP_M` outward (moves every
road on the map).

## Verification

- 120 lunar-atlas unit tests pass.
- Typecheck clean, apart from four pre-existing errors in
  `scripts/verify-deprize-moonbase-sepolia.ts` that predate this branch.
- Span (5.34 m), dish-to-wing clearance (0.31 m) and terminal height (2.28 m,
  which corrected a declared 2.2 m) were measured with a scratch script and
  the script deleted, per §5 of the handoff doc.

**Not yet viewed in a browser** — the same caveat the handoff doc carries for
the whole sky layer. If the framing needs tuning the two knobs are
`QQ_DISH_PITCH` (48° below horizontal) and the station bearing in
`skyplan.ts` (40°, chosen so the sun falls behind an eye standing off outward).

Made with [Cursor](https://cursor.com)