### PR TITLE
fix: stop over-reserving L2 gas for Privy and project wallets

### DIFF
--- a/ui/components/mission/MissionDeployTokenModal.tsx
+++ b/ui/components/mission/MissionDeployTokenModal.tsx
@@ -9,6 +9,7 @@ import toast from 'react-hot-toast'
 import { keccak256 } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import toastStyle from '@/lib/marketplace/marketplace-utils/toastConfig'
+import { DEFAULT_SAFE_TX_GAS } from '@/lib/safe/executionGas'
 import { toUtf8Bytes } from 'ethers/lib/utils'
 import ConditionCheckbox from '../layout/ConditionCheckbox'
 import Input from '../layout/Input'
@@ -90,7 +91,7 @@ export default function MissionDeployTokenModal({
         to: JBV5_CONTROLLER_ADDRESS,
         data: txData,
         value: '0',
-        safeTxGas: '1000000',
+        safeTxGas: DEFAULT_SAFE_TX_GAS,
       })
       setSentTxToSafe(true)
     } catch (error) {

--- a/ui/components/mission/MissionMetadataModal.tsx
+++ b/ui/components/mission/MissionMetadataModal.tsx
@@ -13,6 +13,7 @@ import toast from 'react-hot-toast'
 import { readContract } from 'thirdweb'
 import { useActiveAccount } from 'thirdweb/react'
 import { pinBlobOrFile } from '@/lib/ipfs/pinBlobOrFile'
+import { DEFAULT_SAFE_TX_GAS } from '@/lib/safe/executionGas'
 import useSafe from '@/lib/safe/useSafe'
 import useSafeApiKit from '@/lib/safe/useSafeApiKit'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -290,7 +291,7 @@ export default function MissionMetadataModal({
         to: jbControllerContract.address,
         data: txData,
         value: '0',
-        safeTxGas: '1000000',
+        safeTxGas: DEFAULT_SAFE_TX_GAS,
       })
 
       setSafeTxHash(txHash)

--- a/ui/components/subscription/GuestActions.tsx
+++ b/ui/components/subscription/GuestActions.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { readContract } from 'thirdweb'
+import { L2_GAS_BUDGET_ETH } from '@/lib/rpc/gasBudget'
 import viemChains from '@/lib/viem/viemChains'
 import Frame from '@/components/layout/Frame'
 import Action from './Action'
@@ -28,7 +29,7 @@ export default function GuestActions({
       })
 
       const formattedCost = ethers.utils.formatEther(cost.toString()).toString()
-      const estimatedMaxGas = 0.0001
+      const estimatedMaxGas = L2_GAS_BUDGET_ETH
       const totalCost = Number(formattedCost) + estimatedMaxGas
 
       if (nativeBalance >= totalCost) {

--- a/ui/components/subscription/TeamManageMembers.tsx
+++ b/ui/components/subscription/TeamManageMembers.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/hats/teamRoles'
 import useHatNames from '@/lib/hats/useHatNames'
 import useUniqueHatWearers from '@/lib/hats/useUniqueHatWearers'
+import { DEFAULT_SAFE_TX_GAS } from '@/lib/safe/executionGas'
 import useSafe from '@/lib/safe/useSafe'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import HatsABI from '../../const/abis/Hats.json'
@@ -160,7 +161,7 @@ function TeamMembers({
       // Granting the manager hat is always admin-gated, so it routes through
       // the team Safe (queued for signers to execute).
       if (tx.routing === 'safe') {
-        await queueSafeTx({ to: tx.to, data: txData, value: '0', safeTxGas: '1000000' })
+        await queueSafeTx({ to: tx.to, data: txData, value: '0', safeTxGas: DEFAULT_SAFE_TX_GAS })
         setHasAddedMember?.(true)
         toast.success('Promotion queued.')
       } else {
@@ -265,7 +266,7 @@ function TeamMembers({
                         )
 
                         if (tx.routing === 'safe') {
-                          await queueSafeTx({ to: tx.to, data: txData, value: '0', safeTxGas: '1000000' })
+                          await queueSafeTx({ to: tx.to, data: txData, value: '0', safeTxGas: DEFAULT_SAFE_TX_GAS })
                           setHasDeletedMember(true)
                         } else {
                           await account?.sendTransaction({
@@ -481,7 +482,7 @@ function TeamManageMembersModal({
 
             try {
               if (tx.routing === 'safe') {
-                await queueSafeTx({ to: tx.to, data: txData, value: '0', safeTxGas: '1000000' })
+                await queueSafeTx({ to: tx.to, data: txData, value: '0', safeTxGas: DEFAULT_SAFE_TX_GAS })
                 setHasAddedMember(true)
               } else {
                 await account?.sendTransaction({ to: tx.to, data: txData, value: '0', gas: 1000000 })

--- a/ui/cypress/integration/unit/l2-gas-budget.cy.ts
+++ b/ui/cypress/integration/unit/l2-gas-budget.cy.ts
@@ -3,11 +3,14 @@ import {
   applyFeeOverrides,
   computeMaxFeePerGas,
   feesFromProviderSnapshot,
+  hasFeeValue,
   parseGasPriceApiPayload,
 } from '@/lib/rpc/eip1559Fees'
 import { L2_GAS_BUDGET_ETH, L2_GAS_BUDGET_WEI } from '@/lib/rpc/gasBudget'
 import {
   buildSafeExecutionOptions,
+  encodeExecTransactionData,
+  estimateSafeExecutionGas,
   resolveSafeExecutionGasLimit,
 } from '@/lib/safe/executionGas'
 
@@ -54,6 +57,17 @@ describe('EIP-1559 fee math', () => {
     expect(parsed?.maxPriorityFeePerGas).to.equal(1n)
   })
 
+  it('treats a 0 tip as present and recovers maxFee from baseFee', () => {
+    expect(hasFeeValue(0n)).to.equal(true)
+    expect(hasFeeValue(undefined)).to.equal(false)
+    const parsed = parseGasPriceApiPayload({
+      baseFeePerGas: '0x1312d00',
+      maxPriorityFeePerGas: '0x0',
+    })
+    expect(parsed?.maxPriorityFeePerGas).to.equal(0n)
+    expect(parsed?.maxFeePerGas).to.equal(computeMaxFeePerGas(0x1312d00n, 0n))
+  })
+
   it('stamps API fees onto a prepared tx', () => {
     const decorated = applyFeeOverrides(
       { to: '0x1', gas: 200000n, maxFeePerGas: 1_000_000_000n },
@@ -95,6 +109,47 @@ describe('Safe execution gas', () => {
     })
     expect(options.gasLimit).to.equal('500000')
     expect(options.maxFeePerGas).to.equal('48033600')
+  })
+
+  it('encodes execTransaction and estimates via the provider', async () => {
+    const owner = '0x1111111111111111111111111111111111111111'
+    const safeTx = {
+      to: '0x2222222222222222222222222222222222222222',
+      value: '0',
+      data: '0xabcdef',
+      operation: 0,
+      safeTxGas: '0',
+      baseGas: '0',
+      gasPrice: '0',
+      gasToken: '0x0000000000000000000000000000000000000000',
+      refundReceiver: '0x0000000000000000000000000000000000000000',
+      confirmations: [
+        { owner, signature: '0x' + 'ab'.repeat(65) },
+      ],
+    }
+    const encoded = encodeExecTransactionData(safeTx)
+    expect(encoded.slice(0, 10)).to.equal('0x6a761202')
+
+    let seen: { to?: string; data?: string; from?: string } = {}
+    const estimated = await estimateSafeExecutionGas({
+      safe: {
+        getAddress: async () => '0x3333333333333333333333333333333333333333',
+      },
+      safeTx,
+      provider: {
+        getSigner: () => ({
+          getAddress: async () => owner,
+        }),
+        estimateGas: async (tx) => {
+          seen = tx
+          return { toString: () => '220000' }
+        },
+      },
+    })
+    expect(estimated).to.equal(220000n)
+    expect(seen.to).to.equal('0x3333333333333333333333333333333333333333')
+    expect(seen.from).to.equal(owner)
+    expect(seen.data).to.equal(encoded)
   })
 })
 

--- a/ui/cypress/integration/unit/l2-gas-budget.cy.ts
+++ b/ui/cypress/integration/unit/l2-gas-budget.cy.ts
@@ -11,6 +11,7 @@ import {
   buildSafeExecutionOptions,
   encodeExecTransactionData,
   estimateSafeExecutionGas,
+  minGasLimitForSafeTxGas,
   resolveSafeExecutionGasLimit,
 } from '@/lib/safe/executionGas'
 
@@ -111,6 +112,18 @@ describe('Safe execution gas', () => {
     expect(options.maxFeePerGas).to.equal('48033600')
   })
 
+  it('floors the outer limit so a queued 1M safeTxGas cannot GS010', () => {
+    const floor = minGasLimitForSafeTxGas(1_000_000n)
+    expect(floor > 1_000_000n).to.equal(true)
+    const limit = resolveSafeExecutionGasLimit({
+      isRejectionTx: false,
+      safeTxGas: 1_000_000n,
+    })
+    expect(limit).to.equal(floor)
+    const reserved = limit * computeMaxFeePerGas(ARBITRUM_GAS_PRICE_WEI, 0n)
+    expect(reserved < HAVE_WEI).to.equal(true)
+  })
+
   it('encodes execTransaction and estimates via the provider', async () => {
     const owner = '0x1111111111111111111111111111111111111111'
     const safeTx = {
@@ -130,12 +143,19 @@ describe('Safe execution gas', () => {
     const encoded = encodeExecTransactionData(safeTx)
     expect(encoded.slice(0, 10)).to.equal('0x6a761202')
 
-    let seen: { to?: string; data?: string; from?: string } = {}
+    let seen: {
+      to?: string
+      data?: string
+      from?: string
+      maxFeePerGas?: string
+    } = {}
     const estimated = await estimateSafeExecutionGas({
       safe: {
         getAddress: async () => '0x3333333333333333333333333333333333333333',
       },
       safeTx,
+      maxFeePerGas: 48_033_600n,
+      maxPriorityFeePerGas: 0n,
       provider: {
         getSigner: () => ({
           getAddress: async () => owner,
@@ -150,6 +170,7 @@ describe('Safe execution gas', () => {
     expect(seen.to).to.equal('0x3333333333333333333333333333333333333333')
     expect(seen.from).to.equal(owner)
     expect(seen.data).to.equal(encoded)
+    expect(seen.maxFeePerGas).to.equal('48033600')
   })
 })
 

--- a/ui/cypress/integration/unit/l2-gas-budget.cy.ts
+++ b/ui/cypress/integration/unit/l2-gas-budget.cy.ts
@@ -1,0 +1,125 @@
+import { computeContributionMaxUsd } from '@/lib/mission/computeContributionMaxUsd'
+import {
+  applyFeeOverrides,
+  computeMaxFeePerGas,
+  feesFromProviderSnapshot,
+  parseGasPriceApiPayload,
+} from '@/lib/rpc/eip1559Fees'
+import { L2_GAS_BUDGET_ETH, L2_GAS_BUDGET_WEI } from '@/lib/rpc/gasBudget'
+import {
+  buildSafeExecutionOptions,
+  resolveSafeExecutionGasLimit,
+} from '@/lib/safe/executionGas'
+
+// Reported production failure:
+// insufficient funds for gas * price + value
+// have 93794013200000 want 120084000000000
+const HAVE_WEI = 93794013200000n
+const WANT_WEI = 120084000000000n
+// 2_000_000 gas * 3 * 20_014_000 wei = 120_084_000_000_000
+const ARBITRUM_GAS_PRICE_WEI = 20_014_000n
+
+describe('L2 gas budget', () => {
+  it('is larger than the observed wallet lock and the failed balance', () => {
+    expect(L2_GAS_BUDGET_WEI > WANT_WEI).to.equal(true)
+    expect(L2_GAS_BUDGET_WEI > HAVE_WEI).to.equal(true)
+    expect(L2_GAS_BUDGET_ETH).to.be.closeTo(0.00025, 1e-12)
+  })
+})
+
+describe('EIP-1559 fee math', () => {
+  it('uses 2.4× base + priority', () => {
+    expect(computeMaxFeePerGas(10n, 2n)).to.equal(26n)
+  })
+
+  it('prefers block base fee over inflated provider maxFee', () => {
+    const fees = feesFromProviderSnapshot(
+      {
+        maxFeePerGas: 1_000_000_000n,
+        maxPriorityFeePerGas: 0n,
+        gasPrice: ARBITRUM_GAS_PRICE_WEI,
+      },
+      { baseFeePerGas: ARBITRUM_GAS_PRICE_WEI }
+    )
+    expect(fees.maxFeePerGas).to.equal(computeMaxFeePerGas(ARBITRUM_GAS_PRICE_WEI, 0n))
+    expect(fees.maxFeePerGas < 1_000_000_000n).to.equal(true)
+  })
+
+  it('parses the gas-price API payload', () => {
+    const parsed = parseGasPriceApiPayload({
+      maxFeePerGas: '0x2e90edd',
+      maxPriorityFeePerGas: '0x1',
+    })
+    expect(parsed?.maxFeePerGas).to.equal(0x2e90eddn)
+    expect(parsed?.maxPriorityFeePerGas).to.equal(1n)
+  })
+
+  it('stamps API fees onto a prepared tx', () => {
+    const decorated = applyFeeOverrides(
+      { to: '0x1', gas: 200000n, maxFeePerGas: 1_000_000_000n },
+      { maxFeePerGas: 48_033_600n, maxPriorityFeePerGas: 0n }
+    )
+    expect(decorated.maxFeePerGas).to.equal(48_033_600n)
+    expect(decorated.gas).to.equal(200000n)
+  })
+})
+
+describe('Safe execution gas', () => {
+  it('reproduces the reported want amount from the old 2M * 3x gasPrice lock', () => {
+    const oldWant = 2_000_000n * 3n * ARBITRUM_GAS_PRICE_WEI
+    expect(oldWant).to.equal(WANT_WEI)
+    expect(HAVE_WEI < oldWant).to.equal(true)
+  })
+
+  it('falls back well below the reported wallet balance', () => {
+    const gasLimit = resolveSafeExecutionGasLimit({ isRejectionTx: false })
+    const maxFee = computeMaxFeePerGas(ARBITRUM_GAS_PRICE_WEI, 0n)
+    const reserved = gasLimit * maxFee
+    expect(reserved < HAVE_WEI).to.equal(true)
+    expect(reserved < WANT_WEI).to.equal(true)
+  })
+
+  it('buffers an estimate without returning to the 2M default', () => {
+    const gasLimit = resolveSafeExecutionGasLimit({
+      estimatedGas: 200_000n,
+      isRejectionTx: false,
+    })
+    expect(gasLimit).to.equal(300_000n)
+  })
+
+  it('builds string options the Safe SDK accepts', () => {
+    const options = buildSafeExecutionOptions({
+      isRejectionTx: false,
+      maxFeePerGas: 48_033_600n,
+      maxPriorityFeePerGas: 0n,
+    })
+    expect(options.gasLimit).to.equal('500000')
+    expect(options.maxFeePerGas).to.equal('48033600')
+  })
+})
+
+describe('computeContributionMaxUsd L2 reserve', () => {
+  it('leaves the shared L2 budget behind on Arbitrum', () => {
+    const maxUsd = computeContributionMaxUsd({
+      balanceWei: 10n ** 16n, // 0.01 ETH
+      selectedChainId: 42161,
+      chainSlug: 'arbitrum',
+      defaultChainSlug: 'arbitrum',
+      ethUsdPrice: 3000,
+    })
+    // (0.01 - 0.00025) ETH * $3000 = $29.25
+    expect(maxUsd).to.equal(29.25)
+  })
+
+  it('does not treat 0.00015 ETH as spendable (old 0.0001 reserve would have)', () => {
+    expect(
+      computeContributionMaxUsd({
+        balanceWei: 150000000000000n,
+        selectedChainId: 42161,
+        chainSlug: 'arbitrum',
+        defaultChainSlug: 'arbitrum',
+        ethUsdPrice: 3000,
+      })
+    ).to.equal(null)
+  })
+})

--- a/ui/lib/deprize/gas-reserve.ts
+++ b/ui/lib/deprize/gas-reserve.ts
@@ -1,3 +1,5 @@
+import { L2_GAS_BUDGET_WEI } from '@/lib/rpc/gasBudget'
+
 /**
  * Native ETH held back from the "spendable" figure so placing a bet can never
  * consume the gas needed to send it.
@@ -11,8 +13,8 @@
 /** Conservative default for L1-style gas markets. */
 export const DEFAULT_GAS_RESERVE_WEI = 10n ** 15n // 0.001 ETH
 
-/** ~8x a measured Arbitrum bet, so it still covers a busy-network spike. */
-export const L2_GAS_RESERVE_WEI = 2n * 10n ** 14n // 0.0002 ETH
+/** Shared L2 budget — covers the observed ~0.00012 ETH wallet lock. */
+export const L2_GAS_RESERVE_WEI = L2_GAS_BUDGET_WEI
 
 const GAS_RESERVE_WEI_BY_CHAIN: Record<number, bigint> = {
   42161: L2_GAS_RESERVE_WEI, // Arbitrum One

--- a/ui/lib/google/hsm-signer.ts
+++ b/ui/lib/google/hsm-signer.ts
@@ -11,7 +11,7 @@
  * - Proxies unknown JSON-RPC methods to the configured RPC node
  */
 import { KeyManagementServiceClient } from '@google-cloud/kms'
-import { utils, providers } from 'ethers'
+import { BigNumber, providers, utils } from 'ethers'
 import {
   arrayify,
   hexlify,
@@ -19,6 +19,7 @@ import {
   toUtf8Bytes,
   joinSignature,
 } from 'ethers/lib/utils'
+import { resolveEip1559FeesFromProvider } from '@/lib/rpc/eip1559Fees'
 import { arbitrum, sepolia } from '../rpc/chains'
 
 // -----------------------------
@@ -324,6 +325,7 @@ export async function sendTransaction(
   const nonce = await provider.getTransactionCount(from)
   const fee = await provider.getFeeData()
   const network = await provider.getNetwork()
+  const eip1559 = await resolveHsmEip1559Fees(provider, tx, fee)
 
   // Estimate gas if not provided
   let gasLimit = tx.gasLimit
@@ -350,8 +352,8 @@ export async function sendTransaction(
     type: 2,
     chainId: network.chainId,
     gasLimit,
-    maxFeePerGas: tx.maxFeePerGas ?? fee.maxFeePerGas ?? fee.gasPrice,
-    maxPriorityFeePerGas: tx.maxPriorityFeePerGas ?? fee.maxPriorityFeePerGas,
+    maxFeePerGas: eip1559.maxFeePerGas,
+    maxPriorityFeePerGas: eip1559.maxPriorityFeePerGas,
   }
 
   console.log('HSM sendTransaction - Final transaction:', {
@@ -412,6 +414,41 @@ function getHSMProvider(): providers.JsonRpcProvider {
   )
 }
 
+function toFeeBigNumber(value: bigint): BigNumber {
+  return BigNumber.from(value.toString())
+}
+
+async function resolveHsmEip1559Fees(
+  provider: providers.Provider,
+  tx: { maxFeePerGas?: unknown; maxPriorityFeePerGas?: unknown },
+  fee: providers.FeeData
+): Promise<{ maxFeePerGas: BigNumber; maxPriorityFeePerGas?: BigNumber }> {
+  try {
+    const resolved = await resolveEip1559FeesFromProvider(provider)
+    if (resolved.maxFeePerGas > 0n) {
+      return {
+        maxFeePerGas: toFeeBigNumber(resolved.maxFeePerGas),
+        maxPriorityFeePerGas: toFeeBigNumber(resolved.maxPriorityFeePerGas),
+      }
+    }
+  } catch (error) {
+    console.warn(
+      'HSM EIP-1559 fee resolve failed, falling back to provider fee data:',
+      error
+    )
+  }
+  return {
+    maxFeePerGas: (tx.maxFeePerGas as BigNumber | undefined) ??
+      fee.maxFeePerGas ??
+      fee.gasPrice ??
+      BigNumber.from(0),
+    maxPriorityFeePerGas:
+      (tx.maxPriorityFeePerGas as BigNumber | undefined) ??
+      fee.maxPriorityFeePerGas ??
+      undefined,
+  }
+}
+
 // Sign a fully-populated EIP-1559 tx object with the KMS key and return the
 // serialized raw tx, recovering the correct `v`. Shared by the single-send
 // and batch-send paths so their signing logic can't drift apart.
@@ -461,6 +498,7 @@ export async function sendTransactionBatch(
   const from = (await getPublicKey(cfg)).address
   const fee = await provider.getFeeData()
   const network = await provider.getNetwork()
+  const eip1559 = await resolveHsmEip1559Fees(provider, {}, fee)
   let nonce = await provider.getTransactionCount(from, 'pending')
 
   const hashes: string[] = []
@@ -491,8 +529,8 @@ export async function sendTransactionBatch(
         type: 2,
         chainId: network.chainId,
         gasLimit,
-        maxFeePerGas: fee.maxFeePerGas ?? fee.gasPrice,
-        maxPriorityFeePerGas: fee.maxPriorityFeePerGas ?? undefined,
+        maxFeePerGas: eip1559.maxFeePerGas,
+        maxPriorityFeePerGas: eip1559.maxPriorityFeePerGas,
       }
 
       const raw = await signSerializedTx(cfg, finalTx, from)

--- a/ui/lib/mission/computeContributionMaxUsd.ts
+++ b/ui/lib/mission/computeContributionMaxUsd.ts
@@ -1,16 +1,17 @@
 import { LAYERZERO_MAX_CONTRIBUTION_ETH } from 'const/config'
 import { arbitrum, base, ethereum } from '@/lib/rpc/chains'
+import { L2_GAS_BUDGET_WEI } from '@/lib/rpc/gasBudget'
 
 const WEI = BigInt('1000000000000000000')
 
-/** 0.0001 ETH — Arbitrum / Base same-chain gas reserve */
-const RESERVE_WEI_LOW = BigInt('100000000000000')
+/** Shared L2 budget — must cover wallet `gasLimit * maxFeePerGas` lock. */
+const RESERVE_WEI_LOW = L2_GAS_BUDGET_WEI
 /** 0.001 ETH — default same-chain reserve, cross-chain leave-behind */
 const RESERVE_WEI_DEFAULT = BigInt('1000000000000000')
 
 /**
  * Max USD contribution from native ETH balance, matching mission contribute modal / pay card rules:
- * same-chain gas reserves (Arbitrum/Base 0.0001 ETH, mainnet 0.001 ETH, else 0.001),
+ * same-chain gas reserves (Arbitrum/Base L2 budget, mainnet 0.001 ETH, else 0.001),
  * cross-chain leaves 0.001 ETH, LayerZero cap from config for eth/base sources.
  */
 export function computeContributionMaxUsd(input: {

--- a/ui/lib/privy/PrivyThirdwebV5Provider.tsx
+++ b/ui/lib/privy/PrivyThirdwebV5Provider.tsx
@@ -9,6 +9,7 @@ import {
   useSetActiveWallet,
 } from 'thirdweb/react'
 import { createWalletAdapter } from 'thirdweb/wallets'
+import { withClientFeeOverrides } from '@/lib/rpc/eip1559Fees'
 import client from '@/lib/thirdweb/client'
 import { getWalletEthersProvider } from './getWalletEthersProvider'
 import PrivyWalletContext from './privy-wallet-context'
@@ -67,6 +68,21 @@ export function PrivyThirdwebV5Provider({ selectedChain, children }: any) {
         const adaptedAccount = await ethers5Adapter.signer.fromEthers({
           signer,
         })
+
+        // Privy / wallet RPCs often populate inflated maxFeePerGas. Nodes then
+        // reject with "insufficient funds for gas * price + value" even when
+        // the signer has enough ETH for the real L2 fee. Stamp our gas-price
+        // API values (2.4× base + priority) onto every send from this adapter.
+        const originalSendTransaction = adaptedAccount.sendTransaction.bind(
+          adaptedAccount
+        )
+        adaptedAccount.sendTransaction = async (tx) => {
+          const decorated = await withClientFeeOverrides(
+            tx as Record<string, unknown>,
+            selectedChain.id
+          )
+          return originalSendTransaction(decorated as typeof tx)
+        }
 
         const thirdwebWallet = createWalletAdapter({
           adaptedAccount,

--- a/ui/lib/rpc/eip1559Fees.ts
+++ b/ui/lib/rpc/eip1559Fees.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared EIP-1559 fee math.
+ *
+ * Wallet providers (Privy embedded, some RPCs) return inflated `getFeeData()`
+ * values. We compute maxFee from the block base fee instead: 2.4× base +
+ * priority, matching `/api/rpc/gas-price` and the contribute-modal budget.
+ */
+
+export const MAX_FEE_BASE_MULTIPLIER_BPS = 240n
+
+export function computeMaxFeePerGas(
+  baseFeePerGas: bigint,
+  maxPriorityFeePerGas: bigint
+): bigint {
+  return (
+    (baseFeePerGas * MAX_FEE_BASE_MULTIPLIER_BPS) / 100n + maxPriorityFeePerGas
+  )
+}
+
+export type Eip1559FeeOverrides = {
+  maxFeePerGas: bigint
+  maxPriorityFeePerGas: bigint
+}
+
+type FeeLike = { toString(): string } | null | undefined
+
+export type FeeDataLike = {
+  maxFeePerGas?: FeeLike
+  maxPriorityFeePerGas?: FeeLike
+  gasPrice?: FeeLike
+}
+
+export type BlockLike = {
+  baseFeePerGas?: FeeLike
+} | null
+
+function toBigInt(value: FeeLike): bigint {
+  if (value == null) return 0n
+  return BigInt(value.toString())
+}
+
+export function feesFromBaseAndPriority(
+  baseFeePerGas: bigint,
+  maxPriorityFeePerGas: bigint,
+  fallbackMaxFeePerGas = 0n
+): Eip1559FeeOverrides {
+  if (baseFeePerGas > 0n) {
+    return {
+      maxFeePerGas: computeMaxFeePerGas(baseFeePerGas, maxPriorityFeePerGas),
+      maxPriorityFeePerGas,
+    }
+  }
+  return {
+    maxFeePerGas: fallbackMaxFeePerGas,
+    maxPriorityFeePerGas,
+  }
+}
+
+export function feesFromProviderSnapshot(
+  fee: FeeDataLike,
+  block: BlockLike
+): Eip1559FeeOverrides {
+  const priority = toBigInt(fee.maxPriorityFeePerGas)
+  const baseFee = toBigInt(block?.baseFeePerGas)
+  const fallback = toBigInt(fee.maxFeePerGas) || toBigInt(fee.gasPrice)
+  return feesFromBaseAndPriority(baseFee, priority, fallback)
+}
+
+export async function resolveEip1559FeesFromProvider(provider: {
+  getFeeData: () => Promise<FeeDataLike>
+  getBlock: (tag: string) => Promise<BlockLike>
+}): Promise<Eip1559FeeOverrides> {
+  const [fee, block] = await Promise.all([
+    provider.getFeeData(),
+    provider.getBlock('latest'),
+  ])
+  return feesFromProviderSnapshot(fee, block)
+}
+
+export function parseGasPriceApiPayload(
+  data: Record<string, unknown> | null | undefined
+): Eip1559FeeOverrides | null {
+  if (!data) return null
+  const maxFeeRaw = data.maxFeePerGas
+  const priorityRaw = data.maxPriorityFeePerGas
+  if (typeof maxFeeRaw !== 'string' && typeof maxFeeRaw !== 'number') {
+    return null
+  }
+  if (typeof priorityRaw !== 'string' && typeof priorityRaw !== 'number') {
+    return null
+  }
+  try {
+    const maxFeePerGas = BigInt(maxFeeRaw)
+    const maxPriorityFeePerGas = BigInt(priorityRaw)
+    if (maxFeePerGas <= 0n) return null
+    return { maxFeePerGas, maxPriorityFeePerGas }
+  } catch {
+    return null
+  }
+}
+
+export async function fetchClientFeeOverrides(
+  chainId: number
+): Promise<Eip1559FeeOverrides | null> {
+  const response = await fetch(`/api/rpc/gas-price?chainId=${chainId}`)
+  if (!response.ok) return null
+  const data = await response.json()
+  return parseGasPriceApiPayload(data)
+}
+
+export function applyFeeOverrides<T extends Record<string, unknown>>(
+  tx: T,
+  fees: Eip1559FeeOverrides
+): T {
+  return {
+    ...tx,
+    maxFeePerGas: fees.maxFeePerGas,
+    maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+  }
+}
+
+export async function withClientFeeOverrides<T extends Record<string, unknown>>(
+  tx: T,
+  chainId: number
+): Promise<T> {
+  try {
+    const fees = await fetchClientFeeOverrides(chainId)
+    if (!fees) return tx
+    return applyFeeOverrides(tx, fees)
+  } catch {
+    return tx
+  }
+}

--- a/ui/lib/rpc/eip1559Fees.ts
+++ b/ui/lib/rpc/eip1559Fees.ts
@@ -77,26 +77,41 @@ export async function resolveEip1559FeesFromProvider(provider: {
   return feesFromProviderSnapshot(fee, block)
 }
 
+export function parseOptionalHexBigInt(value: unknown): bigint | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined
+  try {
+    return BigInt(value)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * `0n` is a valid Arbitrum tip. Treat only `undefined` as missing so we still
+ * emit / consume fee fields when `eth_maxPriorityFeePerGas` returns 0.
+ */
+export function hasFeeValue(value: bigint | undefined): value is bigint {
+  return value !== undefined
+}
+
 export function parseGasPriceApiPayload(
   data: Record<string, unknown> | null | undefined
 ): Eip1559FeeOverrides | null {
   if (!data) return null
-  const maxFeeRaw = data.maxFeePerGas
-  const priorityRaw = data.maxPriorityFeePerGas
-  if (typeof maxFeeRaw !== 'string' && typeof maxFeeRaw !== 'number') {
-    return null
+  const priority = parseOptionalHexBigInt(data.maxPriorityFeePerGas) ?? 0n
+  const maxFee = parseOptionalHexBigInt(data.maxFeePerGas)
+  if (maxFee !== undefined && maxFee > 0n) {
+    return { maxFeePerGas: maxFee, maxPriorityFeePerGas: priority }
   }
-  if (typeof priorityRaw !== 'string' && typeof priorityRaw !== 'number') {
-    return null
+  // Recover when the API omitted maxFee/priority because 0n is falsy.
+  const baseFee = parseOptionalHexBigInt(data.baseFeePerGas)
+  if (baseFee !== undefined && baseFee > 0n) {
+    return {
+      maxFeePerGas: computeMaxFeePerGas(baseFee, priority),
+      maxPriorityFeePerGas: priority,
+    }
   }
-  try {
-    const maxFeePerGas = BigInt(maxFeeRaw)
-    const maxPriorityFeePerGas = BigInt(priorityRaw)
-    if (maxFeePerGas <= 0n) return null
-    return { maxFeePerGas, maxPriorityFeePerGas }
-  } catch {
-    return null
-  }
+  return null
 }
 
 export async function fetchClientFeeOverrides(

--- a/ui/lib/rpc/gasBudget.ts
+++ b/ui/lib/rpc/gasBudget.ts
@@ -1,0 +1,11 @@
+/**
+ * Native ETH we budget for a typical Arbitrum / Base contract call.
+ *
+ * Wallets and nodes lock `gasLimit * maxFeePerGas` *before* the tx lands, and
+ * refund the unused reserve. A real L2 call often costs ~0.00001–0.00003 ETH,
+ * but conservative limits (and a 2.4× EIP-1559 cap) have required ~0.00012 ETH
+ * up front. 0.00025 ETH covers that lock with room for a busy-network spike.
+ */
+export const L2_GAS_BUDGET_WEI = 25n * 10n ** 13n // 0.00025 ETH
+
+export const L2_GAS_BUDGET_ETH = Number(L2_GAS_BUDGET_WEI) / 1e18

--- a/ui/lib/safe/executionGas.ts
+++ b/ui/lib/safe/executionGas.ts
@@ -1,0 +1,93 @@
+import { TransactionOptions } from '@safe-global/safe-core-sdk-types'
+import { resolveEip1559FeesFromProvider } from '@/lib/rpc/eip1559Fees'
+
+/**
+ * Project Safe `execTransaction` typically lands in the 150–400k gas range.
+ * Hardcoding 2M/3M made nodes demand `gasLimit * maxFee` of ~0.00012 ETH on
+ * Arbitrum at ~0.02 gwei — more than many Privy / project-signer balances.
+ */
+const FALLBACK_GAS_LIMIT = 500_000n
+const REJECTION_FALLBACK_GAS_LIMIT = 750_000n
+const MAX_GAS_LIMIT = 1_500_000n
+const REJECTION_MAX_GAS_LIMIT = 2_000_000n
+const MIN_GAS_LIMIT = 150_000n
+const ESTIMATE_BUFFER_BPS = 150n
+
+export function resolveSafeExecutionGasLimit(params: {
+  estimatedGas?: bigint | null
+  isRejectionTx: boolean
+}): bigint {
+  const fallback = params.isRejectionTx
+    ? REJECTION_FALLBACK_GAS_LIMIT
+    : FALLBACK_GAS_LIMIT
+  const cap = params.isRejectionTx ? REJECTION_MAX_GAS_LIMIT : MAX_GAS_LIMIT
+  const estimated = params.estimatedGas
+  if (estimated == null || estimated <= 0n) return fallback
+
+  const buffered = (estimated * ESTIMATE_BUFFER_BPS) / 100n
+  if (buffered < MIN_GAS_LIMIT) return MIN_GAS_LIMIT
+  if (buffered > cap) return cap
+  return buffered
+}
+
+export function buildSafeExecutionOptions(params: {
+  estimatedGas?: bigint | null
+  isRejectionTx: boolean
+  maxFeePerGas: bigint
+  maxPriorityFeePerGas: bigint
+}): TransactionOptions {
+  return {
+    gasLimit: resolveSafeExecutionGasLimit(params).toString(),
+    maxFeePerGas: params.maxFeePerGas.toString(),
+    maxPriorityFeePerGas: params.maxPriorityFeePerGas.toString(),
+  }
+}
+
+export async function estimateSafeExecutionGas(
+  safe: {
+    estimateGas?: (tx: unknown) => Promise<unknown>
+    getEstimatedGas?: (tx: unknown) => Promise<unknown>
+  },
+  safeTx: unknown
+): Promise<bigint | null> {
+  const estimator = safe.getEstimatedGas ?? safe.estimateGas
+  if (!estimator) return null
+  try {
+    const est = await estimator.call(safe, safeTx)
+    if (est == null) return null
+    const value = BigInt(est.toString())
+    return value > 0n ? value : null
+  } catch {
+    return null
+  }
+}
+
+export async function resolveSafeExecutionOptions(params: {
+  safe: {
+    estimateGas?: (tx: unknown) => Promise<unknown>
+    getEstimatedGas?: (tx: unknown) => Promise<unknown>
+  }
+  safeTx: unknown
+  isRejectionTx: boolean
+  provider: {
+    getFeeData: () => Promise<{
+      maxFeePerGas?: { toString(): string } | null
+      maxPriorityFeePerGas?: { toString(): string } | null
+      gasPrice?: { toString(): string } | null
+    }>
+    getBlock: (tag: string) => Promise<{
+      baseFeePerGas?: { toString(): string } | null
+    } | null>
+  }
+}): Promise<TransactionOptions> {
+  const [estimatedGas, fees] = await Promise.all([
+    estimateSafeExecutionGas(params.safe, params.safeTx),
+    resolveEip1559FeesFromProvider(params.provider),
+  ])
+  return buildSafeExecutionOptions({
+    estimatedGas,
+    isRejectionTx: params.isRejectionTx,
+    maxFeePerGas: fees.maxFeePerGas,
+    maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+  })
+}

--- a/ui/lib/safe/executionGas.ts
+++ b/ui/lib/safe/executionGas.ts
@@ -1,4 +1,5 @@
 import { TransactionOptions } from '@safe-global/safe-core-sdk-types'
+import { ethers } from 'ethers'
 import { resolveEip1559FeesFromProvider } from '@/lib/rpc/eip1559Fees'
 
 /**
@@ -12,6 +13,25 @@ const MAX_GAS_LIMIT = 1_500_000n
 const REJECTION_MAX_GAS_LIMIT = 2_000_000n
 const MIN_GAS_LIMIT = 150_000n
 const ESTIMATE_BUFFER_BPS = 150n
+
+const EXEC_TRANSACTION_IFACE = new ethers.utils.Interface([
+  'function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures)',
+])
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+export type SafeExecTxLike = {
+  to?: string
+  value?: string
+  data?: string
+  operation?: number
+  safeTxGas?: string
+  baseGas?: string
+  gasPrice?: string
+  gasToken?: string
+  refundReceiver?: string
+  confirmations?: Array<{ owner?: string; signature?: string }>
+}
 
 export function resolveSafeExecutionGasLimit(params: {
   estimatedGas?: bigint | null
@@ -43,18 +63,84 @@ export function buildSafeExecutionOptions(params: {
   }
 }
 
-export async function estimateSafeExecutionGas(
+function packConfirmations(
+  confirmations: Array<{ owner?: string; signature?: string }> | undefined
+): string {
+  const sorted = [...(confirmations ?? [])]
+    .filter((c) => c.signature)
+    .sort((a, b) =>
+      (a.owner ?? '').toLowerCase().localeCompare((b.owner ?? '').toLowerCase())
+    )
+  return `0x${sorted.map((c) => (c.signature ?? '').replace(/^0x/i, '')).join('')}`
+}
+
+/** Encode Safe `execTransaction` from a Transaction Service payload. */
+export function encodeExecTransactionData(safeTx: SafeExecTxLike): string {
+  if (!safeTx.to) {
+    throw new Error('Safe transaction is missing `to`')
+  }
+  return EXEC_TRANSACTION_IFACE.encodeFunctionData('execTransaction', [
+    safeTx.to,
+    safeTx.value ?? '0',
+    safeTx.data || '0x',
+    safeTx.operation ?? 0,
+    safeTx.safeTxGas ?? '0',
+    safeTx.baseGas ?? '0',
+    safeTx.gasPrice ?? '0',
+    safeTx.gasToken || ZERO_ADDRESS,
+    safeTx.refundReceiver || ZERO_ADDRESS,
+    packConfirmations(safeTx.confirmations),
+  ])
+}
+
+async function encodeSafeExecCalldata(
   safe: {
-    estimateGas?: (tx: unknown) => Promise<unknown>
-    getEstimatedGas?: (tx: unknown) => Promise<unknown>
+    getEncodedTransaction?: (tx: unknown) => Promise<string>
   },
   safeTx: unknown
-): Promise<bigint | null> {
-  const estimator = safe.getEstimatedGas ?? safe.estimateGas
-  if (!estimator) return null
+): Promise<string | null> {
+  if (typeof safe.getEncodedTransaction === 'function') {
+    try {
+      const encoded = await safe.getEncodedTransaction(safeTx)
+      if (encoded && encoded !== '0x') return encoded
+    } catch {
+      // API-kit payloads are not always a protocol-kit SafeTransaction.
+    }
+  }
   try {
-    const est = await estimator.call(safe, safeTx)
-    if (est == null) return null
+    return encodeExecTransactionData(safeTx as SafeExecTxLike)
+  } catch {
+    return null
+  }
+}
+
+export async function estimateSafeExecutionGas(params: {
+  safe: {
+    getAddress: () => Promise<string>
+    getEncodedTransaction?: (tx: unknown) => Promise<string>
+  }
+  safeTx: unknown
+  provider: {
+    estimateGas: (tx: {
+      to: string
+      from?: string
+      data: string
+    }) => Promise<{ toString(): string }>
+    getSigner?: () => { getAddress: () => Promise<string> }
+  }
+}): Promise<bigint | null> {
+  try {
+    const data = await encodeSafeExecCalldata(params.safe, params.safeTx)
+    if (!data) return null
+    const to = await params.safe.getAddress()
+    const from = params.provider.getSigner
+      ? await params.provider.getSigner().getAddress()
+      : undefined
+    const est = await params.provider.estimateGas({
+      to,
+      data,
+      ...(from ? { from } : {}),
+    })
     const value = BigInt(est.toString())
     return value > 0n ? value : null
   } catch {
@@ -64,8 +150,8 @@ export async function estimateSafeExecutionGas(
 
 export async function resolveSafeExecutionOptions(params: {
   safe: {
-    estimateGas?: (tx: unknown) => Promise<unknown>
-    getEstimatedGas?: (tx: unknown) => Promise<unknown>
+    getAddress: () => Promise<string>
+    getEncodedTransaction?: (tx: unknown) => Promise<string>
   }
   safeTx: unknown
   isRejectionTx: boolean
@@ -78,10 +164,20 @@ export async function resolveSafeExecutionOptions(params: {
     getBlock: (tag: string) => Promise<{
       baseFeePerGas?: { toString(): string } | null
     } | null>
+    estimateGas: (tx: {
+      to: string
+      from?: string
+      data: string
+    }) => Promise<{ toString(): string }>
+    getSigner?: () => { getAddress: () => Promise<string> }
   }
 }): Promise<TransactionOptions> {
   const [estimatedGas, fees] = await Promise.all([
-    estimateSafeExecutionGas(params.safe, params.safeTx),
+    estimateSafeExecutionGas({
+      safe: params.safe,
+      safeTx: params.safeTx,
+      provider: params.provider,
+    }),
     resolveEip1559FeesFromProvider(params.provider),
   ])
   return buildSafeExecutionOptions({

--- a/ui/lib/safe/executionGas.ts
+++ b/ui/lib/safe/executionGas.ts
@@ -13,6 +13,11 @@ const MAX_GAS_LIMIT = 1_500_000n
 const REJECTION_MAX_GAS_LIMIT = 2_000_000n
 const MIN_GAS_LIMIT = 150_000n
 const ESTIMATE_BUFFER_BPS = 150n
+/** Signature checks + execTransaction overhead above the GS010 remaining-gas check. */
+const EXEC_TRANSACTION_OVERHEAD = 80_000n
+
+/** New Safe txs should leave this at 0 so the contract forwards all remaining gas. */
+export const DEFAULT_SAFE_TX_GAS = '0'
 
 const EXEC_TRANSACTION_IFACE = new ethers.utils.Interface([
   'function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures)',
@@ -33,26 +38,55 @@ export type SafeExecTxLike = {
   confirmations?: Array<{ owner?: string; signature?: string }>
 }
 
+export function parseSafeTxGas(safeTx: unknown): bigint {
+  const raw = (safeTx as SafeExecTxLike | undefined)?.safeTxGas
+  if (raw == null || raw === '') return 0n
+  try {
+    const value = BigInt(raw)
+    return value > 0n ? value : 0n
+  } catch {
+    return 0n
+  }
+}
+
+/**
+ * Outer gas that must be supplied so Safe does not revert GS010
+ * (`gasleft() < max(safeTxGas * 64/63, safeTxGas + 2500) + 500`).
+ */
+export function minGasLimitForSafeTxGas(safeTxGas: bigint): bigint {
+  if (safeTxGas <= 0n) return 0n
+  const scaled = (safeTxGas * 64n) / 63n
+  const inner = scaled > safeTxGas + 2500n ? scaled : safeTxGas + 2500n
+  return inner + 500n + EXEC_TRANSACTION_OVERHEAD
+}
+
 export function resolveSafeExecutionGasLimit(params: {
   estimatedGas?: bigint | null
   isRejectionTx: boolean
+  safeTxGas?: bigint | null
 }): bigint {
   const fallback = params.isRejectionTx
     ? REJECTION_FALLBACK_GAS_LIMIT
     : FALLBACK_GAS_LIMIT
   const cap = params.isRejectionTx ? REJECTION_MAX_GAS_LIMIT : MAX_GAS_LIMIT
+  const safeFloor = minGasLimitForSafeTxGas(params.safeTxGas ?? 0n)
   const estimated = params.estimatedGas
-  if (estimated == null || estimated <= 0n) return fallback
 
-  const buffered = (estimated * ESTIMATE_BUFFER_BPS) / 100n
-  if (buffered < MIN_GAS_LIMIT) return MIN_GAS_LIMIT
-  if (buffered > cap) return cap
-  return buffered
+  let limit =
+    estimated == null || estimated <= 0n
+      ? fallback
+      : (estimated * ESTIMATE_BUFFER_BPS) / 100n
+  if (limit < MIN_GAS_LIMIT) limit = MIN_GAS_LIMIT
+  if (limit < safeFloor) limit = safeFloor
+  if (limit > cap && safeFloor <= cap) limit = cap
+  if (limit < safeFloor) limit = safeFloor
+  return limit
 }
 
 export function buildSafeExecutionOptions(params: {
   estimatedGas?: bigint | null
   isRejectionTx: boolean
+  safeTxGas?: bigint | null
   maxFeePerGas: bigint
   maxPriorityFeePerGas: bigint
 }): TransactionOptions {
@@ -120,11 +154,15 @@ export async function estimateSafeExecutionGas(params: {
     getEncodedTransaction?: (tx: unknown) => Promise<string>
   }
   safeTx: unknown
+  maxFeePerGas?: bigint
+  maxPriorityFeePerGas?: bigint
   provider: {
     estimateGas: (tx: {
       to: string
       from?: string
       data: string
+      maxFeePerGas?: string
+      maxPriorityFeePerGas?: string
     }) => Promise<{ toString(): string }>
     getSigner?: () => { getAddress: () => Promise<string> }
   }
@@ -136,10 +174,18 @@ export async function estimateSafeExecutionGas(params: {
     const from = params.provider.getSigner
       ? await params.provider.getSigner().getAddress()
       : undefined
+    const feeFields =
+      params.maxFeePerGas != null && params.maxFeePerGas > 0n
+        ? {
+            maxFeePerGas: params.maxFeePerGas.toString(),
+            maxPriorityFeePerGas: (params.maxPriorityFeePerGas ?? 0n).toString(),
+          }
+        : {}
     const est = await params.provider.estimateGas({
       to,
       data,
       ...(from ? { from } : {}),
+      ...feeFields,
     })
     const value = BigInt(est.toString())
     return value > 0n ? value : null
@@ -168,21 +214,27 @@ export async function resolveSafeExecutionOptions(params: {
       to: string
       from?: string
       data: string
+      maxFeePerGas?: string
+      maxPriorityFeePerGas?: string
     }) => Promise<{ toString(): string }>
     getSigner?: () => { getAddress: () => Promise<string> }
   }
 }): Promise<TransactionOptions> {
-  const [estimatedGas, fees] = await Promise.all([
-    estimateSafeExecutionGas({
-      safe: params.safe,
-      safeTx: params.safeTx,
-      provider: params.provider,
-    }),
-    resolveEip1559FeesFromProvider(params.provider),
-  ])
+  // Resolve fees first so estimateGas uses the same (non-inflated) cap the
+  // signed tx will. Passing `from` without fees can make the node apply
+  // wallet getFeeData() and reject the estimate as insufficient funds.
+  const fees = await resolveEip1559FeesFromProvider(params.provider)
+  const estimatedGas = await estimateSafeExecutionGas({
+    safe: params.safe,
+    safeTx: params.safeTx,
+    provider: params.provider,
+    maxFeePerGas: fees.maxFeePerGas,
+    maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+  })
   return buildSafeExecutionOptions({
     estimatedGas,
     isRejectionTx: params.isRejectionTx,
+    safeTxGas: parseSafeTxGas(params.safeTx),
     maxFeePerGas: fees.maxFeePerGas,
     maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
   })

--- a/ui/lib/safe/useSafe.tsx
+++ b/ui/lib/safe/useSafe.tsx
@@ -20,7 +20,7 @@ import { getWalletEthersProvider } from '../privy/getWalletEthersProvider'
 import PrivyWalletContext from '../privy/privy-wallet-context'
 import ChainContextV5 from '../thirdweb/chain-context-v5'
 import client from '../thirdweb/client'
-import { resolveSafeExecutionOptions } from './executionGas'
+import { DEFAULT_SAFE_TX_GAS, resolveSafeExecutionOptions } from './executionGas'
 import useSafeApiKit from './useSafeApiKit'
 
 export type PendingTransaction =
@@ -199,7 +199,7 @@ export default function useSafe(
       value: '0',
       data: (contractManager.safeContract as any).encode(method, args),
       operation: 0,
-      safeTxGas: '1000000',
+      safeTxGas: DEFAULT_SAFE_TX_GAS,
       baseGas: '0',
       gasPrice: '0',
       gasToken: ethers.constants.AddressZero,
@@ -380,7 +380,7 @@ export default function useSafe(
         value: '0',
         data: '0x', // Empty data for rejection
         operation: 0,
-        safeTxGas: '1000000',
+        safeTxGas: DEFAULT_SAFE_TX_GAS,
         baseGas: '0',
         gasPrice: '0',
         gasToken: ethers.constants.AddressZero,
@@ -577,7 +577,7 @@ export default function useSafe(
         value: '0',
         data,
         operation: 0,
-        safeTxGas: '1000000',
+        safeTxGas: DEFAULT_SAFE_TX_GAS,
         baseGas: '0',
         gasPrice: '0',
         gasToken: ethers.constants.AddressZero,
@@ -601,7 +601,7 @@ export default function useSafe(
         value: amount,
         data: '0x',
         operation: 0,
-        safeTxGas: '1000000',
+        safeTxGas: DEFAULT_SAFE_TX_GAS,
         baseGas: '0',
         gasPrice: '0',
         gasToken: ethers.constants.AddressZero,

--- a/ui/lib/safe/useSafe.tsx
+++ b/ui/lib/safe/useSafe.tsx
@@ -9,7 +9,6 @@ import {
   SafeTransaction,
   SafeTransactionData,
   SafeTransactionDataPartial,
-  TransactionOptions,
 } from '@safe-global/safe-core-sdk-types'
 import ERC20ABI from 'const/abis/ERC20.json'
 import { ethers } from 'ethers'
@@ -21,6 +20,7 @@ import { getWalletEthersProvider } from '../privy/getWalletEthersProvider'
 import PrivyWalletContext from '../privy/privy-wallet-context'
 import ChainContextV5 from '../thirdweb/chain-context-v5'
 import client from '../thirdweb/client'
+import { resolveSafeExecutionOptions } from './executionGas'
 import useSafeApiKit from './useSafeApiKit'
 
 export type PendingTransaction =
@@ -287,21 +287,21 @@ export default function useSafe(
       )
     }
 
-    // Get current gas price
     const provider = await getWalletEthersProvider(wallets?.[selectedWallet])
     if (!provider) throw new Error('No provider available')
-    const gasPrice = await provider.getGasPrice()
 
-    // For rejection transactions, we need to ensure we have enough gas
+    // Rejection txs are empty/reject calls; still estimate instead of locking
+    // 2–3M gas * 3x gasPrice (that reserve alone has failed ~0.00009 ETH wallets).
     const isRejectionTx =
       safeTx.data === '0x' ||
       safeTx.dataDecoded?.method?.toLowerCase().includes('reject')
 
-    const options: TransactionOptions = {
-      gasLimit: isRejectionTx ? '3000000' : '2000000', // Higher gas limit for rejections
-      maxFeePerGas: gasPrice.mul(3).toString(), // Higher max fee for rejections
-      maxPriorityFeePerGas: gasPrice.mul(2).toString(), // Higher priority fee for rejections
-    }
+    const options = await resolveSafeExecutionOptions({
+      safe,
+      safeTx,
+      isRejectionTx,
+      provider,
+    })
 
     try {
       // Execute the existing transaction directly

--- a/ui/pages/api/mission/freeMint.ts
+++ b/ui/pages/api/mission/freeMint.ts
@@ -19,6 +19,7 @@ import { CitizenInvite, consumeInvite, peekInvite, restoreInvite } from '@/lib/c
 import { enforceRegionNotRestricted } from '@/lib/geo'
 import { createHSMWallet, sendEthFromHSM } from '@/lib/google/hsm-signer'
 import { addressBelongsToPrivyUser } from '@/lib/privy'
+import { L2_GAS_BUDGET_WEI } from '@/lib/rpc/gasBudget'
 import { escapeSingleQuotes } from '@/lib/tableland/cleanData'
 import queryTable from '@/lib/tableland/queryTable'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -356,11 +357,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       })
       mintSucceeded = true
 
-      // Send a small gas stipend (~$0.05 worth of ETH) so new citizens can
-      // interact on-chain right away without needing to fund their wallet first.
-      // 0.00002 ETH ≈ $0.06 at $3 000/ETH on Arbitrum.
-      const GAS_STIPEND_WEI = BigInt('20000000000000') // 0.00002 ETH
-      sendEthFromHSM(address, GAS_STIPEND_WEI).catch((err) =>
+      // Send enough ETH to cover a conservative wallet gas lock
+      // (`gasLimit * maxFeePerGas`), not just the expected L2 execution cost.
+      // 0.00002 ETH was below observed Arbitrum locks (~0.00012 ETH).
+      sendEthFromHSM(address, L2_GAS_BUDGET_WEI).catch((err) =>
         console.error('Gas stipend transfer failed (non-critical):', err)
       )
 

--- a/ui/pages/api/rpc/gas-price.ts
+++ b/ui/pages/api/rpc/gas-price.ts
@@ -1,6 +1,7 @@
 import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { computeMaxFeePerGas } from '@/lib/rpc/eip1559Fees'
 import { cacheGet, cacheSet } from '@/lib/rpc/rpcCache'
 import {
   isSupportedRpcChain,
@@ -109,11 +110,9 @@ export async function handler(
       }
 
       // If both base fee and priority fee are available, calculate max fee
-      // Max fee = base fee * 2 + priority fee (standard wallet formula)
+      // Max fee = base fee * 2.4 + priority fee (2× standard + 20% drift buffer)
       if (baseFeePerGas && maxPriorityFeePerGas) {
-        // Add 20% buffer to account for base fee fluctuations
-        maxFeePerGas =
-          (baseFeePerGas * BigInt(240)) / BigInt(100) + maxPriorityFeePerGas
+        maxFeePerGas = computeMaxFeePerGas(baseFeePerGas, maxPriorityFeePerGas)
       }
     } catch (eip1559Error) {
       // EIP-1559 not supported or failed

--- a/ui/pages/api/rpc/gas-price.ts
+++ b/ui/pages/api/rpc/gas-price.ts
@@ -1,7 +1,7 @@
 import { rateLimit } from 'middleware/rateLimit'
 import withMiddleware from 'middleware/withMiddleware'
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { computeMaxFeePerGas } from '@/lib/rpc/eip1559Fees'
+import { computeMaxFeePerGas, hasFeeValue } from '@/lib/rpc/eip1559Fees'
 import { cacheGet, cacheSet } from '@/lib/rpc/rpcCache'
 import {
   isSupportedRpcChain,
@@ -105,14 +105,20 @@ export async function handler(
         'eth_maxPriorityFeePerGas',
         []
       )
-      if (priorityFee) {
+      if (priorityFee !== undefined && priorityFee !== null && priorityFee !== '') {
         maxPriorityFeePerGas = BigInt(priorityFee)
       }
 
-      // If both base fee and priority fee are available, calculate max fee
-      // Max fee = base fee * 2.4 + priority fee (2× standard + 20% drift buffer)
-      if (baseFeePerGas && maxPriorityFeePerGas) {
-        maxFeePerGas = computeMaxFeePerGas(baseFeePerGas, maxPriorityFeePerGas)
+      // 0 is a valid L2 tip. `if (maxPriorityFeePerGas)` is false for 0n and
+      // would skip the max-fee field, leaving Privy on inflated wallet fees.
+      if (hasFeeValue(baseFeePerGas)) {
+        maxFeePerGas = computeMaxFeePerGas(
+          baseFeePerGas,
+          maxPriorityFeePerGas ?? 0n
+        )
+        if (maxPriorityFeePerGas === undefined) {
+          maxPriorityFeePerGas = 0n
+        }
       }
     } catch (eip1559Error) {
       // EIP-1559 not supported or failed
@@ -125,19 +131,19 @@ export async function handler(
       chainId: chainIdNum,
     }
 
-    if (maxFeePerGas) {
+    if (hasFeeValue(maxFeePerGas)) {
       response.maxFeePerGas = `0x${maxFeePerGas.toString(16)}`
       response.maxFeePerGasGwei = (Number(maxFeePerGas) / 1e9).toFixed(2)
     }
 
-    if (maxPriorityFeePerGas) {
+    if (hasFeeValue(maxPriorityFeePerGas)) {
       response.maxPriorityFeePerGas = `0x${maxPriorityFeePerGas.toString(16)}`
       response.maxPriorityFeePerGasGwei = (
         Number(maxPriorityFeePerGas) / 1e9
       ).toFixed(2)
     }
 
-    if (baseFeePerGas) {
+    if (hasFeeValue(baseFeePerGas)) {
       response.baseFeePerGas = `0x${baseFeePerGas.toString(16)}`
       response.baseFeePerGasGwei = (Number(baseFeePerGas) / 1e9).toFixed(2)
     }

--- a/ui/scripts/.mocharc-cypress-unit.json
+++ b/ui/scripts/.mocharc-cypress-unit.json
@@ -41,6 +41,7 @@
     "cypress/integration/lib/deprize/quote.cy.ts",
     "cypress/integration/lib/deprize/lifecycle.cy.ts",
     "cypress/integration/lib/deprize/odds-chart.cy.ts",
-    "cypress/integration/lib/deprize/status.cy.ts"
+    "cypress/integration/lib/deprize/status.cy.ts",
+    "cypress/integration/unit/l2-gas-budget.cy.ts"
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Project Safes and Privy users were getting intermittent

`insufficient funds for gas * price + value`

even when the signer had enough Arbitrum ETH for the real fee.

A reported case:

- have `0.000093794 ETH`
- want `0.000120084 ETH`

That “want” is the **pre-flight lock** (`gasLimit * maxFeePerGas + value`), not the fee that actually burns. It matches the old project-Safe path:

`2,000,000 gas × 3 × ~0.02 gwei = 0.000120084 ETH`

Privy / some RPCs also stamp inflated EIP-1559 `maxFeePerGas`, so a wallet with enough ETH for the real L2 fee still fails the node check. The citizen gas stipend (`0.00002 ETH`) and the Arbitrum contribution reserve (`0.0001 ETH`) were both below that lock.

## Fix

- **Project Safes:** estimate `execTransaction` gas (500k fallback, 1.5× buffer) instead of hardcoding 2M/3M, and price it from block base fee (`2.4× + priority`) instead of `3× getGasPrice()`.
- **Privy adapter:** stamp `/api/rpc/gas-price` fees on every send so embedded wallets do not lock an inflated max fee.
- **HSM signer:** same base-fee math, so server-sponsored txs do not inherit inflated provider `getFeeData()`.
- **Shared L2 budget:** `0.00025 ETH` for the free-mint stipend, contribution MAX reserve, guest “can mint” check, and DePrize L2 reserve.

The unused portion of `maxFeePerGas * gasLimit` is refunded; users still only pay the actual fee.

## Tests

Unit tests in `ui/cypress/integration/unit/l2-gas-budget.cy.ts` replay the reported `have`/`want` numbers and assert the new Safe reserve fits in the failed wallet’s balance.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54e78936-ecb5-4314-a4a9-e6cc3704c380?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54e78936-ecb5-4314-a4a9-e6cc3704c380&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

