### PR TITLE
fix(citizen): keep polling Comfy.icu RUNNING jobs

### DIFF
--- a/ui/lib/image-generator/pollComfyImageJob.ts
+++ b/ui/lib/image-generator/pollComfyImageJob.ts
@@ -16,7 +16,44 @@ const POLL_MAX_ATTEMPTS = 150
 const POLL_TRANSIENT_ERROR_LIMIT = 6
 const GET_IMAGE_MAX_RETRIES = 3
 
-const PENDING_STATUSES = new Set(['QUEUED', 'STARTED', 'INIT', 'PENDING'])
+const COMFY_SUCCESS_STATUS = 'COMPLETED'
+const COMFY_CREDIT_STATUS = 'INSUFFICIENT_CREDIT'
+const COMFY_FAILURE_STATUSES = new Set([
+  'ERROR',
+  'FAILED',
+  'CANCELLED',
+  'CANCELED',
+  'TIMEOUT',
+])
+const COMFY_GENERATING_STATUSES = new Set(['STARTED', 'RUNNING'])
+
+export type ComfyJobClass =
+  | 'pending'
+  | 'completed'
+  | 'insufficient_credit'
+  | 'failed'
+
+/**
+ * Classify a comfy.icu run status. Only known terminal statuses stop polling.
+ * In-progress and unknown statuses stay pending so a provider change (e.g.
+ * adding RUNNING on canary workers) cannot mark a live job as failed.
+ */
+export function classifyComfyJobStatus(status: unknown): ComfyJobClass {
+  if (status === COMFY_SUCCESS_STATUS) return 'completed'
+  if (status === COMFY_CREDIT_STATUS) return 'insufficient_credit'
+  if (typeof status === 'string' && COMFY_FAILURE_STATUSES.has(status)) {
+    return 'failed'
+  }
+  return 'pending'
+}
+
+export function isComfyJobPending(status: unknown): boolean {
+  return classifyComfyJobStatus(status) === 'pending'
+}
+
+export function isComfyJobGenerating(status: unknown): boolean {
+  return typeof status === 'string' && COMFY_GENERATING_STATUSES.has(status)
+}
 
 const inFlightJobIds = new Set<string>()
 const inFlightPromises = new Map<string, Promise<void>>()
@@ -136,8 +173,8 @@ export async function pollComfyImageJob(
           continue
         }
 
-        if (PENDING_STATUSES.has(job.status)) {
-          setPhase(job.status === 'STARTED' ? 'generating' : 'queued')
+        if (isComfyJobPending(job.status)) {
+          setPhase(isComfyJobGenerating(job.status) ? 'generating' : 'queued')
           await sleep(POLL_INTERVAL_MS)
           continue
         }
@@ -145,11 +182,11 @@ export async function pollComfyImageJob(
         break
       }
 
-      if (!job || PENDING_STATUSES.has(job?.status)) {
+      if (!job || isComfyJobPending(job?.status)) {
         throw new Error('Image generation timed out')
       }
 
-      if (job.status === 'COMPLETED') {
+      if (classifyComfyJobStatus(job.status) === 'completed') {
         const outputUrl = job?.output?.[0]?.url
         if (!outputUrl) {
           throw new Error('Job completed without an output image')
@@ -193,7 +230,7 @@ export async function pollComfyImageJob(
         throw lastErr ?? new Error('Failed to download generated image')
       }
 
-      if (job.status === 'INSUFFICIENT_CREDIT') {
+      if (classifyComfyJobStatus(job.status) === 'insufficient_credit') {
         setError?.('There was an error generating your image, please contact support.')
       } else {
         console.error('Job failed with status:', job.status)

--- a/ui/scripts/citizen-onboarding-image.test.ts
+++ b/ui/scripts/citizen-onboarding-image.test.ts
@@ -7,7 +7,13 @@ import {
   isUsableAiPortrait,
   restoredCitizenImageLooksLikeAi,
 } from '../lib/image-generator/citizenOnboardingImage'
-import { comfyJobStatusUrl, parseComfyJobStatus } from '../lib/image-generator/pollComfyImageJob'
+import {
+  classifyComfyJobStatus,
+  comfyJobStatusUrl,
+  isComfyJobGenerating,
+  isComfyJobPending,
+  parseComfyJobStatus,
+} from '../lib/image-generator/pollComfyImageJob'
 
 function mockFile(name: string): File {
   return new File(['x'], name, { type: 'image/png' })
@@ -293,6 +299,33 @@ describe('citizenOnboardingImage', () => {
         throw err
       }
     }
+  })
+
+  it('keeps polling through RUNNING and unknown in-progress statuses', () => {
+    for (const status of ['QUEUED', 'STARTED', 'INIT', 'PENDING', 'RUNNING']) {
+      expectEqual(classifyComfyJobStatus(status), 'pending', status)
+      expectTruthy(isComfyJobPending(status), `${status} is pending`)
+    }
+    expectTruthy(isComfyJobGenerating('STARTED'), 'STARTED generating')
+    expectTruthy(isComfyJobGenerating('RUNNING'), 'RUNNING generating')
+    expectFalsy(isComfyJobGenerating('QUEUED'), 'QUEUED not generating')
+
+    // Production outage: Comfy.icu canary workers emit RUNNING. The old
+    // allow-list treated that as a terminal failure and discarded the portrait.
+    expectTruthy(isComfyJobPending('RUNNING'), 'RUNNING must not fail the job')
+    expectEqual(classifyComfyJobStatus('COMPLETED'), 'completed', 'COMPLETED')
+    expectEqual(
+      classifyComfyJobStatus('INSUFFICIENT_CREDIT'),
+      'insufficient_credit',
+      'credits'
+    )
+    expectEqual(classifyComfyJobStatus('ERROR'), 'failed', 'ERROR')
+    expectEqual(classifyComfyJobStatus('TIMEOUT'), 'failed', 'TIMEOUT')
+    expectEqual(
+      classifyComfyJobStatus('PREPARING'),
+      'pending',
+      'unknown status stays pending'
+    )
   })
 
   it('Privy-return regression: stale full-size citizenImage must not win over crop', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was down

The MoonDAO AI Citizen portrait pipeline is **not** a Comfy.icu outage. Production still creates jobs, workers still run them, and a live generation I submitted completed in ~2.5 minutes with a valid `r2.comfy.icu` output.

What users see as “down” is the **client poller treating the new `RUNNING` status as a failure**.

Comfy.icu canary workers (`modal-L40S-25-canary`) now report:

`INIT` → `STARTED` → **`RUNNING`** → `COMPLETED`

The poller only treated `QUEUED` / `STARTED` / `INIT` / `PENDING` as in-progress. The first `RUNNING` poll exited the loop and fell into the generic failure path (`Unable to generate an image…`), then swapped in the fitted upload. Jobs kept finishing on Comfy.icu; portraits never reached Review/mint.

## Fix

- Classify only known **terminal** statuses as done/failed (`COMPLETED`, `ERROR`, `INSUFFICIENT_CREDIT`, etc.).
- Keep polling `RUNNING` and any unknown in-progress status.
- Map `STARTED` / `RUNNING` to the generating phase.
- Add a regression test so a new intermediate status cannot take the pipeline down the same way.

## Verification

- `POST /api/image-gen/citizen-image` on production: job created (`200`).
- Dummy URL job: `ERROR` as expected (bad input URL).
- Real public face photo job `wmMgmwEacm_sZkWbQ5a-i`: `RUNNING` for ~2 min, then `COMPLETED` with output.
- Unit tests in `ui/scripts/citizen-onboarding-image.test.ts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a9b388b-6e55-4299-b491-99501360a2fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a9b388b-6e55-4299-b491-99501360a2fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

