### PR TITLE
feat(jobs): keep apply details citizen-only

### DIFF
--- a/ui/components/jobs/Job.tsx
+++ b/ui/components/jobs/Job.tsx
@@ -1,9 +1,10 @@
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { prepareContractCall, sendAndConfirmTransaction } from 'thirdweb'
 import { getNFT } from 'thirdweb/extensions/erc721'
 import { useActiveAccount } from 'thirdweb/react'
+import CitizenContext from '@/lib/citizen/citizen-context'
 import {
   formatDeadlineCountdown,
   getApplicationDeadline,
@@ -59,6 +60,8 @@ export default function Job({
   previewMode = false,
 }: JobProps) {
   const account = useActiveAccount()
+  const { citizen } = useContext(CitizenContext)
+  const canApply = Boolean(citizen || editable)
 
   const [enabledEditJobModal, setEnabledEditJobModal] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -103,7 +106,7 @@ export default function Job({
 
   const jobActions = (
     <div className="flex gap-2 items-center">
-      {job.contactInfo && !previewMode && (
+      {job.contactInfo && !previewMode && canApply && (
         <StandardButton
           className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white rounded-lg px-4 py-2 text-sm font-semibold transition-all duration-200 hover:scale-105"
           onClick={() => {
@@ -203,7 +206,7 @@ export default function Job({
           </p>
 
           <span className="text-xs text-blue-400 group-hover:text-blue-300 mt-3 transition-colors">
-            View role and apply →
+            {canApply ? 'View role and apply →' : 'View role →'}
           </span>
         </Link>
 

--- a/ui/components/jobs/JobApplyPanel.tsx
+++ b/ui/components/jobs/JobApplyPanel.tsx
@@ -3,10 +3,13 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { formatDeadlineCountdown, formatPostedAt } from '@/lib/jobs/jobMetadata'
 import useCurrUnixTime from '@/lib/utils/hooks/useCurrUnixTime'
+import JobCitizenUpsell from '@/components/jobs/JobCitizenUpsell'
 import ShareButtons from '@/components/layout/ShareButtons'
 
 type JobApplyPanelProps = {
   applyUrl?: string
+  canApply?: boolean
+  citizenLoading?: boolean
   deadline?: number
   postedAt?: number
   teamName?: string
@@ -18,6 +21,8 @@ type JobApplyPanelProps = {
 
 export default function JobApplyPanel({
   applyUrl,
+  canApply = true,
+  citizenLoading = false,
   deadline,
   postedAt,
   teamName,
@@ -39,7 +44,9 @@ export default function JobApplyPanel({
   return (
     <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-slate-700/30 to-slate-800/40 backdrop-blur-xl p-5 flex flex-col gap-4">
       <div>
-        <p className="font-GoodTimes text-white text-lg leading-tight">Apply for this role</p>
+        <p className="font-GoodTimes text-white text-lg leading-tight">
+          {canApply ? 'Apply for this role' : 'This opportunity is open'}
+        </p>
         {countdown && (
           <p className={`text-sm mt-1 ${isClosed ? 'text-red-400' : 'text-blue-300'}`}>
             {countdown}
@@ -50,21 +57,30 @@ export default function JobApplyPanel({
         ) : null}
       </div>
 
-      {applyUrl ? (
-        <a
-          id="job-apply-button"
-          href={applyUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="w-full inline-flex items-center justify-center gap-2 rounded-xl px-4 py-3 font-semibold text-white bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 transition-all duration-200"
-        >
-          Apply now
-          <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-        </a>
+      {citizenLoading ? (
+        <div
+          className="h-12 rounded-xl bg-white/5 border border-white/10 animate-pulse"
+          aria-hidden="true"
+        />
+      ) : canApply ? (
+        applyUrl ? (
+          <a
+            id="job-apply-button"
+            href={applyUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-full inline-flex items-center justify-center gap-2 rounded-xl px-4 py-3 font-semibold text-white bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 transition-all duration-200"
+          >
+            Apply now
+            <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+          </a>
+        ) : (
+          <p className="text-sm text-slate-400">
+            No application link was provided for this role. Reach out to the team directly.
+          </p>
+        )
       ) : (
-        <p className="text-sm text-slate-400">
-          No application link was provided for this role. Reach out to the team directly.
-        </p>
+        <JobCitizenUpsell />
       )}
 
       <ShareButtons url={shareUrl} text={shareText} />
@@ -90,8 +106,9 @@ export default function JobApplyPanel({
       )}
 
       <p className="text-xs text-slate-500 leading-relaxed">
-        Applications are handled by the posting team. MoonDAO Citizens get the full board plus early
-        access to new roles.
+        {canApply
+          ? 'Applications are handled by the posting team. MoonDAO Citizens get early access to new roles.'
+          : 'Anyone can read the role. MoonDAO Citizens unlock how to apply.'}
       </p>
     </div>
   )

--- a/ui/components/jobs/JobCitizenUpsell.tsx
+++ b/ui/components/jobs/JobCitizenUpsell.tsx
@@ -1,0 +1,64 @@
+import { LockClosedIcon } from '@heroicons/react/24/outline'
+import StandardButton from '@/components/layout/StandardButton'
+
+type JobCitizenUpsellProps = {
+  variant?: 'panel' | 'banner'
+  headline?: string
+  body?: string
+}
+
+const COPY = {
+  panel: {
+    headline: 'Become a Citizen to apply',
+    body: 'The role is public. The apply link and how-to-apply steps are for MoonDAO Citizens — people already in the Space Acceleration Network.',
+  },
+  banner: {
+    headline: 'Read every role. Apply as a Citizen.',
+    body: 'Browse the full opportunity. Citizenship unlocks application details so teams hear from people who are already part of the network.',
+  },
+} as const
+
+export default function JobCitizenUpsell({
+  variant = 'panel',
+  headline,
+  body,
+}: JobCitizenUpsellProps) {
+  const copy = COPY[variant]
+  const isBanner = variant === 'banner'
+
+  return (
+    <div
+      id="job-apply-citizen-upsell"
+      className={
+        isBanner
+          ? 'rounded-2xl border border-blue-400/20 bg-gradient-to-br from-blue-600/15 via-purple-600/10 to-slate-800/40 p-5 md:p-6'
+          : 'rounded-xl border border-white/10 bg-white/5 p-4'
+      }
+    >
+      <div className={isBanner ? 'flex flex-col md:flex-row md:items-center gap-4' : 'flex flex-col gap-3'}>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start gap-3">
+            <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-500/20 text-blue-300">
+              <LockClosedIcon className="h-5 w-5" />
+            </span>
+            <div>
+              <p className="font-GoodTimes text-white text-base leading-tight">
+                {headline || copy.headline}
+              </p>
+              <p className="text-sm text-slate-300 mt-2 leading-relaxed">{body || copy.body}</p>
+            </div>
+          </div>
+        </div>
+        <StandardButton
+          className={`${isBanner ? 'md:w-auto w-full shrink-0' : 'w-full'} gradient-2 hover:opacity-90 transition-opacity`}
+          textColor="text-white"
+          borderRadius="rounded-xl"
+          hoverEffect={false}
+          link="/citizen"
+        >
+          Become a Citizen
+        </StandardButton>
+      </div>
+    </div>
+  )
+}

--- a/ui/components/subscription/TeamJobs.tsx
+++ b/ui/components/subscription/TeamJobs.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { readContract } from 'thirdweb'
 import { useTablelandQuery } from '@/lib/swr/useTablelandQuery'
 import Job, { Job as JobType } from '../jobs/Job'
+import JobCitizenUpsell from '../jobs/JobCitizenUpsell'
 import StandardButton from '../layout/StandardButton'
 import Card from './Card'
 import TeamJobModal from './TeamJobModal'
@@ -127,87 +128,28 @@ export default function TeamJobs({
             </StandardButton>
           )}
         </div>
-        {isManager || isCitizen ? (
-          <div className="mt-4">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-              {jobs?.[0] ? (
-                jobs.map((job, i) => (
-                  <Job
-                    id={`team-job-${job.id}`}
-                    key={`team-job-${job.id}`}
-                    job={job}
-                    jobTableContract={jobTableContract}
-                    editable={isManager}
-                    refreshJobs={getEntityJobs}
-                    previewMode={false}
-                  />
-                ))
-              ) : (
-                <p className="text-slate-300 text-center py-8 col-span-2">{`This team hasn't listed any open roles yet.`}</p>
-              )}
-            </div>
+        <div className="mt-4 flex flex-col gap-4">
+          {!isManager && !isCitizen && (
+            <JobCitizenUpsell
+              variant="banner"
+              headline="Read the roles. Apply as a Citizen."
+              body="This team's open opportunities are public. Citizenship unlocks the apply link and how-to-apply steps."
+            />
+          )}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {jobs.map((job) => (
+              <Job
+                id={`team-job-${job.id}`}
+                key={`team-job-${job.id}`}
+                job={job}
+                jobTableContract={jobTableContract}
+                editable={isManager}
+                refreshJobs={getEntityJobs}
+                previewMode={false}
+              />
+            ))}
           </div>
-        ) : jobs?.[0] ? (
-          // Show preview for non-citizens
-          <div className="mt-4">
-            <div className="bg-slate-800/50 rounded-xl border border-slate-600/30 p-6 mb-4">
-              <div className="text-center">
-                <h4 className="text-lg font-semibold text-white mb-2">
-                  🔒 {jobs.length} Job{jobs.length !== 1 ? 's' : ''} Available
-                </h4>
-                <p className="text-slate-300 mb-4">
-                  This team has active job postings. Become a Citizen to view full details, salary
-                  information, and application links.
-                </p>
-                <StandardButton
-                  className="min-w-[200px] gradient-2 rounded-[2vmax] rounded-bl-[10px]"
-                  onClick={() => {
-                    router.push('/citizen')
-                  }}
-                >
-                  Become a Citizen
-                </StandardButton>
-              </div>
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 opacity-50 pointer-events-none">
-              {jobs.slice(0, 3).map((job, i) => (
-                <Job
-                  id={`team-job-preview-${job.id}`}
-                  key={`team-job-preview-${job.id}`}
-                  job={job}
-                  jobTableContract={jobTableContract}
-                  editable={false}
-                  refreshJobs={getEntityJobs}
-                  previewMode={true}
-                />
-              ))}
-              {jobs.length > 3 && (
-                <div className="bg-slate-700/30 rounded-xl border border-slate-600/30 p-6 flex items-center justify-center min-h-[200px]">
-                  <p className="text-slate-400 text-center">
-                    +{jobs.length - 3} more job
-                    {jobs.length - 3 !== 1 ? 's' : ''}
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-4 ">
-            <p>
-              {
-                '⚠️ You must be a Citizen of the Space Acceleration Network or a Manager of the team to view the job board. If you are already a Citizen or Manager, please sign in.'
-              }
-            </p>
-            <StandardButton
-              className="min-w-[200px] gradient-2 rounded-[2vmax] rounded-bl-[10px]"
-              onClick={() => {
-                router.push('/citizen')
-              }}
-            >
-              Become a Citizen
-            </StandardButton>
-          </div>
-        )}
+        </div>
 
         {teamJobModalEnabled && (
           <TeamJobModal

--- a/ui/const/joinPageContent.ts
+++ b/ui/const/joinPageContent.ts
@@ -80,7 +80,7 @@ export const whyJoinPillars: WhyJoinPillar[] = [
     iconAlt: 'Jobs',
     header: 'Real Jobs, Real Teams',
     paragraph:
-      'Access a jobs board full of high-signal roles from teams already building in space — no mass-applicant noise, just people genuinely aligned with the mission.',
+      'Read every high-signal role from teams already building in space, then apply as a Citizen — no mass-applicant noise, just people genuinely aligned with the mission.',
   },
   {
     icon: '/assets/icon-astronaut.svg',

--- a/ui/cypress/integration/jobs/job-apply-panel.cy.tsx
+++ b/ui/cypress/integration/jobs/job-apply-panel.cy.tsx
@@ -1,0 +1,42 @@
+import JobApplyPanel from '@/components/jobs/JobApplyPanel'
+
+const share = {
+  shareUrl: 'https://www.moondao.com/jobs/22',
+  shareText: 'Social Media Manager at MoonDAO',
+}
+
+describe('<JobApplyPanel />', () => {
+  beforeEach(() => {
+    cy.mountNextRouter('/')
+  })
+
+  it('shows the apply link to citizens', () => {
+    cy.mount(
+      <JobApplyPanel
+        {...share}
+        canApply
+        applyUrl="https://airtable.com/apply"
+        teamName="MoonDAO"
+        teamHref="/team/1"
+      />
+    )
+
+    cy.get('#job-apply-button')
+      .should('be.visible')
+      .and('have.attr', 'href', 'https://airtable.com/apply')
+    cy.contains('Apply now').should('be.visible')
+    cy.get('#job-apply-citizen-upsell').should('not.exist')
+  })
+
+  it('shows the citizenship teaser instead of how to apply', () => {
+    cy.mount(
+      <JobApplyPanel {...share} canApply={false} applyUrl="https://airtable.com/apply" />
+    )
+
+    cy.get('#job-apply-button').should('not.exist')
+    cy.contains('https://airtable.com/apply').should('not.exist')
+    cy.get('#job-apply-citizen-upsell').should('be.visible')
+    cy.contains('Become a Citizen to apply').should('be.visible')
+    cy.contains('Become a Citizen').should('be.visible')
+  })
+})

--- a/ui/cypress/integration/subscription/team-job.cy.tsx
+++ b/ui/cypress/integration/subscription/team-job.cy.tsx
@@ -1,11 +1,35 @@
-import TestnetProviders from '@/cypress/mock/TestnetProviders'
 import { CYPRESS_CHAIN_SLUG, CYPRESS_CHAIN_V5 } from '@/cypress/mock/config'
 import JobTableABI from 'const/abis/JobBoardTable.json'
 import { JOBS_TABLE_ADDRESSES } from 'const/config'
 import { getContract } from 'thirdweb'
+import { ThirdwebProvider } from 'thirdweb/react'
+import CitizenContext from '@/lib/citizen/citizen-context'
 import { serverClient } from '@/lib/thirdweb/serverClient'
 import { daysFromNowTimestamp } from '@/lib/utils/timestamp'
 import Job, { Job as JobType } from '@/components/jobs/Job'
+
+function JobProviders({
+  citizen = false,
+  children,
+}: {
+  citizen?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <ThirdwebProvider>
+      <CitizenContext.Provider
+        value={{
+          citizen: citizen ? { metadata: { id: '1' } } : undefined,
+          setCitizen: () => {},
+          seedCitizen: () => {},
+          isLoading: false,
+        }}
+      >
+        {children}
+      </CitizenContext.Provider>
+    </ThirdwebProvider>
+  )
+}
 
 describe('<Job />', () => {
   let job: JobType
@@ -39,9 +63,9 @@ describe('<Job />', () => {
     const timestamp = daysFromNowTimestamp(0)
 
     cy.mount(
-      <TestnetProviders>
+      <JobProviders citizen>
         <Job {...props} job={{ ...job, timestamp }} />
-      </TestnetProviders>
+      </JobProviders>
     )
 
     cy.contains(job.title).should('be.visible')
@@ -56,11 +80,26 @@ describe('<Job />', () => {
     cy.contains('Posted today').should('be.visible')
   })
 
+  it('hides the apply button for guests and still shows the role', () => {
+    const timestamp = daysFromNowTimestamp(0)
+
+    cy.mount(
+      <JobProviders>
+        <Job {...props} job={{ ...job, timestamp }} />
+      </JobProviders>
+    )
+
+    cy.contains(job.title).should('be.visible')
+    cy.contains(job.description).should('be.visible')
+    cy.contains('View role →').should('be.visible')
+    cy.contains('Apply').should('not.exist')
+  })
+
   it('Shows edit and delete buttons when editable', () => {
     cy.mount(
-      <TestnetProviders>
+      <JobProviders>
         <Job {...props} editable />
-      </TestnetProviders>
+      </JobProviders>
     )
 
     cy.get('#edit-job-button').should('exist')
@@ -69,9 +108,9 @@ describe('<Job />', () => {
 
   it('Deletes the job', () => {
     cy.mount(
-      <TestnetProviders>
+      <JobProviders>
         <Job {...props} editable />
-      </TestnetProviders>
+      </JobProviders>
     )
 
     cy.get('#delete-job-button').click()
@@ -80,9 +119,9 @@ describe('<Job />', () => {
   it("Hides the job if it's expired", () => {
     const endTime = daysFromNowTimestamp(-1)
     cy.mount(
-      <TestnetProviders>
+      <JobProviders>
         <Job {...props} job={{ ...job, endTime }} />
-      </TestnetProviders>
+      </JobProviders>
     )
 
     cy.contains(job.title).should('not.exist')
@@ -91,9 +130,9 @@ describe('<Job />', () => {
   it("Shows 'expired' message if the job is expired and editable", () => {
     const endTime = daysFromNowTimestamp(-1)
     cy.mount(
-      <TestnetProviders>
+      <JobProviders>
         <Job {...props} job={{ ...job, endTime }} editable />
-      </TestnetProviders>
+      </JobProviders>
     )
 
     cy.contains('This job post has expired').should('be.visible')

--- a/ui/cypress/integration/unit/job-metadata.cy.ts
+++ b/ui/cypress/integration/unit/job-metadata.cy.ts
@@ -10,6 +10,7 @@ import {
   normalizeJobPostingDoc,
   parseJobMetadata,
   serializeJobMetadata,
+  stripJobApplicationFields,
 } from '@/lib/jobs/jobMetadata'
 
 const DAY = 86400
@@ -263,6 +264,30 @@ describe('normalizeJobPostingDoc', () => {
     })
 
     expect(doc?.body).to.equal('### The pitch\n\nOwn the account.')
+  })
+})
+
+describe('stripJobApplicationFields', () => {
+  it('removes apply URL, how-to-apply, and hiring process', () => {
+    const stripped = stripJobApplicationFields({
+      v: 1,
+      summary: 'Grow the account',
+      body: 'Own day-to-day posting.',
+      applyUrl: 'https://airtable.com/apply',
+      applicationRequirements: ['Send metrics'],
+      hiringProcess: [{ label: 'Intro call' }],
+    })
+
+    expect(stripped?.summary).to.equal('Grow the account')
+    expect(stripped?.body).to.equal('Own day-to-day posting.')
+    expect(stripped?.applyUrl).to.equal(undefined)
+    expect(stripped?.applicationRequirements).to.equal(undefined)
+    expect(stripped?.hiringProcess).to.equal(undefined)
+  })
+
+  it('returns null for a missing document', () => {
+    expect(stripJobApplicationFields(null)).to.equal(null)
+    expect(stripJobApplicationFields(undefined)).to.equal(null)
   })
 })
 

--- a/ui/cypress/integration/unit/job-metadata.cy.ts
+++ b/ui/cypress/integration/unit/job-metadata.cy.ts
@@ -2,6 +2,7 @@ import {
   MAX_METADATA_BYTES,
   buildJobMetadata,
   extractPublicJobBody,
+  stripApplicationSectionsFromBody,
   formatCommitment,
   formatCompensation,
   formatDeadlineCountdown,
@@ -267,19 +268,68 @@ describe('normalizeJobPostingDoc', () => {
   })
 })
 
+describe('stripApplicationSectionsFromBody', () => {
+  it('removes how-to-apply and hiring process, keeps the role', () => {
+    const stripped = stripApplicationSectionsFromBody(
+      [
+        '### The pitch',
+        '',
+        'Own the account.',
+        '',
+        '### How to apply',
+        '',
+        'Send a package with metrics and 2–3 posts.',
+        '',
+        '### Hiring process and timeline',
+        '',
+        '| Stage | What happens |',
+        '|---|---|',
+        '| Interview | A conversation about prior results. |',
+        '',
+        '### About MoonDAO',
+        '',
+        "The Internet's Space Program.",
+        '',
+        'Worth reading before you apply:',
+      ].join('\n')
+    )
+
+    expect(stripped).to.include('Own the account.')
+    expect(stripped).to.include('About MoonDAO')
+    expect(stripped).to.include('Worth reading before you apply')
+    expect(stripped).to.not.include('How to apply')
+    expect(stripped).to.not.include('Send a package')
+    expect(stripped).to.not.include('Hiring process')
+    expect(stripped).to.not.include('Interview')
+  })
+
+  it('leaves a posting without apply sections untouched', () => {
+    const body = '### The pitch\n\nOwn the account.'
+    expect(stripApplicationSectionsFromBody(body)).to.equal(body)
+  })
+})
+
 describe('stripJobApplicationFields', () => {
   it('removes apply URL, how-to-apply, and hiring process', () => {
     const stripped = stripJobApplicationFields({
       v: 1,
       summary: 'Grow the account',
-      body: 'Own day-to-day posting.',
+      body: [
+        '### The pitch',
+        '',
+        'Own day-to-day posting.',
+        '',
+        '### How to apply',
+        '',
+        'Email the team with your X metrics.',
+      ].join('\n'),
       applyUrl: 'https://airtable.com/apply',
       applicationRequirements: ['Send metrics'],
       hiringProcess: [{ label: 'Intro call' }],
     })
 
     expect(stripped?.summary).to.equal('Grow the account')
-    expect(stripped?.body).to.equal('Own day-to-day posting.')
+    expect(stripped?.body).to.equal('### The pitch\n\nOwn day-to-day posting.')
     expect(stripped?.applyUrl).to.equal(undefined)
     expect(stripped?.applicationRequirements).to.equal(undefined)
     expect(stripped?.hiringProcess).to.equal(undefined)

--- a/ui/cypress/integration/unit/job-posting-jsonld.cy.ts
+++ b/ui/cypress/integration/unit/job-posting-jsonld.cy.ts
@@ -32,6 +32,28 @@ describe('serializeJsonLd', () => {
     expect(parsed['@type']).to.equal('JobPosting')
   })
 
+  it('does not publish an apply URL in public JobPosting markup', () => {
+    const jsonLd = buildJobPostingJsonLd({
+      job: {
+        id: 22,
+        title: 'Social Media Manager',
+        description: 'Own the X account',
+        teamId: 1,
+        timestamp: 1_700_000_000,
+        endTime: 0,
+        contactInfo: 'https://airtable.com/apply',
+      } as any,
+      envelope: { v: 1 },
+      doc: { v: 1, applyUrl: 'https://airtable.com/apply', summary: 'Own the X account' },
+      teamName: 'MoonDAO',
+    })
+
+    const serialized = serializeJsonLd(jsonLd)
+    expect(serialized).to.not.include('airtable.com')
+    expect(jsonLd.directApply).to.equal(false)
+    expect(String(jsonLd.url)).to.match(/\/jobs\/22$/)
+  })
+
   it('escapes ampersands and unicode line separators', () => {
     const serialized = serializeJsonLd({ a: 'x & y', b: 'line\u2028sep\u2029here' })
     expect(serialized).to.not.include('&')

--- a/ui/lib/jobs/jobMetadata.ts
+++ b/ui/lib/jobs/jobMetadata.ts
@@ -23,9 +23,9 @@ import { bytesOfString } from '@/lib/utils/strings'
 export const JOB_METADATA_VERSION = 1
 
 /**
- * The `/jobs` index stays a Citizen perk, but an individual role is publicly
- * readable so a link shared on X isn't a dead end behind a blur overlay. Flip
- * this to `false` to gate single roles the same way the index is gated.
+ * Role descriptions are public so a link shared on X is not a dead end.
+ * Application details (apply URL, how-to-apply, hiring process) stay a
+ * Citizen perk. Flip this to `false` to also hide the description body.
  */
 export const JOB_DETAIL_PUBLIC = true
 
@@ -494,6 +494,16 @@ export function normalizeJobPostingDoc(raw: any): JobPostingDoc | null {
 
   const hasContent = Object.keys(doc).some((key) => key !== 'v')
   return hasContent ? doc : null
+}
+
+/** Drop apply-only fields so guests can read the role without the contact path. */
+export function stripJobApplicationFields(
+  doc: JobPostingDoc | null | undefined
+): JobPostingDoc | null {
+  if (!doc) return null
+  const { applyUrl: _applyUrl, applicationRequirements: _reqs, hiringProcess: _process, ...rest } =
+    doc
+  return rest
 }
 
 /** True when a posting carries more than the four original fields. */

--- a/ui/lib/jobs/jobMetadata.ts
+++ b/ui/lib/jobs/jobMetadata.ts
@@ -496,6 +496,41 @@ export function normalizeJobPostingDoc(raw: any): JobPostingDoc | null {
   return hasContent ? doc : null
 }
 
+/**
+ * Headings that are the apply path, not the opportunity. Several live postings
+ * keep these in the markdown body rather than the structured fields, so guests
+ * would otherwise read how to apply while the apply button is hidden.
+ */
+const APPLICATION_SECTION_HEADING =
+  /^#{1,3}\s+(?:how\s+to\s+apply|to\s+apply|hiring\s+process|applications?|application\s+(?:requirements|instructions|process|details|steps)|apply(?:ing)?(?:\s+here|\s+now)?)\b/i
+
+/** Remove how-to-apply / hiring-process markdown sections; leave the role intact. */
+export function stripApplicationSectionsFromBody(markdown: string): string {
+  if (!markdown || !markdown.trim()) return markdown || ''
+
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n')
+  const out: string[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    const heading = lines[i].match(/^(#{1,3})\s+\S/)
+    if (heading && APPLICATION_SECTION_HEADING.test(lines[i].trim())) {
+      const level = heading[1].length
+      i += 1
+      while (i < lines.length) {
+        const next = lines[i].match(/^(#{1,3})\s+\S/)
+        if (next && next[1].length <= level) break
+        i += 1
+      }
+      continue
+    }
+    out.push(lines[i])
+    i += 1
+  }
+
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').trim()
+}
+
 /** Drop apply-only fields so guests can read the role without the contact path. */
 export function stripJobApplicationFields(
   doc: JobPostingDoc | null | undefined
@@ -503,7 +538,9 @@ export function stripJobApplicationFields(
   if (!doc) return null
   const { applyUrl: _applyUrl, applicationRequirements: _reqs, hiringProcess: _process, ...rest } =
     doc
-  return rest
+  if (!rest.body) return rest
+  const body = stripApplicationSectionsFromBody(rest.body)
+  return body ? { ...rest, body } : { ...rest, body: undefined }
 }
 
 /** True when a posting carries more than the four original fields. */

--- a/ui/pages/jobs.tsx
+++ b/ui/pages/jobs.tsx
@@ -20,7 +20,7 @@ import Container from '@/components/layout/Container'
 import ContentLayout from '@/components/layout/ContentLayout'
 import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import Search from '@/components/layout/Search'
-import StandardButton from '@/components/layout/StandardButton'
+import JobCitizenUpsell from '@/components/jobs/JobCitizenUpsell'
 import TeamABI from '../const/abis/Team.json'
 
 type JobsProps = {
@@ -269,74 +269,35 @@ export default function Jobs({ jobs }: JobsProps) {
           popOverEffect={false}
           isProfile
         >
-          <div className="relative">
-            {/* Blur overlay for non-citizens */}
-            {!citizen && (
-              <div className="absolute inset-0 z-10 bg-slate-900/40 backdrop-blur-[20px] rounded-2xl flex items-center justify-center">
-                <div className="text-center px-6 relative z-20">
-                  <div className="w-20 h-20 bg-blue-600/30 rounded-full flex items-center justify-center mx-auto mb-6">
-                    <svg
-                      className="w-10 h-10 text-blue-400"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                      />
-                    </svg>
-                  </div>
-                  <h3 className="text-2xl font-GoodTimes text-white mb-4 drop-shadow-lg">
-                    Citizens Only
-                  </h3>
-                  <p className="text-slate-300 mb-6 max-w-md mx-auto drop-shadow-md">
-                    Become a MoonDAO Citizen to access the jobs board and connect with teams
-                    building the future of space exploration.
-                  </p>
-                  <StandardButton
-                    className="gradient-2 hover:opacity-90 transition-opacity"
-                    textColor="text-white"
-                    borderRadius="rounded-xl"
-                    hoverEffect={false}
-                    link="/citizen"
+          <div className="flex flex-col gap-6">
+            {!citizen && <JobCitizenUpsell variant="banner" />}
+
+            {filteredJobs?.[0] ? (
+              <CardGridContainer>
+                {filteredJobs.map((job: JobType) => (
+                  <Job key={`job-${job.id}`} job={job} showTeam teamContract={teamContract} />
+                ))}
+              </CardGridContainer>
+            ) : (
+              <div className="mt-4 w-full h-[400px] flex flex-col gap-3 justify-center items-center">
+                <p>No jobs found.</p>
+                {hasFilters && (
+                  <button
+                    type="button"
+                    className="text-sm text-blue-400 hover:text-blue-300"
+                    onClick={() => {
+                      setInput('')
+                      setCategory(ALL)
+                      setCommitment(ALL)
+                      setLocation(ALL)
+                      setPaidOnly(false)
+                    }}
                   >
-                    Become a Citizen
-                  </StandardButton>
-                </div>
+                    Clear filters
+                  </button>
+                )}
               </div>
             )}
-
-            <div className={citizen ? '' : 'pointer-events-none select-none'}>
-              {filteredJobs?.[0] ? (
-                <CardGridContainer>
-                  {filteredJobs.map((job: JobType) => (
-                    <Job key={`job-${job.id}`} job={job} showTeam teamContract={teamContract} />
-                  ))}
-                </CardGridContainer>
-              ) : (
-                <div className="mt-4 w-full h-[400px] flex flex-col gap-3 justify-center items-center">
-                  <p>No jobs found.</p>
-                  {hasFilters && (
-                    <button
-                      type="button"
-                      className="text-sm text-blue-400 hover:text-blue-300"
-                      onClick={() => {
-                        setInput('')
-                        setCategory(ALL)
-                        setCommitment(ALL)
-                        setLocation(ALL)
-                        setPaidOnly(false)
-                      }}
-                    >
-                      Clear filters
-                    </button>
-                  )}
-                </div>
-              )}
-            </div>
           </div>
         </ContentLayout>
       </Container>

--- a/ui/pages/jobs/[id].tsx
+++ b/ui/pages/jobs/[id].tsx
@@ -17,6 +17,7 @@ import {
   getApplicationDeadline,
   getJobShareUrl,
   parseJobMetadata,
+  stripJobApplicationFields,
 } from '@/lib/jobs/jobMetadata'
 import { fetchJobPostingDoc } from '@/lib/jobs/jobPostingDoc'
 import { buildJobPostingJsonLd, serializeJsonLd } from '@/lib/jobs/jobPostingJsonLd'
@@ -69,15 +70,17 @@ export default function JobDetail({
 }: JobDetailProps) {
   const { selectedChain } = useContext(ChainContextV5)
   const chainSlug = getChainSlug(selectedChain)
-  const { citizen } = useContext(CitizenContext)
+  const { citizen, isLoading: citizenLoading } = useContext(CitizenContext)
   useChainDefault()
 
   const isGated = !JOB_DETAIL_PUBLIC && !citizen
+  const canSeeApplication = Boolean(citizen)
   // Pages Router reuses this component across /jobs/[id] navigations, so a
   // fetched doc is tagged with its CID and ignored once the route moves on.
   const [clientDoc, setClientDoc] = useState<{ cid: string; doc: JobPostingDoc } | null>(null)
   const fetchedDoc = clientDoc && clientDoc.cid === metadata.cid ? clientDoc.doc : null
-  const posting = isGated ? null : doc || fetchedDoc
+  const fullPosting = isGated ? null : doc || fetchedDoc
+  const posting = canSeeApplication ? fullPosting : stripJobApplicationFields(fullPosting)
 
   // ISR can ship without the IPFS body (slow gateway). Retry in the browser
   // whenever the on-chain envelope has a CID but the server did not load it.
@@ -101,7 +104,7 @@ export default function JobDetail({
 
   const deadline = getApplicationDeadline(metadata, job.endTime)
   const summary = posting?.summary || job.description
-  const applyUrl = isGated ? undefined : posting?.applyUrl || job.contactInfo
+  const applyUrl = canSeeApplication ? fullPosting?.applyUrl || job.contactInfo : undefined
   const teamHref = team ? `/team/${team.id}` : undefined
   const shareUrl = getJobShareUrl(job)
   const ogFields = jobOgFieldsFrom({ job, envelope: metadata, doc: posting, teamName: team?.name })
@@ -330,6 +333,8 @@ export default function JobDetail({
                 {!isGated && (
                   <JobApplyPanel
                     applyUrl={applyUrl}
+                    canApply={canSeeApplication}
+                    citizenLoading={citizenLoading}
                     deadline={deadline}
                     postedAt={job.timestamp}
                     teamName={team?.name}
@@ -338,27 +343,6 @@ export default function JobDetail({
                     shareText={`${job.title}${team?.name ? ` at ${team.name}` : ' at MoonDAO'}`}
                     otherRolesCount={otherRolesCount}
                   />
-                )}
-
-                {!citizen && (
-                  <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-5">
-                    <p className="font-GoodTimes text-white text-base leading-tight mb-2">
-                      New to MoonDAO?
-                    </p>
-                    <p className="text-sm text-slate-300 mb-4 leading-relaxed">
-                      Citizens of the Space Acceleration Network see every open role on the board,
-                      plus the teams and projects behind them.
-                    </p>
-                    <StandardButton
-                      className="w-full gradient-2 hover:opacity-90 transition-opacity"
-                      textColor="text-white"
-                      borderRadius="rounded-xl"
-                      hoverEffect={false}
-                      link="/citizen"
-                    >
-                      Become a Citizen
-                    </StandardButton>
-                  </div>
                 )}
               </aside>
             </div>
@@ -392,6 +376,20 @@ export default function JobDetail({
             Apply now
             <ArrowTopRightOnSquareIcon className="h-4 w-4" />
           </a>
+        </div>
+      )}
+
+      {!citizenLoading && !canSeeApplication && !isGated && (
+        <div className="lg:hidden fixed bottom-0 left-0 right-0 z-40 border-t border-white/10 bg-slate-900/95 backdrop-blur px-4 py-3">
+          <StandardButton
+            className="w-full gradient-2 hover:opacity-90 transition-opacity"
+            textColor="text-white"
+            borderRadius="rounded-xl"
+            hoverEffect={false}
+            link="/citizen"
+          >
+            Become a Citizen to apply
+          </StandardButton>
         </div>
       )}
     </>

--- a/ui/pages/jobs/[id].tsx
+++ b/ui/pages/jobs/[id].tsx
@@ -79,22 +79,28 @@ export default function JobDetail({
   // fetched doc is tagged with its CID and ignored once the route moves on.
   const [clientDoc, setClientDoc] = useState<{ cid: string; doc: JobPostingDoc } | null>(null)
   const fetchedDoc = clientDoc && clientDoc.cid === metadata.cid ? clientDoc.doc : null
-  const fullPosting = isGated ? null : doc || fetchedDoc
+  const fullPosting = isGated ? null : fetchedDoc || doc
   const posting = canSeeApplication ? fullPosting : stripJobApplicationFields(fullPosting)
 
-  // ISR can ship without the IPFS body (slow gateway). Retry in the browser
-  // whenever the on-chain envelope has a CID but the server did not load it.
+  // ISR ships a guest-safe doc (apply sections already stripped). Citizens load
+  // the full IPFS posting so how-to-apply stays off the public HTML. Guests only
+  // retry when the server missed the body entirely, and that retry is stripped.
   useEffect(() => {
     const cid = metadata.cid
-    if (doc || !cid || isGated) return
+    if (!cid || isGated) return
+    const shouldFetch = canSeeApplication || !doc
+    if (!shouldFetch) return
     let cancelled = false
     fetchJobPostingDoc(cid).then((loaded) => {
-      if (!cancelled && loaded) setClientDoc({ cid, doc: loaded })
+      if (!cancelled && loaded) {
+        const next = canSeeApplication ? loaded : stripJobApplicationFields(loaded)
+        if (next) setClientDoc({ cid, doc: next })
+      }
     })
     return () => {
       cancelled = true
     }
-  }, [doc, metadata.cid, isGated])
+  }, [doc, metadata.cid, isGated, canSeeApplication])
 
   const teamContract = useContract({
     chain: selectedChain,
@@ -427,7 +433,9 @@ export const getStaticProps: GetStaticProps<JobDetailProps> = async ({ params })
       props: {
         job,
         metadata,
-        doc,
+        // Apply instructions stay off the public ISR payload / View Source.
+        // Citizens re-fetch the full IPFS document in the browser.
+        doc: stripJobApplicationFields(doc),
         team,
         relatedJobs: related.jobs,
         otherRolesCount: related.otherCount,

--- a/ui/pages/join.tsx
+++ b/ui/pages/join.tsx
@@ -54,6 +54,7 @@ import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import PaginationButtons from '@/components/layout/PaginationButtons'
 import Search from '@/components/layout/Search'
 import { SectionSkeleton } from '@/components/layout/SkeletonLoader'
+import JobCitizenUpsell from '@/components/jobs/JobCitizenUpsell'
 import StandardButton from '@/components/layout/StandardButton'
 import StandardDetailCard from '@/components/layout/StandardDetailCard'
 import Tab from '@/components/layout/Tab'
@@ -304,7 +305,7 @@ export default function Join({
 
       <InlineJoinCTA
         headline="Be Part of the First Space Program by and for the People"
-        subtext="Vote on proposals, access the jobs board, and help decide where humanity goes next."
+        subtext="Vote on proposals, apply to roles on the jobs board, and help decide where humanity goes next."
       />
 
       <Container>
@@ -353,7 +354,7 @@ export default function Join({
                     <h3 className="text-2xl font-GoodTimes text-white mb-4">Become a Citizen</h3>
                     <ul className="text-slate-300 mb-6 leading-relaxed text-left space-y-2 w-full max-w-xs">
                       <li>✓ Vote on proposals &amp; funding</li>
-                      <li>✓ Access the jobs board</li>
+                      <li>✓ Apply to roles on the jobs board</li>
                       <li>✓ Eligible for flights &amp; experiences</li>
                       <li>✓ A permanent onchain identity</li>
                     </ul>
@@ -584,47 +585,14 @@ export default function Join({
             </p>
           </div>
 
-          <div className="bg-white/5 backdrop-blur-sm rounded-2xl border border-white/10 p-6 md:p-8 relative">
-            {/* Blur overlay for non-citizens */}
+          <div className="bg-white/5 backdrop-blur-sm rounded-2xl border border-white/10 p-6 md:p-8">
             {!citizen && (
-              <div className="absolute inset-0 z-10 bg-slate-900/40 backdrop-blur-[20px] rounded-2xl flex items-center justify-center">
-                <div className="text-center px-6 relative z-30">
-                  <div className="w-20 h-20 bg-blue-600/30 rounded-full flex items-center justify-center mx-auto mb-6">
-                    <svg
-                      className="w-10 h-10 text-blue-400"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                      />
-                    </svg>
-                  </div>
-                  <h3 className="text-2xl font-GoodTimes text-white mb-4 drop-shadow-lg">
-                    Citizens Only
-                  </h3>
-                  <p className="text-slate-300 mb-6 max-w-md mx-auto drop-shadow-md">
-                    Become a MoonDAO Citizen to access the jobs board and connect with teams
-                    building the future of space exploration.
-                  </p>
-                  <StandardButton
-                    className="gradient-2 hover:opacity-90 transition-opacity"
-                    textColor="text-white"
-                    borderRadius="rounded-xl"
-                    hoverEffect={false}
-                    link="/citizen"
-                  >
-                    Become a Citizen
-                  </StandardButton>
-                </div>
+              <div className="mb-6">
+                <JobCitizenUpsell variant="banner" />
               </div>
             )}
 
-            <div className={citizen ? '' : 'pointer-events-none select-none blur-md'}>
+            <div>
               {jobs && jobs.length > 0 ? (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                   {jobs.slice(0, 6).map((job: JobType, index: number) => (
@@ -663,7 +631,7 @@ export default function Join({
                           textColor="text-white"
                           borderRadius="rounded-lg"
                           hoverEffect={false}
-                          link="/jobs"
+                          link={`/jobs/${job.id}`}
                           className="text-sm py-2 px-4"
                         >
                           View Job
@@ -681,17 +649,15 @@ export default function Join({
                   <p className="text-slate-300 mb-6">
                     Check back soon for new opportunities in the Space Acceleration Network.
                   </p>
-                  {citizen && (
-                    <StandardButton
-                      backgroundColor="bg-blue-600 hover:bg-blue-700"
-                      textColor="text-white"
-                      borderRadius="rounded-xl"
-                      hoverEffect={false}
-                      link="/jobs"
-                    >
-                      View All Jobs
-                    </StandardButton>
-                  )}
+                  <StandardButton
+                    backgroundColor="bg-blue-600 hover:bg-blue-700"
+                    textColor="text-white"
+                    borderRadius="rounded-xl"
+                    hoverEffect={false}
+                    link="/jobs"
+                  >
+                    View All Jobs
+                  </StandardButton>
                 </div>
               )}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Anyone can read a MoonDAO job. How to apply is for Citizens.

Guests still see the full role — title, team, compensation, description, responsibilities, and related openings. The apply link, how-to-apply steps, and hiring process stay behind a citizenship upsell.

## What changed

- `/jobs` is no longer a blurred lock screen. Guests can browse and open any role.
- `/jobs/[id]` always renders the public description. The apply panel becomes a “Become a Citizen to apply” teaser until the visitor is a Citizen.
- Job cards hide the Apply button for guests and say “View role” instead of “View role and apply”.
- Team job boards and the join-page jobs section follow the same rule.
- Structured apply fields (`applyUrl`, `applicationRequirements`, `hiringProcess`) are stripped from the guest-facing posting.
- How-to-apply and hiring-process **markdown sections** in the body (as on the Social Media Manager posting) are also stripped for guests. The public ISR payload ships that redacted document; Citizens load the full IPFS posting in the browser.

## Testing

- Mocha: `stripJobApplicationFields` / `stripApplicationSectionsFromBody` + JobPosting JSON-LD does not publish an apply URL
- Cypress CT: `JobApplyPanel` citizen vs guest, `Job` card apply button hidden for guests

After deploy, scrapers can still read on-chain `contactInfo` and the IPFS document. This is a product gate and upsell, not a new access-control layer on Tableland.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-548d78c6-fd9a-491b-a144-858dd94cac08?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-548d78c6-fd9a-491b-a144-858dd94cac08&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

