### PR TITLE
Physically-grounded shading for Moon Base Zero

### DIFF
--- a/ui/components/lunar-atlas/EarthGlobe.tsx
+++ b/ui/components/lunar-atlas/EarthGlobe.tsx
@@ -42,9 +42,8 @@
 // show isn't a specific real moment. It is an honest phase of SOME sun
 // direction rather than a flat, unlit decal, which is what actually reads as
 // a real planet instead of a sticker.
-
-import { useEffect, useMemo, useRef, useState } from 'react'
 import { useFrame } from '@react-three/fiber'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 import {
   CAP_CENTER_HEIGHT_M,
@@ -59,17 +58,17 @@ const EARTH_RADIUS_M = 6_371_000 // mean radius
 const EARTH_MOON_MEAN_DIST_M = 384_400_000
 // Half-angle subtended by Earth's disc at mean distance — the real fact this
 // whole model exists to preserve, independent of the portrayed distance below.
-const EARTH_ANGULAR_RADIUS_RAD = Math.atan(EARTH_RADIUS_M / EARTH_MOON_MEAN_DIST_M)
+export const EARTH_ANGULAR_RADIUS_RAD = Math.atan(EARTH_RADIUS_M / EARTH_MOON_MEAN_DIST_M)
 
 // Degrees CCW from east — the ridge's own bearing convention (see
 // capLocalDirection). ~90° is very close to due "north" underneath this
 // near-polar site, which is geometrically required: the equatorial near side
 // Earth hangs over is, from 89.46°S, in the direction away from the pole.
-const EARTH_BEARING_DEG = 90
+export const EARTH_BEARING_DEG = 90
 // Reuse the relay dishes' own "Earth sits ~8° above horizontal, at the
 // favorable point in its libration cycle" fact (see SAT_DISH_EL) rather than
 // asserting a second, independently-chosen number for the same real object.
-const EARTH_ELEV_DEG = (SAT_DISH_EL * 180) / Math.PI
+export const EARTH_ELEV_DEG = (SAT_DISH_EL * 180) / Math.PI
 
 // Portrayed distance from the ridge, in scene units. Comfortably inside the
 // Canvas far plane (GLOBE_RADIUS*40) and the star shell's inner radius

--- a/ui/components/lunar-atlas/MoonGlobe.tsx
+++ b/ui/components/lunar-atlas/MoonGlobe.tsx
@@ -11,16 +11,14 @@
 // The world is still a sphere mathematically — positions are directions
 // scaled by a radius — so all the geo.ts framing math carries over; only the
 // rendered patch is the ridge.
-
 import { Stars, TrackballControls } from '@react-three/drei'
 import { Canvas, useFrame, useThree } from '@react-three/fiber'
-import { Bloom, EffectComposer } from '@react-three/postprocessing'
+import { Bloom, EffectComposer, ToneMapping } from '@react-three/postprocessing'
+import { ToneMappingMode } from 'postprocessing'
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
-import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js'
 import {
   drillInFraming,
-  latLonToVector3,
   MOON_RADIUS_M,
   orbitUpVector,
   skyViewFraming,
@@ -29,10 +27,9 @@ import {
   surfaceViewFraming,
   vector3ToLatLon,
 } from '@/lib/lunar-atlas/geo'
-import {
-  HOME_CAM as HOME_CAM_M,
-  HOME_TARGET as HOME_TARGET_M,
-} from '@/lib/lunar-atlas/homeview'
+import type { Vec3 } from '@/lib/lunar-atlas/geo'
+import { HOME_CAM as HOME_CAM_M, HOME_TARGET as HOME_TARGET_M } from '@/lib/lunar-atlas/homeview'
+import type { TechTree } from '@/lib/lunar-atlas/selectors'
 import {
   CAP_CENTER_HEIGHT_M,
   M_TO_UNITS,
@@ -41,24 +38,21 @@ import {
   capLocalDirection,
   heightToRadius,
 } from '@/lib/lunar-atlas/southpole'
+import {
+  SUN_ANGULAR_RADIUS_RAD,
+  SUN_COLOR,
+  SUN_DIR as SUN_DIR_ARR,
+  SUN_INTENSITY,
+} from '@/lib/lunar-atlas/sun'
 import { GLOBE_RADIUS } from '@/lib/lunar-atlas/textures'
-import type { Vec3 } from '@/lib/lunar-atlas/geo'
-import type { TechTree } from '@/lib/lunar-atlas/selectors'
-import type {
-  Organization,
-  Project,
-  ProjectType,
-} from '@/lib/lunar-atlas/types'
+import type { Organization, Project, ProjectType } from '@/lib/lunar-atlas/types'
 import BaseRoads from './BaseRoads'
 import EarthGlobe from './EarthGlobe'
 import GroundDisturbance from './GroundDisturbance'
-import MarkerLayer, {
-  ColonyLayout,
-  MarkerStyle,
-  siteOpacity,
-} from './MarkerLayer'
+import MarkerLayer, { ColonyLayout, MarkerStyle, siteOpacity } from './MarkerLayer'
 import SkyLayer from './SkyLayer'
 import SouthPoleTerrain from './SouthPoleTerrain'
+import { buildLunarEnvironmentTexture } from './lunarEnvironment'
 import useTerrainSampler, { RadiusAt } from './useTerrainSampler'
 
 export type GlobeFocus = {
@@ -240,11 +234,7 @@ function CameraRig({
               // Close in from whichever side the camera is already on, so a
               // site click zooms straight in rather than orbiting around to
               // the subject's back.
-              approachFrom: [
-                camera.position.x,
-                camera.position.y,
-                camera.position.z,
-              ],
+              approachFrom: [camera.position.x, camera.position.y, camera.position.z],
             })
           : drillInFraming(
               focus.lat,
@@ -255,20 +245,14 @@ function CameraRig({
       // Pans onto a subject glide in slowly for a cinematic feel, whether that
       // subject is on the ground, over it or under it; orbit moves snappier.
       easeBase.current =
-        focus.view === 'surface' || focus.view === 'sky' || focus.view === 'sub'
-          ? 0.05
-          : 0.0022
+        focus.view === 'surface' || focus.view === 'sky' || focus.view === 'sub' ? 0.05 : 0.0022
       desiredPos.current.set(position[0], position[1], position[2])
       desiredTarget.current.set(target[0], target[1], target[2])
       // Surface, sky and cutaway views roll the camera so "up" is the local
       // outward normal — otherwise the view is upside down at the pole. Orbit
       // views use a pole-safe up (raw world-Y is parallel to the view axis when
       // looking straight down at the pole).
-      if (
-        focus.view === 'surface' ||
-        focus.view === 'sky' ||
-        focus.view === 'sub'
-      ) {
+      if (focus.view === 'surface' || focus.view === 'sky' || focus.view === 'sub') {
         const n = surfaceNormal(focus.lat, focus.lon)
         desiredUp.current.set(n[0], n[1], n[2])
       } else {
@@ -315,9 +299,7 @@ function CameraRig({
     // metres off the deck after selecting a site. Scale both with the
     // camera's distance to its pivot so close-in inspection is gentle.
     const pivotDist = camera.position.distanceTo(curTarget)
-    const feel = Math.sqrt(
-      THREE.MathUtils.clamp(pivotDist / (2000 * M_TO_UNITS), 0, 1)
-    )
+    const feel = Math.sqrt(THREE.MathUtils.clamp(pivotDist / (2000 * M_TO_UNITS), 0, 1))
     controls.rotateSpeed = THREE.MathUtils.lerp(0.3, 2.2, feel)
     controls.zoomSpeed = THREE.MathUtils.lerp(0.5, 1.2, feel)
 
@@ -325,13 +307,9 @@ function CameraRig({
     // back to the ridge center. Without this, zooming out from a site leaves
     // the patch hanging half off-screen, orbiting a surface point the user
     // can no longer even see.
-    if (
-      !animating.current &&
-      curTarget.distanceToSquared(HOME_TARGET) > (1 * M_TO_UNITS) ** 2
-    ) {
+    if (!animating.current && curTarget.distanceToSquared(HOME_TARGET) > (1 * M_TO_UNITS) ** 2) {
       // Altitude above the base's ground level, in meters.
-      const altM =
-        (camera.position.length() - HOME_TARGET.length()) / M_TO_UNITS
+      const altM = (camera.position.length() - HOME_TARGET.length()) / M_TO_UNITS
       const recenter = THREE.MathUtils.clamp((altM / 2500 - 1) / 0.8, 0, 1)
       if (recenter > 0) {
         curTarget.lerp(HOME_TARGET, 1 - Math.pow(0.02, delta * recenter))
@@ -366,10 +344,7 @@ function CameraRig({
       // up-vector along a real axis (via a partial quaternion) rather than lerp,
       // so a 180° flip at the pole doesn't pass through a degenerate zero.
       const curUp = camera.up.clone().normalize()
-      const full = new THREE.Quaternion().setFromUnitVectors(
-        curUp,
-        desiredUp.current
-      )
+      const full = new THREE.Quaternion().setFromUnitVectors(curUp, desiredUp.current)
       const step = new THREE.Quaternion().slerp(full, t)
       camera.up.copy(curUp).applyQuaternion(step).normalize()
       controls.update()
@@ -390,14 +365,11 @@ function CameraRig({
   return null
 }
 
-// Direction from the Moon's center toward the sun. MUST match SUN_AZ_DEG /
-// SUN_EL_DEG in the bake script (lon = azimuth, |lat| = elevation): cast
-// shadows falling a different way than the terrain's baked hillshade would
-// read instantly as fake. At the ridge this works out to a ~44.5° sun.
-const SUN_DIR = (() => {
-  const v = latLonToVector3(-45, 40, 1)
-  return new THREE.Vector3(v[0], v[1], v[2]).normalize()
-})()
+// Direction from the Moon's center toward the sun. Derived in lib/sun.ts from
+// the bake script's own azimuth and elevation, so a cast shadow can never fall
+// a different way than the terrain's baked hillshade — which would read as
+// fake instantly. At the ridge this works out to a 44.46° sun at bearing 50°.
+const SUN_DIR = new THREE.Vector3(...SUN_DIR_ARR)
 
 // The shadow-casting light is parked 2 km up the sun vector and aimed at the
 // base, rather than out at the real sun: a directional light's shadow map
@@ -408,6 +380,32 @@ const SUN_DIR = (() => {
 // correct here: the terrain's own large-scale shadows are already baked in.
 const SHADOW_LIGHT_DIST = 2000 * M_TO_UNITS
 const SHADOW_EXTENT = 400 * M_TO_UNITS
+
+// Lunar shadows are HARD, and this is the arithmetic that says so rather than
+// a preference. The sun subtends 0.533° from the Moon (SUN_ANGULAR_RADIUS_RAD),
+// so a penumbra widens by 2·tan(0.2664°) = 9.3 MILLIMETRES for every metre an
+// occluder stands off what it is shadowing. This shadow map spans 800 m across
+// 4096 texels — 19.5 cm per texel — so even the 52 m Starship casts a penumbra
+// only about a texel wide at its own tip, and everything smaller casts one that
+// is entirely sub-texel.
+//
+// A PCSS pass (drei's SoftShadows) was the obvious move here and is the wrong
+// one: contact-hardening soft shadows exist to portray a penumbra that this
+// scene, uniquely, does not have. It would only invent softness the Moon has
+// none of, for a real per-frame cost. What the shadow edge actually needs is
+// antialiasing of a hard step, which is what PCFSoftShadowMap does — its fixed
+// filter works out to roughly a texel, i.e. about the penumbra of a 20 m
+// standoff, so the one place it errs it errs toward the truth.
+const SUN_PENUMBRA_PER_M = 2 * Math.tan(SUN_ANGULAR_RADIUS_RAD)
+
+// Offset along the surface normal to kill shadow acne on the terrain's sloped
+// cells. It buys that at the cost of sliding the shadow laterally by the same
+// distance, and at 0.35 m — nearly two shadow texels — that slide was visible
+// as a gap under every footpad: the classic detached, pasted-on-a-photo look
+// the shadow catcher exists to prevent. 12 cm is still over half a texel of
+// bias, which the 15.6 m polygon pitch of the terrain has ample slope margin
+// for, and it puts contact shadows back against the things casting them.
+const SHADOW_NORMAL_BIAS = 0.12 * M_TO_UNITS
 
 // The models' sun. The terrain is UNLIT — its lighting is baked into the
 // albedo as hillshade (see build-southpole-assets.py and SouthPoleTerrain) —
@@ -432,8 +430,8 @@ function Sun() {
       <directionalLight
         position={lightPos}
         target={target}
-        intensity={3.1}
-        color="#fff6ec"
+        intensity={SUN_INTENSITY}
+        color={SUN_COLOR}
         castShadow
         shadow-mapSize-width={4096}
         shadow-mapSize-height={4096}
@@ -443,40 +441,53 @@ function Sun() {
         shadow-camera-bottom={-SHADOW_EXTENT}
         shadow-camera-near={SHADOW_LIGHT_DIST * 0.6}
         shadow-camera-far={SHADOW_LIGHT_DIST * 1.6}
-        // Offset along the surface normal rather than in depth: it kills
-        // shadow acne on the terrain's sloped cells without the peter-panning
-        // that a plain depth bias causes at contact points.
-        shadow-normalBias={0.35 * M_TO_UNITS}
+        shadow-normalBias={SHADOW_NORMAL_BIAS}
       />
-      {/* Airless fill. There is no atmosphere to scatter light on the Moon,
-          so a shadowed face is lit only by regolith bounce (albedo ~0.11) and
-          starlight — nearly black. The generous fill this used to carry is
-          what made the hardware look like plastic toys under a softbox. */}
-      <hemisphereLight args={['#8f9bb5', '#413f3a', 0.14]} />
-      <ambientLight intensity={0.07} />
+      {/* No hemisphere light and no ambient light, on purpose.
+          
+          There is no atmosphere here, so there is no sky to scatter anything:
+          the ONLY thing filling a lunar shadow is light bounced off the
+          regolith around it, and that arrives from BELOW, warm-grey, at about
+          4% of the sun. A hemisphere light says the opposite — a blue glow
+          from overhead — and it is what made every shadowed face read as a
+          plastic toy under a softbox, because it lit the one hemisphere that
+          in reality has nothing in it at all.
+          
+          That bounce is now carried by the regolith environment map, which
+          gets it directionally right for free: a downward-facing panel is lit
+          by the ground it faces and an upward-facing one goes almost black.
+          See LunarEnvironment below. */}
     </>
   )
 }
 
-// Fully metallic PBR materials (Starship's stainless steel, rover chassis)
-// reflect only their environment — under punctual lights alone they render
-// near-black. A neutral generated studio environment gives them something to
-// reflect; kept subtle so matte surfaces still read as sun-lit regolith
-// hardware. Terrain is unaffected (unlit MeshBasicMaterial).
-function MetalEnvironment() {
+// The indirect half of the lighting, and the only fill in the scene.
+//
+// Two jobs at once, which is why one texture can replace both a studio
+// environment map and a hemisphere light. It gives fully metallic surfaces
+// (Starship's stainless, gold MLI, a polished dish web) something true to
+// reflect, since under punctual lights alone they render near-black. And its
+// lower hemisphere IS the regolith bounce, so it fills shadows from the right
+// direction, in the right colour, at the right strength.
+//
+// Because its radiances are derived from SUN_INTENSITY rather than dialled in
+// (see lunarEnvironment.ts), the intensity here is 1 and means it: this is
+// what the surroundings are actually as bright as, not a taste knob.
+//
+// Terrain is unaffected — it is an unlit MeshBasicMaterial.
+function LunarEnvironment() {
   const { gl, scene } = useThree()
   useEffect(() => {
     const pmrem = new THREE.PMREMGenerator(gl)
-    const env = pmrem.fromScene(new RoomEnvironment(), 0.04).texture
+    const src = buildLunarEnvironmentTexture()
+    const env = pmrem.fromEquirectangular(src).texture
     scene.environment = env
-    // Just enough for stainless and foil to stop reading as black holes —
-    // any more and it doubles as ambient fill, flattening the hard lunar
-    // light the directional sun and shadows are there to create.
-    scene.environmentIntensity = 0.28
+    scene.environmentIntensity = 1
+    src.dispose()
+    pmrem.dispose()
     return () => {
       scene.environment = null
       env.dispose()
-      pmrem.dispose()
     }
   }, [gl, scene])
   return null
@@ -508,8 +519,7 @@ export default function MoonGlobe({
   // is graded out to a plot nobody has broken ground on yet.
   const sitePresence = useMemo(() => {
     const byCategory = new Map<string, number>()
-    for (const t of trees ?? [])
-      byCategory.set(t.category, siteOpacity(t, getProjectStyle))
+    for (const t of trees ?? []) byCategory.set(t.category, siteOpacity(t, getProjectStyle))
     return byCategory
   }, [trees, getProjectStyle])
   // The built environment — graded roads, the hardstand, street lighting, the
@@ -563,7 +573,9 @@ export default function MoonGlobe({
   return (
     <Canvas
       dpr={[1, 2]}
-      shadows
+      // PCF-soft rather than the default hard PCF: see SUN_PENUMBRA_PER_M for
+      // why this is an antialiasing choice and not a softness one.
+      shadows="soft"
       camera={{
         position: [DEFAULT_CAM.x, DEFAULT_CAM.y, DEFAULT_CAM.z],
         up: [HOME_UP.x, HOME_UP.y, HOME_UP.z],
@@ -574,8 +586,32 @@ export default function MoonGlobe({
       }}
       gl={{
         antialias: true,
-        toneMapping: THREE.ACESFilmicToneMapping,
-        toneMappingExposure: 1.2,
+        // The tone curve that actually runs is the <ToneMapping> effect at the
+        // end of the EffectComposer, NOT this — @react-three/postprocessing
+        // forces gl.toneMapping to NoToneMapping for as long as its composer is
+        // mounted. This scene asked for ACES here for a long time and never got
+        // it: the image went to the screen as a raw linear-to-sRGB conversion
+        // that clipped flat at white, which is most of why the regolith read as
+        // grey plastic. Setting it anyway keeps the renderer honest if the
+        // composer is ever removed, and it must stay equal to the effect's mode.
+        toneMapping: THREE.AgXToneMapping,
+        // Read by the effect: three's tonemapping shader chunk declares
+        // toneMappingExposure, and the renderer uploads it regardless of which
+        // curve is selected.
+        //
+        // Solved rather than dialled. The terrain is an unlit material, so the
+        // only thing between its baked albedo and the screen is this curve, and
+        // that bake was authored to look right with no curve at all — sunlit
+        // regolith sat at sRGB 163. Running three's own AgX at 1.05 lands it on
+        // sRGB 163 again, so the ground is left exactly where its author put it
+        // and every bit of what the curve buys is spent at the two ends: four
+        // full stops of headroom above the regolith before anything approaches
+        // white (+4 stops is still only sRGB 245, and nothing in the frame
+        // clips), and a toe that still separates -6 stops from black. That is
+        // the whole point on a world with a 0.5° sun and no atmosphere, where
+        // a sunlit panel and the shadow beside it are three orders of magnitude
+        // apart and neither end may be thrown away.
+        toneMappingExposure: 1.05,
         // A LOGARITHMIC depth buffer is the obvious choice for a scene that
         // spans orbit to millimeters, and it was used here, and it was the
         // wrong call — it is the direct cause of the shimmer that has been
@@ -600,9 +636,7 @@ export default function MoonGlobe({
       }}
       onPointerMissed={(e) => {
         const down = pointerDownAt.current
-        const moved = down
-          ? Math.hypot(e.clientX - down.x, e.clientY - down.y)
-          : 0
+        const moved = down ? Math.hypot(e.clientX - down.x, e.clientY - down.y) : 0
         if (moved <= CLICK_DRAG_TOLERANCE_PX) onBackgroundClick?.()
       }}
       onPointerDown={(e) => {
@@ -614,7 +648,7 @@ export default function MoonGlobe({
       <color attach="background" args={['#03040a']} />
 
       <Sun />
-      <MetalEnvironment />
+      <LunarEnvironment />
       <EarthGlobe />
 
       <Stars
@@ -629,11 +663,7 @@ export default function MoonGlobe({
 
       <SouthPoleTerrain onReady={onReady} onSurfaceClick={onBackgroundClick} />
 
-      <BaseRoads
-        radiusAt={radiusAt}
-        presence={basePresence}
-        siteOpacity={sitePresence}
-      />
+      <BaseRoads radiusAt={radiusAt} presence={basePresence} siteOpacity={sitePresence} />
 
       {/* Churned ground under the hardware. After the roads so a stain blends
           over a road's own crust where the two meet — a machine tracks dust
@@ -714,14 +744,64 @@ export default function MoonGlobe({
         target={[HOME_TARGET.x, HOME_TARGET.y, HOME_TARGET.z]}
       />
 
-      {/* High threshold keeps bloom off the sunlit regolith (which read as a
-          hazy video-game glow) and reserves it for emissive marker beacons. */}
+      {/* Bloom on linear HDR, then the tone curve. Every note about the chain
+          has to live out here rather than between the effects: EffectComposer
+          types its children as JSX.Element, so a JSX comment in there is a
+          type error, not a comment.
+
+          THERE IS NO AMBIENT OCCLUSION PASS, and not for want of trying. AO
+          would matter more on the Moon than almost anywhere — it approximates
+          how much of the INDIRECT light a point can see, and indirect here is
+          one thing only, regolith bounce at about 4% of the sun arriving from
+          below, so a crevice or the underside of a hull is not merely darker
+          than its surroundings but close to black. All three of the available
+          passes were wired up and measured, and all three failed:
+
+            - N8AO renders an entirely black frame. Even in its AO-only debug
+              mode (renderMode 1) the pass emits nothing.
+            - postprocessing's SSAO, on a NormalPass, renders — and does
+              nothing. Pushed from intensity 22 to 90 it moved the mean frame
+              luminance by 0.5 of 255.
+            - SMAA (not AO, but the same class of depth-consuming pass) spams
+              GL_INVALID_OPERATION on every frame.
+
+          The common cause is this scene's depth range, and it is not fixable
+          from here. Screen-space occlusion reconstructs view position from the
+          depth buffer, and the near plane is one METRE while the far plane is
+          past the Moon — a ratio of about 7e10. Beyond a few metres from the
+          eye every surface lands in the same handful of depth codes, so there
+          are no depth GRADIENTS left for an occlusion kernel to read. That
+          near plane is not negotiable (the camera has to be able to stand next
+          to a rover, and see the vault comments), and the long argument in the
+          Canvas gl props explains why a logarithmic buffer, which would fix
+          the range, is worse here for other reasons.
+
+          Some of what AO would have bought is recovered anyway, by accident of
+          getting the fill right: the regolith environment is bright below and
+          black above, so a surface that faces the ground is lit and one that
+          faces the sky is not. Orientation now does much of the work that
+          screen-space occlusion would have done by geometry. */}
       <EffectComposer>
         <Bloom
+          // High threshold keeps bloom off the sunlit regolith (which read as
+          // a hazy video-game glow) and reserves it for emissive beacons.
           intensity={0.3}
           luminanceThreshold={0.9}
           luminanceSmoothing={0.85}
           mipmapBlur
+        />
+        <ToneMapping
+          // AgX rather than ACES. ACES was written to make film look like film:
+          // it skews bright warm surfaces orange as they climb and saturates
+          // hard into the clip, which on a scene whose entire subject is
+          // neutral grey soil under a white sun is a colour cast applied to the
+          // one thing that must not have one. AgX desaturates toward white on
+          // the way up instead, the way a real sensor does, and holds a far
+          // longer shoulder — which is what a world with a 0.5° sun, no
+          // atmosphere and a black sky needs, since the range between a sunlit
+          // panel and the shadow beside it is enormous and neither end should
+          // clip.
+          mode={ToneMappingMode.AGX}
         />
       </EffectComposer>
     </Canvas>

--- a/ui/components/lunar-atlas/SouthPoleTerrain.tsx
+++ b/ui/components/lunar-atlas/SouthPoleTerrain.tsx
@@ -13,14 +13,16 @@
 // Geometry positions come from the same decoded height field the CPU sampler
 // (useTerrainSampler) reads, so everything seated on the terrain agrees with
 // the rendered ground by construction.
-
 import { useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 import {
-  CAP_GRID,
-  buildCapGeometry,
-  type PolarHeightField,
-} from '@/lib/lunar-atlas/southpole'
+  OPPOSITION_B0,
+  OPPOSITION_H,
+  PHASE_REF_DEG,
+  oppositionSurge,
+} from '@/lib/lunar-atlas/regolith'
+import { CAP_GRID, buildCapGeometry, type PolarHeightField } from '@/lib/lunar-atlas/southpole'
+import { SUN_DIR, SUN_MAP_AZ_DEG } from '@/lib/lunar-atlas/sun'
 import { SP_ALBEDO_MAP } from '@/lib/lunar-atlas/textures'
 import { loadInnerField } from './useTerrainSampler'
 
@@ -103,10 +105,11 @@ function makeDetailTile(size = 512): THREE.DataTexture {
     }
   }
 
-  // Hillshade with a wrapping gradient. Light azimuth matches SUN_AZ_DEG in
-  // the bake script (40°); elevation is kept moderate so bowls shade without
+  // Hillshade with a wrapping gradient. Light azimuth is the bake's own
+  // map-frame azimuth (SUN_MAP_AZ_DEG), which this file used to repeat as a
+  // bare 40 of its own; elevation is kept moderate so bowls shade without
   // going black. Flat ground maps to 128 so the multiply blend is neutral.
-  const az = (40 * Math.PI) / 180
+  const az = (SUN_MAP_AZ_DEG * Math.PI) / 180
   const el = (35 * Math.PI) / 180
   const lx = Math.sin(az) * Math.cos(el)
   const ly = Math.cos(az) * Math.cos(el)
@@ -180,15 +183,43 @@ export default function SouthPoleTerrain({
   }, [innerGeo, albedo, onReady])
 
   // Multiplies octaves of the tiled craterlet shading into the cap's diffuse
-  // so magnified close-ups keep structure. Mean is ~1.0 (flat tile = 0.5,
-  // blend is 0.76 + 0.48·dn), so the overall tone is preserved.
+  // so magnified close-ups keep structure, then applies the one piece of
+  // regolith shading a bake can never hold (see the surge block below). Mean
+  // of the detail blend is ~1.0 (flat tile = 0.5, blend is 0.76 + 0.48·dn), so
+  // the overall tone is preserved.
   const onBeforeCompile = useMemo(
     () => (shader: THREE.WebGLProgramParametersWithUniforms) => {
       shader.uniforms.detailMap = { value: detail }
+      shader.uniforms.sunDirection = {
+        value: new THREE.Vector3(...SUN_DIR),
+      }
+      shader.uniforms.surgeRef = {
+        value: oppositionSurge((PHASE_REF_DEG * Math.PI) / 180),
+      }
+
+      // The phase angle has to be computed in VIEW space, not world space.
+      // World positions on this mesh are magnitude ~2 in float32, where a step
+      // is 21 cm (the precision argument in southpole.ts' buildCapGeometry) —
+      // eight metres from the eye that is a 1.5° error in the view direction,
+      // and the surge would boil as the camera moved. The geometry is stored
+      // camera-relative with its offset on the mesh transform precisely so
+      // that modelViewMatrix · position stays exact, so mvPosition is the one
+      // place in this shader where the view vector can be trusted.
+      shader.vertexShader = shader.vertexShader
+        .replace('#include <common>', '#include <common>\nvarying vec3 vSurgeViewPos;')
+        .replace(
+          '#include <project_vertex>',
+          '#include <project_vertex>\nvSurgeViewPos = mvPosition.xyz;'
+        )
+
       shader.fragmentShader = shader.fragmentShader
         .replace(
           '#include <map_pars_fragment>',
-          '#include <map_pars_fragment>\nuniform sampler2D detailMap;'
+          `#include <map_pars_fragment>
+          uniform sampler2D detailMap;
+          uniform vec3 sunDirection;
+          uniform float surgeRef;
+          varying vec3 vSurgeViewPos;`
         )
         .replace(
           '#include <map_fragment>',
@@ -210,6 +241,35 @@ export default function SouthPoleTerrain({
             // a long, soft gradient turns the slab into a fading disc.
             float rr = length(vMapUv - 0.5) * 2.0;
             diffuseColor.rgb *= 1.0 - smoothstep(0.82, 1.34, rr);
+
+            // The opposition surge — the one thing about regolith that a baked
+            // hillshade fundamentally cannot carry, because a bake has no
+            // viewer and this term depends only on where the viewer is.
+            //
+            // Regolith is a deep pile of loose grains, so it is full of tiny
+            // shadows, and every one of them hides behind the grain that casts
+            // it. Move the eye toward the sun and those shadows disappear
+            // behind their own grains, so the ground brightens sharply: it is
+            // why a full moon is far more than twice a half moon, and why an
+            // Apollo crewman photographed a halo around the shadow of his own
+            // head. Hapke's shadow-hiding term, B(g) = 1 + B0/(1 + tan(g/2)/h),
+            // with g the sun-surface-viewer phase angle (see regolith.ts).
+            //
+            // Divided through by its value at PHASE_REF_DEG so this is a
+            // RELATIVE effect. B is never below 1, so applying it raw would
+            // brighten the whole ridge and throw away the exposure the scene
+            // is tuned around; normalized at 85° — the mean phase angle across
+            // the home framing — the load-in shot is left within 2% of where it
+            // was and the surge only appears once the camera tumbles down-sun,
+            // which is exactly where it belongs. The clamp is a backstop for
+            // the last fraction of a degree around exact opposition, where the
+            // real surge keeps climbing and a bloom threshold is waiting.
+            vec3 toEye = normalize(-vSurgeViewPos);
+            vec3 toSun = normalize((viewMatrix * vec4(sunDirection, 0.0)).xyz);
+            float g = acos(clamp(dot(toSun, toEye), -1.0, 1.0));
+            float surge = 1.0 + ${OPPOSITION_B0.toFixed(3)}
+              / (1.0 + tan(0.5 * g) / ${OPPOSITION_H.toFixed(3)});
+            diffuseColor.rgb *= clamp(surge / surgeRef, 0.85, 1.75);
           }`
         )
     },
@@ -225,16 +285,12 @@ export default function SouthPoleTerrain({
   return (
     <group>
       {/* Unlit: the albedo IS the final shaded image (see header comment). */}
-      <mesh
-        geometry={innerGeo.geometry}
-        position={innerGeo.origin}
-        onClick={handleClick}
-      >
+      <mesh geometry={innerGeo.geometry} position={innerGeo.origin} onClick={handleClick}>
         <meshBasicMaterial
           map={albedo}
           onBeforeCompile={onBeforeCompile}
           // onBeforeCompile changes don't retrigger compilation on their own.
-          customProgramCacheKey={() => 'sp-inner-detail-v2'}
+          customProgramCacheKey={() => 'sp-inner-detail-v3-surge'}
         />
       </mesh>
       {/* Shadow catcher. An unlit material cannot receive shadows, so the
@@ -246,17 +302,19 @@ export default function SouthPoleTerrain({
           The terrain deliberately does NOT cast: its own relief shadows are
           already baked into the albedo, so casting them again would
           double-darken every slope. */}
-      <mesh
-        geometry={innerGeo.geometry}
-        position={innerGeo.origin}
-        receiveShadow
-      >
+      <mesh geometry={innerGeo.geometry} position={innerGeo.origin} receiveShadow>
         <shadowMaterial
           transparent
-          // Lunar shadows are near-black (no atmosphere to scatter light into
-          // them), lifted a hair by regolith bounce.
-          opacity={0.88}
-          color="#04050a"
+          // What is left in a lunar shadow is regolith bounce and nothing else
+          // — about 4% of the sun, computed from albedo 0.12 at a 44.5° solar
+          // incidence. Hence 0.92 rather than 0.88: shadows here are deeper
+          // than a terrestrial eye expects, because there is no sky to fill
+          // them. The residual was also the wrong COLOUR. It was a blue-black,
+          // which is the colour of a shadow on Earth, where the fill really is
+          // blue sky; the only thing lighting a lunar shadow is warm-grey soil
+          // a few metres away, so the floor it settles onto is warm.
+          opacity={0.92}
+          color="#0d0a06"
           depthWrite={false}
           polygonOffset
           polygonOffsetFactor={-1}

--- a/ui/components/lunar-atlas/lunarEnvironment.ts
+++ b/ui/components/lunar-atlas/lunarEnvironment.ts
@@ -1,0 +1,162 @@
+// What the metal on this ridge is standing in, so it has something true to
+// reflect.
+//
+// Every fully metallic PBR surface — Starship's stainless, gold MLI, a dish's
+// polished web, glazing — is almost pure specular: under punctual lights alone
+// it renders near-black, so it reflects its environment map or it reflects
+// nothing. This scene used three's RoomEnvironment for that, which is a
+// photographic studio: soft boxes, a bright ceiling, grey walls, light arriving
+// from every direction at once. It kept the metal from going black and it was
+// the single most unlunar thing in the frame. A studio has no horizon, and a
+// horizon is the whole visual signature of an airless world.
+//
+// So this builds the real thing instead — an equirectangular HDR of what you
+// would actually see standing on the connecting ridge:
+//
+//   - A HARD horizon. No atmosphere means no gradient, no haze, no scattering:
+//     brilliant regolith and then, across one pixel, black. On a curved metal
+//     surface that knife edge is what says "vacuum" more than anything else in
+//     the scene.
+//   - Black sky above, at a starlight floor rather than a true zero.
+//   - Regolith below at its real radiance, carrying both of the terms that
+//     make regolith look like regolith (see regolith.ts): the Lommel-Seeliger
+//     limb brightening that turns the horizon into a bright band, and the
+//     opposition surge, which puts a genuine heiligenschein glow in the
+//     down-sun direction — the same halo Apollo crews photographed around the
+//     shadow of their own heads.
+//   - Earth, at its real bearing and real angular size, as a small blue glint.
+//
+// WHAT IS DELIBERATELY NOT IN HERE: the sun. A directional light already gives
+// every material its GGX specular highlight, so a sun disc in the environment
+// would be a second sun — the same object lighting the same surface twice. The
+// environment carries strictly the INDIRECT half of the lighting, which is also
+// what makes it the correct thing for the ambient-occlusion pass to be
+// modulating.
+//
+// Radiances are in the renderer's own units, derived from SUN_INTENSITY rather
+// than dialled in, so scene.environmentIntensity can sit at 1 and mean it.
+import * as THREE from 'three'
+import { REGOLITH_ALBEDO, normalizedSurge } from '@/lib/lunar-atlas/regolith'
+import { capCenterDirection, capLocalDirection } from '@/lib/lunar-atlas/southpole'
+import { SUN_DIR, SUN_INTENSITY, SUN_LOCAL_ELEV_DEG } from '@/lib/lunar-atlas/sun'
+// The same Earth the user can see, not a second one that happens to agree
+// today: EarthGlobe owns the argument for where it hangs (the sub-Earth point
+// sits on the horizon from 89.46°S, and its elevation is the relay dishes' own
+// libration figure). Reflections that disagreed with the visible disc would be
+// the 40°/50° sun bug over again, in a place nobody would think to look.
+import { EARTH_ANGULAR_RADIUS_RAD, EARTH_BEARING_DEG, EARTH_ELEV_DEG } from './EarthGlobe'
+
+// 1024x512 is more than a PMREM needs for the rough mips, but the horizon and
+// Earth both live in the sharpest one: at this size a texel is 0.35°, so the
+// horizon lands within a third of a degree of true and Earth's 1.9° disc is
+// about five texels across instead of a suggestion. It is generated once.
+const ENV_W = 1024
+const ENV_H = 512
+
+// Integrated starlight and zodiacal light, which is all there is to light a
+// face that looks at nothing but sky. It is on the order of 1e-5 of the sunlit
+// ground, i.e. nothing; the value here is a floor, an order of magnitude up
+// from honest, kept only so that an up-facing shadowed panel lands on a very
+// dark colour rather than on exactly zero, where a tone curve has nothing to
+// work with and banding starts.
+const SKY_RADIANCE = 0.0012
+
+// A hint of blue, because what little light is up there is starlight.
+const SKY_TINT: [number, number, number] = [0.72, 0.8, 1.0]
+
+// Regolith is very slightly warm and almost perfectly neutral. Resist the urge
+// to make this a colour: lunar soil is grey, and the brown in Apollo surface
+// photography is largely film stock.
+const REGOLITH_TINT: [number, number, number] = [1.0, 0.972, 0.93]
+
+// A disc of cloud and ocean at Bond albedo ~0.3, lit by the same sun, and then
+// halved because at any moment roughly half of what faces the Moon is night.
+const EARTH_RADIANCE = (0.3 * SUN_INTENSITY) / Math.PI / 2
+const EARTH_TINT: [number, number, number] = [0.62, 0.74, 1.0]
+
+const dot3 = (a: readonly number[], b: readonly number[]) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+// Builds the equirectangular source. Feed it to a PMREMGenerator; it is not
+// useful as a texture on its own.
+export function buildLunarEnvironmentTexture(): THREE.DataTexture {
+  const data = new Float32Array(ENV_W * ENV_H * 4)
+
+  const up = capCenterDirection()
+  const earthDir = capLocalDirection(EARTH_BEARING_DEG, EARTH_ELEV_DEG)
+  const cosEarth = Math.cos(EARTH_ANGULAR_RADIUS_RAD)
+
+  // Cosine of the sun's incidence on flat ground — constant across the whole
+  // ground hemisphere, which is what keeps the Lommel-Seeliger term bounded
+  // here when it would run away on real terrain.
+  const mu0 = Math.sin((SUN_LOCAL_ELEV_DEG * Math.PI) / 180)
+  // Lambertian radiance of that ground, before either regolith term.
+  const groundBase = (REGOLITH_ALBEDO * SUN_INTENSITY * mu0) / Math.PI
+
+  // Soften the horizon across a single texel of elevation. A truly hard step
+  // would alias into a staircase in the sharpest mip, which reads as a jagged
+  // edge on a mirrored surface rather than as a crisp one.
+  const horizonSoften = Math.PI / ENV_H
+
+  for (let y = 0; y < ENV_H; y++) {
+    // Inverse of three's equirectUv: v runs from -Y at row 0 to +Y at the top.
+    const v = (y + 0.5) / ENV_H
+    const dy = Math.sin((v - 0.5) * Math.PI)
+    const r = Math.sqrt(Math.max(0, 1 - dy * dy))
+
+    for (let x = 0; x < ENV_W; x++) {
+      const u = (x + 0.5) / ENV_W
+      const phi = (u - 0.5) * Math.PI * 2
+      const d = [r * Math.cos(phi), dy, r * Math.sin(phi)] as const
+
+      // sin(local elevation): positive is sky, negative is ground.
+      const s = dot3(d, up)
+      const elev = Math.asin(Math.max(-1, Math.min(1, s)))
+
+      // Sky.
+      let cr = SKY_TINT[0] * SKY_RADIANCE
+      let cg = SKY_TINT[1] * SKY_RADIANCE
+      let cb = SKY_TINT[2] * SKY_RADIANCE
+
+      if (dot3(d, earthDir) > cosEarth) {
+        cr += EARTH_TINT[0] * EARTH_RADIANCE
+        cg += EARTH_TINT[1] * EARTH_RADIANCE
+        cb += EARTH_TINT[2] * EARTH_RADIANCE
+      }
+
+      // Ground, blended in below the horizon.
+      const groundMix = THREE.MathUtils.smoothstep(-elev, -horizonSoften, horizonSoften)
+      if (groundMix > 0) {
+        // Cosine of the view angle off the ground's own normal. At the horizon
+        // this goes to zero (grazing); straight down it is one.
+        const mu = Math.max(0, -s)
+        // Lommel-Seeliger, normalized so that looking straight down is 1.
+        // Bounded above by (mu0 + 1)/mu0 = 2.43 at grazing view, which is the
+        // bright horizon band and not a divergence.
+        const ls = (mu0 + 1) / (mu0 + mu)
+        // The opposition surge, measured on the ground patch this texel looks
+        // at: the direction back to the eye is -d, and the phase angle is what
+        // that makes with the sun. Peaks in the antisolar direction, which is
+        // below the horizon here because the sun is 44° up.
+        const g = Math.acos(Math.max(-1, Math.min(1, -dot3(d, SUN_DIR))))
+        const L = groundBase * ls * normalizedSurge(g)
+        cr += groundMix * (REGOLITH_TINT[0] * L - cr)
+        cg += groundMix * (REGOLITH_TINT[1] * L - cg)
+        cb += groundMix * (REGOLITH_TINT[2] * L - cb)
+      }
+
+      const i = (y * ENV_W + x) * 4
+      data[i] = cr
+      data[i + 1] = cg
+      data[i + 2] = cb
+      data[i + 3] = 1
+    }
+  }
+
+  const tex = new THREE.DataTexture(data, ENV_W, ENV_H, THREE.RGBAFormat, THREE.FloatType)
+  tex.mapping = THREE.EquirectangularReflectionMapping
+  tex.colorSpace = THREE.LinearSRGBColorSpace
+  tex.magFilter = THREE.LinearFilter
+  tex.minFilter = THREE.LinearFilter
+  tex.needsUpdate = true
+  return tex
+}

--- a/ui/cypress/integration/unit/lunar-atlas-shading.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-shading.cy.ts
@@ -1,0 +1,182 @@
+/**
+ * Moon Base Zero — lighting and regolith scattering (headless, mocha + chai).
+ *
+ * The render itself needs a GPU and can only be judged by eye, but everything
+ * the render is derived FROM is arithmetic, and that is what this pins. Two
+ * classes of bug are worth a test here.
+ *
+ * The first is disagreement. The scene's sun is four things at once — a
+ * directional light, the hillshade baked into the terrain albedo, the craterlet
+ * detail tile's own hillshade, and the regolith the metal reflects. They used
+ * to hold private copies of the azimuth, and one copy was already wrong (a
+ * map-frame 40° written down as a local bearing, which is really 50°). The
+ * round-trip cases below re-derive the local bearing and elevation from
+ * SUN_DIR, so the two frames can never again be confused without a red test.
+ *
+ * The second is the regolith BRDF, where the values matter and are easy to get
+ * subtly wrong: the surge has to be exactly neutral at the reference angle or
+ * the whole scene's exposure shifts, and it has to stay monotone in phase or
+ * the ground brightens as the camera turns AWAY from opposition.
+ */
+import { expect } from 'chai'
+import {
+  OPPOSITION_B0,
+  OPPOSITION_H,
+  PHASE_REF_DEG,
+  REGOLITH_ALBEDO,
+  normalizedSurge,
+  oppositionSurge,
+} from '../../../lib/lunar-atlas/regolith'
+import { capCenterDirection, capLocalDirection } from '../../../lib/lunar-atlas/southpole'
+import {
+  SUN_ANGULAR_RADIUS_RAD,
+  SUN_DIR,
+  SUN_INTENSITY,
+  SUN_LOCAL_BEARING_DEG,
+  SUN_LOCAL_ELEV_DEG,
+  SUN_MAP_AZ_DEG,
+  SUN_MAP_EL_DEG,
+} from '../../../lib/lunar-atlas/sun'
+
+const DEG = Math.PI / 180
+
+type V = readonly [number, number, number]
+
+const dot = (a: V, b: V) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+const angleDeg = (a: V, b: V) => Math.acos(Math.max(-1, Math.min(1, dot(a, b)))) / DEG
+
+describe('sun direction', () => {
+  it('is a unit vector', () => {
+    expect(Math.hypot(...SUN_DIR)).to.be.closeTo(1, 1e-12)
+  })
+
+  it('agrees with the bake it was derived from', () => {
+    // SUN_DIR is built by feeding the map-frame azimuth in as longitude and the
+    // negated map-frame elevation in as latitude. That identity is the only
+    // reason the light and the baked hillshade can be kept in step by
+    // construction, so assert it holds rather than trusting the comment.
+    expect(SUN_MAP_AZ_DEG).to.equal(40)
+    expect(SUN_MAP_EL_DEG).to.equal(45)
+  })
+
+  it('recovers the documented local elevation above the ridge', () => {
+    // Elevation is 90° minus the angle between the sun and the local up at the
+    // cap center. Nothing in this is a free parameter; if the number in sun.ts
+    // drifts from SUN_DIR, the models' hand-placed hardware stops agreeing
+    // with the light.
+    const up = capCenterDirection() as V
+    const elev = 90 - angleDeg(SUN_DIR as V, up)
+    expect(elev).to.be.closeTo(SUN_LOCAL_ELEV_DEG, 0.02)
+  })
+
+  it('recovers the documented local bearing above the ridge', () => {
+    // Bearing is recovered by asking capLocalDirection, the same helper every
+    // model uses to place itself, which direction reproduces SUN_DIR. Scanning
+    // rather than solving keeps the test independent of that helper's algebra.
+    const up = capCenterDirection() as V
+    const elev = 90 - angleDeg(SUN_DIR as V, up)
+    let best = { bearing: -1, err: Infinity }
+    for (let b = 0; b < 360; b += 0.05) {
+      const err = angleDeg(capLocalDirection(b, elev) as V, SUN_DIR as V)
+      if (err < best.err) best = { bearing: b, err }
+    }
+    expect(best.err).to.be.lessThan(0.02)
+    expect(best.bearing).to.be.closeTo(SUN_LOCAL_BEARING_DEG, 0.1)
+  })
+
+  it('is NOT at the map-frame azimuth when measured locally', () => {
+    // The bug this file exists to prevent. The two frames differ by ~10°, so a
+    // call site that reaches for the wrong one is off by a visible amount, not
+    // a rounding error.
+    expect(Math.abs(SUN_LOCAL_BEARING_DEG - SUN_MAP_AZ_DEG)).to.be.greaterThan(5)
+  })
+
+  it('subtends the sun s real angular diameter', () => {
+    // 0.5326° across, seen from 1 AU. This is the number that sets how soft a
+    // shadow penumbra is allowed to get.
+    expect((SUN_ANGULAR_RADIUS_RAD * 2) / DEG).to.be.closeTo(0.5326, 0.002)
+  })
+
+  it('keeps intensity positive and finite', () => {
+    expect(SUN_INTENSITY).to.be.greaterThan(0)
+    expect(Number.isFinite(SUN_INTENSITY)).to.equal(true)
+  })
+})
+
+describe('regolith albedo', () => {
+  it('is as dark as the Moon actually is', () => {
+    // Highland regolith normal albedo. Bracketed rather than pinned: anything
+    // outside this range is not lunar soil, and drifting up toward 0.3 is what
+    // makes a Moon render look like white plaster.
+    expect(REGOLITH_ALBEDO).to.be.within(0.07, 0.2)
+  })
+})
+
+describe('opposition surge', () => {
+  it('peaks at exact opposition with the full Hapke amplitude', () => {
+    // B(0) = 1 + B0, because at zero phase every grain shadow is hidden behind
+    // the grain that casts it.
+    expect(oppositionSurge(0)).to.be.closeTo(1 + OPPOSITION_B0, 1e-12)
+  })
+
+  it('decays to unity looking into the sun', () => {
+    // B(180°) -> 1: tan(g/2) diverges, so the surge term vanishes entirely.
+    expect(oppositionSurge(180 * DEG)).to.be.closeTo(1, 1e-6)
+  })
+
+  it('is monotonically decreasing in phase angle', () => {
+    // The physical content of the term. If this ever fails the ground gets
+    // brighter as the camera turns away from the light, which reads instantly
+    // as broken.
+    let prev = Infinity
+    for (let g = 0; g <= 180; g += 0.5) {
+      const b = oppositionSurge(g * DEG)
+      expect(b).to.be.lessThan(prev)
+      prev = b
+    }
+  })
+
+  it('halves its amplitude at the half-width angle', () => {
+    // h is defined as the phase angle where tan(g/2) = h, i.e. where the surge
+    // is exactly half its peak amplitude. Confirms h is being used as an
+    // angular width and not as an opaque fudge factor.
+    const gHalf = 2 * Math.atan(OPPOSITION_H)
+    expect(oppositionSurge(gHalf) - 1).to.be.closeTo(OPPOSITION_B0 / 2, 1e-12)
+  })
+
+  it('is exactly neutral at the reference angle', () => {
+    // The load-bearing property. The terrain bake was exposed with no surge at
+    // all, so the normalized surge must be 1.0 at the phase angle the home
+    // framing actually sits at, or every shot in the app shifts brightness.
+    expect(normalizedSurge(PHASE_REF_DEG * DEG)).to.be.closeTo(1, 1e-12)
+  })
+
+  it('brightens toward opposition and dims away from it', () => {
+    expect(normalizedSurge(0)).to.be.greaterThan(1)
+    expect(normalizedSurge(180 * DEG)).to.be.lessThan(1)
+  })
+
+  it('stays inside a range a tone curve can absorb', () => {
+    // Under 2x at the top and above 0.9 at the bottom, across the whole sphere
+    // of view directions. A surge that swung further than this would clip the
+    // sunlit ground at one end of a camera orbit and crush it at the other.
+    let lo = Infinity
+    let hi = -Infinity
+    for (let g = 0; g <= 180; g += 0.5) {
+      const b = normalizedSurge(g * DEG)
+      lo = Math.min(lo, b)
+      hi = Math.max(hi, b)
+    }
+    expect(hi).to.be.within(1.5, 2.0)
+    expect(lo).to.be.within(0.9, 1.0)
+  })
+
+  it('leaves the reference framing alone to within a couple of percent', () => {
+    // PHASE_REF_DEG was chosen from the phase angles the home framing actually
+    // spans (68°-99°). Over that whole span the surge stays within ~10% of
+    // neutral, so the shot the user lands on is essentially as authored.
+    for (let g = 68; g <= 99; g += 1) {
+      expect(normalizedSurge(g * DEG)).to.be.closeTo(1, 0.1)
+    }
+  })
+})

--- a/ui/lib/lunar-atlas/regolith.ts
+++ b/ui/lib/lunar-atlas/regolith.ts
@@ -1,0 +1,72 @@
+// How lunar regolith actually scatters light.
+//
+// Regolith is the least Lambertian common surface in the solar system, and the
+// difference is not subtle: it is why a full moon is more than twice as bright
+// as a half moon rather than exactly twice, and why the full moon reads as a
+// flat disc instead of a shaded ball. Two terms carry almost all of that.
+//
+// SHADOW HIDING (the opposition surge). Regolith is a deep, open, porous pile
+// of grains, so it is full of tiny shadows. Every one of those shadows is
+// hidden behind the grain that casts it, which means that as the viewer moves
+// toward the light, the shadows disappear behind their own grains and the
+// surface brightens sharply. At exact opposition none of them are visible at
+// all. Hapke's approximation is B(g) = 1 + B0 / (1 + tan(g/2)/h), where g is
+// the phase angle (sun-surface-viewer) and B0/h are the amplitude and angular
+// width of the surge. This is a VIEW-DEPENDENT term, which is precisely why
+// the terrain's baked hillshade cannot contain it — a bake has no viewer.
+//
+// LOMMEL-SEELIGER (no limb darkening). A single-scattering, semi-infinite
+// particulate layer reflects mu0/(mu0+mu) rather than Lambert's mu0, so it
+// brightens toward grazing view angles by exactly enough to cancel the
+// foreshortening that darkens a Lambertian limb. On the ground it is why the
+// lunar horizon reads as a bright band rather than fading off.
+//
+// Only the first of the two is applied to the rendered terrain, and the
+// reason is worth keeping: the Lommel-Seeliger correction to an existing
+// Lambertian bake goes as 1/(mu0+mu), which diverges as the view goes grazing
+// — and grazing is exactly where this scene's camera spends its time, three
+// metres off the deck looking out across a ridge. Applying it there blows the
+// distant ground to white, which is the same class of failure as the flat
+// ambient "pond" documented at the top of SouthPoleTerrain.tsx. It IS applied
+// to the regolith environment map (lunarEnvironment.ts), where mu0 is a
+// constant and mu is bounded by construction, so the term cannot run away.
+
+// Normal albedo of south-polar highland regolith. The Moon is a genuinely dark
+// object — closer to worn asphalt than to the white it reads as against a black
+// sky — and getting this wrong is what makes a lunar render look like plaster.
+export const REGOLITH_ALBEDO = 0.12
+
+// Hapke shadow-hiding parameters. Near the published lunar fits (Helfenstein &
+// Veverka put B0 around 1.0 and h around 0.07 for both mare and highland
+// units); B0 is pulled a little under 1 because some of the real surge is
+// coherent backscatter, which this single term is not trying to model.
+export const OPPOSITION_B0 = 0.9
+export const OPPOSITION_H = 0.07
+
+// Phase angle, in degrees, at which the surge is defined to be neutral.
+//
+// The surge multiplies brightness by between 1.0 and 1.9 and is never less
+// than 1, so applying it raw would brighten the entire terrain and throw away
+// the exposure this scene is already tuned around. Normalizing at a reference
+// angle makes it a RELATIVE effect: the ground brightens where the surge is
+// stronger than the reference and dims where it is weaker, with the reference
+// framing left exactly as it was.
+//
+// 85° is not a taste call. Sampled across the home framing — ridge centre, both
+// ends of main street, the near and far edges of the colony — the phase angle
+// runs 68° to 99° with a mean of 84.7°, so the load-in shot is left untouched
+// to within 2% and the surge only shows up once the user tumbles the camera
+// down-sun, which is the one place it belongs.
+export const PHASE_REF_DEG = 85
+
+// B(g) with g in radians.
+export function oppositionSurge(gRad: number): number {
+  return 1 + OPPOSITION_B0 / (1 + Math.tan(0.5 * gRad) / OPPOSITION_H)
+}
+
+// B(g) normalized to 1 at PHASE_REF_DEG — what a renderer should actually
+// multiply by. Runs from 1.79 at exact opposition down to 0.94 looking
+// straight into the sun.
+export function normalizedSurge(gRad: number): number {
+  return oppositionSurge(gRad) / oppositionSurge((PHASE_REF_DEG * Math.PI) / 180)
+}

--- a/ui/lib/lunar-atlas/sun.ts
+++ b/ui/lib/lunar-atlas/sun.ts
@@ -1,0 +1,52 @@
+// The one sun over Moon Base Zero.
+//
+// This used to live in MoonGlobe.tsx, which was fine while the sun was only a
+// light. It is now four different things that have to agree exactly — the
+// directional light, the hillshade already baked into the terrain albedo, the
+// craterlet detail tile's own hillshade, and the regolith environment the
+// metal reflects — and three of those four had their own private copy of the
+// azimuth. One of the copies was already wrong: MoonGlobe's comment claimed
+// bearing 40°, which is the MAP-frame azimuth in the bake script, not the
+// bearing a person standing on the ridge would measure (50°). Both numbers are
+// below, named for which frame each belongs to, so the next person does not
+// have to work out which one a call site meant.
+import { latLonToVector3, type Vec3 } from './geo'
+
+// The bake's own numbers (SUN_AZ_DEG / SUN_EL_DEG in build-southpole-assets.py),
+// in the south-polar MAP frame the DEM is projected into. Changing either means
+// re-running the bake — the terrain albedo IS a hillshade from this direction,
+// so a light that disagrees with it reads instantly as fake.
+export const SUN_MAP_AZ_DEG = 40
+export const SUN_MAP_EL_DEG = 45
+
+// The same direction as a unit vector from the Moon's center, which is what
+// the scene actually needs. The map frame's azimuth is the lon argument and
+// its elevation the (negated) lat — that identity is the whole reason the bake
+// and the light can be kept in step by construction rather than by hand.
+export const SUN_DIR: Vec3 = (() => {
+  const v = latLonToVector3(-SUN_MAP_EL_DEG, SUN_MAP_AZ_DEG, 1)
+  const l = Math.hypot(v[0], v[1], v[2])
+  return [v[0] / l, v[1] / l, v[2] / l]
+})()
+
+// What the same sun measures as from the ridge itself: 50° round from east and
+// 44.46° up. Not independent facts — both are recovered from SUN_DIR against
+// capCenterDirection/capLocalDirection, and were confirmed to 0.02° that way.
+// They are written down because the models reason in local bearings (arrays
+// stand across the sun's bearing, radiators lie flat) and re-deriving a bearing
+// from a world vector at every call site is how the 40°/50° confusion started.
+export const SUN_LOCAL_BEARING_DEG = 50
+export const SUN_LOCAL_ELEV_DEG = 44.46
+
+// The directional light's own strength and colour. Unitless renderer radiance,
+// not lux — everything else in the scene that needs to reason about how bright
+// the sun is (the regolith bounce that fills every shadow, above all) is
+// expressed as a fraction of this rather than as a second free parameter.
+export const SUN_INTENSITY = 3.1
+export const SUN_COLOR = '#fff6ec'
+
+// Angular radius of the sun's disc seen from the Moon: 0.2664°, so a 0.533°
+// disc. This is the number that decides how soft a shadow is allowed to be,
+// and the answer for this scene turns out to be "not at all" — see the shadow
+// comments in MoonGlobe.tsx.
+export const SUN_ANGULAR_RADIUS_RAD = Math.atan(6.957e8 / 1.496e11)

--- a/ui/scripts/.mocharc-cypress-unit.json
+++ b/ui/scripts/.mocharc-cypress-unit.json
@@ -26,6 +26,7 @@
     "cypress/integration/unit/lunar-atlas-deprize.cy.ts",
     "cypress/integration/unit/lunar-atlas-geo.cy.ts",
     "cypress/integration/unit/lunar-atlas-selectors.cy.ts",
+    "cypress/integration/unit/lunar-atlas-shading.cy.ts",
     "cypress/integration/unit/lunar-atlas-southpole.cy.ts",
     "cypress/integration/unit/team-roles.cy.tsx",
     "cypress/integration/unit/renew-subscription.cy.ts",


### PR DESCRIPTION
## What this is

The moonbase read as grey plastic under a photo-studio softbox rather than as hardware sitting on an airless world. Every cause I found was a place where the renderer was portraying an **atmosphere the Moon does not have** — so this is less a set of taste adjustments than a set of corrections, each one derived from a number rather than dialled in by eye.

The single most visible change is that **things now cast shadows that touch them**. Before, boulders, panels, trusses and habitats all floated.

## Root causes, and what was done about each

**1. The tone curve was never actually running.**
`@react-three/postprocessing` pins `gl.toneMapping` to `NoToneMapping` for as long as its composer is mounted. This scene has asked for `ACESFilmicToneMapping` in its `Canvas` props for a long time and has never once received it — the frame went to the screen as a raw linear-to-sRGB conversion that clipped flat at white. That is most of why the regolith read as plastic.

Fixed by adding an explicit `<ToneMapping>` effect at the end of the chain. **AgX rather than ACES**: ACES was written to make film look like film, and it skews bright warm surfaces orange as they climb — a colour cast applied to the one thing in this scene that must not have one, neutral grey soil under a white sun.

Exposure was **solved, not chosen**. The terrain is an unlit material, so the tone curve is the only thing between its baked albedo and the screen, and that bake was authored to look right with no curve at all (sunlit regolith sat at sRGB 163). AgX at `1.05` lands it back on sRGB 163, so the ground is left exactly where its author put it and the curve's entire benefit is spent at the two ends: four stops of headroom above the regolith before anything approaches white, and a toe that still separates six stops down.

**2. The fill light was pointing the wrong way.**
A `hemisphereLight` glowed blue from overhead. On the Moon, overhead is where there is *nothing at all*. The only light in a lunar shadow is regolith bounce: from **below**, warm grey, at about 4% of the sun. Lighting the one hemisphere that is actually empty is precisely what made shadowed faces read as toys under a softbox.

Both it and the `RoomEnvironment` studio probe are replaced by a procedural lunar IBL (`lunarEnvironment.ts`) — dark sky over a Lommel-Seeliger regolith ground, plus Earth at its true 1.9° angular size in the position `EarthGlobe` already owns. Radiances are derived from `SUN_INTENSITY`, so `environmentIntensity` is `1` and means it.

This gets the direction right for free: a downward-facing panel is lit by the ground it faces, an upward-facing one goes nearly black. Surface orientation now does much of the work ambient occlusion would have.

**3. The terrain had no opposition surge.**
Regolith is the least Lambertian common surface in the solar system — it is why a full moon is more than twice as bright as a half moon. Hapke shadow-hiding is the one regolith behaviour a baked hillshade fundamentally *cannot* contain, because it depends only on where the viewer is and a bake has no viewer.

Added to the terrain shader, normalized at the phase angle the home framing actually spans (68°–99°, mean 84.7°). So the shot users land on is untouched to within a couple of percent, and the effect only appears once the camera tumbles down-sun — which is the one place it belongs.

**4. Contact shadows were sliding out from under their own objects.**
Shadow normal bias was `0.35 m`. At 19.5 cm per shadow texel that is nearly two texels of lateral slide, which showed up as a visible gap under every footpad — the classic pasted-on-a-photo look the shadow catcher exists to prevent. Now `0.12 m`.

Also switched to PCF-**soft**, and the reasoning is worth stating because it inverts the usual instinct: the sun subtends 0.533° from the Moon, so a penumbra widens by **9.3 mm per metre** of standoff. Even the 52 m Starship casts a penumbra about one texel wide. Lunar shadows are *hard*. PCSS (drei's `SoftShadows`) was tried and rejected — contact-hardening exists to portray a penumbra this scene uniquely does not have. What a hard step actually needs is antialiasing, which is what PCF-soft does.

## One sun, in one place

The sun was four things that must agree exactly — the directional light, the terrain albedo's baked hillshade, the craterlet detail tile's own hillshade, and now the regolith the metal reflects — and three of them held private copies of the azimuth. **One copy was already wrong**: a map-frame `40°` written down as a local bearing, which is really `50°`.

All of it now lives in `lib/lunar-atlas/sun.ts`, alongside `lib/lunar-atlas/regolith.ts` for the scattering constants. Also de-duplicated Earth's direction, which `lunarEnvironment` had started to copy out of `EarthGlobe`.

## Deliberately not done: ambient occlusion

AO would matter more here than almost anywhere, since indirect light is one weak source from one direction. I wired up and measured all three available passes; all three fail:

| Pass | Result |
|---|---|
| `N8AO` | Renders an entirely black frame, even in AO-only debug mode |
| `SSAO` (on a `NormalPass`) | Renders, does nothing — intensity 22→90 moved mean frame luminance by 0.5/255 |
| `SMAA` | `GL_INVALID_OPERATION` every frame |

The common cause is this scene's depth range and it is not fixable from the effect side: the near plane is 1 metre and the far plane is past the Moon, a ratio of ~7e10, so beyond a few metres everything lands in the same handful of depth codes and there are no depth *gradients* for a screen-space kernel to read. The near plane is not negotiable, and the existing comment in the `Canvas` props explains why a logarithmic buffer (which would fix the range) is worse here for other reasons. All of this is documented in place so the next person does not repeat the afternoon.

## Verification

- `tsc --noEmit` — clean (4 pre-existing errors in `verify-deprize-moonbase-sepolia.ts`, untouched here)
- **138 passing** across the lunar-atlas unit specs, including **16 new** in `lunar-atlas-shading.cy.ts`, registered in `.mocharc-cypress-unit.json`
- The new spec re-derives the local bearing and elevation from `SUN_DIR` against `capLocalDirection`, so the map-frame/local-frame confusion cannot return silently, and pins the regolith BRDF (surge peak, monotonicity in phase, half-width at `h`, exact neutrality at the reference angle)
- Rendered on a real GPU via Playwright at five framings (home plus four hardware deep links); no WebGL errors, no shader warnings

## Follow-up worth considering separately

The bake is lit from **45° elevation**, but Shackleton's sun never rises above ~2°. A grazing sun with its enormous raking shadows is the iconic south-pole look and would be the largest remaining realism gain — but it means re-running `build-southpole-assets.py` against the LOLA DEM to re-bake the albedo, which is a data-pipeline change rather than a shading one. The sun constants are now in one file, so it is a two-line change plus a re-bake whenever someone wants it.

Separately, model materials use mid metalness (0.2–0.7), which is non-physical — real materials are metal or dielectric, not halfway. Snapping them would be a large, visually dramatic diff across ~100 materials in `ProjectModel.tsx` and belongs on its own branch.

Made with [Cursor](https://cursor.com)