### PR TITLE
feat(deprize,moonbase): prize detail pages, Sepolia races, standings

### DIFF
--- a/ui/components/deprize/BetModal.tsx
+++ b/ui/components/deprize/BetModal.tsx
@@ -5,13 +5,15 @@ import toast from 'react-hot-toast'
 import { getContract, prepareContractCall, type Chain } from 'thirdweb'
 import { fireDePrizeConfetti } from '@/lib/deprize/confetti'
 import { DEPRIZE_TERMS_URL, UNIT } from '@/lib/deprize/constants'
-import { fmt, formatPrizeTokenLabel, toEth, toWei } from '@/lib/deprize/format'
+import { fmt, fmtEthWithUsd, fmtUsdFromEth, formatPrizeTokenLabel, toEth, toWei } from '@/lib/deprize/format'
 import { betBudget, betSlice, quoteQtyForBudget } from '@/lib/deprize/quote'
 import { deprizeReadChain, deprizeReadClient } from '@/lib/deprize/read'
 import { sendDePrizeTx } from '@/lib/deprize/tx'
 import { useDePrizeChainGuard } from '@/lib/deprize/useDePrizeChainGuard'
 import { useDePrizeLaunchpadToken } from '@/lib/deprize/useDePrizeLaunchpad'
+import useETHPrice from '@/lib/etherscan/useETHPrice'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import EthUsd from '@/components/deprize/EthUsd'
 import client from '@/lib/thirdweb/client'
 import Modal from '@/components/layout/Modal'
 import StandardButton from '@/components/layout/StandardButton'
@@ -59,6 +61,7 @@ export default function BetModal({
   const [busy, setBusy] = useState(false)
   const { wrongNetwork, chainLabel, switching, switchToChain, blockedByNetwork } =
     useDePrizeChainGuard(chain)
+  const { ethPrice } = useETHPrice(1, 'ETH_TO_USD')
 
   const launchpad = useDePrizeLaunchpadToken(jbProjectId, chain)
   const prizeToken = formatPrizeTokenLabel(launchpad.symbol)
@@ -155,7 +158,7 @@ export default function BetModal({
       const qtyNum = Number(qty) / Number(UNIT)
       fireDePrizeConfetti()
       toast.success(
-        `Backed ${teamName} with ${fmt(betAmountNum)} ETH. To win ≈ ${fmt(qtyNum)} ETH if it wins.`,
+        `Backed ${teamName} with ${fmtEthWithUsd(betAmountNum, ethPrice)}. To win ≈ ${fmtEthWithUsd(qtyNum, ethPrice)} if it wins.`,
         { style: toastStyle, duration: 8000 }
       )
       onDone(outcomeIndex, betAmountNum, qtyNum)
@@ -197,6 +200,11 @@ export default function BetModal({
             placeholder="e.g. 0.01"
             className="mt-1 w-full px-4 py-3 bg-white/5 border border-white/20 rounded-xl text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
+          {betAmountNum > 0 && fmtUsdFromEth(betAmountNum, ethPrice) && (
+            <p className="text-white/55 text-xs mt-1 tabular-nums">
+              ≈ {fmtUsdFromEth(betAmountNum, ethPrice)}
+            </p>
+          )}
           <div className="flex gap-2 mt-2 flex-wrap">
             {['0.01', '0.05', '0.1'].map((a) => (
               <button
@@ -205,6 +213,9 @@ export default function BetModal({
                 className="px-3 py-1 rounded-full bg-white/5 hover:bg-white/10 text-gray-300 text-xs"
               >
                 {a} ETH
+                {fmtUsdFromEth(Number(a), ethPrice)
+                  ? ` (${fmtUsdFromEth(Number(a), ethPrice)})`
+                  : ''}
               </button>
             ))}
             {spendableEth > 0 && (
@@ -212,7 +223,7 @@ export default function BetModal({
                 onClick={() => setBetAmount(String(Math.floor(spendableEth * 1e6) / 1e6))}
                 className="px-3 py-1 rounded-full bg-white/5 hover:bg-white/10 text-gray-300 text-xs"
               >
-                Max ({fmt(spendableEth)})
+                Max ({fmtEthWithUsd(spendableEth, ethPrice, { prize: true })})
               </button>
             )}
           </div>
@@ -226,7 +237,7 @@ export default function BetModal({
                 <div className="flex items-center justify-between">
                   <span className="text-gray-400 text-sm">To win if it wins</span>
                   <span className="text-moon-green text-lg font-bold">
-                    ≈ {fmt(quote.qty)} ETH
+                    <EthUsd eth={quote.qty} approx usdClassName="text-moon-green/70 font-normal text-sm" />
                   </span>
                 </div>
                 <div className="flex items-center justify-between">
@@ -245,7 +256,9 @@ export default function BetModal({
               <span className="text-gray-500 text-xs">
                 Prize contribution (5% → {prizeToken})
               </span>
-              <span className="text-gray-300 text-xs">{fmt(sliceEth)} ETH</span>
+              <span className="text-gray-300 text-xs">
+                <EthUsd eth={sliceEth} prize usdClassName="text-gray-400 font-normal" />
+              </span>
             </div>
           </div>
         )}
@@ -302,8 +315,8 @@ export default function BetModal({
           </div>
         ) : insufficient ? (
           <p className="text-amber-300 text-sm">
-            You only have ≈ {fmt(spendableEth)} ETH available (a little is kept back for gas). Lower
-            your bet or add funds.
+            You only have ≈ {fmtEthWithUsd(spendableEth, ethPrice, { prize: true })} available (a
+            little is kept back for gas). Lower your bet or add funds.
           </p>
         ) : (
           <StandardButton
@@ -315,7 +328,7 @@ export default function BetModal({
             {busy
               ? 'Placing bet…'
               : betAmountNum > 0
-                ? `Bet ${fmt(betAmountNum)} ETH`
+                ? `Bet ${fmtEthWithUsd(betAmountNum, ethPrice)}`
                 : 'Enter an amount'}
           </StandardButton>
         )}

--- a/ui/components/deprize/ClaimPanel.tsx
+++ b/ui/components/deprize/ClaimPanel.tsx
@@ -5,10 +5,12 @@ import { useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import { getContract, prepareContractCall, type Chain } from 'thirdweb'
 import { fireDePrizeConfetti } from '@/lib/deprize/confetti'
-import { fmt, formatPrizeTokenLabel, toEth } from '@/lib/deprize/format'
+import { fmtEthWithUsd, formatPrizeTokenLabel, toEth } from '@/lib/deprize/format'
 import { sendDePrizeTx } from '@/lib/deprize/tx'
 import { useDePrizeChainGuard } from '@/lib/deprize/useDePrizeChainGuard'
 import { useDePrizeLaunchpadToken } from '@/lib/deprize/useDePrizeLaunchpad'
+import useETHPrice from '@/lib/etherscan/useETHPrice'
+import EthUsd from '@/components/deprize/EthUsd'
 import { useDePrizeRedeemPreview } from '@/lib/deprize/useDePrizeRedeem'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -46,6 +48,7 @@ export default function ClaimPanel({
   const [claimed, setClaimed] = useState(false)
   const { wrongNetwork, chainLabel, switching, switchToChain, blockedByNetwork } =
     useDePrizeChainGuard(chain)
+  const { ethPrice } = useETHPrice(1, 'ETH_TO_USD')
 
   // Local success flag is per-session; clear it when the holder or DePrize changes
   // so a wallet switch cannot leave the previous address's "Claimed" UI stuck.
@@ -128,7 +131,7 @@ export default function ClaimPanel({
       fireDePrizeConfetti()
       toast.success(
         claimEth !== undefined
-          ? `Claimed ≈ ${fmt(claimEth)} ETH.`
+          ? `Claimed ≈ ${fmtEthWithUsd(claimEth, ethPrice)}.`
           : 'Claimed.',
         { style: toastStyle, duration: 8000 }
       )
@@ -171,7 +174,7 @@ export default function ClaimPanel({
       ) : (
         <>
           <p className="text-white text-2xl font-bold mt-1">
-            {claimEth !== undefined ? `${fmt(claimEth)} ETH` : '…'}
+            {claimEth !== undefined ? <EthUsd eth={claimEth} /> : '…'}
           </p>
           <div className="mt-3">
             {wrongNetwork ? (

--- a/ui/components/deprize/DePrizeAdminPanel.tsx
+++ b/ui/components/deprize/DePrizeAdminPanel.tsx
@@ -22,10 +22,11 @@ import {
   MarketStage,
   UNIT,
 } from '@/lib/deprize/constants'
-import { fmt } from '@/lib/deprize/format'
+import { fmtEthWithUsd } from '@/lib/deprize/format'
 import { rpcRead } from '@/lib/deprize/read'
 import { sendDePrizeTx } from '@/lib/deprize/tx'
 import { useDePrizeChainGuard } from '@/lib/deprize/useDePrizeChainGuard'
+import useETHPrice from '@/lib/etherscan/useETHPrice'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import client from '@/lib/thirdweb/client'
@@ -70,6 +71,7 @@ export default function DePrizeAdminPanel({
   const [busy, setBusy] = useState(false)
   const { wrongNetwork, chainLabel, switching, switchToChain, blockedByNetwork } =
     useDePrizeChainGuard(chain)
+  const { ethPrice } = useETHPrice(1, 'ETH_TO_USD')
   const [isRegistryOwner, setIsRegistryOwner] = useState(false)
   const [routerOwned, setRouterOwned] = useState(false)
   const [isMarketController, setIsMarketController] = useState(false)
@@ -701,7 +703,7 @@ export default function DePrizeAdminPanel({
                 backgroundColor="bg-white/10"
               >
                 {marketFeesWei !== undefined
-                  ? `Sweep fees (${fmt(Number(marketFeesWei) / Number(UNIT), 4)} WETH)`
+                  ? `Sweep fees (${fmtEthWithUsd(Number(marketFeesWei) / Number(UNIT), ethPrice, { decimals: 4, unit: 'WETH' })})`
                   : `Sweep fees to ${sweepDestination}`}
               </StandardButton>
             ) : (
@@ -712,7 +714,7 @@ export default function DePrizeAdminPanel({
                 backgroundColor="bg-white/10"
               >
                 {marketFeesWei !== undefined
-                  ? `Withdraw fees (${fmt(Number(marketFeesWei) / Number(UNIT), 4)} WETH)`
+                  ? `Withdraw fees (${fmtEthWithUsd(Number(marketFeesWei) / Number(UNIT), ethPrice, { decimals: 4, unit: 'WETH' })})`
                   : 'Withdraw fees'}
               </StandardButton>
             )}

--- a/ui/components/deprize/DePrizeTeamCard.tsx
+++ b/ui/components/deprize/DePrizeTeamCard.tsx
@@ -1,6 +1,7 @@
 import { fmt } from '@/lib/deprize/format'
 import type { Outcome } from '@/lib/deprize/useDePrizeMarket'
 import DePrizeTeamLink from '@/components/deprize/DePrizeTeamLink'
+import EthUsd from '@/components/deprize/EthUsd'
 import StandardButton from '@/components/layout/StandardButton'
 
 type DePrizeTeamCardProps = {
@@ -43,6 +44,8 @@ type DePrizeTeamCardProps = {
    * listing never reads as an endorsement. See ROSTER_DISCLAIMER.
    */
   unclaimed?: boolean
+  /** Official = claimed listing; unofficial = MoonDAO-listed, not confirmed. */
+  participation?: 'official' | 'unofficial'
 }
 
 /** Dashed-circle mark for the Open Field slot, which has no Team NFT. */
@@ -56,8 +59,8 @@ function PnlSuffix({ pnl }: { pnl: number | undefined }) {
   if (pnl === undefined) return null
   return (
     <span className={`ml-1.5 font-medium ${pnl >= 0 ? 'text-emerald-400/80' : 'text-rose-400/80'}`}>
-      ({pnl >= 0 ? '+' : ''}
-      {fmt(pnl)} ETH)
+      (
+      <EthUsd eth={pnl} signed usdClassName="opacity-80 font-normal" />)
     </span>
   )
 }
@@ -86,6 +89,7 @@ export default function DePrizeTeamCard({
   nameOverride,
   imageOverride,
   unclaimed = false,
+  participation,
 }: DePrizeTeamCardProps) {
   const holding = Number.isFinite(outcome.balance) && outcome.balance > 0
   const realizedValue = resolved ? redeemValueEth : sellQuoteEth
@@ -95,15 +99,29 @@ export default function DePrizeTeamCard({
       : undefined
   const canCashOut = holding && !tradingHalted && !resolved
   const showWinSubtitle = holding && !resolved
+  const participationTone =
+    participation === 'official'
+      ? 'from-emerald-950/55 border-emerald-400/25'
+      : participation === 'unofficial'
+        ? 'from-zinc-950/80 border-zinc-400/20'
+        : 'from-slate-900/90 border-white/[0.08]'
 
   return (
     <div
-      className={`p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border shadow-lg ${
+      className={`relative overflow-hidden p-4 sm:p-5 rounded-2xl bg-gradient-to-br via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border shadow-lg ${participationTone} ${
         resolved && isWinningSlot
           ? 'border-emerald-400/40 ring-1 ring-emerald-400/20'
-          : 'border-white/[0.08]'
+          : ''
       }`}
     >
+      {participation && (
+        <span
+          aria-hidden
+          className={`absolute inset-y-0 left-0 w-1 ${
+            participation === 'official' ? 'bg-emerald-400' : 'bg-zinc-400'
+          }`}
+        />
+      )}
       {/* Top row: chance/result · team (+ if-wins subtitle) · bet CTA */}
       <div className="flex items-center gap-4 flex-wrap">
         <div className="flex items-center gap-3 min-w-[96px]">
@@ -173,7 +191,7 @@ export default function DePrizeTeamCard({
             <p className="text-xs text-gray-500 pl-12">
               If wins ·{' '}
               <span className="text-emerald-400/90 font-medium tabular-nums">
-                {fmt(outcome.balance)} ETH
+                <EthUsd eth={outcome.balance} usdClassName="text-emerald-400/70 font-normal" />
               </span>
             </p>
           )}
@@ -201,7 +219,7 @@ export default function DePrizeTeamCard({
               {resolved ? (
                 redeemValueEth !== undefined ? (
                   <>
-                    {fmt(redeemValueEth)} ETH
+                    <EthUsd eth={redeemValueEth} />
                     <PnlSuffix pnl={pnl} />
                   </>
                 ) : (
@@ -211,7 +229,7 @@ export default function DePrizeTeamCard({
                 '—'
               ) : sellQuoteEth !== undefined ? (
                 <>
-                  ≈ {fmt(sellQuoteEth)} ETH
+                  <EthUsd eth={sellQuoteEth} approx />
                   <PnlSuffix pnl={pnl} />
                 </>
               ) : (

--- a/ui/components/deprize/DePrizeTeamLink.tsx
+++ b/ui/components/deprize/DePrizeTeamLink.tsx
@@ -104,42 +104,25 @@ function isInternalHref(href: string): boolean {
   return href.startsWith('/') && !href.startsWith('//')
 }
 
-/**
- * Team identity that navigates to `/team/{id}` by default. Optional overrides
- * let Moon Base Zero feed atlas org name/logo and link to `/moonbase/{projectId}`
- * for competitors that will never hold a Team NFT.
- */
-export default function DePrizeTeamLink({
+function TeamIdentity({
   teamId,
-  teamContract,
-  color = '#3b82f6',
-  className = '',
-  nameOnly = false,
-  size = 28,
-  nameOverride,
-  imageOverride,
-  hrefOverride,
-  unclaimed = false,
-}: DePrizeTeamLinkProps) {
-  // Only skip the NFT read when neither name nor image would come from it. An
-  // unclaimed competitor shows no logo at all, so a name is the whole identity.
-  const identityOverridden = !!nameOverride && (!!imageOverride || unclaimed)
-
-  const { data: teamNFT } = useReadContract(getNFT, {
-    contract: teamContract,
-    tokenId: BigInt(teamId),
-    queryOptions: {
-      enabled: !identityOverridden && !!teamContract && teamId > 0n,
-    },
-  })
-
-  // `||` (not `??`): an empty metadata name must still fall back to the id,
-  // and an empty override must not blank the row.
-  const name =
-    nameOverride || (teamNFT as any)?.metadata?.name || `Team #${teamId.toString()}`
-  const image = unclaimed ? '' : imageOverride || (teamNFT as any)?.metadata?.image || ''
-  const href = hrefOverride || `/team/${teamId.toString()}`
-
+  name,
+  image,
+  color,
+  className,
+  nameOnly,
+  size,
+  href,
+}: {
+  teamId: bigint
+  name: string
+  image: string
+  color: string
+  className: string
+  nameOnly: boolean
+  size: number
+  href: string
+}) {
   const linkClassName = `group inline-flex items-center gap-2 min-w-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 transition-opacity hover:opacity-90 ${className}`
   const title = `View ${name} profile`
   const onClick = (e: MouseEvent) => e.stopPropagation()
@@ -173,6 +156,112 @@ export default function DePrizeTeamLink({
     <a href={href} className={linkClassName} title={title} onClick={onClick}>
       {body}
     </a>
+  )
+}
+
+/**
+ * Team identity that navigates to `/team/{id}` by default. Optional overrides
+ * let Moon Base Zero feed atlas org name/logo and link to `/moonbase/{projectId}`
+ * for competitors that will never hold a Team NFT.
+ *
+ * thirdweb's `useReadContract` reads `contract.chain` even when the query is
+ * disabled, so the NFT hook lives in a child that only mounts when a contract
+ * is actually present. Atlas / demo rows (no Team NFT) skip it entirely.
+ */
+export default function DePrizeTeamLink({
+  teamId,
+  teamContract,
+  color = '#3b82f6',
+  className = '',
+  nameOnly = false,
+  size = 28,
+  nameOverride,
+  imageOverride,
+  hrefOverride,
+  unclaimed = false,
+}: DePrizeTeamLinkProps) {
+  // Only skip the NFT read when neither name nor image would come from it. An
+  // unclaimed competitor shows no logo at all, so a name is the whole identity.
+  const identityOverridden = !!nameOverride && (!!imageOverride || unclaimed)
+  const canReadNft = !!teamContract && teamId > 0n && !identityOverridden
+  const href = hrefOverride || `/team/${teamId.toString()}`
+
+  if (!canReadNft) {
+    return (
+      <TeamIdentity
+        teamId={teamId}
+        name={nameOverride || `Team #${teamId.toString()}`}
+        image={unclaimed ? '' : imageOverride || ''}
+        color={color}
+        className={className}
+        nameOnly={nameOnly}
+        size={size}
+        href={href}
+      />
+    )
+  }
+
+  return (
+    <DePrizeTeamLinkFromChain
+      teamId={teamId}
+      teamContract={teamContract}
+      color={color}
+      className={className}
+      nameOnly={nameOnly}
+      size={size}
+      nameOverride={nameOverride}
+      imageOverride={imageOverride}
+      href={href}
+      unclaimed={unclaimed}
+    />
+  )
+}
+
+function DePrizeTeamLinkFromChain({
+  teamId,
+  teamContract,
+  color,
+  className,
+  nameOnly,
+  size,
+  nameOverride,
+  imageOverride,
+  href,
+  unclaimed,
+}: {
+  teamId: bigint
+  teamContract: any
+  color: string
+  className: string
+  nameOnly: boolean
+  size: number
+  nameOverride?: string
+  imageOverride?: string
+  href: string
+  unclaimed: boolean
+}) {
+  const { data: teamNFT } = useReadContract(getNFT, {
+    contract: teamContract,
+    tokenId: BigInt(teamId),
+  })
+
+  // `||` (not `??`): an empty metadata name must still fall back to the id,
+  // and an empty override must not blank the row.
+  const name =
+    nameOverride || (teamNFT as any)?.metadata?.name || `Team #${teamId.toString()}`
+  const image = unclaimed ? '' : imageOverride || (teamNFT as any)?.metadata?.image || ''
+
+  return (
+    <TeamIdentity
+      teamId={teamId}
+      name={name}
+      image={image}
+      color={color}
+      className={className}
+      nameOnly={nameOnly}
+      size={size}
+      href={href}
+    />
   )
 }
 

--- a/ui/components/deprize/DePrizeTeamLink.tsx
+++ b/ui/components/deprize/DePrizeTeamLink.tsx
@@ -186,3 +186,38 @@ export function useDePrizeTeamName(teamId: bigint | undefined, teamContract: any
   if (!teamId || teamId <= 0n) return ''
   return (teamNFT as any)?.metadata?.name || `Team #${teamId.toString()}`
 }
+
+/** Resolve all roster names in one pass (chart legend / tooltips). */
+export function useDePrizeTeamNames(
+  teamIds: readonly bigint[] | undefined,
+  teamContract: any
+): string[] {
+  const key = (teamIds ?? []).map((id) => id.toString()).join(',')
+  const [names, setNames] = useState<string[]>(() =>
+    (teamIds ?? []).map((id, i) => (id > 0n ? `Team #${id.toString()}` : `Team #${i + 1}`))
+  )
+
+  useEffect(() => {
+    if (!teamContract || !teamIds?.length) return
+    let cancelled = false
+    ;(async () => {
+      const resolved = await Promise.all(
+        teamIds.map(async (id, i) => {
+          if (!id || id <= 0n) return `Team #${i + 1}`
+          try {
+            const nft = await getNFT({ contract: teamContract, tokenId: id })
+            return (nft as any)?.metadata?.name || `Team #${id.toString()}`
+          } catch {
+            return `Team #${id.toString()}`
+          }
+        })
+      )
+      if (!cancelled) setNames(resolved)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [teamContract, key])
+
+  return names
+}

--- a/ui/components/deprize/EthUsd.tsx
+++ b/ui/components/deprize/EthUsd.tsx
@@ -1,0 +1,61 @@
+import useETHPrice from '@/lib/etherscan/useETHPrice'
+import { fmt, fmtPrizeEth, fmtUsdFromEth } from '@/lib/deprize/format'
+
+type EthUsdProps = {
+  eth?: number | null
+  approx?: boolean
+  prize?: boolean
+  signed?: boolean
+  unit?: string
+  decimals?: number
+  /** `inline` (default) keeps ETH and USD on one line; `below` stacks USD under ETH. */
+  layout?: 'inline' | 'below'
+  className?: string
+  usdClassName?: string
+  empty?: string
+}
+
+/**
+ * ETH amount with a live USD equivalent, using the same `useETHPrice` quote
+ * as missions / the weekly reward pool. USD is omitted (ETH only) until a
+ * price is available so a missing quote never blanks the primary figure.
+ */
+export default function EthUsd({
+  eth,
+  approx = false,
+  prize = false,
+  signed = false,
+  unit = 'ETH',
+  decimals,
+  layout = 'inline',
+  className,
+  usdClassName = 'text-white/55 font-normal',
+  empty = '—',
+}: EthUsdProps) {
+  const { ethPrice } = useETHPrice(1, 'ETH_TO_USD')
+
+  if (eth == null || !Number.isFinite(eth)) {
+    return <span className={className}>{empty}</span>
+  }
+
+  const ethStr = prize ? fmtPrizeEth(Math.abs(eth)) : fmt(Math.abs(eth), decimals)
+  const sign = signed ? (eth > 0 ? '+' : eth < 0 ? '-' : '') : eth < 0 ? '-' : ''
+  const usd = fmtUsdFromEth(eth, ethPrice, { signed })
+  const ethLabel = `${approx ? '≈ ' : ''}${sign}${ethStr} ${unit}`
+
+  if (layout === 'below') {
+    return (
+      <span className={`inline-flex flex-col items-end ${className ?? ''}`}>
+        <span>{ethLabel}</span>
+        {usd != null && <span className={usdClassName}>~{usd}</span>}
+      </span>
+    )
+  }
+
+  return (
+    <span className={className}>
+      {ethLabel}
+      {usd != null && <span className={usdClassName}> (~{usd})</span>}
+    </span>
+  )
+}

--- a/ui/components/deprize/ExitPositionModal.tsx
+++ b/ui/components/deprize/ExitPositionModal.tsx
@@ -7,12 +7,14 @@ import toast from 'react-hot-toast'
 import { getContract, prepareContractCall, type Chain } from 'thirdweb'
 import { fireDePrizeConfetti } from '@/lib/deprize/confetti'
 import { UNIT } from '@/lib/deprize/constants'
-import { fmt } from '@/lib/deprize/format'
+import { fmtEthWithUsd } from '@/lib/deprize/format'
 import { buildAmounts } from '@/lib/deprize/quote'
 import { deprizeReadChain, deprizeReadClient, rpcRead } from '@/lib/deprize/read'
 import { sendDePrizeTx } from '@/lib/deprize/tx'
 import { useDePrizeChainGuard } from '@/lib/deprize/useDePrizeChainGuard'
+import useETHPrice from '@/lib/etherscan/useETHPrice'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import EthUsd from '@/components/deprize/EthUsd'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import client from '@/lib/thirdweb/client'
 import Modal from '@/components/layout/Modal'
@@ -49,6 +51,7 @@ export default function ExitPositionModal({
   const [busy, setBusy] = useState(false)
   const { wrongNetwork, chainLabel, switching, switchToChain, blockedByNetwork } =
     useDePrizeChainGuard(chain)
+  const { ethPrice } = useETHPrice(1, 'ETH_TO_USD')
 
   const ctfAddress = CONDITIONAL_TOKEN_ADDRESSES[getChainSlug(chain)] ?? ''
 
@@ -169,7 +172,9 @@ export default function ExitPositionModal({
       )
       toast.dismiss('sell')
       fireDePrizeConfetti()
-      toast.success(`Cashed out ${teamName} for ≈ ${fmt(Number(-net) / Number(UNIT))} ETH.`, {
+      toast.success(
+        `Cashed out ${teamName} for ≈ ${fmtEthWithUsd(Number(-net) / Number(UNIT), ethPrice)}.`,
+        {
         style: toastStyle,
       })
       // Best-effort: sweep the sell's 1% market fee into the Juicebox prize
@@ -223,7 +228,11 @@ export default function ExitPositionModal({
           <div className="flex items-center justify-between">
             <span className="text-gray-400 text-sm">You receive (est.)</span>
             <span className="text-moon-green text-lg font-bold">
-              {quoteEth !== undefined ? `≈ ${fmt(quoteEth)} ETH` : '…'}
+              {quoteEth !== undefined ? (
+                <EthUsd eth={quoteEth} approx usdClassName="text-moon-green/70 font-normal text-sm" />
+              ) : (
+                '…'
+              )}
             </span>
           </div>
           <p className="text-gray-500 text-[11px] mt-1">

--- a/ui/components/deprize/GoalDePrizeDetail.tsx
+++ b/ui/components/deprize/GoalDePrizeDetail.tsx
@@ -240,6 +240,13 @@ export default function GoalDePrizeDetail({ goal }: { goal: SharedGoal }) {
               {outcomes.map((o) => {
                 const competitor = competitors[o.outcome.index]
                 const org = competitor?.organization
+                const pos = market.positions[o.projectId]
+                const sellQuoteEth =
+                  pos && pos.qty > 0
+                    ? Math.round(
+                        pos.qty * ((market.odds[o.projectId] ?? 0) / 100) * 1e6,
+                      ) / 1e6
+                    : undefined
                 return (
                   <DePrizeTeamCard
                     key={o.projectId}
@@ -251,7 +258,8 @@ export default function GoalDePrizeDetail({ goal }: { goal: SharedGoal }) {
                     resolved={false}
                     isRefundVector={false}
                     isWinningSlot={false}
-                    investedEth={market.positions[o.projectId]?.costEth ?? 0}
+                    investedEth={pos?.costEth ?? 0}
+                    sellQuoteEth={sellQuoteEth}
                     bettingOpen={hasRace}
                     tradingHalted={false}
                     busy={false}
@@ -290,6 +298,20 @@ export default function GoalDePrizeDetail({ goal }: { goal: SharedGoal }) {
                 .
               </p>
             </div>
+
+            {!userAddress && hasRace && (
+              <div className="p-4 sm:p-5 rounded-2xl bg-indigo-500/10 border border-indigo-500/30 flex items-center justify-between gap-3 flex-wrap">
+                <p className="text-indigo-100 text-sm font-medium">
+                  Connect a wallet to back a team or cash out.
+                </p>
+                <button
+                  onClick={() => login()}
+                  className="px-5 py-2.5 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white text-sm font-semibold transition-all"
+                >
+                  Connect Wallet
+                </button>
+              </div>
+            )}
 
             {goal.criteria && goal.criteria.length > 0 && (
               <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">

--- a/ui/components/deprize/GoalDePrizeDetail.tsx
+++ b/ui/components/deprize/GoalDePrizeDetail.tsx
@@ -1,0 +1,356 @@
+import { useLogin } from '@privy-io/react-auth'
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { useActiveAccount } from 'thirdweb/react'
+import {
+  ROSTER_DISCLAIMER,
+  isCompetitiveRace,
+} from '@/lib/deprize/competitions'
+import { OUTCOME_COLORS } from '@/lib/deprize/constants'
+import { fmt, fmtPrizeEth } from '@/lib/deprize/format'
+import { exitMockPosition, useMockMarket } from '@/lib/deprize/mockMarket'
+import type { Outcome } from '@/lib/deprize/useDePrizeMarket'
+import { orgById, projectById, SEED_ATLAS } from '@/lib/lunar-atlas'
+import {
+  orgColor,
+  PROJECT_TYPE_COLOR,
+  PROJECT_TYPE_LABEL,
+} from '@/lib/lunar-atlas/display'
+import type { SharedGoal } from '@/lib/lunar-atlas/types'
+import toast from 'react-hot-toast'
+import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import Container from '@/components/layout/Container'
+import Head from '@/components/layout/Head'
+import { NoticeFooter } from '@/components/layout/NoticeFooter'
+import CategoryIcon from '@/components/deprize/CategoryIcon'
+import DemoBetModal from '@/components/deprize/DemoBetModal'
+import DePrizeTeamCard from '@/components/deprize/DePrizeTeamCard'
+
+/**
+ * Prize detail for a Moon Base Zero capability race that is not (yet) bound
+ * to an on-chain DePrize on the selected chain. Same page chrome as
+ * `/deprize/{id}` so every index card has a real destination — not moonbase.
+ */
+export default function GoalDePrizeDetail({ goal }: { goal: SharedGoal }) {
+  const account = useActiveAccount()
+  const userAddress = account?.address
+  const { login } = useLogin()
+  const [betProjectId, setBetProjectId] = useState<string | null>(null)
+
+  const competitors = useMemo(
+    () =>
+      goal.projectIds
+        .map((id) => {
+          const project = projectById(SEED_ATLAS, id)
+          if (!project) return undefined
+          return { project, organization: orgById(SEED_ATLAS, project.orgId) }
+        })
+        .filter(
+          (c): c is { project: NonNullable<typeof c>['project']; organization: ReturnType<typeof orgById> } =>
+            !!c,
+        ),
+    [goal.projectIds],
+  )
+
+  const projectIds = useMemo(
+    () => competitors.map((c) => c.project.id),
+    [competitors],
+  )
+  const hasRace = isCompetitiveRace(competitors.length)
+  const market = useMockMarket(
+    goal.id,
+    projectIds,
+    goal.market?.impliedOdds,
+    userAddress,
+  )
+
+  const category = goal.category ?? 'other'
+  const categoryLabel = PROJECT_TYPE_LABEL[category]
+  const categoryColor = PROJECT_TYPE_COLOR[category]
+
+  const outcomes: { projectId: string; outcome: Outcome; name: string }[] =
+    useMemo(
+      () =>
+        competitors.map((c, i) => {
+          const pos = market.positions[c.project.id]
+          return {
+            projectId: c.project.id,
+            name: c.organization?.name || c.project.name,
+            outcome: {
+              index: i,
+              probability: hasRace ? (market.odds[c.project.id] ?? 0) : Number.NaN,
+              balance: pos && pos.qty > 0 ? pos.qty : 0,
+              positionId: 0n,
+            },
+          }
+        }),
+      [competitors, hasRace, market.odds, market.positions],
+    )
+
+  const betRow = betProjectId
+    ? outcomes.find((o) => o.projectId === betProjectId)
+    : undefined
+
+  const handleBet = (projectId: string) => {
+    if (!userAddress) {
+      login()
+      return
+    }
+    setBetProjectId(projectId)
+  }
+
+  const handleCashOut = (projectId: string, name: string) => {
+    const valueEth = exitMockPosition(goal.id, projectId, userAddress)
+    toast.success(`Cashed out ${name} (demo) for ≈ ${fmt(valueEth)} ETH.`, {
+      style: toastStyle,
+    })
+  }
+
+  return (
+    <div className="animate-fadeIn flex flex-col items-center">
+      <Head
+        title={goal.title}
+        description={goal.description.slice(0, 160)}
+      />
+      <Container>
+        <div className="w-full max-w-[860px] mx-auto pt-6 sm:pt-8 pb-10 px-4 sm:px-5 md:px-0">
+          <div className="flex flex-col gap-4 w-full">
+            <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <div className="flex items-start gap-3 min-w-0">
+                  <div
+                    className="shrink-0 w-11 h-11 rounded-xl flex items-center justify-center"
+                    style={{
+                      background: `${categoryColor}22`,
+                      border: `1px solid ${categoryColor}55`,
+                      color: categoryColor,
+                    }}
+                  >
+                    <CategoryIcon category={category} className="w-6 h-6" />
+                  </div>
+                  <div className="min-w-0">
+                    <h1 className="text-white font-GoodTimes text-lg sm:text-xl leading-snug">
+                      {goal.title}
+                    </h1>
+                    <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-400">
+                      <span>{categoryLabel}</span>
+                      {goal.targetWindow && (
+                        <>
+                          <span className="text-gray-600">·</span>
+                          <span>
+                            {goal.targetWindow.from ?? '?'}–{goal.targetWindow.to ?? '?'}
+                          </span>
+                        </>
+                      )}
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                          hasRace
+                            ? 'text-fuchsia-200 border-fuchsia-400/30 bg-fuchsia-500/10'
+                            : 'text-gray-400 border-white/15 bg-white/5'
+                        }`}
+                      >
+                        {hasRace ? 'Demo' : 'No developer yet'}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <Link
+                  href="/deprize"
+                  className="shrink-0 text-sm text-indigo-300/90 hover:text-indigo-200 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/50 rounded"
+                >
+                  ← All prizes
+                </Link>
+              </div>
+              <div className="mt-3 grid grid-cols-3 gap-3">
+                <div>
+                  <p className="text-xs text-gray-400">Prize pool</p>
+                  <p className="text-sm font-semibold text-white">
+                    {hasRace ? `${fmtPrizeEth(market.pool)} ETH` : '—'}
+                    {hasRace && (
+                      <span className="ml-1.5 text-[10px] font-medium uppercase tracking-wide text-gray-500">
+                        demo
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400">Providers</p>
+                  <p className="text-sm font-semibold text-white">
+                    {competitors.length || '—'}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400">Target window</p>
+                  <p className="text-sm font-semibold text-white">
+                    {goal.targetWindow
+                      ? `${goal.targetWindow.from ?? '?'}–${goal.targetWindow.to ?? '?'}`
+                      : '—'}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {hasRace && (
+              <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
+                <p className="text-white font-semibold mb-3">Predictions</p>
+                <div className="flex w-full h-2 rounded-full overflow-hidden bg-white/5 mb-3">
+                  {outcomes.map((o) => (
+                    <div
+                      key={o.projectId}
+                      style={{
+                        width: `${Math.max(0, Math.min(100, o.outcome.probability))}%`,
+                        background:
+                          OUTCOME_COLORS[o.outcome.index % OUTCOME_COLORS.length],
+                      }}
+                    />
+                  ))}
+                </div>
+                <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+                  {outcomes.map((o) => (
+                    <div key={o.projectId} className="flex items-center gap-1.5">
+                      <span
+                        className="inline-block w-2.5 h-2.5 rounded-full"
+                        style={{
+                          background:
+                            OUTCOME_COLORS[o.outcome.index % OUTCOME_COLORS.length],
+                        }}
+                      />
+                      <span className="text-gray-300 text-xs">
+                        {o.name}
+                        {Number.isFinite(o.outcome.probability)
+                          ? ` · ${fmt(o.outcome.probability, 0)}%`
+                          : ''}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="flex flex-col gap-3">
+              <h3 className="title-text-colors text-lg font-GoodTimes">
+                Competitors
+              </h3>
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 -mt-1">
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-3 w-1 rounded-full bg-zinc-400" />
+                  Unofficial — not confirmed
+                </span>
+              </div>
+              {outcomes.map((o) => {
+                const competitor = competitors[o.outcome.index]
+                const org = competitor?.organization
+                return (
+                  <DePrizeTeamCard
+                    key={o.projectId}
+                    outcome={o.outcome}
+                    teamId={0n}
+                    teamContract={undefined}
+                    color={orgColor(org)}
+                    loading={false}
+                    resolved={false}
+                    isRefundVector={false}
+                    isWinningSlot={false}
+                    investedEth={market.positions[o.projectId]?.costEth ?? 0}
+                    bettingOpen={hasRace}
+                    tradingHalted={false}
+                    busy={false}
+                    userConnected={!!userAddress}
+                    onBet={() => handleBet(o.projectId)}
+                    onCashOut={() => handleCashOut(o.projectId, o.name)}
+                    hrefOverride={`/moonbase/${o.projectId}`}
+                    nameOverride={o.name}
+                    unclaimed
+                    participation="unofficial"
+                  />
+                )
+              })}
+            </div>
+
+            <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
+              <p className="text-gray-300 text-sm">{goal.description}</p>
+              {goal.regionLabel && (
+                <p className="text-gray-500 text-xs mt-2">{goal.regionLabel}</p>
+              )}
+              {hasRace && (
+                <p className="text-gray-500 text-xs leading-relaxed mt-3">
+                  {ROSTER_DISCLAIMER}
+                </p>
+              )}
+              <p className="text-gray-500 text-xs mt-3">
+                {hasRace
+                  ? 'Switch to Sepolia to view the live on-chain market for this race. '
+                  : 'No funded developer has entered this capability yet, so there is no market. '}
+                <Link
+                  href={`/moonbase?race=${goal.id}`}
+                  className="text-indigo-300/90 underline-offset-2 hover:underline"
+                >
+                  See this race on Moon Base Zero
+                </Link>
+                .
+              </p>
+            </div>
+
+            {goal.criteria && goal.criteria.length > 0 && (
+              <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
+                <h3 className="text-white font-semibold text-sm mb-3">
+                  Capability criteria (draft)
+                </h3>
+                <ol className="flex flex-col gap-2.5">
+                  {goal.criteria.map((c, i) => (
+                    <li key={c.id} className="text-sm text-gray-300">
+                      <span className="text-gray-500 mr-2">{i + 1}</span>
+                      {c.statement}
+                      {c.threshold && (
+                        <p className="text-xs text-gray-500 mt-0.5 pl-5">
+                          {c.threshold}
+                        </p>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            )}
+
+            {goal.sources.length > 0 && (
+              <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
+                <h3 className="text-white font-semibold text-sm mb-3">Sources</h3>
+                <ul className="flex flex-col gap-1.5">
+                  {goal.sources.map((s) => (
+                    <li key={s.url}>
+                      <a
+                        href={s.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-indigo-300/90 hover:text-indigo-200 text-sm underline-offset-2 hover:underline"
+                      >
+                        {s.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+        <NoticeFooter />
+      </Container>
+
+      {betRow && (
+        <DemoBetModal
+          sharedGoalId={goal.id}
+          projectIds={projectIds}
+          impliedOdds={goal.market?.impliedOdds}
+          projectId={betRow.projectId}
+          teamName={betRow.name}
+          probability={betRow.outcome.probability}
+          address={userAddress}
+          onClose={() => setBetProjectId(null)}
+          onDone={() => {
+            setBetProjectId(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/ui/components/deprize/OddsHistoryChart.tsx
+++ b/ui/components/deprize/OddsHistoryChart.tsx
@@ -65,8 +65,8 @@ export default function OddsHistoryChart({
         className="flex items-center justify-center text-gray-500 text-xs text-center px-4"
         style={{ height }}
       >
-        Live odds will plot here as the market updates. Leave this open (or place
-        a bet) and the chart fills in over time.
+        Odds history will plot here as the market moves. Samples persist across
+        visits, so the line grows from market open to now.
       </div>
     )
   }

--- a/ui/components/deprize/RaceMarketCard.tsx
+++ b/ui/components/deprize/RaceMarketCard.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Chain } from 'thirdweb'
 import {
+  deprizeDetailHref,
   findDePrizeIdForGoal,
   getDePrizeRaceBinding,
   isCompetitiveRace,
@@ -278,7 +279,10 @@ export default function RaceMarketCard({
   const poolEth = bound ? realPoolEth : demo.pool
   const poolLoading = bound && live.jbProjectId !== undefined && isLoadingFunding
 
-  const detailHref = bound ? `/deprize/${deprizeId}` : `/moonbase?race=${goal.id}`
+  // Always the prize page. Bound races resolve the slug to the live DePrize;
+  // unbound ones render the atlas detail at the same URL. Never moonbase —
+  // the globe is a secondary link from the prize page, not the destination.
+  const detailHref = deprizeDetailHref(goal.id)
 
   const ranked = useMemo(
     () => [...outcomes].sort((a, b) => (b.probability || 0) - (a.probability || 0)),

--- a/ui/components/lunar-atlas/MarkerLayer.tsx
+++ b/ui/components/lunar-atlas/MarkerLayer.tsx
@@ -37,7 +37,11 @@ import {
   vector3ToLatLon,
   Vec3,
 } from '@/lib/lunar-atlas/geo'
-import { PROJECT_TYPE_LABEL, orgColor } from '@/lib/lunar-atlas/display'
+import {
+  PROJECT_TYPE_LABEL,
+  formatPlace,
+  orgColor,
+} from '@/lib/lunar-atlas/display'
 import {
   M_TO_UNITS,
   capCenterDirection,
@@ -236,6 +240,7 @@ function CompetitorPlot({
   patrolPhase,
   raceOpen,
   called,
+  standing,
   onSelect,
   onHover,
   radiusAt,
@@ -265,6 +270,7 @@ function CompetitorPlot({
   raceOpen: boolean
   // Picked out specifically — hovered, or chosen from the competitor list.
   called: boolean
+  standing?: { place: number; probability: number }
   onSelect?: () => void
   onHover?: (hovered: boolean) => void
   radiusAt?: RadiusAt | null
@@ -452,7 +458,13 @@ function CompetitorPlot({
                 : 'border-white/10 bg-black/55 text-white/70'
             }`}
           >
-            {project.name}
+            <div>{project.name}</div>
+            {standing && (
+              <div className="tabular-nums text-cyan-200/90">
+                {formatPlace(standing.place)} ·{' '}
+                {Math.round(standing.probability * 100)}%
+              </div>
+            )}
           </div>
         </Html>
       )}
@@ -1439,6 +1451,7 @@ export default function MarkerLayer({
               }
               if (!style.visible) return null
               const org = orgMap.get(project.orgId)
+              const probability = tree.goal?.market?.impliedOdds?.[project.id]
               return (
                 <CompetitorPlot
                   key={project.id}
@@ -1453,6 +1466,11 @@ export default function MarkerLayer({
                   patrolPhase={(i / count) * Math.PI * 2}
                   raceOpen={isOpen}
                   called={selectedProject?.id === project.id}
+                  standing={
+                    probability != null && Number.isFinite(probability)
+                      ? { place: i + 1, probability }
+                      : undefined
+                  }
                   onSelect={() => onSelectProject?.(project.id)}
                   onHover={(h) => onHoverTree?.(h ? tree.category : null)}
                   radiusAt={radiusAt}

--- a/ui/components/lunar-atlas/ProjectPanel.tsx
+++ b/ui/components/lunar-atlas/ProjectPanel.tsx
@@ -124,7 +124,10 @@ export default function ProjectPanel({
   )
   const otherGoals = sharedGoals.filter((g) => !standingGoalIds.has(g.id))
 
-  const hasRace = !!betGoal && isCompetitiveRace(betGoal.projectIds.length)
+  const hasRace =
+    !!betGoal &&
+    isCompetitiveRace(betGoal.projectIds.length) &&
+    betGoal.projectIds.includes(project.id)
   const bound =
     !!betGoal && !!chainSlug && isDePrizeGoalMarketBound(chainSlug, betGoal.id)
   const marketDeprizeId = bound

--- a/ui/components/lunar-atlas/ProjectPanel.tsx
+++ b/ui/components/lunar-atlas/ProjectPanel.tsx
@@ -1,16 +1,24 @@
 import { ArrowLeftIcon, MapPinIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { useMemo } from 'react'
-import { parseAtlasYear } from '@/lib/lunar-atlas/selectors'
+import {
+  parseAtlasYear,
+  raceStandingForProject,
+} from '@/lib/lunar-atlas/selectors'
 import {
   LOCATION_PRECISION_LABEL,
   MILESTONE_STATUS_CLASSES,
   MILESTONE_STATUS_LABEL,
   PROJECT_TYPE_GLYPH,
   PROJECT_TYPE_LABEL,
-  ROSTER_STATUS_CLASSES,
   ROSTER_STATUS_LABEL,
+  formatPlace,
+  participationKind,
   orgColor,
 } from '@/lib/lunar-atlas/display'
+import {
+  PARTICIPATION_BAR_CLASSES,
+  PARTICIPATION_ROW_CLASSES,
+} from './participation-styles'
 import type {
   Organization,
   Project,
@@ -43,6 +51,19 @@ export default function ProjectPanel({
 }: ProjectPanelProps) {
   const color = orgColor(organization)
   const approximate = project.locationPrecision !== 'exact'
+  const rosterKind = participationKind(project.rosterStatus)
+  const standings = useMemo(
+    () =>
+      sharedGoals
+        .map((g) => raceStandingForProject(project.id, g))
+        .filter((s): s is NonNullable<typeof s> => s !== undefined),
+    [sharedGoals, project.id]
+  )
+  const standingGoalIds = useMemo(
+    () => new Set(standings.map((s) => s.goalId)),
+    [standings]
+  )
+  const otherGoals = sharedGoals.filter((g) => !standingGoalIds.has(g.id))
 
   const milestones = useMemo(
     () =>
@@ -86,6 +107,12 @@ export default function ProjectPanel({
             <span>{PROJECT_TYPE_GLYPH[project.type]}</span>
             <span>{PROJECT_TYPE_LABEL[project.type]}</span>
           </div>
+          {standings[0] && (
+            <p className="mt-1 text-sm font-medium tabular-nums text-cyan-200/90">
+              {formatPlace(standings[0].place)} place ·{' '}
+              {Math.round(standings[0].probability * 100)}%
+            </p>
+          )}
         </div>
         <button
           onClick={onClose}
@@ -118,16 +145,66 @@ export default function ProjectPanel({
           )}
         </div>
 
+        {standings.length > 0 && (
+          <div className="space-y-2">
+            {standings.map((s) => {
+              const body = (
+                <>
+                  <span className="flex items-baseline justify-between gap-3">
+                    <span className="text-sm font-semibold text-white">
+                      {formatPlace(s.place)} place
+                    </span>
+                    <span className="text-lg font-semibold tabular-nums text-cyan-200">
+                      {Math.round(s.probability * 100)}%
+                    </span>
+                  </span>
+                  <span className="mt-0.5 block truncate text-sm text-white/80">
+                    {s.title}
+                  </span>
+                  <span className="mt-1.5 flex items-center gap-2">
+                    <MarketPill status={s.marketStatus ?? 'none'} />
+                    <span className="text-[11px] text-white/40">
+                      {s.fieldSize} competitor{s.fieldSize === 1 ? '' : 's'}
+                    </span>
+                  </span>
+                </>
+              )
+              return onSelectSharedGoal ? (
+                <button
+                  key={s.goalId}
+                  type="button"
+                  onClick={() => onSelectSharedGoal(s.goalId)}
+                  className="w-full rounded-lg border border-fuchsia-400/25 bg-fuchsia-500/[0.07] px-3 py-2.5 text-left transition hover:border-fuchsia-400/45 hover:bg-fuchsia-500/10"
+                >
+                  {body}
+                </button>
+              ) : (
+                <div
+                  key={s.goalId}
+                  className="w-full rounded-lg border border-fuchsia-400/25 bg-fuchsia-500/[0.07] px-3 py-2.5 text-left"
+                >
+                  {body}
+                </div>
+              )
+            })}
+          </div>
+        )}
+
         {/* Summary */}
         <p className="text-sm leading-relaxed text-white/80">{project.summary}</p>
 
-        {/* DePrize roster status — honest consent state, not implied endorsement */}
-        {project.rosterStatus && (
-          <span
-            className={`inline-flex rounded-md border px-2 py-1 text-xs font-medium ${ROSTER_STATUS_CLASSES[project.rosterStatus]}`}
+        {rosterKind && project.rosterStatus && (
+          <div
+            className={`flex overflow-hidden rounded-lg border ${PARTICIPATION_ROW_CLASSES[rosterKind]}`}
           >
-            {ROSTER_STATUS_LABEL[project.rosterStatus]}
-          </span>
+            <span
+              aria-hidden
+              className={`w-1 shrink-0 ${PARTICIPATION_BAR_CLASSES[rosterKind]}`}
+            />
+            <p className="px-3 py-2 text-xs leading-relaxed text-white/80">
+              {ROSTER_STATUS_LABEL[project.rosterStatus]}
+            </p>
+          </div>
         )}
 
         {/* Milestones */}
@@ -168,14 +245,13 @@ export default function ProjectPanel({
           </div>
         )}
 
-        {/* Shared goals */}
-        {sharedGoals.length > 0 && (
+        {otherGoals.length > 0 && (
           <div>
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-white/40">
               Shared goals
             </h3>
             <div className="space-y-2">
-              {sharedGoals.map((g) =>
+              {otherGoals.map((g) =>
                 // Only render an interactive affordance when there is a real
                 // handler — a button that does nothing reads as broken.
                 onSelectSharedGoal ? (

--- a/ui/components/lunar-atlas/ProjectPanel.tsx
+++ b/ui/components/lunar-atlas/ProjectPanel.tsx
@@ -1,5 +1,18 @@
 import { ArrowLeftIcon, MapPinIcon, XMarkIcon } from '@heroicons/react/24/outline'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import toast from 'react-hot-toast'
+import type { Chain } from 'thirdweb'
+import {
+  findDePrizeIdForGoal,
+  getDePrizeRaceBinding,
+  isCompetitiveRace,
+  isDePrizeGoalMarketBound,
+} from '@/lib/deprize/competitions'
+import { positionRedeemValue, UNIT } from '@/lib/deprize/constants'
+import { fmt } from '@/lib/deprize/format'
+import { exitMockPosition, useMockMarket } from '@/lib/deprize/mockMarket'
+import type { Outcome } from '@/lib/deprize/useDePrizeMarket'
+import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import {
   parseAtlasYear,
   raceStandingForProject,
@@ -24,6 +37,9 @@ import type {
   Project,
   SharedGoal,
 } from '@/lib/lunar-atlas/types'
+import BetModal from '@/components/deprize/BetModal'
+import DemoBetModal from '@/components/deprize/DemoBetModal'
+import ExitPositionModal from '@/components/deprize/ExitPositionModal'
 import SourceBadge from './SourceBadge'
 
 type ProjectPanelProps = {
@@ -37,6 +53,28 @@ type ProjectPanelProps = {
   // return to that list.
   onBack?: () => void
   backLabel?: string
+  /** Race this competitor was opened from (or its first competitive goal). */
+  betGoal?: SharedGoal
+  chainSlug?: string
+  chain?: Chain
+  account?: any
+  userAddress?: string
+  onConnectWallet?: () => void
+  spendableEth?: number
+  deprizeId?: number
+  mintAddress?: string
+  marketAddress?: string
+  numOutcomes?: number
+  outcomes?: Outcome[]
+  bettingAllowed?: boolean
+  tradingHalted?: boolean
+  resolved?: boolean
+  winningIndex?: number
+  isRefundVector?: boolean
+  payoutDen?: bigint
+  payoutNums?: bigint[]
+  jbProjectId?: number | bigint
+  onDone?: () => void
 }
 
 export default function ProjectPanel({
@@ -48,6 +86,27 @@ export default function ProjectPanel({
   onSelectSharedGoal,
   onBack,
   backLabel = 'Back to competitors',
+  betGoal,
+  chainSlug,
+  chain,
+  account,
+  userAddress,
+  onConnectWallet,
+  spendableEth = 0,
+  deprizeId,
+  mintAddress,
+  marketAddress,
+  numOutcomes = 0,
+  outcomes,
+  bettingAllowed = false,
+  tradingHalted = false,
+  resolved = false,
+  winningIndex = -1,
+  isRefundVector = false,
+  payoutDen,
+  payoutNums,
+  jbProjectId,
+  onDone,
 }: ProjectPanelProps) {
   const color = orgColor(organization)
   const approximate = project.locationPrecision !== 'exact'
@@ -64,6 +123,89 @@ export default function ProjectPanel({
     [standings]
   )
   const otherGoals = sharedGoals.filter((g) => !standingGoalIds.has(g.id))
+
+  const hasRace = !!betGoal && isCompetitiveRace(betGoal.projectIds.length)
+  const bound =
+    !!betGoal && !!chainSlug && isDePrizeGoalMarketBound(chainSlug, betGoal.id)
+  const marketDeprizeId = bound
+    ? deprizeId ?? findDePrizeIdForGoal(chainSlug!, betGoal!.id)
+    : undefined
+  const binding =
+    marketDeprizeId !== undefined && chainSlug
+      ? getDePrizeRaceBinding(chainSlug, marketDeprizeId)
+      : undefined
+  const outcomeIndex = binding
+    ? binding.outcomes.findIndex((o) => !o.field && o.projectId === project.id)
+    : -1
+  const outcome =
+    bound && outcomeIndex >= 0 ? outcomes?.[outcomeIndex] : undefined
+  const canBack =
+    hasRace &&
+    (bound ? marketDeprizeId !== undefined && outcomeIndex >= 0 : true)
+  const demo = useMockMarket(
+    betGoal?.id ?? project.id,
+    betGoal?.projectIds ?? [project.id],
+    betGoal?.market?.impliedOdds,
+    userAddress,
+  )
+  const demoPosition = demo.positions[project.id]
+  const holding = bound
+    ? !!outcome && Number.isFinite(outcome.balance) && outcome.balance > 0
+    : !!demoPosition && demoPosition.qty > 0
+  const heldValueEth = bound ? outcome?.balance : demoPosition?.qty
+  const redeemValueEth =
+    bound && resolved && outcome?.balanceWei !== undefined && payoutDen
+      ? Number(
+          positionRedeemValue(
+            outcome.balanceWei,
+            payoutNums?.[outcomeIndex] ?? 0n,
+            payoutDen,
+          ),
+        ) / Number(UNIT)
+      : undefined
+  const isWinningSlot =
+    bound && resolved && outcomeIndex >= 0 && outcomeIndex === winningIndex
+  const backDisabled =
+    !!userAddress && bound && (!bettingAllowed || tradingHalted)
+
+  const [betOpen, setBetOpen] = useState(false)
+  const [exitOpen, setExitOpen] = useState(false)
+  const [demoBetOpen, setDemoBetOpen] = useState(false)
+  useEffect(() => {
+    setBetOpen(false)
+    setExitOpen(false)
+    setDemoBetOpen(false)
+  }, [project.id, betGoal?.id])
+
+  const handleBetClick = () => {
+    if (!userAddress) {
+      onConnectWallet?.()
+      return
+    }
+    if (!bound) {
+      setDemoBetOpen(true)
+      return
+    }
+    if (
+      !bettingAllowed ||
+      outcomeIndex < 0 ||
+      !marketAddress ||
+      !mintAddress ||
+      outcomeIndex >= numOutcomes
+    ) {
+      return
+    }
+    setBetOpen(true)
+  }
+
+  const handleDemoExit = () => {
+    if (!betGoal) return
+    const valueEth = exitMockPosition(betGoal.id, project.id, userAddress)
+    toast.success(`Cashed out ${project.name} (demo) for ≈ ${fmt(valueEth)} ETH.`, {
+      style: toastStyle,
+    })
+    onDone?.()
+  }
 
   const milestones = useMemo(
     () =>
@@ -114,13 +256,36 @@ export default function ProjectPanel({
             </p>
           )}
         </div>
-        <button
-          onClick={onClose}
-          aria-label="Close"
-          className="shrink-0 rounded-lg p-1.5 text-white/50 transition hover:bg-white/10 hover:text-white"
-        >
-          <XMarkIcon className="h-5 w-5" />
-        </button>
+        <div className="flex shrink-0 items-start gap-2">
+          {canBack && !resolved && (
+            <button
+              type="button"
+              onClick={handleBetClick}
+              disabled={backDisabled}
+              className="rounded-md px-3 py-1.5 text-xs font-semibold text-white transition-all
+                bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500
+                disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {userAddress ? 'Buy' : 'Connect'}
+            </button>
+          )}
+          {resolved && redeemValueEth !== undefined && (
+            <span
+              className={`self-center text-xs font-semibold tabular-nums ${
+                isWinningSlot || isRefundVector ? 'text-emerald-300' : 'text-gray-500'
+              }`}
+            >
+              ≈ {fmt(redeemValueEth)} ETH
+            </span>
+          )}
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-lg p-1.5 text-white/50 transition hover:bg-white/10 hover:text-white"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 space-y-5 overflow-y-auto p-4">
@@ -187,6 +352,23 @@ export default function ProjectPanel({
                 </div>
               )
             })}
+          </div>
+        )}
+
+        {holding && !resolved && (
+          <div className="flex items-center justify-between gap-2 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2">
+            <span className="text-[11px] text-white/50">
+              {fmt(heldValueEth ?? 0)} {bound ? 'ETH' : 'demo ETH'} if wins
+            </span>
+            {(bound ? !tradingHalted : true) && (
+              <button
+                type="button"
+                onClick={() => (bound ? setExitOpen(true) : handleDemoExit())}
+                className="shrink-0 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-white transition-all hover:border-indigo-400/35 hover:bg-indigo-500/15"
+              >
+                Cash out
+              </button>
+            )}
           </div>
         )}
 
@@ -296,6 +478,74 @@ export default function ProjectPanel({
           endorsement, guarantee, or prediction of outcomes.
         </p>
       </div>
+
+      {betOpen &&
+        chain &&
+        account &&
+        marketAddress &&
+        mintAddress &&
+        marketDeprizeId !== undefined &&
+        outcomeIndex >= 0 && (
+          <BetModal
+            deprizeId={marketDeprizeId}
+            outcomeIndex={outcomeIndex}
+            teamName={project.name}
+            probability={outcome?.probability ?? NaN}
+            numOutcomes={numOutcomes}
+            mintAddress={mintAddress}
+            marketAddress={marketAddress}
+            jbProjectId={jbProjectId}
+            chain={chain}
+            account={account}
+            spendableEth={spendableEth}
+            onClose={() => setBetOpen(false)}
+            onDone={() => {
+              setBetOpen(false)
+              onDone?.()
+            }}
+          />
+        )}
+
+      {exitOpen &&
+        chain &&
+        account &&
+        marketAddress &&
+        marketDeprizeId !== undefined &&
+        outcomeIndex >= 0 && (
+          <ExitPositionModal
+            deprizeId={marketDeprizeId}
+            outcomeIndex={outcomeIndex}
+            teamName={project.name}
+            balanceWei={outcome?.balanceWei ?? 0n}
+            positionId={outcome?.positionId ?? 0n}
+            numOutcomes={numOutcomes}
+            marketAddress={marketAddress}
+            chain={chain}
+            account={account}
+            onClose={() => setExitOpen(false)}
+            onDone={() => {
+              setExitOpen(false)
+              onDone?.()
+            }}
+          />
+        )}
+
+      {demoBetOpen && betGoal && (
+        <DemoBetModal
+          sharedGoalId={betGoal.id}
+          projectIds={betGoal.projectIds}
+          impliedOdds={betGoal.market?.impliedOdds}
+          projectId={project.id}
+          teamName={project.name}
+          probability={demo.odds[project.id] ?? 0}
+          address={userAddress}
+          onClose={() => setDemoBetOpen(false)}
+          onDone={() => {
+            setDemoBetOpen(false)
+            onDone?.()
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/ui/components/lunar-atlas/SharedGoalPanel.tsx
+++ b/ui/components/lunar-atlas/SharedGoalPanel.tsx
@@ -1,7 +1,7 @@
-// Race view for a DePrize-shaped shared goal: the competitor roster (with
-// honest consent badges), the draft capability criteria, market structure,
-// and sources. Opened from a shared-goal row in ProjectPanel or by clicking
-// the goal's region marker on the globe.
+// Race view for a DePrize-shaped shared goal: the competitor roster (official
+// vs unofficial via color, not a repeating "listed" chip), the draft
+// capability criteria, market structure, and sources. Opened from a
+// shared-goal row in ProjectPanel or by clicking the goal's region marker.
 
 import { FlagIcon, MapPinIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
@@ -24,10 +24,14 @@ import { exitMockPosition, useMockMarket } from '@/lib/deprize/mockMarket'
 import type { Outcome } from '@/lib/deprize/useDePrizeMarket'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
 import {
-  ROSTER_STATUS_CLASSES,
-  ROSTER_STATUS_LABEL,
+  PARTICIPATION_LABEL,
+  participationKind,
   orgColor,
 } from '@/lib/lunar-atlas/display'
+import {
+  PARTICIPATION_BAR_CLASSES,
+  PARTICIPATION_ROW_CLASSES,
+} from './participation-styles'
 import type {
   Organization,
   Project,
@@ -144,11 +148,13 @@ export default function SharedGoalPanel({
     marketDeprizeId !== undefined && chainSlug
       ? getDePrizeRaceBinding(chainSlug, marketDeprizeId)
       : undefined
-  const anyUnconfirmed = competitors.some(
-    (c) =>
-      c.project.rosterStatus === 'listed' ||
-      c.project.rosterStatus === 'invited'
+  const kinds = competitors.map((c) =>
+    participationKind(c.project.rosterStatus)
   )
+  const anyOfficial = kinds.includes('official')
+  const anyUnofficial = kinds.includes('unofficial')
+  const anyDeclined = kinds.includes('declined')
+  const showParticipationLegend = anyOfficial || anyUnofficial || anyDeclined
 
   // Demo betting sandbox for races without a bound on-chain market yet — same
   // local ledger the /deprize index uses, so "Back this team" always does
@@ -333,6 +339,34 @@ export default function SharedGoalPanel({
                 active competition to bet on. Shown below for reference.
               </p>
             )}
+            {hasRace && showParticipationLegend && (
+              <div className="mb-2 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-white/45">
+                {anyOfficial && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <span
+                      className={`h-3 w-1 rounded-full ${PARTICIPATION_BAR_CLASSES.official}`}
+                    />
+                    Official participant
+                  </span>
+                )}
+                {anyUnofficial && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <span
+                      className={`h-3 w-1 rounded-full ${PARTICIPATION_BAR_CLASSES.unofficial}`}
+                    />
+                    Unofficial — not confirmed
+                  </span>
+                )}
+                {anyDeclined && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <span
+                      className={`h-3 w-1 rounded-full ${PARTICIPATION_BAR_CLASSES.declined}`}
+                    />
+                    Declined
+                  </span>
+                )}
+              </div>
+            )}
             <div className="space-y-2">
               {ranked.map(({ project, organization }) => {
                 const color = accentFor(project.id, organization)
@@ -348,6 +382,7 @@ export default function SharedGoalPanel({
                   (bound
                     ? marketDeprizeId !== undefined && outcomeIndex !== undefined
                     : true)
+                const kind = participationKind(project.rosterStatus)
                 const outcome = outcomeAt(outcomeIndex)
                 const demoPosition = demo.positions[project.id]
                 const holding = bound
@@ -373,15 +408,26 @@ export default function SharedGoalPanel({
                 return (
                   <div
                     key={project.id}
-                    className="relative overflow-hidden rounded-lg border border-white/[0.06] bg-white/[0.03] transition-colors hover:border-cyan-400/30"
+                    title={kind ? PARTICIPATION_LABEL[kind] : undefined}
+                    className={`relative overflow-hidden rounded-lg border transition-colors hover:border-cyan-400/30 ${
+                      kind
+                        ? PARTICIPATION_ROW_CLASSES[kind]
+                        : 'border-white/[0.06] bg-white/[0.03]'
+                    }`}
                   >
+                    {kind && (
+                      <span
+                        aria-hidden
+                        className={`absolute inset-y-0 left-0 z-20 w-1 ${PARTICIPATION_BAR_CLASSES[kind]}`}
+                      />
+                    )}
                     {p != null && (
                       <div
                         className="pointer-events-none absolute inset-y-0 left-0 opacity-[0.14]"
                         style={{ width: `${Math.round(p * 100)}%`, background: color }}
                       />
                     )}
-                    <div className="relative z-10 flex items-center gap-2.5 px-2.5 py-2">
+                    <div className="relative z-10 flex items-center gap-2.5 px-2.5 py-2 pl-3.5">
                       <button
                         type="button"
                         onClick={() => onSelectProject(project.id)}
@@ -406,14 +452,6 @@ export default function SharedGoalPanel({
                           </span>
                         </span>
                       </button>
-                      {project.rosterStatus && (
-                        <span
-                          className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-medium ${ROSTER_STATUS_CLASSES[project.rosterStatus]}`}
-                          title={ROSTER_STATUS_LABEL[project.rosterStatus]}
-                        >
-                          {project.rosterStatus}
-                        </span>
-                      )}
                       {holding && (
                         <span className="shrink-0 text-[10px] font-medium text-moon-green">
                           {resolved
@@ -590,11 +628,11 @@ export default function SharedGoalPanel({
               </p>
             ) : (
               hasRace &&
-              anyUnconfirmed && (
+              anyUnofficial && (
                 <p className="mt-2 text-[11px] leading-relaxed text-white/40">
-                  &ldquo;Listed&rdquo; reflects MoonDAO&apos;s curatorial judgment
-                  of credible competitors. It does not imply these organizations
-                  have agreed to participate in any MoonDAO prize.
+                  Unofficial competitors are listed at MoonDAO&apos;s editorial
+                  discretion. That does not mean the organization has agreed to
+                  participate in any MoonDAO prize.
                 </p>
               )
             )}

--- a/ui/components/lunar-atlas/participation-styles.ts
+++ b/ui/components/lunar-atlas/participation-styles.ts
@@ -1,0 +1,14 @@
+import type { ParticipationKind } from '@/lib/lunar-atlas/display'
+
+// Keep these class strings in `components/` so Tailwind's content scan emits them.
+export const PARTICIPATION_ROW_CLASSES: Record<ParticipationKind, string> = {
+  official: 'border-emerald-400/30 bg-emerald-500/[0.08]',
+  unofficial: 'border-zinc-400/25 bg-zinc-500/[0.10]',
+  declined: 'border-rose-400/25 bg-rose-500/[0.06]',
+}
+
+export const PARTICIPATION_BAR_CLASSES: Record<ParticipationKind, string> = {
+  official: 'bg-emerald-400',
+  unofficial: 'bg-zinc-400',
+  declined: 'bg-rose-400',
+}

--- a/ui/cypress/integration/lib/deprize/competitions.cy.ts
+++ b/ui/cypress/integration/lib/deprize/competitions.cy.ts
@@ -71,14 +71,24 @@ describe('deprize competitions registry', () => {
 
   it('reverse-looks up the DePrize id for a bound goal (hit and miss)', () => {
     expect(findDePrizeIdForGoal('sepolia', 'shared-fission-power')).to.equal(9)
-    expect(findDePrizeIdForGoal('sepolia', 'shared-landing-pads')).to.equal(undefined)
+    expect(findDePrizeIdForGoal('sepolia', 'shared-crewed-lander')).to.equal(10)
+    expect(findDePrizeIdForGoal('sepolia', 'shared-lunar-rover')).to.equal(12)
+    expect(findDePrizeIdForGoal('sepolia', 'shared-isru-oxygen')).to.equal(15)
+    expect(findDePrizeIdForGoal('sepolia', 'shared-landing-pads')).to.equal(17)
+    expect(findDePrizeIdForGoal('sepolia', 'shared-habitat')).to.equal(18)
+    expect(findDePrizeIdForGoal('sepolia', 'shared-lunar-comms')).to.equal(19)
+    expect(findDePrizeIdForGoal('sepolia', 'shared-mass-driver')).to.equal(undefined)
     expect(findDePrizeIdForGoal('arbitrum', 'shared-fission-power')).to.equal(undefined)
     expect(findDePrizeIdForGoal('sepolia', undefined)).to.equal(undefined)
   })
 
   it('reports a bound race regardless of consent, and unbound goals as unbound', () => {
     expect(isDePrizeGoalMarketBound('sepolia', 'shared-fission-power')).to.equal(true)
-    expect(isDePrizeGoalMarketBound('sepolia', 'shared-landing-pads')).to.equal(false)
+    expect(isDePrizeGoalMarketBound('sepolia', 'shared-crewed-lander')).to.equal(true)
+    expect(isDePrizeGoalMarketBound('sepolia', 'shared-landing-pads')).to.equal(true)
+    expect(isDePrizeGoalMarketBound('sepolia', 'shared-habitat')).to.equal(true)
+    expect(isDePrizeGoalMarketBound('sepolia', 'shared-lunar-comms')).to.equal(true)
+    expect(isDePrizeGoalMarketBound('sepolia', 'shared-mass-driver')).to.equal(false)
     // Arbitrum has no binding at all, so there is no market to report.
     expect(isDePrizeGoalMarketBound('arbitrum', 'shared-fission-power')).to.equal(false)
     expect(isDePrizeGoalMarketBound('sepolia', undefined)).to.equal(false)
@@ -116,18 +126,28 @@ describe('deprize competitions registry', () => {
     expect(chainHasRaceBindings('sepolia')).to.equal(true)
     expect(chainHasRaceBindings('arbitrum')).to.equal(false)
 
-    const sepolia = partitionDePrizeIndexByRace('sepolia', 10)
+    const sepolia = partitionDePrizeIndexByRace('sepolia', 19)
     expect(sepolia[0]).to.deep.equal({
       raceLabel: 'Fission surface power',
       deprizeIds: [9],
       showHeading: true,
     })
+    const lander = sepolia.find((g) => g.raceLabel === 'Crewed lunar landing')
+    expect(lander?.deprizeIds).to.deep.equal([10])
+    const pads = sepolia.find((g) => g.raceLabel === 'Landing pads')
+    expect(pads?.deprizeIds).to.deep.equal([17])
+    const habitat = sepolia.find((g) => g.raceLabel === 'Pressurized habitat')
+    expect(habitat?.deprizeIds).to.deep.equal([18])
+    const comms = sepolia.find((g) => g.raceLabel === 'Lunar comms')
+    expect(comms?.deprizeIds).to.deep.equal([19])
     const other = sepolia.find((g) => g.raceLabel === null)
     expect(other).to.not.equal(undefined)
     expect(other!.showHeading).to.equal(true)
     expect(other!.deprizeIds).to.include(1)
-    expect(other!.deprizeIds).to.include(10)
+    expect(other!.deprizeIds).to.include(11)
     expect(other!.deprizeIds).to.not.include(9)
+    expect(other!.deprizeIds).to.not.include(10)
+    expect(other!.deprizeIds).to.not.include(17)
 
     const arbitrum = partitionDePrizeIndexByRace('arbitrum', 3)
     expect(arbitrum).to.deep.equal([

--- a/ui/cypress/integration/lib/deprize/format.cy.ts
+++ b/ui/cypress/integration/lib/deprize/format.cy.ts
@@ -1,0 +1,60 @@
+import { formatUsd, fmtEthWithUsd, fmtUsdFromEth } from '@/lib/deprize/format'
+
+const ETH_PRICE = 3000
+
+describe('deprize USD denomination', () => {
+  describe('formatUsd', () => {
+    it('matches the launchpad style for typical amounts', () => {
+      expect(formatUsd(36)).to.equal('$36.00')
+      expect(formatUsd(1.234)).to.equal('$1.23')
+      expect(formatUsd(0.045)).to.equal('$0.045')
+      expect(formatUsd(150_000)).to.equal('$150,000')
+    })
+
+    it('signs PnL when asked', () => {
+      expect(formatUsd(3, { signed: true })).to.equal('+$3.00')
+      expect(formatUsd(-1.2, { signed: true })).to.equal('-$1.20')
+      expect(formatUsd(0, { signed: true })).to.equal('$0.00')
+    })
+  })
+
+  describe('fmtUsdFromEth', () => {
+    it('converts ETH at the live quote', () => {
+      expect(fmtUsdFromEth(0.01, ETH_PRICE)).to.equal('$30.00')
+      expect(fmtUsdFromEth(0.0003, ETH_PRICE)).to.equal('$0.90')
+    })
+
+    it('omits USD when the price or amount is unusable', () => {
+      expect(fmtUsdFromEth(0.01, undefined)).to.equal(undefined)
+      expect(fmtUsdFromEth(0.01, 0)).to.equal(undefined)
+      expect(fmtUsdFromEth(undefined, ETH_PRICE)).to.equal(undefined)
+      expect(fmtUsdFromEth(Number.NaN, ETH_PRICE)).to.equal(undefined)
+    })
+  })
+
+  describe('fmtEthWithUsd', () => {
+    it('keeps ETH as the primary figure and tucks USD beside it', () => {
+      expect(fmtEthWithUsd(0.01, ETH_PRICE)).to.equal('0.01 ETH (~$30.00)')
+      expect(fmtEthWithUsd(0.0006, ETH_PRICE, { approx: true })).to.equal(
+        '≈ 0.0006 ETH (~$1.80)'
+      )
+    })
+
+    it('falls back to ETH-only when the quote is missing', () => {
+      expect(fmtEthWithUsd(0.01, null)).to.equal('0.01 ETH')
+    })
+
+    it('formats the 5% prize slice instead of rounding it to 0 ETH', () => {
+      // 5% of the 0.0003 ETH bet that previously displayed as "0 ETH".
+      expect(fmtEthWithUsd(0.000015, ETH_PRICE, { prize: true })).to.equal(
+        '0.000015 ETH (~$0.045)'
+      )
+    })
+
+    it('labels WETH fees the same way as ETH', () => {
+      expect(fmtEthWithUsd(0.004, ETH_PRICE, { decimals: 4, unit: 'WETH' })).to.equal(
+        '0.004 WETH (~$12.00)'
+      )
+    })
+  })
+})

--- a/ui/cypress/integration/unit/lunar-atlas-selectors.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-selectors.cy.ts
@@ -7,6 +7,11 @@
  */
 
 import { expect } from 'chai'
+import {
+  PARTICIPATION_LABEL,
+  formatPlace,
+  participationKind,
+} from '../../../lib/lunar-atlas/display'
 import { SEED_ATLAS } from '../../../lib/lunar-atlas/seed'
 import {
   atlasYear,
@@ -19,6 +24,8 @@ import {
   projectDateRange,
   projectStateAtYear,
   raceArrivalYear,
+  raceStandingForProject,
+  sharedGoalById,
 } from '../../../lib/lunar-atlas/selectors'
 import type {
   Milestone,
@@ -471,6 +478,15 @@ describe('lunar-atlas selectors', () => {
         }
       }
     })
+    it('maps roster status to official / unofficial instead of curator jargon', () => {
+      expect(participationKind(undefined)).to.equal(undefined)
+      expect(participationKind('consented')).to.equal('official')
+      expect(participationKind('listed')).to.equal('unofficial')
+      expect(participationKind('invited')).to.equal('unofficial')
+      expect(participationKind('declined')).to.equal('declined')
+      expect(PARTICIPATION_LABEL.unofficial).to.match(/Unofficial/i)
+      expect(PARTICIPATION_LABEL.unofficial).to.not.match(/^listed$/i)
+    })
     it('capability criteria are well-formed and goals with criteria are sourced', () => {
       for (const g of SEED_ATLAS.sharedGoals) {
         if (!g.criteria) continue
@@ -512,6 +528,24 @@ describe('lunar-atlas selectors', () => {
           `goal ${g.id} has no ${g.category} competitor`
         ).to.be.greaterThan(0)
       }
+    })
+    it('surfaces a competitor\'s place and odds from a race goal', () => {
+      expect(formatPlace(1)).to.equal('1st')
+      expect(formatPlace(2)).to.equal('2nd')
+      expect(formatPlace(3)).to.equal('3rd')
+      expect(formatPlace(11)).to.equal('11th')
+      expect(formatPlace(12)).to.equal('12th')
+      const lander = sharedGoalById(SEED_ATLAS, 'shared-crewed-lander')
+      expect(lander).to.exist
+      const blue = raceStandingForProject('blue-origin-blue-moon-mk2', lander!)
+      expect(blue?.place).to.equal(2)
+      expect(blue?.fieldSize).to.equal(2)
+      expect(Math.round((blue?.probability ?? 0) * 100)).to.equal(36)
+      const starship = raceStandingForProject('spacex-starship-hls', lander!)
+      expect(starship?.place).to.equal(1)
+      expect(raceStandingForProject('not-a-competitor', lander!)).to.equal(
+        undefined
+      )
     })
     it('at most one goal declares each race category', () => {
       const seen = new Map<string, string>()

--- a/ui/lib/deprize/competitions.ts
+++ b/ui/lib/deprize/competitions.ts
@@ -87,6 +87,11 @@ export const GENERIC_DEPRIZE_COMPETITION: DePrizeCompetition = {
     'Back the team you think will win — live odds, payout when a winner is declared.',
 }
 
+/** Stable prize-page path for a Moon Base Zero race. Resolves live or atlas. */
+export function deprizeDetailHref(sharedGoalId: string): string {
+  return `/deprize/${sharedGoalId}`
+}
+
 /** chainSlug → deprizeId → competition */
 const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> = {
   arbitrum: {
@@ -130,6 +135,109 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
           projectId: 'ix-fission-surface-power',
           teamId: 303,
         },
+      ],
+    },
+    // 10–16 were registered OPEN on Sepolia with Team 24 as the Open Field
+    // slot. Bind the three whose roster length matches a capability race
+    // (named competitors + field). Pads / habitat / comms are 17–19
+    // (provision-sepolia-races.ts).
+    10: {
+      title: 'First commercial crewed lunar landing',
+      tagline:
+        'Which crewed lander puts astronauts on the lunar surface first? Back a team — every bet grows the prize pool.',
+      metaDescription:
+        'Sepolia DePrize for the first commercial crewed lunar landing. SpaceX Starship HLS vs Blue Origin Blue Moon MK2.',
+      sharedGoalId: 'shared-crewed-lander',
+      raceLabel: 'Crewed lunar landing',
+      outcomes: [
+        { projectId: 'spacex-starship-hls', teamId: 22 },
+        { projectId: 'blue-origin-blue-moon-mk2', teamId: 23 },
+        { projectId: OPEN_FIELD_PROJECT_ID, teamId: 24, field: true },
+      ],
+    },
+    12: {
+      title: 'First crewed lunar terrain vehicle in service',
+      tagline:
+        'Which LTV is driving on the lunar surface first? Back a team — every bet grows the prize pool.',
+      metaDescription:
+        'Sepolia DePrize for the first crewed lunar terrain vehicle. Astrolab, Lunar Outpost, and Intuitive Machines.',
+      sharedGoalId: 'shared-lunar-rover',
+      raceLabel: 'Crewed lunar rover',
+      outcomes: [
+        { projectId: 'astrolab-flex', teamId: 27 },
+        { projectId: 'lunar-outpost-lunar-dawn', teamId: 28 },
+        { projectId: 'im-moon-racer', teamId: 29 },
+        { projectId: OPEN_FIELD_PROJECT_ID, teamId: 24, field: true },
+      ],
+    },
+    15: {
+      title: 'First sustained oxygen and metals from lunar regolith',
+      tagline:
+        'Which ISRU plant makes oxygen from regolith first? Back a team — every bet grows the prize pool.',
+      metaDescription:
+        'Sepolia DePrize for the first sustained lunar ISRU plant. Blue Alchemist, Sierra Space, Lunar Resources, and Cislune.',
+      sharedGoalId: 'shared-isru-oxygen',
+      raceLabel: 'ISRU oxygen',
+      outcomes: [
+        { projectId: 'blue-origin-blue-alchemist', teamId: 36 },
+        { projectId: 'sierra-space-carbothermal', teamId: 37 },
+        { projectId: 'lunar-resources-mre', teamId: 38 },
+        { projectId: 'cislune-lunar-isru', teamId: 39 },
+        { projectId: OPEN_FIELD_PROJECT_ID, teamId: 24, field: true },
+      ],
+    },
+    17: {
+      title: 'First demonstrated lunar landing-pad construction system',
+      tagline:
+        'Which team hardens a lunar landing pad first? Back a team — every bet grows the prize pool.',
+      metaDescription:
+        'Sepolia DePrize for the first demonstrated lunar landing-pad construction system. ICON, Redwire, Astroport, AI SpaceFactory, and Astrobotic.',
+      questionId: '0x8cea9bc514c3b1f069f68b62046ab8679c2d8aaffcf91fdfd071b40399c1ab9b',
+      sharedGoalId: 'shared-landing-pads',
+      raceLabel: 'Landing pads',
+      outcomes: [
+        { projectId: 'icon-project-olympus', teamId: 501 },
+        { projectId: 'redwire-mason', teamId: 502 },
+        { projectId: 'astroport-lunatron', teamId: 503 },
+        { projectId: 'ai-spacefactory-react', teamId: 504 },
+        { projectId: 'astrobotic-additive-construction', teamId: 505 },
+        { projectId: OPEN_FIELD_PROJECT_ID, teamId: 24, field: true },
+      ],
+    },
+    18: {
+      title: 'First pressurized habitat occupied on the lunar surface',
+      tagline:
+        'Which habitat houses crew on the Moon first? Back a team — every bet grows the prize pool.',
+      metaDescription:
+        'Sepolia DePrize for the first pressurized lunar habitat. Artemis Base Camp, ILRS, Thales MPH, Sierra Space LIFE, and JAXA Lunar Cruiser.',
+      questionId: '0xb450b8b519b564b86a2ded23034b5e808080705e2567f0fc947676cb39cebc72',
+      sharedGoalId: 'shared-habitat',
+      raceLabel: 'Pressurized habitat',
+      outcomes: [
+        { projectId: 'nasa-artemis-base-camp', teamId: 511 },
+        { projectId: 'ilrs', teamId: 512 },
+        { projectId: 'thales-mph', teamId: 513 },
+        { projectId: 'sierra-space-life', teamId: 514 },
+        { projectId: 'jaxa-lunar-cruiser', teamId: 515 },
+        { projectId: OPEN_FIELD_PROJECT_ID, teamId: 24, field: true },
+      ],
+    },
+    19: {
+      title: 'First operational lunar communications and navigation service',
+      tagline:
+        'Which network sells lunar comms first? Back a team — every bet grows the prize pool.',
+      metaDescription:
+        'Sepolia DePrize for the first operational lunar communications and navigation service. Modul8, Intuitive Machines, ESA Moonlight, Crescent Parsec, and Solstar.',
+      questionId: '0xb97bc9385d44cda940b222c2027923496c034d44348931be525acf34970db986',
+      sharedGoalId: 'shared-lunar-comms',
+      raceLabel: 'Lunar comms',
+      outcomes: [
+        { projectId: 'nokia-lunar-lte', teamId: 521 },
+        { projectId: 'im-near-space-network', teamId: 522 },
+        { projectId: 'esa-lunar-pathfinder', teamId: 523 },
+        { projectId: 'crescent-parsec', teamId: 524 },
+        { projectId: 'solstar-lunar-wifi', teamId: 525 },
+        { projectId: OPEN_FIELD_PROJECT_ID, teamId: 24, field: true },
       ],
     },
   },

--- a/ui/lib/deprize/format.ts
+++ b/ui/lib/deprize/format.ts
@@ -11,8 +11,71 @@ export const fmt = (n: number, d = 4) =>
 export const fmtPrizeEth = (n: number) => {
   if (!Number.isFinite(n)) return '—'
   if (n === 0) return '0'
+  if (n < 0.0001) return fmt(n, 6)
   if (n < 0.01) return fmt(n, 4)
   return fmt(n, 3)
+}
+
+/**
+ * USD label used next to ETH amounts. Mirrors MissionActivityList so DePrize
+ * and the launchpad read as the same denomination.
+ */
+export function formatUsd(amount: number, opts?: { signed?: boolean }): string {
+  if (!Number.isFinite(amount)) return '—'
+  const abs = Math.abs(amount)
+  let body: string
+  if (abs >= 100_000) {
+    body = `$${abs.toLocaleString('en-US', { maximumFractionDigits: 0 })}`
+  } else if (abs >= 1) {
+    body = `$${abs.toLocaleString('en-US', {
+      maximumFractionDigits: 2,
+      minimumFractionDigits: 2,
+    })}`
+  } else {
+    body = `$${abs.toLocaleString('en-US', {
+      maximumFractionDigits: 4,
+      minimumFractionDigits: 2,
+    })}`
+  }
+  if (opts?.signed) {
+    if (amount > 0) return `+${body}`
+    if (amount < 0) return `-${body}`
+    return body
+  }
+  return amount < 0 ? `-${body}` : body
+}
+
+export function fmtUsdFromEth(
+  eth: number | undefined | null,
+  ethPrice: number | null | undefined,
+  opts?: { signed?: boolean }
+): string | undefined {
+  if (eth == null || !Number.isFinite(eth) || ethPrice == null || ethPrice <= 0) {
+    return undefined
+  }
+  return formatUsd(eth * ethPrice, opts)
+}
+
+/** Toast / button copy: `0.01 ETH (~$30.00)`. Omits USD when the price is missing. */
+export function fmtEthWithUsd(
+  eth: number | undefined | null,
+  ethPrice: number | null | undefined,
+  opts?: {
+    decimals?: number
+    prize?: boolean
+    approx?: boolean
+    signed?: boolean
+    unit?: string
+  }
+): string {
+  if (eth == null || !Number.isFinite(eth)) return '—'
+  const unit = opts?.unit ?? 'ETH'
+  const ethStr = opts?.prize ? fmtPrizeEth(Math.abs(eth)) : fmt(Math.abs(eth), opts?.decimals)
+  const sign = opts?.signed ? (eth > 0 ? '+' : eth < 0 ? '-' : '') : eth < 0 ? '-' : ''
+  const prefix = opts?.approx ? '≈ ' : ''
+  const ethLabel = `${prefix}${sign}${ethStr} ${unit}`
+  const usd = fmtUsdFromEth(eth, ethPrice, { signed: opts?.signed })
+  return usd ? `${ethLabel} (~${usd})` : ethLabel
 }
 
 // Parse a decimal ETH string into wei, tolerant of empty/invalid input.

--- a/ui/lib/deprize/read.ts
+++ b/ui/lib/deprize/read.ts
@@ -1,4 +1,5 @@
 import { createThirdwebClient, defineChain, readContract } from 'thirdweb'
+import { getChainById } from '@/lib/thirdweb/chain'
 
 // Dedicated read client with RPC batching DISABLED (maxBatchSize: 1). Batching is
 // broken in this thirdweb/viem version: when several eth_call results come back
@@ -6,19 +7,31 @@ import { createThirdwebClient, defineChain, readContract } from 'thirdweb'
 // them ("Cannot read properties of undefined (reading 'buffer')"), which silently
 // blanks reads. So each call goes on its own.
 //
-// The flip side of no batching is request volume, and the chain RPC is a single
-// Infura endpoint shared with the rest of the app — so we additionally cap
-// concurrency and retry on 429 (see rpcRead below) to stay under the rate limit.
+// The flip side of no batching is request volume, so we cap concurrency and
+// retry on 429 (see rpcRead below).
 export const deprizeReadClient = createThirdwebClient({
   clientId: process.env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID as string,
   config: { rpc: { maxBatchSize: 1, fetch: { requestTimeoutMs: 15000 } } },
 })
 
-// Read through thirdweb's RPC edge (derived from the client id) rather than the
-// app's hardcoded Infura endpoint. `defineChain(<id>)` with no explicit rpc makes
-// thirdweb use https://<id>.rpc.thirdweb.com/<clientId>, isolating these reads
-// from the app's Infura traffic and its 429 rate limit.
-export const deprizeReadChain = (chainId: number) => defineChain(chainId)
+/**
+ * Use the app's chain RPC (browser → `/api/rpc/<id>` with Infura + public
+ * fallbacks; SSR → Infura/Ankr directly). `defineChain(id)` with no `rpc`
+ * used to isolate DePrize from Infura 429s via thirdweb's edge
+ * (`https://<id>.rpc.thirdweb.com/<clientId>`), but that endpoint now returns
+ * HTTP 401 Unauthorized, which is what blanked `/deprize/1` on Arbitrum.
+ */
+export function deprizeReadChain(chainId: number) {
+  const known = getChainById(chainId)
+  if (known) return known
+  if (typeof window !== 'undefined') {
+    return defineChain({
+      id: chainId,
+      rpc: `${window.location.origin}/api/rpc/${chainId}`,
+    })
+  }
+  return defineChain(chainId)
+}
 
 // ---- Concurrency-limited, 429-retrying read layer ----
 // Never let more than a few reads hit the RPC at once (the app makes its own

--- a/ui/lib/lunar-atlas/display.ts
+++ b/ui/lib/lunar-atlas/display.ts
@@ -55,20 +55,30 @@ export const PROJECT_TYPE_COLOR: Record<ProjectType, string> = {
   other: '#d1d5db', // gray
 }
 
-// Roster status of a DePrize competitor. Wording is deliberately honest:
-// "listed" is MoonDAO's curatorial judgment, not the company's commitment.
-export const ROSTER_STATUS_LABEL: Record<RosterStatus, string> = {
-  listed: 'Listed competitor — participation not confirmed',
-  invited: 'Invited — awaiting response',
-  consented: 'Confirmed competitor',
+// How a roster status reads to a visitor. "Listed" was curator jargon and
+// looked like a confirmed entry; official / unofficial is the actual split.
+export type ParticipationKind = 'official' | 'unofficial' | 'declined'
+
+export function participationKind(
+  status?: RosterStatus
+): ParticipationKind | undefined {
+  if (!status) return undefined
+  if (status === 'consented') return 'official'
+  if (status === 'declined') return 'declined'
+  return 'unofficial'
+}
+
+export const PARTICIPATION_LABEL: Record<ParticipationKind, string> = {
+  official: 'Official participant',
+  unofficial: 'Unofficial — listed by MoonDAO, not confirmed',
   declined: 'Declined to participate',
 }
 
-export const ROSTER_STATUS_CLASSES: Record<RosterStatus, string> = {
-  listed: 'text-white/60 bg-white/5 border-white/15',
-  invited: 'text-amber-200 bg-amber-500/15 border-amber-400/30',
-  consented: 'text-emerald-200 bg-emerald-500/15 border-emerald-400/30',
-  declined: 'text-rose-200 bg-rose-500/15 border-rose-400/30',
+export const ROSTER_STATUS_LABEL: Record<RosterStatus, string> = {
+  listed: PARTICIPATION_LABEL.unofficial,
+  invited: 'Unofficial — invited, awaiting a response',
+  consented: PARTICIPATION_LABEL.official,
+  declined: PARTICIPATION_LABEL.declined,
 }
 
 export const MILESTONE_STATUS_LABEL: Record<MilestoneStatus, string> = {
@@ -105,4 +115,21 @@ export const LOCATION_PRECISION_LABEL: Record<string, string> = {
   exact: 'Exact location',
   approximate: 'Approximate location',
   region: 'Regional (target area)',
+}
+
+export function formatPlace(n: number): string {
+  const v = Math.abs(n)
+  const mod100 = v % 100
+  const mod10 = v % 10
+  const suffix =
+    mod100 >= 11 && mod100 <= 13
+      ? 'th'
+      : mod10 === 1
+        ? 'st'
+        : mod10 === 2
+          ? 'nd'
+          : mod10 === 3
+            ? 'rd'
+            : 'th'
+  return `${n}${suffix}`
 }

--- a/ui/lib/lunar-atlas/selectors.ts
+++ b/ui/lib/lunar-atlas/selectors.ts
@@ -7,6 +7,7 @@ import type {
   AtlasDataset,
   AtlasIndexRow,
   LatLon,
+  MarketStatus,
   Milestone,
   Project,
   ProjectType,
@@ -371,4 +372,40 @@ export function projectById(dataset: AtlasDataset, id: string) {
 }
 export function sharedGoalById(dataset: AtlasDataset, id: string) {
   return dataset.sharedGoals.find((g) => g.id === id)
+}
+
+export type RaceStanding = {
+  goalId: string
+  title: string
+  place: number
+  fieldSize: number
+  probability: number
+  marketStatus?: MarketStatus
+}
+
+/** Place + implied odds for a competitor in one shared goal, if priced. */
+export function raceStandingForProject(
+  projectId: string,
+  goal: SharedGoal
+): RaceStanding | undefined {
+  if (!goal.projectIds.includes(projectId)) return undefined
+  const odds = goal.market?.impliedOdds
+  const probability = odds?.[projectId]
+  if (probability == null || !Number.isFinite(probability)) return undefined
+  const ranked = [...goal.projectIds].sort((a, b) => {
+    const pa = odds?.[a]
+    const pb = odds?.[b]
+    const na = pa != null && Number.isFinite(pa) ? pa : -1
+    const nb = pb != null && Number.isFinite(pb) ? pb : -1
+    if (nb !== na) return nb - na
+    return goal.projectIds.indexOf(a) - goal.projectIds.indexOf(b)
+  })
+  return {
+    goalId: goal.id,
+    title: goal.title,
+    place: ranked.indexOf(projectId) + 1,
+    fieldSize: goal.projectIds.length,
+    probability,
+    marketStatus: goal.market?.status,
+  }
 }

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -16,6 +16,7 @@ import { useActiveAccount } from 'thirdweb/react'
 import { eth_getBalance, getRpcClient } from 'thirdweb/rpc'
 import {
   ROSTER_DISCLAIMER,
+  findDePrizeIdForGoal,
   getDePrizeCompetition,
   getDePrizeGenerationNumber,
   getDePrizeRaceBinding,
@@ -23,7 +24,8 @@ import {
   isKnownDePrizeCompetition,
   isRaceBindingComplete,
 } from '@/lib/deprize/competitions'
-import { SEED_ATLAS, orgById, projectById } from '@/lib/lunar-atlas'
+import { SEED_ATLAS, orgById, projectById, sharedGoalById } from '@/lib/lunar-atlas'
+import GoalDePrizeDetail from '@/components/deprize/GoalDePrizeDetail'
 import { orgColor } from '@/lib/lunar-atlas/display'
 import {
   DePrizeState,
@@ -114,12 +116,21 @@ export default function DePrizeDetailPage() {
 function DePrizeDetailContent() {
   const router = useRouter()
   const rawId = router.query.id
-  const deprizeId = typeof rawId === 'string' && /^\d+$/.test(rawId) ? Number(rawId) : undefined
+  const numericId =
+    typeof rawId === 'string' && /^\d+$/.test(rawId) ? Number(rawId) : undefined
+  const goalFromSlug =
+    typeof rawId === 'string' && !/^\d+$/.test(rawId)
+      ? sharedGoalById(SEED_ATLAS, rawId)
+      : undefined
+  const { selectedChain: chain } = useContext(ChainContextV5)
+  const chainSlug = getChainSlug(chain)
+  const boundFromSlug = goalFromSlug
+    ? findDePrizeIdForGoal(chainSlug, goalFromSlug.id)
+    : undefined
+  const deprizeId = numericId ?? boundFromSlug
 
   // Follow the app's live selected chain (wallet / header dropdown), not the
   // build-time default — otherwise switching networks never re-queries DePrize.
-  const { selectedChain: chain } = useContext(ChainContextV5)
-  const chainSlug = getChainSlug(chain)
   const competition = getDePrizeCompetition(chainSlug, deprizeId)
   const raceBinding = getDePrizeRaceBinding(chainSlug, deprizeId)
   const namedRaceOutcomes = raceBinding?.outcomes.filter((o) => !o.field) ?? []
@@ -460,6 +471,16 @@ function DePrizeDetailContent() {
         : competition.title
 
   // --- Render states ---
+  if (!router.isReady) {
+    return (
+      <Shell title={shellTitle} description={competition.metaDescription}>
+        <div className="p-8 text-center text-gray-400">Loading DePrize…</div>
+      </Shell>
+    )
+  }
+  if (goalFromSlug && boundFromSlug === undefined) {
+    return <GoalDePrizeDetail goal={goalFromSlug} />
+  }
   if (!registryConfigured) {
     return (
       <Shell title={shellTitle} description={competition.metaDescription}>
@@ -470,10 +491,10 @@ function DePrizeDetailContent() {
       </Shell>
     )
   }
-  if (!router.isReady) {
+  if (typeof rawId === 'string' && !numericId && !goalFromSlug) {
     return (
       <Shell title={shellTitle} description={competition.metaDescription}>
-        <div className="p-8 text-center text-gray-400">Loading DePrize…</div>
+        <Notice tone="amber">This prize doesn&apos;t exist.</Notice>
       </Shell>
     )
   }

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -34,13 +34,14 @@ import {
   shouldSurfaceResolution,
   UNIT,
 } from '@/lib/deprize/constants'
-import { fmt, fmtPrizeEth } from '@/lib/deprize/format'
+import { fmt } from '@/lib/deprize/format'
 import { spendableFromBalanceEth } from '@/lib/deprize/gas-reserve'
 import { buildAmounts } from '@/lib/deprize/quote'
 import { deprizeReadChain, deprizeReadClient, rpcRead } from '@/lib/deprize/read'
 import { formatBettingCloses, isMintConfigured, reconcileBettingStatus } from '@/lib/deprize/status'
 import { useDePrize } from '@/lib/deprize/useDePrize'
 import { useDePrizeLaunchpadToken } from '@/lib/deprize/useDePrizeLaunchpad'
+import EthUsd from '@/components/deprize/EthUsd'
 import { useDePrizeMarket } from '@/lib/deprize/useDePrizeMarket'
 import useRegionRestriction from '@/lib/geo/useRegionRestriction'
 import useTotalFunding from '@/lib/juicebox/useTotalFunding'
@@ -54,12 +55,29 @@ import BetModal from '@/components/deprize/BetModal'
 import ClaimPanel from '@/components/deprize/ClaimPanel'
 import DePrizeAdminPanel from '@/components/deprize/DePrizeAdminPanel'
 import DePrizeTeamCard from '@/components/deprize/DePrizeTeamCard'
-import DePrizeTeamLink, { useDePrizeTeamName } from '@/components/deprize/DePrizeTeamLink'
+import DePrizeTeamLink, {
+  useDePrizeTeamName,
+  useDePrizeTeamNames,
+} from '@/components/deprize/DePrizeTeamLink'
 import ExitPositionModal from '@/components/deprize/ExitPositionModal'
 
 const OddsHistoryChart = dynamic(() => import('@/components/deprize/OddsHistoryChart'), {
   ssr: false,
 })
+
+function outcomeDisplayName(
+  index: number,
+  raceBinding: ReturnType<typeof getDePrizeRaceBinding>
+): string {
+  const binding = raceBinding?.outcomes[index]
+  if (binding?.field) return 'Open Field'
+  if (binding?.projectId) {
+    const project = projectById(SEED_ATLAS, binding.projectId)
+    const org = project ? orgById(SEED_ATLAS, project.orgId) : undefined
+    return org?.name || project?.name || `Team #${index + 1}`
+  }
+  return `Team #${index + 1}`
+}
 
 function StateBadge({
   state,
@@ -104,6 +122,13 @@ function DePrizeDetailContent() {
   const chainSlug = getChainSlug(chain)
   const competition = getDePrizeCompetition(chainSlug, deprizeId)
   const raceBinding = getDePrizeRaceBinding(chainSlug, deprizeId)
+  const namedRaceOutcomes = raceBinding?.outcomes.filter((o) => !o.field) ?? []
+  const anyOfficialCompetitor = namedRaceOutcomes.some((o) =>
+    isCompetitorClaimed(o)
+  )
+  const anyUnofficialCompetitor = namedRaceOutcomes.some(
+    (o) => !isCompetitorClaimed(o)
+  )
   const generationNumber = getDePrizeGenerationNumber(chainSlug, deprizeId)
   const knownCompetition = isKnownDePrizeCompetition(chainSlug, deprizeId)
   const account = useActiveAccount()
@@ -420,6 +445,12 @@ function DePrizeDetailContent() {
     winningTeamId > 0n ? winningTeamId : undefined,
     teamContract,
   )
+  const rosterNames = useDePrizeTeamNames(deprize?.teamIds, teamContract)
+  const predictionLabels = market.outcomes.map((o) => {
+    const bound = outcomeDisplayName(o.index, raceBinding)
+    if (!bound.startsWith('Team #')) return bound
+    return rosterNames[o.index] || bound
+  })
 
   const shellTitle =
     knownCompetition && deprizeId !== undefined
@@ -477,8 +508,8 @@ function DePrizeDetailContent() {
 
   return (
     <Shell title={shellTitle} description={competition.metaDescription}>
-      <div className="flex flex-col gap-6 w-full max-w-[860px] mx-auto">
-        {/* Header */}
+      <div className="flex flex-col gap-4 w-full max-w-[860px] mx-auto">
+        {/* Compact header — title + prize stats only. Copy lives below the fold. */}
         <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
           <div className="flex items-center justify-between gap-3 flex-wrap">
             <div className="flex items-center gap-2 sm:gap-3 flex-wrap min-w-0">
@@ -507,52 +538,17 @@ function DePrizeDetailContent() {
               ← All prizes
             </Link>
           </div>
-          <p className="text-gray-300 text-sm mt-2">{competition.tagline}</p>
-          {deprize?.state === DePrizeState.SUPERSEDED && (
-            <p className="text-amber-200/90 text-sm mt-2">
-              This generation was superseded
-              {competition.supersededBy
-                ? ` by DePrize #${competition.supersededBy}`
-                : ''}
-              . New bets are closed; you can still sell your position at the market price. Odds for
-              this race live on the current generation.
-              {competition.supersededBy && (
-                <>
-                  {' '}
-                  <Link
-                    href={`/deprize/${competition.supersededBy}`}
-                    className="underline underline-offset-2 hover:text-amber-100"
-                  >
-                    Open generation {generationNumber + 1}
-                  </Link>
-                </>
-              )}
-            </p>
-          )}
-          {competition.supersedes !== undefined && deprize?.state !== DePrizeState.SUPERSEDED && (
-            <p className="text-gray-500 text-xs mt-2">
-              Continues from{' '}
-              <Link
-                href={`/deprize/${competition.supersedes}`}
-                className="text-indigo-300/90 underline underline-offset-2 hover:text-indigo-200"
-              >
-                generation {generationNumber - 1} (DePrize #{competition.supersedes})
-              </Link>
-              . Legacy positions remain sellable there until the race settles.
-            </p>
-          )}
-          {effectiveDescription && (
-            <p className="text-gray-500 text-sm mt-1">{effectiveDescription}</p>
-          )}
-          <div className="mt-4 grid grid-cols-3 gap-3">
+          <div className="mt-3 grid grid-cols-3 gap-3">
             <Stat
               label="Prize pool"
               href={launchpad.missionHref}
               title={launchpad.missionHref ? 'Open the launchpad prize pool' : undefined}
             >
-              {jbProjectId !== undefined && !isLoadingFunding
-                ? `${fmtPrizeEth(Number(totalFunding) / Number(UNIT))} ETH`
-                : '—'}
+              {jbProjectId !== undefined && !isLoadingFunding ? (
+                <EthUsd eth={Number(totalFunding) / Number(UNIT)} prize />
+              ) : (
+                '—'
+              )}
             </Stat>
             <Stat label="Providers">{numOutcomes || '—'}</Stat>
             <Stat
@@ -563,7 +559,7 @@ function DePrizeDetailContent() {
             </Stat>
           </div>
           {winningTeamId > 0n && (
-            <div className="mt-4 flex items-center gap-2 flex-wrap px-3 py-2.5 rounded-xl bg-moon-green/10 border border-moon-green/35">
+            <div className="mt-3 flex items-center gap-2 flex-wrap px-3 py-2.5 rounded-xl bg-moon-green/10 border border-moon-green/35">
               <span className="text-moon-green text-xs font-semibold uppercase tracking-wide">
                 Winner
               </span>
@@ -580,7 +576,7 @@ function DePrizeDetailContent() {
             (deprize.state === DePrizeState.NO_WINNER ||
               deprize.state === DePrizeState.CANCELLED ||
               deprize.state === DePrizeState.M2_FAILED) && (
-              <div className="mt-4 px-3 py-2.5 rounded-xl bg-amber-500/10 border border-amber-500/30 text-amber-200 text-sm">
+              <div className="mt-3 px-3 py-2.5 rounded-xl bg-amber-500/10 border border-amber-500/30 text-amber-200 text-sm">
                 {deprize.state === DePrizeState.NO_WINNER
                   ? 'No winner — positions redeem on an equal-payout basis.'
                   : deprize.state === DePrizeState.CANCELLED
@@ -590,7 +586,6 @@ function DePrizeDetailContent() {
             )}
         </div>
 
-        {/* Cancellation notice */}
         {deprize?.cancellationPending && (
           <Notice tone="red">
             A cancellation has been announced for this DePrize. New bets are paused during the 7-day
@@ -598,21 +593,24 @@ function DePrizeDetailContent() {
           </Notice>
         )}
 
-        {/* Geo notice — also when country is unresolved (default-deny). */}
-        {(region.isRestricted || (!region.isLoading && !region.isError && !region.country)) && (
-          <Notice tone="amber">
-            Betting isn&apos;t available in your region. You can still view live odds and, if you
-            hold a position, claim or cash out.
+        {market.error && (
+          <Notice tone="red">
+            Couldn&apos;t fully load market data: {market.error}. Reload the page and try again.
           </Notice>
         )}
 
-        {/* Live odds */}
+        {/* Predictions — first thing after the title so the history is above the fold. */}
         {numOutcomes > 0 && (
           <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
             <div className="flex items-center justify-between gap-3 flex-wrap mb-3">
               <div>
-                <p className="text-white font-semibold">Live odds</p>
-                <p className="text-gray-500 text-xs">Implied chance over time</p>
+                <p className="text-white font-semibold">Predictions</p>
+                <p className="text-gray-500 text-xs">
+                  Implied chance since the market opened
+                  {market.marketStartMs !== undefined
+                    ? ` (${new Date(market.marketStartMs).toLocaleDateString()})`
+                    : ''}
+                </p>
               </div>
               <div className="flex items-center gap-3 flex-wrap">
                 {market.outcomes.map((o) => (
@@ -622,7 +620,7 @@ function DePrizeDetailContent() {
                       style={{ background: OUTCOME_COLORS[o.index % OUTCOME_COLORS.length] }}
                     />
                     <span className="text-gray-300 text-xs">
-                      #{o.index + 1}
+                      {predictionLabels[o.index]}
                       {Number.isNaN(o.probability) ? '' : ` · ${fmt(o.probability, 0)}%`}
                     </span>
                   </div>
@@ -631,50 +629,32 @@ function DePrizeDetailContent() {
             </div>
             <OddsHistoryChart
               history={market.oddsHistory}
-              labels={market.outcomes.map((o) => `Team #${o.index + 1}`)}
+              labels={predictionLabels}
               colors={OUTCOME_COLORS}
               domainStartMs={market.marketStartMs}
             />
-            {market.marketStartMs !== undefined && (
-              <p className="text-gray-500 text-[11px] mt-2">
-                Axis spans the market since it opened
-                {` (${new Date(market.marketStartMs).toLocaleDateString()})`}. Detailed odds samples
-                collect while this page is open.
-              </p>
-            )}
           </div>
         )}
 
-        {/* Connect prompt */}
-        {!userAddress && bettingAllowed && (
-          <div className="p-4 sm:p-5 rounded-2xl bg-indigo-500/10 border border-indigo-500/30 flex items-center justify-between gap-3 flex-wrap">
-            <p className="text-indigo-100 text-sm font-medium">
-              Connect a wallet to back a team, cash out, or claim.
-            </p>
-            <button
-              onClick={() => login()}
-              className="px-5 py-2.5 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white text-sm font-semibold transition-all"
-            >
-              Connect Wallet
-            </button>
-          </div>
-        )}
-
-        {/* Market load error (non-fatal) */}
-        {market.error && (
-          <Notice tone="red">
-            Couldn&apos;t fully load market data: {market.error}. Reload the page and try again.
-          </Notice>
-        )}
-
-        {/* Team cards */}
+        {/* Competitors */}
         {numOutcomes > 0 && (
           <div className="flex flex-col gap-3">
-            <h3 className="title-text-colors text-lg font-GoodTimes">Providers</h3>
-            {isRaceBindingComplete(raceBinding?.outcomes) && (
-              <p className="text-gray-500 text-xs leading-relaxed max-w-3xl">
-                {ROSTER_DISCLAIMER}
-              </p>
+            <h3 className="title-text-colors text-lg font-GoodTimes">Competitors</h3>
+            {(anyOfficialCompetitor || anyUnofficialCompetitor) && (
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 -mt-1">
+                {anyOfficialCompetitor && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="h-3 w-1 rounded-full bg-emerald-400" />
+                    Official participant
+                  </span>
+                )}
+                {anyUnofficialCompetitor && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="h-3 w-1 rounded-full bg-zinc-400" />
+                    Unofficial — not confirmed
+                  </span>
+                )}
+              </div>
             )}
             {market.outcomes.map((o) => {
               const teamId = deprize?.teamIds[o.index] ?? 0n
@@ -735,10 +715,82 @@ function DePrizeDetailContent() {
                   nameOverride={atlasOrg?.name || atlasProject?.name}
                   imageOverride={claimed ? atlasOrg?.logoURI : undefined}
                   unclaimed={!isField && !!outcomeBinding && !claimed}
+                  participation={
+                    isField || !outcomeBinding
+                      ? undefined
+                      : claimed
+                        ? 'official'
+                        : 'unofficial'
+                  }
                 />
                 </div>
               )
             })}
+          </div>
+        )}
+
+        {/* Description — below the predictions and competitors. */}
+        <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
+          <p className="text-gray-300 text-sm">{competition.tagline}</p>
+          {effectiveDescription && (
+            <p className="text-gray-500 text-sm mt-2">{effectiveDescription}</p>
+          )}
+          {deprize?.state === DePrizeState.SUPERSEDED && (
+            <p className="text-amber-200/90 text-sm mt-2">
+              This generation was superseded
+              {competition.supersededBy
+                ? ` by DePrize #${competition.supersededBy}`
+                : ''}
+              . New bets are closed; you can still sell your position at the market price. Odds for
+              this race live on the current generation.
+              {competition.supersededBy && (
+                <>
+                  {' '}
+                  <Link
+                    href={`/deprize/${competition.supersededBy}`}
+                    className="underline underline-offset-2 hover:text-amber-100"
+                  >
+                    Open generation {generationNumber + 1}
+                  </Link>
+                </>
+              )}
+            </p>
+          )}
+          {competition.supersedes !== undefined && deprize?.state !== DePrizeState.SUPERSEDED && (
+            <p className="text-gray-500 text-xs mt-2">
+              Continues from{' '}
+              <Link
+                href={`/deprize/${competition.supersedes}`}
+                className="text-indigo-300/90 underline underline-offset-2 hover:text-indigo-200"
+              >
+                generation {generationNumber - 1} (DePrize #{competition.supersedes})
+              </Link>
+              . Legacy positions remain sellable there until the race settles.
+            </p>
+          )}
+          {isRaceBindingComplete(raceBinding?.outcomes) && (
+            <p className="text-gray-500 text-xs leading-relaxed mt-3">{ROSTER_DISCLAIMER}</p>
+          )}
+        </div>
+
+        {(region.isRestricted || (!region.isLoading && !region.isError && !region.country)) && (
+          <Notice tone="amber">
+            Betting isn&apos;t available in your region. You can still view live odds and, if you
+            hold a position, claim or cash out.
+          </Notice>
+        )}
+
+        {!userAddress && bettingAllowed && (
+          <div className="p-4 sm:p-5 rounded-2xl bg-indigo-500/10 border border-indigo-500/30 flex items-center justify-between gap-3 flex-wrap">
+            <p className="text-indigo-100 text-sm font-medium">
+              Connect a wallet to back a team, cash out, or claim.
+            </p>
+            <button
+              onClick={() => login()}
+              className="px-5 py-2.5 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white text-sm font-semibold transition-all"
+            >
+              Connect Wallet
+            </button>
           </div>
         )}
 
@@ -784,11 +836,7 @@ function DePrizeDetailContent() {
         <BetModal
           deprizeId={deprizeId}
           outcomeIndex={betIndex}
-          teamName={
-            raceBinding?.outcomes[betIndex]?.field
-              ? 'Open Field'
-              : `Team #${betIndex + 1}`
-          }
+          teamName={predictionLabels[betIndex] || outcomeDisplayName(betIndex, raceBinding)}
           probability={market.outcomes[betIndex]?.probability ?? NaN}
           numOutcomes={numOutcomes}
           mintAddress={mintAddress}
@@ -810,11 +858,7 @@ function DePrizeDetailContent() {
         <ExitPositionModal
           deprizeId={deprizeId}
           outcomeIndex={exitIndex}
-          teamName={
-            raceBinding?.outcomes[exitIndex]?.field
-              ? 'Open Field'
-              : `Team #${exitIndex + 1}`
-          }
+          teamName={predictionLabels[exitIndex] || outcomeDisplayName(exitIndex, raceBinding)}
           balanceWei={market.outcomes[exitIndex]?.balanceWei ?? 0n}
           positionId={market.outcomes[exitIndex]?.positionId ?? 0n}
           numOutcomes={numOutcomes}

--- a/ui/pages/moonbase/index.tsx
+++ b/ui/pages/moonbase/index.tsx
@@ -276,12 +276,21 @@ export default function MoonBaseZeroIndex() {
     [dataset.projects, selectedOrgIds]
   )
 
-  // Mount one DePrize market — the open race only. Eight concurrent 30s polls
-  // on the r3f scene is exactly what the bridge was designed to avoid. Also
-  // the single source for the race's betting/positions surface (marketAddress,
-  // per-outcome balances) so "Back this team" can bet inline instead of
-  // navigating to /deprize/{id}.
-  const liveOdds = useDePrizeGoalOdds(chain, selectedGoalId ?? undefined, userAddress)
+  // Mount one DePrize market — the open race, or the race a competitor
+  // panel was opened from. Clearing selectedGoalId to show ProjectPanel
+  // must not drop the market, or Buy would vanish and force a trip back.
+  const oddsGoalId = useMemo(() => {
+    if (selectedGoalId) return selectedGoalId
+    if (raceReturn?.kind === 'goal') return raceReturn.id
+    if (!selectedProjectId) return undefined
+    const project = projectById(dataset, selectedProjectId)
+    return project?.sharedGoalIds.find((id) => {
+      const goal = sharedGoalById(dataset, id)
+      return !!goal && isCompetitiveRace(goal.projectIds.length)
+    })
+  }, [selectedGoalId, raceReturn, selectedProjectId, dataset])
+
+  const liveOdds = useDePrizeGoalOdds(chain, oddsGoalId, userAddress)
   const { totalFunding, isLoading: isLoadingPrizePool } = useTotalFunding(
     liveOdds.jbProjectId,
     chain
@@ -343,13 +352,13 @@ export default function MoonBaseZeroIndex() {
     () =>
       mergeLiveMarketInto(
         dataset.sharedGoals,
-        selectedGoalId ?? undefined,
+        oddsGoalId,
         liveOdds
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional field deps
     [
       dataset.sharedGoals,
-      selectedGoalId,
+      oddsGoalId,
       liveOdds.deprizeId,
       liveOdds.status,
       liveOdds.fieldOdds,
@@ -904,6 +913,34 @@ export default function MoonBaseZeroIndex() {
                 onFocusRegion={flyToProject}
                 onSelectSharedGoal={handleSelectSharedGoal}
                 onBack={raceReturn ? handleBackToRace : undefined}
+                betGoal={
+                  (raceReturn?.kind === 'goal'
+                    ? sharedGoals.find((g) => g.id === raceReturn.id)
+                    : undefined) ??
+                  selectedSharedGoals.find((g) =>
+                    isCompetitiveRace(g.projectIds.length)
+                  )
+                }
+                chainSlug={chainSlug}
+                chain={chain}
+                account={account}
+                userAddress={userAddress}
+                onConnectWallet={() => login()}
+                spendableEth={spendableEth}
+                deprizeId={liveOdds.deprizeId}
+                mintAddress={liveOdds.mintAddress}
+                marketAddress={liveOdds.marketAddress}
+                numOutcomes={liveOdds.numOutcomes}
+                outcomes={liveOdds.outcomes}
+                bettingAllowed={bettingAllowed}
+                tradingHalted={liveOdds.tradingHalted}
+                resolved={liveOdds.resolved}
+                winningIndex={liveOdds.winningIndex}
+                isRefundVector={liveOdds.isRefundVector}
+                payoutDen={liveOdds.payoutDen}
+                payoutNums={liveOdds.payoutNums}
+                jbProjectId={liveOdds.jbProjectId}
+                onDone={handleRaceMarketDone}
               />
             ) : null}
           </div>

--- a/ui/pages/moonbase/index.tsx
+++ b/ui/pages/moonbase/index.tsx
@@ -723,9 +723,10 @@ export default function MoonBaseZeroIndex() {
         title="Moon Base Zero"
         description="A true-to-scale moonbase on the Shackleton connecting ridge — real NASA LOLA terrain at 5 m/px. Explore capability races, competitors, and who's leading each tech tree."
       />
-      {/* 4rem top nav + 4rem ProjectBanner. The globe and year slider must
-          sit in the leftover band so the banner never covers the sim. */}
-      <div className="relative h-[calc(100vh-8rem)] w-full overflow-hidden bg-[#03040a]">
+      {/* Only the 4rem top nav is subtracted: ProjectBanner lists /moonbase as
+          a fullscreen route and never renders here, so reserving its 4rem too
+          would leave a dead band under the year slider. */}
+      <div className="relative h-[calc(100vh-4rem)] w-full overflow-hidden bg-[#03040a]">
         <MoonGlobeLazy
           focus={focus}
           trees={surfaceTrees}

--- a/ui/pages/moonbase/index.tsx
+++ b/ui/pages/moonbase/index.tsx
@@ -723,7 +723,9 @@ export default function MoonBaseZeroIndex() {
         title="Moon Base Zero"
         description="A true-to-scale moonbase on the Shackleton connecting ridge — real NASA LOLA terrain at 5 m/px. Explore capability races, competitors, and who's leading each tech tree."
       />
-      <div className="relative h-[calc(100vh-4rem)] w-full overflow-hidden bg-[#03040a]">
+      {/* 4rem top nav + 4rem ProjectBanner. The globe and year slider must
+          sit in the leftover band so the banner never covers the sim. */}
+      <div className="relative h-[calc(100vh-8rem)] w-full overflow-hidden bg-[#03040a]">
         <MoonGlobeLazy
           focus={focus}
           trees={surfaceTrees}

--- a/ui/pages/moonbase/index.tsx
+++ b/ui/pages/moonbase/index.tsx
@@ -279,12 +279,24 @@ export default function MoonBaseZeroIndex() {
   // Mount one DePrize market — the open race, or the race a competitor
   // panel was opened from. Clearing selectedGoalId to show ProjectPanel
   // must not drop the market, or Buy would vanish and force a trip back.
+  // raceReturn is only that origin race when this project is on it:
+  // `/moonbase/[projectId]` reuses this page, so a leftover race must not win.
   const oddsGoalId = useMemo(() => {
     if (selectedGoalId) return selectedGoalId
-    if (raceReturn?.kind === 'goal') return raceReturn.id
     if (!selectedProjectId) return undefined
     const project = projectById(dataset, selectedProjectId)
-    return project?.sharedGoalIds.find((id) => {
+    if (!project) return undefined
+    if (raceReturn?.kind === 'goal') {
+      const returned = sharedGoalById(dataset, raceReturn.id)
+      if (
+        returned &&
+        isCompetitiveRace(returned.projectIds.length) &&
+        returned.projectIds.includes(project.id)
+      ) {
+        return raceReturn.id
+      }
+    }
+    return project.sharedGoalIds.find((id) => {
       const goal = sharedGoalById(dataset, id)
       return !!goal && isCompetitiveRace(goal.projectIds.length)
     })
@@ -914,12 +926,9 @@ export default function MoonBaseZeroIndex() {
                 onSelectSharedGoal={handleSelectSharedGoal}
                 onBack={raceReturn ? handleBackToRace : undefined}
                 betGoal={
-                  (raceReturn?.kind === 'goal'
-                    ? sharedGoals.find((g) => g.id === raceReturn.id)
-                    : undefined) ??
-                  selectedSharedGoals.find((g) =>
-                    isCompetitiveRace(g.projectIds.length)
-                  )
+                  oddsGoalId
+                    ? sharedGoals.find((g) => g.id === oddsGoalId)
+                    : undefined
                 }
                 chainSlug={chainSlug}
                 chain={chain}

--- a/ui/pages/moonbase/index.tsx
+++ b/ui/pages/moonbase/index.tsx
@@ -539,25 +539,38 @@ export default function MoonBaseZeroIndex() {
     // Re-clicking the already-selected project is a no-op — the camera is
     // there (or on its way); re-triggering the transition just stutters it.
     if (id === selectedProjectId && !selectedGoalId) return
-    // Remember where we came from so the project panel can return to the list.
+    const project = projectById(dataset, id)
+    if (!project) return
+
+    // The cluster this asset actually stands in — not whichever race was
+    // already open. Each competitor has its own plot now, so picking a
+    // dimmed asset in another district must fill *that* district, the same
+    // way the hovering pin does.
+    const tree =
+      surfaceTrees.find((t) => t.projects.some((p) => p.id === id)) ??
+      trees.find((t) => t.projects.some((p) => p.id === id))
+    const category = tree?.category ?? project.type
+
     if (selectedGoalId) setRaceReturn({ kind: 'goal', id: selectedGoalId })
     else if (selectedTreeCategory)
       setRaceReturn({ kind: 'tree', id: selectedTreeCategory })
     else setRaceReturn(null)
-    // Keep the currently-viewed site focused: the competitor's model swaps in
-    // *there*, so picking a competitor never teleports to a different site.
-    const site =
-      selectedTreeCategory ??
-      (selectedGoalId
-        ? dataset.sharedGoals.find((g) => g.id === selectedGoalId)?.category
-        : undefined) ??
-      projectById(dataset, id)?.type ??
-      null
+
+    if (selectedTreeCategory && selectedTreeCategory !== category) {
+      // Same as the hovering district pin: fill this cluster, dim the rest,
+      // show the race, and frame the site.
+      setSelectedTreeCategory(category)
+      setSelectedGoalId(tree?.goal?.id ?? null)
+      setSelectedProjectId(null)
+      flyToSite(category)
+      replaceMoonbaseQuery({ race: tree?.goal?.id ?? null, year })
+      return
+    }
+
     setSelectedGoalId(null)
-    setSelectedTreeCategory(site)
+    setSelectedTreeCategory(category)
     setSelectedProjectId(id)
-    const p = projectById(dataset, id)
-    if (p) flyToProject(p, site)
+    flyToProject(project, category)
   }
 
   // Keep ?race= / ?year= in sync with selection without remounting the scene.

--- a/ui/pages/moonbase/index.tsx
+++ b/ui/pages/moonbase/index.tsx
@@ -535,7 +535,7 @@ export default function MoonBaseZeroIndex() {
     setFocus({ lat: ll.lat, lon: ll.lon, view: 'surface' })
   }
 
-  const handleSelectProject = (id: string) => {
+  const handleSelectProject = (id: string, opts?: { fromDeepLink?: boolean }) => {
     // Re-clicking the already-selected project is a no-op — the camera is
     // there (or on its way); re-triggering the transition just stutters it.
     if (id === selectedProjectId && !selectedGoalId) return
@@ -556,7 +556,14 @@ export default function MoonBaseZeroIndex() {
       setRaceReturn({ kind: 'tree', id: selectedTreeCategory })
     else setRaceReturn(null)
 
-    if (selectedTreeCategory && selectedTreeCategory !== category) {
+    // Globe clicks on a dimmed asset open that district. Deep links must
+    // still open the requested project — `/moonbase/[projectId]` reuses this
+    // handler without remounting, so a prior race would otherwise win.
+    if (
+      !opts?.fromDeepLink &&
+      selectedTreeCategory &&
+      selectedTreeCategory !== category
+    ) {
       // Same as the hovering district pin: fill this cluster, dim the rest,
       // show the race, and frame the site.
       setSelectedTreeCategory(category)
@@ -605,7 +612,7 @@ export default function MoonBaseZeroIndex() {
     const id = router.query.projectId
     if (typeof id !== 'string' || !id) return
     if (!projectById(dataset, id)) return
-    handleSelectProject(id)
+    handleSelectProject(id, { fromDeepLink: true })
     // Only react to the deep-link param itself; selection handlers stay stable
     // enough for a one-shot open on navigation.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/ui/scripts/provision-sepolia-races.ts
+++ b/ui/scripts/provision-sepolia-races.ts
@@ -1,0 +1,447 @@
+/**
+ * Stand up the remaining Moon Base Zero capability races on Sepolia
+ * (landing pads, habitat, comms) so `/deprize/{goalId}` can load a live
+ * market. Crewed lander / rover / ISRU / fission already exist (ids 10, 12,
+ * 15, 9).
+ *
+ *   source ../prediction/.env   # DEPLOYER_PK
+ *   yarn tsx --tsconfig tsconfig.json scripts/provision-sepolia-races.ts
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import {
+  createPublicClient,
+  createWalletClient,
+  decodeEventLog,
+  http,
+  keccak256,
+  parseAbi,
+  parseEther,
+  stringify,
+  toBytes,
+  type Hex,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { sepolia } from 'viem/chains'
+import { OPEN_FIELD_PROJECT_ID } from '../lib/deprize/competitions'
+import { SEED_ATLAS } from '../lib/lunar-atlas/seed'
+import { sharedGoalById } from '../lib/lunar-atlas/selectors'
+
+const REGISTRY = '0x299F163705AbBFa1A8DE7670F33171730F828F3D' as const
+const MINT = '0xa6f9632ee9848f7c1f252da5a1e869ac90e57cc8' as const
+const FEE_ROUTER = '0xbe8cbc97d4ddee28b938c0ed8245f1b5133b783a' as const
+const FACTORY = '0x8787Dc3c2b48b19D3Cbd25226Cd6cEAff3398de1' as const
+const CTF = '0xC3B0a34fb9a1c5F9464D7249BF564117e1fe6dE8' as const
+const WETH = '0x8cfF28F922AeEe80d3a0663e735681469F7374c6' as const
+const MISSION_CREATOR = '0xa692eEd67c4D2C1C73DC0515240d27cf7d6fF9D1' as const
+const FIELD_TEAM = 24n
+const FUNDING_PER_OUTCOME = parseEther('0.01')
+const FEE = 10_000_000_000_000_000n // 1%
+const SUNSET = BigInt(Math.floor(Date.now() / 1000) + 2 * 365 * 24 * 3600)
+const OUT = '/tmp/sepolia-races.json'
+
+const RACES: {
+  goalId: string
+  raceLabel: string
+  teamIds: bigint[]
+  tokenName: string
+  tokenSymbol: string
+}[] = [
+  {
+    goalId: 'shared-landing-pads',
+    raceLabel: 'Landing pads',
+    teamIds: [501n, 502n, 503n, 504n, 505n, FIELD_TEAM],
+    tokenName: 'DePrize Pads',
+    tokenSymbol: 'DPAD',
+  },
+  {
+    goalId: 'shared-habitat',
+    raceLabel: 'Pressurized habitat',
+    teamIds: [511n, 512n, 513n, 514n, 515n, FIELD_TEAM],
+    tokenName: 'DePrize Habitat',
+    tokenSymbol: 'DHAB',
+  },
+  {
+    goalId: 'shared-lunar-comms',
+    raceLabel: 'Lunar comms',
+    teamIds: [521n, 522n, 523n, 524n, 525n, FIELD_TEAM],
+    tokenName: 'DePrize Comms',
+    tokenSymbol: 'DCOM',
+  },
+]
+
+const registryAbi = parseAbi([
+  'function count() view returns (uint256)',
+  'function register(uint256 jbProjectId, uint256[] teamIds, uint256 sunset) returns (uint256)',
+  'function setCondition(uint256 deprizeId, bytes32 ctfConditionId)',
+  'function open(uint256 deprizeId)',
+  'function deprizeIdByJBProject(uint256 jbProjectId) view returns (uint256)',
+  'event DePrizeRegistered(uint256 indexed deprizeId, uint256 indexed jbProjectId, uint256[] teamIds, uint256 sunset)',
+])
+
+const mintAbi = parseAbi([
+  'function setMarket(uint256 deprizeId, address market)',
+  'function marketOf(uint256 deprizeId) view returns (address)',
+])
+
+const feeAbi = parseAbi([
+  'function setMarket(uint256 deprizeId, address market)',
+])
+
+const ctfAbi = parseAbi([
+  'function prepareCondition(address oracle, bytes32 questionId, uint256 outcomeSlotCount)',
+  'function getConditionId(address oracle, bytes32 questionId, uint256 outcomeSlotCount) view returns (bytes32)',
+  'function getOutcomeSlotCount(bytes32 conditionId) view returns (uint256)',
+])
+
+const factoryAbi = parseAbi([
+  'function createLMSRWithTWAP(address pmSystem, address collateralToken, bytes32[] conditionIds, uint64 fee, address whitelist, uint256 funding) returns (address)',
+  'event LMSRWithTWAPCreation(address indexed creator, address lmsrWithTWAP, address pmSystem, address collateralToken, bytes32[] conditionIds, uint64 fee, uint256 funding)',
+])
+
+const wethAbi = parseAbi([
+  'function deposit()',
+  'function approve(address spender, uint256 amount) returns (bool)',
+  'function balanceOf(address) view returns (uint256)',
+])
+
+const lmsrAbi = parseAbi([
+  'function transferOwnership(address newOwner)',
+  'function owner() view returns (address)',
+])
+
+const missionAbi = parseAbi([
+  'function createMission(uint256 teamId, address to, string projectUri, uint256 fundingGoal, uint256 deadline, uint256 refundPeriod, bool token, string tokenName, string tokenSymbol, string memo) returns (uint256)',
+  'function missionIdToProjectId(uint256) view returns (uint256)',
+  'function missionIdToPayHook(uint256) view returns (address)',
+])
+
+const payhookAbi = parseAbi([
+  'function setDePrizeRegistry(address registry)',
+  'function deprizeRegistry() view returns (address)',
+])
+
+type Result = {
+  goalId: string
+  deprizeId: number
+  questionId: Hex
+  conditionId: Hex
+  market: Hex
+  jbProjectId: string
+  teamIds: string[]
+}
+
+function loadDone(): Result[] {
+  try {
+    return JSON.parse(readFileSync(OUT, 'utf8')) as Result[]
+  } catch {
+    return []
+  }
+}
+
+function pk(): Hex {
+  const raw = process.env.DEPLOYER_PK || process.env.PRIVATE_KEY
+  if (!raw) throw new Error('Set DEPLOYER_PK or PRIVATE_KEY')
+  return (raw.startsWith('0x') ? raw : `0x${raw}`) as Hex
+}
+
+async function main() {
+  const account = privateKeyToAccount(pk())
+  const rpc =
+    process.env.SEPOLIA_RPC_URL || 'https://ethereum-sepolia-rpc.publicnode.com'
+  const publicClient = createPublicClient({
+    chain: sepolia,
+    transport: http(rpc, { timeout: 60_000 }),
+  })
+  const wallet = createWalletClient({
+    account,
+    chain: sepolia,
+    transport: http(rpc, { timeout: 60_000 }),
+  })
+
+  console.log('deployer', account.address)
+  const count = await publicClient.readContract({
+    address: REGISTRY,
+    abi: registryAbi,
+    functionName: 'count',
+  })
+  console.log('registry.count', count.toString())
+
+  const done = loadDone()
+  const results = [...done]
+
+  const send = async (params: Parameters<typeof wallet.writeContract>[0]) => {
+    const hash = await wallet.writeContract(params)
+    const receipt = await publicClient.waitForTransactionReceipt({ hash })
+    if (receipt.status !== 'success') throw new Error(`tx reverted ${hash}`)
+    return receipt
+  }
+
+  for (const race of RACES) {
+    if (results.some((r) => r.goalId === race.goalId)) {
+      console.log(`skip ${race.goalId} (already provisioned)`)
+      continue
+    }
+    const goal = sharedGoalById(SEED_ATLAS, race.goalId)
+    if (!goal) throw new Error(`missing goal ${race.goalId}`)
+    if (goal.projectIds.length + 1 !== race.teamIds.length) {
+      throw new Error(`${race.goalId}: team count must be competitors + field`)
+    }
+
+    const n = BigInt(race.teamIds.length)
+    const funding = FUNDING_PER_OUTCOME * n
+    const questionId = keccak256(toBytes(`deprize:sepolia:${race.goalId}:v1`))
+
+    console.log(`\n=== ${race.goalId} ===`)
+    console.log('questionId', questionId)
+    console.log('outcomes', n.toString(), 'funding', funding.toString())
+
+    let jbProjectId: bigint
+    try {
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + 2 * 365 * 24 * 3600)
+      const missionArgs = [
+        22n,
+        account.address,
+        `https://moondao.com/deprize/${race.goalId}`,
+        parseEther('100'),
+        deadline,
+        30n * 24n * 3600n,
+        true,
+        race.tokenName,
+        race.tokenSymbol,
+        `DePrize ${race.raceLabel}`,
+      ] as const
+      const sim = await publicClient.simulateContract({
+        account,
+        address: MISSION_CREATOR,
+        abi: missionAbi,
+        functionName: 'createMission',
+        args: missionArgs,
+      })
+      await send({
+        address: MISSION_CREATOR,
+        abi: missionAbi,
+        functionName: 'createMission',
+        args: missionArgs,
+      })
+      jbProjectId = await publicClient.readContract({
+        address: MISSION_CREATOR,
+        abi: missionAbi,
+        functionName: 'missionIdToProjectId',
+        args: [sim.result],
+      })
+      if (!jbProjectId) throw new Error('createMission produced no jb project')
+      console.log('  missionId', sim.result.toString(), 'jbProjectId', jbProjectId.toString())
+      const payHook = await publicClient.readContract({
+        address: MISSION_CREATOR,
+        abi: missionAbi,
+        functionName: 'missionIdToPayHook',
+        args: [sim.result],
+      })
+      if (payHook && payHook !== '0x0000000000000000000000000000000000000000') {
+        const current = await publicClient.readContract({
+          address: payHook,
+          abi: payhookAbi,
+          functionName: 'deprizeRegistry',
+        })
+        if (current.toLowerCase() !== REGISTRY.toLowerCase()) {
+          await send({
+            address: payHook,
+            abi: payhookAbi,
+            functionName: 'setDePrizeRegistry',
+            args: [REGISTRY],
+          })
+        }
+        console.log('  payHook', payHook)
+      }
+    } catch (err) {
+      console.warn('  createMission failed, using synthetic jb id:', err)
+      jbProjectId = 0n
+    }
+    if (!jbProjectId) {
+      // register() only needs a unique unused jbProjectId; viewing the market
+      // does not require a live Juicebox project.
+      let candidate = 3000n + BigInt(results.length)
+      for (;;) {
+        const bound = await publicClient.readContract({
+          address: REGISTRY,
+          abi: registryAbi,
+          functionName: 'deprizeIdByJBProject',
+          args: [candidate],
+        })
+        if (bound === 0n) break
+        candidate++
+      }
+      jbProjectId = candidate
+      console.log('  synthetic jbProjectId', jbProjectId.toString())
+    }
+
+    const conditionId = await publicClient.readContract({
+      address: CTF,
+      abi: ctfAbi,
+      functionName: 'getConditionId',
+      args: [account.address, questionId, n],
+    })
+    const slots = await publicClient.readContract({
+      address: CTF,
+      abi: ctfAbi,
+      functionName: 'getOutcomeSlotCount',
+      args: [conditionId],
+    })
+    if (slots === 0n) {
+      await send({
+        address: CTF,
+        abi: ctfAbi,
+        functionName: 'prepareCondition',
+        args: [account.address, questionId, n],
+      })
+    }
+    console.log('  conditionId', conditionId, slots > 0n ? '(pre-existing)' : '')
+
+    const wethBal = await publicClient.readContract({
+      address: WETH,
+      abi: wethAbi,
+      functionName: 'balanceOf',
+      args: [account.address],
+    })
+    if (wethBal < funding) {
+      await send({
+        address: WETH,
+        abi: wethAbi,
+        functionName: 'deposit',
+        value: funding - wethBal,
+      })
+    }
+    await send({
+      address: WETH,
+      abi: wethAbi,
+      functionName: 'approve',
+      args: [FACTORY, funding],
+    })
+
+    const lmsrReceipt = await send({
+      address: FACTORY,
+      abi: factoryAbi,
+      functionName: 'createLMSRWithTWAP',
+      args: [CTF, WETH, [conditionId], FEE, '0x0000000000000000000000000000000000000000', funding],
+    })
+    let market: Hex | undefined
+    for (const log of lmsrReceipt.logs) {
+      try {
+        const parsed = decodeEventLog({
+          abi: factoryAbi,
+          data: log.data,
+          topics: log.topics,
+        })
+        if (parsed.eventName === 'LMSRWithTWAPCreation') {
+          market = (parsed.args as { lmsrWithTWAP: Hex }).lmsrWithTWAP
+        }
+      } catch {
+        /* not this event */
+      }
+    }
+    if (!market) throw new Error('no LMSRWithTWAPCreation log')
+    console.log('  market', market)
+
+    const regReceipt = await send({
+      address: REGISTRY,
+      abi: registryAbi,
+      functionName: 'register',
+      args: [jbProjectId, race.teamIds, SUNSET],
+    })
+    let deprizeId: bigint | undefined
+    for (const log of regReceipt.logs) {
+      try {
+        const parsed = decodeEventLog({
+          abi: registryAbi,
+          data: log.data,
+          topics: log.topics,
+        })
+        if (parsed.eventName === 'DePrizeRegistered') {
+          deprizeId = (parsed.args as { deprizeId: bigint }).deprizeId
+        }
+      } catch {
+        /* skip */
+      }
+    }
+    if (deprizeId === undefined) {
+      const next = await publicClient.readContract({
+        address: REGISTRY,
+        abi: registryAbi,
+        functionName: 'count',
+      })
+      deprizeId = next
+    }
+    console.log('  deprizeId', deprizeId.toString())
+
+    await send({
+      address: REGISTRY,
+      abi: registryAbi,
+      functionName: 'setCondition',
+      args: [deprizeId, conditionId],
+    })
+    await send({
+      address: REGISTRY,
+      abi: registryAbi,
+      functionName: 'open',
+      args: [deprizeId],
+    })
+    await send({
+      address: MINT,
+      abi: mintAbi,
+      functionName: 'setMarket',
+      args: [deprizeId, market],
+    })
+    await send({
+      address: FEE_ROUTER,
+      abi: feeAbi,
+      functionName: 'setMarket',
+      args: [deprizeId, market],
+    })
+    const owner = await publicClient.readContract({
+      address: market,
+      abi: lmsrAbi,
+      functionName: 'owner',
+    })
+    if (owner.toLowerCase() === account.address.toLowerCase()) {
+      await send({
+        address: market,
+        abi: lmsrAbi,
+        functionName: 'transferOwnership',
+        args: [FEE_ROUTER],
+      })
+    }
+
+    results.push({
+      goalId: race.goalId,
+      deprizeId: Number(deprizeId),
+      questionId,
+      conditionId,
+      market,
+      jbProjectId: jbProjectId.toString(),
+      teamIds: race.teamIds.map(String),
+    })
+    writeFileSync(OUT, stringify(results, null, 2))
+    console.log('  recorded', OUT)
+  }
+
+  console.log('\nBind these in competitions.ts:\n')
+  for (const r of results) {
+    const goal = sharedGoalById(SEED_ATLAS, r.goalId)!
+    const named = r.teamIds.slice(0, -1)
+    console.log(`    ${r.deprizeId}: {`)
+    console.log(`      title: ${JSON.stringify(goal.title)},`)
+    console.log(`      sharedGoalId: '${r.goalId}',`)
+    console.log(`      questionId: '${r.questionId}',`)
+    console.log(
+      `      outcomes: [${goal.projectIds
+        .map((id, i) => `{ projectId: '${id}', teamId: ${named[i]} }`)
+        .join(', ')}, { projectId: '${OPEN_FIELD_PROJECT_ID}', teamId: 24, field: true }],`,
+    )
+    console.log(`    },`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- **DePrize index:** prize cards open `/deprize/{goalId}` instead of Moon Base. Bound slugs load the live market; unbound slugs (and mass driver) get an atlas detail page.
- **Sepolia:** bind the competitive Moon Base races — existing #9 / #10 / #12 / #15 plus newly provisioned **#17 landing pads**, **#18 habitat**, and **#19 comms**.
- **Moon Base Zero:** official/unofficial color instead of a repeating “listed” chip; place + odds on assets; year slider above the site banner; clicking a dimmed asset opens that district; stop reserving space for the hidden ProjectBanner.
- **DePrize chrome:** live USD next to ETH amounts; predictions and competitors above the fold.

## Test plan
- [ ] On `/deprize`, click each prize card — lands on `/deprize/{goalId}`, not `/moonbase`
- [ ] Buy on an index card stays on the index (does not navigate)
- [ ] `/deprize/shared-mass-driver` shows the concept page (no market)
- [ ] Switch header to Sepolia: `/deprize/shared-landing-pads` (and habitat / comms / lander / rover / ISRU / fission) load live DePrize #17–19 / #10 / #12 / #15 / #9
- [ ] Open `/moonbase/blue-origin-blue-moon-mk2` — header and card show 2nd place / 36%; globe label matches
- [ ] Click a dimmed asset in another district — that district fills, same as the hovering pin
- [ ] Confirm the year slider sits fully above the proposal banner and can be dragged
- [ ] Open `/deprize/1` — ETH amounts show `(~$…)` where the price feed is available

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches on-chain read paths, wallet bet/exit modals from Moon Base, and many new Sepolia market bindings—wrong RPC or binding data could break market loads or mis-route slugs, but changes are mostly UI and config.
> 
> **Overview**
> Unifies **DePrize navigation** so index and race cards always go to `/deprize/{goalId}`: bound goals resolve to the live on-chain market on the selected chain; unbound goals render a new **atlas/demo detail** (`GoalDePrizeDetail`) instead of sending users to Moon Base. Adds `deprizeDetailHref` and expands **Sepolia `competitions.ts` bindings** (lander, rover, ISRU, pads #17, habitat #18, comms #19) plus a **provision script** for the new markets.
> 
> **Moon Base Zero** gets race **standings** (`raceStandingForProject`, `formatPlace`) on globe labels and in `ProjectPanel`, which now supports inline **Buy / cash out** (live `BetModal` / `ExitPositionModal` or demo ledger). Competitors use **official vs unofficial** color bars instead of repeating roster chips; clicking a dimmed asset in another district opens that district. Live odds stay mounted when drilling into a project via `oddsGoalId`.
> 
> **DePrize UI** shows **ETH with live USD** via `EthUsd`, `fmtEthWithUsd`, and `useETHPrice` across bet/claim/exit flows and team cards. The detail page is reorganized (**Predictions / Competitors** above description), chart legends use resolved team names, and **`deprizeReadChain`** routes reads through the app RPC (fixes thirdweb edge 401 blanking markets). `DePrizeTeamLink` only mounts NFT reads when a contract is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40eda3c3852fa0ba47b02bf9e70d3154d969fc98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->