### PR TITLE
DePrize detail page: criteria above the fold, on-chain activity, ranked competitors, chain-rebuilt odds

### DIFF
--- a/docs/DEPRIZE_DETAIL_PAGE_PLAN.md
+++ b/docs/DEPRIZE_DETAIL_PAGE_PLAN.md
@@ -1,0 +1,839 @@
+# DePrize detail page — implementation plan
+
+Target: `ui/pages/deprize/[id].tsx` (the individual prize page, e.g. `/deprize/1` on
+Arbitrum, `/deprize/22` or `/deprize/shared-next-landing` on Sepolia).
+
+This document is written so that an implementer with no prior context can execute it
+step by step. Read **§0 Context**, **§1 Ground rules** and **Phase 0** fully before
+touching code. All work targets a real on-chain prize (Sepolia DePrize #22) — there is
+no mock page. Work through the phases in order; each phase is independently shippable
+as its own PR.
+
+---
+
+## 0. Context you must understand first
+
+### 0.1 The two pots of money (this is the #1 source of user confusion)
+
+A DePrize has **two completely separate pools**. Never mix them in copy or math.
+
+| Pot | Where it lives | Funded by | Paid to | UI today |
+|---|---|---|---|---|
+| **Prize pool** | Juicebox (JB) project `deprize.jbProjectId` | 5% "slice" of every bet + the LMSR's 1% trade fees (routed by `DePrizeFeeRouter`) | The **winning team/provider** at settlement (`docs/DEPRIZE.md` §Settlement). Bettors never receive it. | Header stat "Prize pool" = `useTotalFunding(jbProjectId)` |
+| **Betting market collateral** | Gnosis CTF + `LMSRWithTWAP` market | LMSR seed funding + 95% of every bet | **Bettors**: each outcome token redeems for exactly **1 ETH** if its outcome wins (payout vector), or pro-rata on refund/no-winner | Team card line "If wins · X ETH" = `outcome.balance` (token count) |
+
+So "Prize pool 0.0008 ETH" and "If wins 0.0093 ETH" are unrelated numbers. The second
+is the bettor's own payout from the market and will normally be much larger than the
+first.
+
+### 0.2 How a bet flows (needed for events work)
+
+`DePrizeMint.bet(deprizeId, outcomeIndex, outcomeTokenAmount, maxCost)` (payable):
+
+1. Splits `msg.value` into `slice` (5%, paid to JB with the bettor as beneficiary) and
+   `budget` (95%).
+2. Prices the trade on the LMSR: `cost = calcNetCost + calcMarketFee`.
+3. Buys outcome tokens, forwards them to the bettor, refunds `budget - cost`.
+4. Emits `Bet(uint256 indexed deprizeId, address indexed bettor, uint256 outcomeIndex, uint256 outcomeTokenAmount, uint256 cost, uint256 slice)`.
+
+Therefore per bet: **total the bettor actually spent = `cost + slice`**.
+
+Cash-outs (sells) do **not** go through the Mint. They call the LMSR directly
+(`ExitPositionModal`). The LMSR emits
+`AMMOutcomeTokenTrade(address indexed transactor, int256[] outcomeTokenAmounts, int256 outcomeTokenNetCost, uint256 marketFees)`
+for **every** trade, buys and sells. For buys routed through the Mint, `transactor` is
+the **Mint contract**, not the bettor — so use `Bet` events for "who bet", and
+`AMMOutcomeTokenTrade` for "how did prices move" and for a user's **sells**
+(`transactor == user`, amounts negative).
+
+### 0.3 LMSR price math (needed for the chart rebuild)
+
+Marginal price of outcome `i` (Gnosis LMSR):
+
+```
+b      = funding / ln(n)                       // n = number of outcomes
+q_i    = net outcome tokens sold for i          // cumulative sum of outcomeTokenAmounts[i] over all trades
+p_i    = exp(q_i / b) / Σ_j exp(q_j / b)        // in [0,1]; ×100 for percent
+```
+
+`funding` is the LMSR's `funding()` (wei, 18 decimals). `q_i` starts at 0 for every
+outcome when the market opens (uniform prior `1/n`). `funding` can change via
+`AMMFundingChanged(int fundingChange)`; include it if present.
+
+Use the stable form `p_i = 1 / Σ_j exp((q_j - q_i) / b)` to avoid overflow.
+
+### 0.4 Key existing files
+
+| Concern | File |
+|---|---|
+| The page | `ui/pages/deprize/[id].tsx` |
+| Team row | `ui/components/deprize/DePrizeTeamCard.tsx` |
+| Odds chart (Recharts) | `ui/components/deprize/OddsHistoryChart.tsx` |
+| Chart domain/padding math (pure) | `ui/lib/deprize/odds-chart.ts` |
+| Market hook (prices, balances, odds history, poll) | `ui/lib/deprize/useDePrizeMarket.tsx` |
+| Registry hook (`deprize` struct) | `ui/lib/deprize/useDePrize.tsx` |
+| Constants (`UNIT`, `OUTCOME_COLORS`, `ODDS_*`, `MarketStage`) | `ui/lib/deprize/constants.ts` |
+| Read client, rate-limited `rpcRead` | `ui/lib/deprize/read.ts` |
+| Bet quote math (pure) | `ui/lib/deprize/quote-math.ts`; on-chain quote `quoteQtyForBudget` in `ui/lib/deprize/quote.ts` |
+| Status copy, `formatBettingCloses` | `ui/lib/deprize/status.ts` |
+| Formatting (`fmt`, `fmtPrizeEth`, `toEth`) | `ui/lib/deprize/format.ts` |
+| ETH + USD display | `ui/components/deprize/EthUsd.tsx` |
+| Competition metadata / race bindings | `ui/lib/deprize/competitions.ts` |
+| Atlas goal (criteria, description) | `ui/lib/lunar-atlas` → `sharedGoalById(SEED_ATLAS, id)`; type `SharedGoal` with `criteria?: CapabilityCriterion[]` in `ui/lib/lunar-atlas/types.ts` |
+| Planned-race page that already renders criteria | `ui/components/deprize/GoalDePrizeDetail.tsx` (lines ~217–235) |
+| Addresses | `ui/const/config.ts`: `DEPRIZE_REGISTRY_ADDRESSES`, `DEPRIZE_MINT_ADDRESSES`, `LMSR_WITH_TWAP_ADDRESSES` |
+| ABIs | `ui/const/abis/DePrizeMint.json`, `ui/const/abis/LMSRWithTWAP.json`, `ui/const/abis/DePrizeRegistry.json` |
+| Moon Base Zero (the 3D simulation) | `ui/pages/moonbase/index.tsx`, `ui/pages/moonbase/[projectId].tsx`, `ui/components/lunar-atlas/SharedGoalPanel.tsx` |
+| Existing examples that already sort by probability | `ui/components/deprize/RaceMarketCard.tsx` (`ranked`), `ui/components/deprize/LiveDePrizeHero.tsx` |
+| Unit tests (mocha, no browser) | `ui/cypress/integration/lib/deprize/*.cy.ts`, run with `yarn test:deprize` |
+
+---
+
+## 1. Ground rules
+
+- Work in `ui/` only. Yarn, not npm. Next.js Pages Router, TypeScript strict.
+- **Reads** go through `rpcRead({ contract, method, params })` from `lib/deprize/read.ts`
+  with `getContract({ client: deprizeReadClient, chain: deprizeReadChain(chain.id), address, abi })`.
+  Never call `readContract` directly from thirdweb in new code — `rpcRead` is rate-limit
+  aware.
+- Never pass a `bigint` into `useRead`/hook param objects that get `JSON.stringify`'d
+  (see comment near `jbProjectId` in the page). Convert to `Number` or `string` first.
+- Pure logic (math, sorting, aggregation) goes in `ui/lib/deprize/*.ts` with **no React
+  and no thirdweb imports**, so it can be unit-tested with `yarn test:deprize`.
+- Every new pure module gets a `ui/cypress/integration/lib/deprize/<name>.cy.ts` mocha
+  spec. Copy the shape of `odds-chart.cy.ts`.
+- Do not touch `deprize-play.tsx` (legacy harness), `mockMarket.ts`, or `DemoBetModal`.
+- Keep the visual language: cards are
+  `p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg`.
+  Labels are `text-xs text-gray-400`, values `text-sm font-semibold text-white`.
+- Before opening a PR: `cd ui && yarn lint && npx tsc --noEmit && yarn test:deprize`.
+  Then run the page locally against Sepolia (`/deprize/22`) with a wallet that has a
+  position, and against Arbitrum (`/deprize/1`) read-only.
+- Keep each phase a separate PR. Do not refactor unrelated code.
+
+---
+
+## Phase 0 — The real Sepolia prize (already live) and how to launch / re-provision
+
+Nothing in this plan is built against a mock. The page to develop and QA against is a
+**real, complete on-chain prize on Sepolia**: DePrize **#22 "Touchdown"**. It was
+provisioned by `ui/scripts/provision-sepolia-prize.ts` from the `$PRIVATE_KEY` wallet
+(the DePrize deployer/owner `0x3c5e…E011`) and merged to `main` in
+[PR #1566](https://github.com/Official-MoonDao/MoonDAO/pull/1566).
+
+### 0.1 Facts for DePrize #22 (copy these, do not re-derive)
+
+| Item | Value |
+|---|---|
+| Chain | Sepolia (11155111) |
+| DePrize id | **22** (state OPEN, betting open) |
+| Shareable URL path | `/deprize/shared-next-landing` (resolves to #22); `/deprize/22` also works |
+| Race binding | `shared-next-landing` (Moon Base Zero "next Qualifying Landing") |
+| Juicebox project | **268** (mission 14), payhook `0xD6597D665cbC74e4Da52da6af34900897A24307B` |
+| LMSR market | `0x9d3b999B347c6F9dc6cB314707397A4B505826D0` (6 outcomes, 1% fee, 0.06 ETH funding) |
+| CTF condition | `0xb1c4d8775e08aabcaed68cb17645aec155a22ce35316d640a3233679dbecfa66` |
+| Question id | `keccak256("deprize:sepolia:shared-next-landing:v2")` = `0x1ba1808c0a0d8a2bbc48462cd3a490e306695713e0cafd362d365c9db3f43513` |
+| Team NFT ids (outcome order) | 601 Astrobotic Griffin · 602 Intuitive Machines · 603 Firefly Blue Ghost · 604 Blue Origin Blue Moon MK1 · 605 CNSA Chang'e-7 · 24 Open Field |
+| Registry / Mint / FeeRouter | `0x299F163705AbBFa1A8DE7670F33171730F828F3D` / `0xa6f9632ee9848f7c1f252da5a1e869ac90e57cc8` / `0xbe8cbc97d4ddee28b938c0ed8245f1b5133b783a` |
+| Existing on-chain activity | one 0.004 ETH bet on outcome 0, tx `0x3c35a1dbe32a7e35877691c48509f7e39979f7b1faf1ac1c438c8369e742364a` |
+| Superseded generation | #21 (synthetic JB id, **not** a real prize — never link to it as the live page) |
+
+### 0.2 Launch checklist (make the real page reachable and share it)
+
+1. **Verify chain state** (read-only, no key needed) from `subscription-contracts/`:
+   ```bash
+   DEPRIZE_REGISTRY=0x299F163705AbBFa1A8DE7670F33171730F828F3D \
+   DEPRIZE_MINT=0xa6f9632ee9848f7c1f252da5a1e869ac90e57cc8 \
+   DEPRIZE_FEE_ROUTER=0xbe8cbc97d4ddee28b938c0ed8245f1b5133b783a \
+   DEPRIZE_ID=22 DEPRIZE_MARKET=0x9d3b999B347c6F9dc6cB314707397A4B505826D0 \
+   DEPRIZE_PAYHOOK=0xD6597D665cbC74e4Da52da6af34900897A24307B \
+   forge script script/deprize/DePrizeVerify.s.sol --rpc-url https://ethereum-sepolia-rpc.publicnode.com
+   ```
+   Expect: state OPEN, bettingOpen true, `mint.marketOf(22)` = the LMSR, LMSR owner =
+   FeeRouter, stage Running, fee 1%.
+2. **Verify the app binding**: `ui/lib/deprize/competitions.ts` has `22` under `sepolia`
+   with `supersedes: 21`, and `21` has `supersededBy: 22`. `yarn test:deprize` passes.
+3. **Run locally as a testnet build** and open the real page:
+   ```bash
+   cd ui && NEXT_PUBLIC_CHAIN=testnet yarn dev
+   # http://localhost:3000/deprize/shared-next-landing
+   ```
+   The app is a testnet build whenever `NEXT_PUBLIC_CHAIN !== 'mainnet'`; the header
+   chain selector must be on Sepolia. Confirm title "Touchdown", six competitors with
+   real names/logos, odds ≈ 26/15/15/15/15/15 (until more bets land), prize pool > 0.
+4. **Find or create the public testnet URL.** Production (`moondao.com`) is a
+   `NEXT_PUBLIC_CHAIN=mainnet` build and shows Arbitrum prizes. The Sepolia page must be
+   shared from a deployment built with `NEXT_PUBLIC_CHAIN=testnet` (CI already uses this
+   value, see `.github/workflows/ci.yml`). Check the Vercel project for an existing
+   testnet/preview environment; if none exists, add a Vercel preview environment for
+   `main` with `NEXT_PUBLIC_CHAIN=testnet` and the same secrets as production. Record the
+   resulting URL in `docs/DEPRIZE_QA.md` under DePrize 22. **Ask Pablo which URL is the
+   share target before publishing it anywhere.**
+5. **Smoke the public URL** with a wallet holding Sepolia ETH: place one small bet
+   (0.001–0.005 ETH) through the UI, confirm the odds move and the prize pool ticks up
+   (5% of the bet), then cash out part of it. This also seeds real trades for the chart
+   work in Phase 3.
+6. **Share** `<testnet-url>/deprize/shared-next-landing`. Tell testers they need Sepolia
+   ETH (faucet links: https://sepoliafaucet.com, https://www.alchemy.com/faucets/ethereum-sepolia)
+   and that betting is geo-gated (restricted regions can view and cash out only).
+
+### 0.3 The `$PRIVATE_KEY` wallet
+
+- `PRIVATE_KEY` is present in the shell environment on Pablo's machine. It is the
+  **owner** of the Sepolia DePrize registry, mint and fee router, and the oracle for the
+  CTF conditions. Only this wallet can `register`, `open`, `setCondition`, `setMarket`,
+  and later resolve. Never print it, never commit it, never write it to a file.
+- Check its Sepolia balance before any provisioning (needs ≥ 0.1 ETH: 0.06 LMSR funding
+  for a 6-outcome prize + gas):
+  ```bash
+  cast balance --ether $(cast wallet address --private-key $PRIVATE_KEY) --rpc-url https://ethereum-sepolia-rpc.publicnode.com
+  ```
+- The provisioning script reads `DEPLOYER_PK` **or** `PRIVATE_KEY`; nothing else is
+  needed for auth.
+
+### 0.4 Provisioning another real prize (only when a new race or generation is needed)
+
+Do **not** re-run the script for Touchdown v2 — the CTF condition already exists and
+`prepareCondition` will revert, and a second registration would create a duplicate
+prize. Provision only when: (a) a new race is going live (e.g. Night Shift → expected
+id **23**, see `docs/DEPRIZE_QA.md`), or (b) a roster change requires a new generation
+(then bump `questionVersion` to `v3` and set `supersedes`/`supersededBy` in
+`competitions.ts`).
+
+Steps, all from `ui/`:
+
+1. Add or edit the `PrizeSpec` in `scripts/provision-sepolia-prize.ts` (`PRIZES` map):
+   `slug` = the atlas shared-goal id, `questionVersion`, `title`, `tagline`,
+   `metaDescription`, `teamIds` (real MoonDAO Team NFT ids — verify each exists with
+   `TeamABI.ownerOf`; a missing NFT makes the page show `Team #NNN` and is what made
+   #21 fake), `tokenName`, `tokenSymbol`.
+2. Use a non-Infura RPC to avoid 429s during the ~15 transactions:
+   ```bash
+   SEPOLIA_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com \
+   PRIZE=<key> yarn tsx --tsconfig tsconfig.json scripts/provision-sepolia-prize.ts
+   ```
+   The script is idempotent per step (it re-reads registry `count()`, `marketOf`, etc.);
+   if it dies mid-way, re-run it with the same `PRIZE`. It writes
+   `/tmp/sepolia-prize.json` and prints the `competitions.ts` block to paste.
+3. Bind in `lib/deprize/competitions.ts` (paste the printed block; add `sharedGoalId`,
+   `raceLabel`, `outcomes[]` with atlas `projectId`s in **the same order as `teamIds`**,
+   Open Field last with `field: true`). If it is a new generation, set `supersededBy`
+   on the old id and `supersedes` on the new one.
+4. Update `cypress/integration/lib/deprize/competitions.cy.ts` and
+   `cypress/integration/unit/lunar-atlas-deprize.cy.ts` (ids, `findDePrizeIdForGoal`,
+   `partitionDePrizeIndexByRace`). Run `yarn test:deprize`.
+5. Run the Forge verify (§0.2 step 1) with the new ids/addresses.
+6. Place one real smoke bet through the UI. Record everything (ids, addresses, tx) in
+   `docs/DEPRIZE_QA.md`.
+7. Open a PR; CI runs the component tests on `NEXT_PUBLIC_CHAIN=testnet`.
+
+---
+
+## Phase 1 — Cut list, then UI-only fixes (no new data)
+
+Ships: the deletions below, ranking (feedback #5), honest labels (#6), criteria above the
+fold (#1).
+
+### 1.0 Cut list — delete before adding anything
+
+Rule: every element must either let the user **act** (bet, cash out, claim, navigate) or
+**decide** (odds, money, deadline, who). Explanations of how the system works, restated
+information, internal identifiers and decorative badges go. Below, every element on the
+page today and the verdict. Items marked **CUT** are deleted in this phase; **MOVE**
+means it relocates as part of §1.3/§4; **KEEP** stays.
+
+**Header card**
+
+| Element | Verdict | Why / how |
+|---|---|---|
+| `DePrize #22 — Touchdown` as the h1 | **CHANGE** | h1 becomes `Touchdown`. Render `#22` as `text-xs font-mono text-gray-500` after it (support/QA still needs the id). For unknown competitions keep `DePrize #N`. |
+| `StateBadge` | **CUT when normal** | Render only if `statusLabelOverride` is set or `deprize.state !== OPEN`. "Open" next to "Betting closes <date>" says nothing. |
+| `Generation N` chip | **CUT** | Lineage is one line at the bottom (§1.0 "Lineage" below). |
+| `← All prizes` | KEEP | Navigation. |
+| Stat `Prize pool` | KEEP, relabel (§1.2) | Decision input. |
+| Stat `Providers` | **CUT** | It is `teamIds.length`; the competitor list already shows it. |
+| Stat `Betting closes` | KEEP | Deadline. |
+| Winner banner / no-winner banner | KEEP | Only renders when resolved; drives Claim. |
+
+**Notices**
+
+| Element | Verdict | Why / how |
+|---|---|---|
+| Cancellation-pending notice | KEEP, shorten | `Cancellation announced — bets paused for 7 days; if it goes through, everyone is refunded.` |
+| `market.error` notice | KEEP, shorten | `Couldn't load market data — reload.` |
+| Region-restricted notice | KEEP, shorten | `Betting isn't available in your region. You can view odds, cash out and claim.` |
+| `Connect a wallet to back a team, cash out, or claim.` card + button | **CUT** | Every `Back this team` button becomes the connect entry point: in `DePrizeTeamCard`, when `!userConnected` render the button **enabled** with label `Connect to back` and have the page's `onBet` call `login()` when there is no `userAddress`. Remove `disabled={!userConnected}`. |
+
+**Predictions card**
+
+| Element | Verdict | Why / how |
+|---|---|---|
+| Title `Predictions` | **CHANGE** | `Odds`. |
+| Subtitle `Implied chance since the market opened (date)` | **CUT** | The X axis shows the dates. |
+| Legend chips (`● Name · 26%`) | **CUT** | The ranked competitor cards directly below are the legend once colors are unified: in the page compute `outcomeColor(index)` with exactly the rule the card uses (`isField → OUTCOME_COLORS[i]`, `claimed → orgColor(org)`, else `#9ca3af`) and pass that array as `colors` to `OddsHistoryChart`. Tooltip on the chart still names the line. |
+| Empty state copy `Odds history will plot here as the market moves. Samples persist across visits, so the line grows from market open to now.` | **CUT** | Replace with `No trades yet.` — the old text explains the implementation. |
+
+**Competitors**
+
+| Element | Verdict | Why / how |
+|---|---|---|
+| `Competitors` heading | KEEP | Section anchor; no caption. |
+| `Official participant` / `Unofficial — not confirmed` legend row | **CUT** | Replace the encoding: remove the colored left bar (`participation` stripe) from the card entirely; render a small `Unconfirmed` chip (`text-[10px] uppercase border border-zinc-500/40 text-zinc-300 rounded-full px-2`) next to the name **only** on unofficial cards, with `title="Listed by MoonDAO; this organization has not confirmed participation."` Official is the default and gets no marker. |
+| Big `NN%` + `chance` | KEEP | One word; without it "26%" is ambiguous to a newcomer. |
+| Team avatar + name link | KEEP | Links to the simulation. |
+| Field subtitle `Any qualifying entrant not listed above` + long tooltip | **SHORTEN** | `Any other team`. Drop the tooltip about the Senate/admin Safe. |
+| `Withdrawn — you can still sell your position` | KEEP, shorten | `Withdrawn — sell only`. |
+| `If wins · X` line | KEEP in Phase 1, **CUT in Phase 2** | Once the Your-position panel exists (§2.5) all holdings info lives there; the card goes back to `%` · name · button only. |
+| Holdings block (`Cash out ~X (+pnl)` + button) | KEEP in Phase 1, **CUT in Phase 2** | Same reason. |
+| `Back this team` / `Back the field` | KEEP | Primary action. |
+
+**Description card (bottom)**
+
+| Element | Verdict | Why / how |
+|---|---|---|
+| `competition.tagline` | **MOVE** | To the question card (§1.3). |
+| `effectiveDescription` | **CUT when normal** | For a healthy OPEN market it is boilerplate ("Accepting bets…"). Render `bettingBlockedReason` **only when set**, as an amber `Notice` directly under the header (it is actionable: paused / no market / cancelling). Never render `DEPRIZE_STATE_META[...].description`. |
+| SUPERSEDED paragraph (3 sentences) | **SHORTEN** | `Superseded by DePrize #23 — new bets happen there. You can still sell here.` with the link. |
+| `Continues from generation N (DePrize #21). Legacy positions remain sellable there until the race settles.` | **SHORTEN** | `Continues from #21` (link). Nothing else. Together with the SUPERSEDED line this is the whole "Lineage" content; render both as `text-xs text-gray-500` at the very bottom. |
+| `ROSTER_DISCLAIMER` | KEEP as footnote | Legal wording; keep the text, render it `text-[11px] text-gray-600` as the last line of the page. Do not rewrite it without legal sign-off. |
+
+**Other**
+
+| Element | Verdict | Why / how |
+|---|---|---|
+| `ClaimPanel` | KEEP | Only when resolved. |
+| `DePrizeAdminPanel` | KEEP | Already returns `null` for non-admins. |
+| `NoticeFooter` | KEEP | Global layout. |
+| Anything proposed elsewhere in this plan that *explains* the system (a "How money moves" block, a three-step strip, chart captions like "each dot is a trade") | **DO NOT BUILD** | Use labels and `title` tooltips only. If a label needs a paragraph to be understood, the label is wrong. |
+
+Also audit `BetModal` and `ExitPositionModal` copy with the same rule when you touch
+them; anything that says "this is how the market works" goes, anything that says "you
+pay X and get Y" stays.
+
+### 1.1 Rank competitors by chance, Open Field pinned last
+
+**File:** `ui/pages/deprize/[id].tsx`
+
+1. Add a pure helper in a new file `ui/lib/deprize/rank-outcomes.ts`:
+
+   ```ts
+   export type RankableOutcome = { index: number; probability: number }
+
+   /**
+    * Order outcomes for display: highest implied chance first. Ties (and NaN)
+    * keep registry order. Outcomes flagged `isField` (Open Field) are always
+    * pinned to the end regardless of chance. When `winningIndex` is provided
+    * (market resolved), that outcome is moved to the very top.
+    */
+   export function rankOutcomes<T extends RankableOutcome>(
+     outcomes: T[],
+     opts: { isField: (index: number) => boolean; winningIndex?: number },
+   ): T[] {
+     const score = (o: T) => (Number.isFinite(o.probability) ? o.probability : -1)
+     return [...outcomes].sort((a, b) => {
+       if (opts.winningIndex !== undefined) {
+         if (a.index === opts.winningIndex) return -1
+         if (b.index === opts.winningIndex) return 1
+       }
+       const af = opts.isField(a.index), bf = opts.isField(b.index)
+       if (af !== bf) return af ? 1 : -1
+       const d = score(b) - score(a)
+       return d !== 0 ? d : a.index - b.index
+     })
+   }
+   ```
+
+2. Unit test `ui/cypress/integration/lib/deprize/rank-outcomes.cy.ts`: descending order;
+   ties keep index order; NaN sinks below numbers but above field; field always last even
+   with 90% chance; winner first when `winningIndex` set.
+
+3. In the page, right after `predictionLabels` is computed, add:
+
+   ```ts
+   const rankedOutcomes = useMemo(
+     () =>
+       rankOutcomes(market.outcomes, {
+         isField: (i) => !!raceBinding?.outcomes[i]?.field,
+         winningIndex: showResolved && market.winningIndex >= 0 ? market.winningIndex : undefined,
+       }),
+     [market.outcomes, raceBinding, showResolved, market.winningIndex],
+   )
+   ```
+
+   Replace **both** `market.outcomes.map(...)` calls in the JSX (the Predictions legend
+   and the Competitors list) with `rankedOutcomes.map(...)`. Everything inside the map
+   already uses `o.index`, so team ids, colors, anchors (`deprize-outcome-${o.index}`)
+   and the `?outcome=N` deep link keep working. Do **not** reorder `market.outcomes`
+   itself — indices must stay aligned with the contract.
+
+4. No caption. The order speaks for itself.
+
+### 1.2 Honest labels for the two pots
+
+**Files:** `ui/pages/deprize/[id].tsx`, `ui/components/deprize/DePrizeTeamCard.tsx`
+
+1. Header stat: change `label="Prize pool"` to `label="Prize pool · to winner"` and add
+   `title="Paid to the winning team when the race settles. This is separate from what bettors win — bettor payouts come from the betting market."`
+   (The `Stat` component already accepts `title`.)
+
+2. Team card `showWinSubtitle` block: change copy from `If wins ·` to
+   `Your payout if wins ·` and wrap the `<p>` with
+   `title="Each share you hold pays 1 ETH if this team is selected as the winner. Paid from the betting market, not from the prize pool."`
+
+3. Nothing else. No explainer block — the two labels plus their tooltips are the whole
+   fix. If the confusion persists in testing, the fix is a better label, not more text.
+
+### 1.3 Criteria and description above the fold
+
+**File:** `ui/pages/deprize/[id].tsx`
+
+1. Resolve the atlas goal for the live race (not just for slugs):
+
+   ```ts
+   const raceGoal = raceBinding ? sharedGoalById(SEED_ATLAS, raceBinding.sharedGoalId) : undefined
+   ```
+
+   `DePrizeRaceBinding.sharedGoalId` is the field (`lib/deprize/competitions.ts` line ~54).
+
+2. Create `ui/components/deprize/DePrizeQuestionCard.tsx`:
+
+   Props: `{ tagline: string; description?: string; criteria?: CapabilityCriterion[]; closesLabel?: string; moonbaseHref?: string }`.
+
+   Layout (one card, same card classes):
+   - Line 1, `text-white text-base font-semibold`: the tagline (this is the market's
+     question, e.g. "Which company lands on the Moon next?").
+   - Line 2, `text-gray-400 text-sm`: `description` if provided.
+   - "What counts as winning" — `<ol>` of `criteria` items, each `text-sm text-gray-300`
+     with the criterion `title` bold and its `description` after. Reuse the exact
+     markup from `GoalDePrizeDetail.tsx` lines ~217–235 so both pages look identical.
+     On screens `< sm`, render inside `<details>` with summary
+     `What counts as winning (N criteria)`, open by default on `sm+` (use two renders
+     guarded by `hidden sm:block` / `sm:hidden`).
+   - Footer row: if `moonbaseHref`, a link `See this race on Moon Base Zero →`. (The
+     closing date already sits in the header stats; do not repeat it here.)
+
+3. Mount it in the page **immediately after the header card and before Predictions**.
+   Pass `tagline={competition.tagline}`, `description={raceGoal?.description}`,
+   `criteria={raceGoal?.criteria}`,
+   `moonbaseHref={raceGoal ? `/moonbase?race=${raceGoal.id}` : undefined}`.
+   Drop the `closesLabel` prop from the component if you find it unused.
+
+4. The old bottom "Description" card becomes the "Lineage" footer described in §1.0:
+   only the shortened SUPERSEDED / "Continues from" line(s) and the `ROSTER_DISCLAIMER`
+   footnote. `competition.tagline` moves up; `effectiveDescription` is gone (its
+   actionable variant `bettingBlockedReason` renders as a Notice under the header).
+
+5. Header stats grid after Phase 1 has two stats (`Prize pool · to winner`,
+   `Betting closes`); Phase 2 grows it to four.
+
+### 1.4 Acceptance for Phase 1
+
+- Every **CUT** row in §1.0 is gone; every **SHORTEN** row uses the new copy.
+- Competitors appear highest chance first; Open Field is last even if it has the highest
+  chance; on a resolved market the winner is first.
+- Chart line colors match the card accent colors one-to-one; there is no legend.
+- Clicking `Connect to back` while logged out opens the Privy login.
+- Above the fold on a 1280×800 laptop: title, two stats, the question, the criteria list,
+  and the top of the odds chart.
+- Hovering "Prize pool · to winner" and "Your payout if wins" shows the explanatory
+  tooltips.
+- `yarn test:deprize` passes with the new `rank-outcomes.cy.ts`.
+
+---
+
+## Phase 2 — On-chain events layer, backers stat, "Your position" panel
+
+Ships: backers metric (#2), personal activity with P/L (#3). Also replaces the fragile
+localStorage cost basis.
+
+> **Implementation note (what actually shipped).** The app's RPC proxy caps `eth_getLogs`
+> at 10,000 blocks per call, which makes scanning from the registry deploy block
+> impractical (Arbitrum is ~25M blocks). Events are therefore served by
+> `pages/api/deprize/logs.ts`, a thin proxy over the Etherscan V2 `logs/getLogs` API
+> (one key, every chain, timestamps included). It reads `ETHERSCAN_API_KEY`
+> (falling back to `NEXT_PUBLIC_ETHERSCAN_API_KEY` / `ARBISCAN_API_KEY`) — **set it in
+> the deployment environment**. The chunked RPC fetcher in `lib/deprize/events.ts`
+> remains as the fallback when the route fails. Deploy blocks in
+> `DEPRIZE_EVENTS_FROM_BLOCK` came from Etherscan `getcontractcreation`
+> (Sepolia registry 11068914, Arbitrum registry 495964196).
+
+### 2.1 Record deployment blocks
+
+**File:** `ui/const/config.ts`
+
+Add, next to `DEPRIZE_REGISTRY_ADDRESSES`:
+
+```ts
+// First block worth scanning for DePrize events on each chain. Use the block in which
+// DePrizeRegistry was deployed (contract-creation tx on the explorer). Every DePrize
+// market, mint and trade is created after this block.
+export const DEPRIZE_EVENTS_FROM_BLOCK: Record<string, number> = {
+  sepolia: 0, // TODO: replace with creation block of DEPRIZE_REGISTRY_ADDRESSES.sepolia
+  arbitrum: 0, // TODO: replace with creation block of DEPRIZE_REGISTRY_ADDRESSES.arbitrum
+}
+```
+
+How to find the numbers: open `https://sepolia.etherscan.io/address/<registry>` and
+`https://arbiscan.io/address/<registry>`, click the "Contract Creator" tx, read its block
+number. Do not guess. Do not leave `0` in the final PR (a zero start makes the first
+scan crawl the whole chain).
+
+### 2.2 Generic chunked log fetcher
+
+**File (new):** `ui/lib/deprize/events.ts`
+
+```ts
+import { getContractEvents, prepareEvent, type ThirdwebContract } from 'thirdweb'
+import { eth_getBlockByNumber, eth_blockNumber, getRpcClient } from 'thirdweb/rpc'
+
+export const BET_EVENT = prepareEvent({
+  signature:
+    'event Bet(uint256 indexed deprizeId, address indexed bettor, uint256 outcomeIndex, uint256 outcomeTokenAmount, uint256 cost, uint256 slice)',
+})
+export const TRADE_EVENT = prepareEvent({
+  signature:
+    'event AMMOutcomeTokenTrade(address indexed transactor, int256[] outcomeTokenAmounts, int256 outcomeTokenNetCost, uint256 marketFees)',
+})
+export const FUNDING_EVENT = prepareEvent({
+  signature: 'event AMMFundingChanged(int256 fundingChange)',
+})
+```
+
+Implement:
+
+```ts
+/** Fetch logs in block chunks; halve the chunk on "range too large"-style RPC errors. */
+export async function fetchEventsChunked<T>(args: {
+  contract: ThirdwebContract
+  events: any[]
+  fromBlock: bigint
+  toBlock: bigint
+  initialChunk?: bigint          // default 200_000n
+}): Promise<T[]>
+```
+
+Rules: loop `from..to`, call `getContractEvents({ contract, events, fromBlock, toBlock })`
+per chunk, on error whose message includes `range`/`limit`/`10000`/`too many` halve the
+chunk and retry (min chunk `1_000n`, then throw). Concatenate. Sort by
+`(blockNumber, logIndex)`.
+
+```ts
+/** Resolve block → unix ms timestamps for a set of block numbers (deduped, batched 8 at a time). */
+export async function fetchBlockTimestamps(chain, blocks: bigint[]): Promise<Map<bigint, number>>
+```
+
+Use `eth_getBlockByNumber(getRpcClient({ client: deprizeReadClient, chain }), { blockNumber })`
+→ `Number(block.timestamp) * 1000`.
+
+Add a small in-memory cache (module-level `Map<string, Promise<...>>` keyed by
+`${chainId}:${address}:${eventName}:${deprizeId ?? ''}`) so navigating between pages
+doesn't refetch within a session. Optional but recommended: persist `{ toBlock, items }`
+to `localStorage` under `deprize:events:v1:<key>` (serialize bigints as strings) and on
+the next load fetch only `toBlock + 1 .. latest`.
+
+### 2.3 Hook: `useDePrizeActivity`
+
+**File (new):** `ui/lib/deprize/useDePrizeActivity.tsx`
+
+```ts
+export type BetRow = {
+  bettor: string           // lowercase
+  outcomeIndex: number
+  qty: number              // outcome tokens, ETH units (wei / UNIT)
+  costEth: number          // LMSR side (95%) incl. 1% fee
+  sliceEth: number         // JB prize slice (5%)
+  totalEth: number         // costEth + sliceEth
+  blockNumber: bigint
+  txHash: string
+  timestampMs: number
+}
+export type SellRow = {
+  seller: string
+  outcomeIndex: number
+  qty: number              // positive number of tokens sold
+  proceedsEth: number      // -(outcomeTokenNetCost) - marketFees, ETH units
+  blockNumber: bigint
+  txHash: string
+  timestampMs: number
+}
+export type DePrizeActivity = {
+  bets: BetRow[]
+  sells: SellRow[]
+  backers: number          // unique bettor addresses
+  totalStakedEth: number   // Σ bets.costEth (what the market collateral received from bettors)
+  loading: boolean
+  error?: string
+  refresh: () => void
+}
+
+export function useDePrizeActivity(args: {
+  deprizeId: number | undefined
+  marketAddress: string | undefined
+  chain: Chain
+  refreshNonce?: number
+}): DePrizeActivity
+```
+
+Implementation:
+
+1. `mint = getContract({ client: deprizeReadClient, chain: deprizeReadChain(chain.id), address: DEPRIZE_MINT_ADDRESSES[slug], abi: DePrizeMintABI })`.
+2. `fromBlock = BigInt(DEPRIZE_EVENTS_FROM_BLOCK[slug])`, `toBlock = await eth_blockNumber(rpc)`.
+3. Bets: `fetchEventsChunked({ contract: mint, events: [prepareEvent({ signature: BET_SIGNATURE, filters: { deprizeId: BigInt(deprizeId) } })], fromBlock, toBlock })`.
+   The `deprizeId` topic filter is essential — do not fetch all bets and filter in JS.
+4. Sells: `fetchEventsChunked({ contract: lmsr, events: [TRADE_EVENT], fromBlock, toBlock })`
+   then keep rows where **any** `outcomeTokenAmounts[i] < 0`. For each such row,
+   `outcomeIndex` = the index with the negative amount (one per sell in our UI),
+   `qty = -amount / UNIT`, `proceedsEth = (-(netCost) - marketFees) / UNIT`.
+   Rows whose `transactor` equals the Mint address are buys — ignore them here (they are
+   already in `bets`).
+5. Timestamps via `fetchBlockTimestamps` for the union of block numbers.
+6. Aggregations as pure functions in `ui/lib/deprize/activity-math.ts` (unit-tested):
+   - `uniqueBackers(bets)`, `totalStaked(bets)`,
+   - `userPosition(bets, sells, user, outcomeIndex)` → `{ qtyBought, qtySold, costEth, sliceEth, proceedsEth }`,
+   - `userSummary(bets, sells, user, currentValueByIndex: Map<number, number>)` →
+     `{ totalSpentEth, realizedEth, currentValueEth, unrealizedPnlEth, netPnlEth }` where
+     `totalSpentEth = Σ(cost+slice)` for the user, `realizedEth = Σ proceeds`,
+     `unrealizedPnlEth = currentValueEth − (Σ cost+slice for tokens still held)`;
+     use average cost per token per outcome to attribute sold vs held cost.
+   - Treat the 5% slice as part of what the user spent (it is real money they paid),
+     and say so in the panel tooltip.
+
+### 2.4 Header stats grid: add Backers and Total staked
+
+**File:** `ui/pages/deprize/[id].tsx`
+
+Replace the 3-column grid with `grid grid-cols-2 sm:grid-cols-4 gap-3`:
+
+| Stat | Value | Tooltip |
+|---|---|---|
+| Prize pool · to winner | existing | existing (Phase 1) |
+| Total staked | `activity.totalStakedEth` via `<EthUsd approx />` | "ETH bettors have put into the market. Winning shares are paid from this pool plus the market's seed funding." |
+| Backers | `activity.backers` (and `activity.bets.length` bets in small text: `12 backers · 31 bets`) | "Unique wallets that have backed a team." |
+| Betting closes | existing | existing |
+
+While `activity.loading` show `…`; on `activity.error` show `—` (never block the page).
+
+### 2.5 "Your position" panel
+
+**File (new):** `ui/components/deprize/DePrizePositionPanel.tsx`
+
+Render **only** when `userAddress` is set **and** (user has any bet or sell, or any
+`outcome.balance > 0`). Place it in the page **after the question card, before
+Predictions**, so a returning bettor sees their money first.
+
+Props:
+
+```ts
+{
+  outcomes: MarketOutcome[]                 // market.outcomes
+  labels: string[]                          // predictionLabels
+  colors: string[]                          // OUTCOME_COLORS (by index)
+  bets: BetRow[]; sells: SellRow[]; user: string
+  sellQuotes: Map<number, number>           // live cash-out value per index
+  redeemValueByIndex?: Map<number, number>  // when resolved
+  resolved: boolean; isRefundVector: boolean; winningIndex: number
+  onCashOut: (index: number) => void; onBet: (index: number) => void
+  loading: boolean
+}
+```
+
+Layout (one card):
+
+1. Title row: `Your position` and on the right a big signed P/L pill:
+   `netPnlEth` via `<EthUsd signed />`, green if ≥ 0 else red, label `so far`.
+   Tooltip: "Current value of your shares plus what you've already cashed out, minus
+   everything you've spent (including the 5% prize slice)."
+2. Four mini stats (`grid-cols-2 sm:grid-cols-4`): `Spent`, `Current value`,
+   `Cashed out`, `If your pick wins` (Σ held tokens on the single outcome with the
+   highest held qty; if the user holds several, show the max and add "best case").
+3. Per-outcome rows, only for outcomes where the user has ever had activity, ordered by
+   current value desc: color dot, team name, `shares`, `avg cost / share`, `now worth`
+   (sell quote or redeem value), small `Cash out` button (reuse the button styles in
+   `DePrizeTeamCard`). If resolved: `WON` / `Lost` / `Refund` chip instead of the quote.
+4. Collapsible `Activity` (`<details>`): reverse-chronological list of bets and sells:
+   `Backed Firefly · 0.004 ETH · Sep 8, 3:12 PM` / `Cashed out 0.9 shares of Astrobotic · +0.0023 ETH · …`,
+   each linking to the explorer tx (`https://sepolia.etherscan.io/tx/` or
+   `https://arbiscan.io/tx/` by chain slug).
+
+### 2.6 Retire the localStorage cost basis and slim the team card
+
+**File:** `ui/pages/deprize/[id].tsx`, `ui/components/deprize/DePrizeTeamCard.tsx`
+
+1. Per §1.0, remove the `If wins` subtitle and the holdings block (`Cash out` quote,
+   P/L suffix, button) from `DePrizeTeamCard`; delete the now-unused props
+   (`redeemValueEth`, `sellQuoteEth`, `investedEth`, `onCashOut`) and `PnlSuffix` if
+   nothing else imports it. The card is `%` · name · `Back this team`. Holdings live in
+   the position panel only.
+2. Delete `costBasis`, `costStorageKey`, `persistCostBasis`, `addCostBasis`,
+   `resetCostBasis`, `clearCostBasis` and their call sites. `BetModal.onDone` and
+   `ExitPositionModal.onDone` just call `refreshAll()`; `refreshAll` must also bump the
+   `refreshNonce` passed to `useDePrizeActivity` (it already increments `refreshNonce`).
+3. After a bet/sell, events land a block or two later. Keep the existing 2.5s delayed
+   second refresh; add a third at 8s.
+
+### 2.7 Acceptance for Phase 2
+
+- `/deprize/22` on Sepolia shows `Backers ≥ 1` and a non-zero `Total staked`.
+- With the wallet that placed the smoke bet, "Your position" shows Spent ≈ 0.0005 ETH
+  (0.000475 cost + 0.000025 slice), current value ≈ the card's cash-out quote, and one
+  activity row linking to the bet tx.
+- Reload in a fresh browser profile: the panel shows the same numbers (no localStorage
+  dependence).
+- `/deprize/1` on Arbitrum loads in under ~3s with the header stats filled; check the
+  Network tab for a handful of `eth_getLogs` calls, not hundreds (tune `initialChunk`).
+- `activity-math.cy.ts` covers: unique backers dedupe by lowercase address; total staked
+  sums `cost` only; average-cost attribution after a partial sell; net P/L sign.
+
+---
+
+## Phase 3 — Odds chart rebuilt from chain
+
+Ships: a chart that is identical on every device and shows every trade (#4).
+
+### 3.1 Pure reconstruction
+
+**File (new):** `ui/lib/deprize/lmsr-history.ts` (no React/thirdweb imports)
+
+```ts
+export type TradeLike = { timestampMs: number; amounts: number[] /* ETH units, signed */ }
+export type FundingLike = { timestampMs: number; deltaEth: number }
+
+export function lmsrMarginalPrices(qEth: number[], fundingEth: number): number[]
+// p_i = 1 / Σ_j exp((q_j - q_i) / b), b = fundingEth / ln(n); returns percents summing to ~100
+
+export function rebuildOddsHistory(args: {
+  marketStartMs: number
+  initialFundingEth: number         // funding() at market open (== current funding if no AMMFundingChanged)
+  trades: TradeLike[]               // all AMMOutcomeTokenTrade rows, chronological (buys AND sells, any transactor)
+  fundingChanges?: FundingLike[]
+  numOutcomes: number
+}): OddsSample[]                    // first sample at marketStartMs with uniform 100/n, then one after each trade
+```
+
+Unit tests (`lmsr-history.cy.ts`): uniform prior at start; one buy on outcome 0 raises
+p_0 and lowers the rest, sums to 100; a sell reverses it; result for the final state
+matches `lmsrMarginalPrices(finalQ, funding)` within 1e-9; with `fundingEth = 0.04`,
+`n = 3`, buying `0.01` of outcome 0 gives p_0 ≈ 41.6% (check against the live Sepolia
+market once, then hard-code the expected value).
+
+### 3.2 Wire into the market hook
+
+**File:** `ui/lib/deprize/useDePrizeMarket.tsx`
+
+1. Read `funding()` from the LMSR alongside `fee`/`startTime` in the static load and
+   store `fundingEth` in `staticRef`.
+2. Add an effect: when `marketAddress`, `marketStartMs`, `fundingEth`, `numOutcomes`
+   are known, fetch `TRADE_EVENT` (+ `FUNDING_EVENT`) via `fetchEventsChunked` from
+   `DEPRIZE_EVENTS_FROM_BLOCK[slug]`, resolve timestamps, run `rebuildOddsHistory`, and
+   `setOddsHistory(rebuilt)` **replacing** whatever was hydrated from localStorage.
+   Keep the `loadGenRef` guard so a stale fetch for a previous market can't overwrite.
+3. Self-check: compare the last rebuilt sample with the live `outcomes[].probability`.
+   If any outcome differs by more than 0.5 pt, `console.warn` and append the live sample
+   so the right edge is always truthful.
+4. Keep `recordOddsSample` for **live** samples from the poll (they extend the rebuilt
+   history in-session). Change the localStorage role to a cache: write the rebuilt +
+   live history under a new key `deprize:oddsHistory:v3:<market>` and delete the v2 key.
+   Hydration from cache should only be used while the chain rebuild is in flight.
+5. Expose `oddsHistoryLoading: boolean` and `tradeMarkers: { t: number; index: number }[]`
+   (one per trade, the outcome that was bought/sold) from the hook.
+
+### 3.3 Chart component
+
+**File:** `ui/components/deprize/OddsHistoryChart.tsx`
+
+1. New optional prop `markers?: { t: number; index: number }[]`. Render a Recharts
+   `<Scatter>` (or `<ReferenceDot>` per marker) at `(t, value of v{index} at t)` using
+   the outcome's color, radius 3. Tooltip on a marker says `Trade · <label>`.
+2. New optional prop `loading?: boolean`. When true and `data.length < 2`, show
+   `Loading odds…` instead of the empty state.
+3. Empty state copy is `No trades yet.` (set in §1.0). No caption under the chart; the
+   marker tooltip (`Trade · <label>`) is the only explanation.
+
+### 3.4 Acceptance for Phase 3
+
+- Open `/deprize/22` in two different browsers: charts are identical and show the
+  smoke bet as a step with a dot.
+- Clear localStorage; reload; the chart is unchanged.
+- The right-hand edge of every line equals the legend percentage.
+- `/deprize/1` on Arbitrum shows the step at the user's bet (the one from the feedback)
+  with the correct date on the X axis.
+
+---
+
+## Phase 4 — Layout, polish, and the simulation link (UX proposal)
+
+This phase is optional but strongly recommended once Phases 1–3 land. It is a set of
+suggestions; each bullet is independent.
+
+### 4.1 Final information order on the page (top → bottom)
+
+1. **Header**: `Touchdown` `#22` · (badge only when abnormal) · `← All prizes` · **`Open in Moon Base Zero`** link (right side).
+2. **Question card** (Phase 1.3): the question, description, criteria, simulation link.
+3. **Stats row** (Phase 2.4): Prize pool · to winner / Total staked / Backers / Betting closes.
+4. **Your position** (Phase 2.5) — only when connected with activity. Nothing renders
+   in its place otherwise.
+5. **Odds chart** with trade dots (Phase 3), no legend.
+6. **Competitors** ranked, Open Field last (Phase 1.1): `%` · name · button.
+7. Claim panel (resolved only), admin panel (admins only), lineage line, roster footnote.
+
+### 4.2 Make competitors feel like the simulation
+
+- Each `DePrizeTeamCard` already links to `/moonbase/<projectId>`. Add a second-line
+  subtitle sourced from the atlas project: type (`PROJECT_TYPE_LABEL`), planned year
+  (`milestoneArrivalYear`), and status (`TIME_STATUS_OPACITY` key) — the same words the
+  simulation shows in its panel — so the two views describe a team identically.
+- Use `orgColor(atlasOrg)` for the team's chart line as well as the card accent (today
+  the chart uses `OUTCOME_COLORS[index]` while the card uses the org color — pick one,
+  prefer org colors so the chart legend matches the simulation's legend).
+- Add a "Where this happens" strip under the question card: a static
+  `moonbase` region screenshot or the goal's `regionLabel` with a `Fly there →` link to
+  `/moonbase?race=<goalId>`.
+
+### 4.3 Connect the simulation back to the prize
+
+- `SharedGoalPanel.tsx` links to `/deprize/${marketDeprizeId}`. Add per-competitor
+  `Back this team` links to `/deprize/${id}?outcome=<index>` — the detail page already
+  scrolls to and opens the bet modal for `?outcome=N`.
+- In the simulation's goal panel, show the same four stats (prize pool, staked,
+  backers, closes) using `useDePrizeActivity` so the numbers match across both surfaces.
+
+### 4.4 Plain-language and reduced clutter
+
+- Team card "Back this team" button: below it show a preview line
+  `0.01 ETH → ~0.02 shares → pays ~0.02 ETH if wins` using `quoteQtyForBudget` at a
+  default stake (e.g. 0.01 ETH). This turns the abstract percentage into money before
+  the user opens the modal.
+- Sticky mini-bar on mobile after scrolling past the header: title + top team % +
+  `Back a team` button.
+- Empty states should always tell the user the one action to take: no wallet →
+  `Connect to back a team`; region blocked → `View only in your region`; resolved →
+  `Claim your winnings` / `Claim your refund`.
+
+### 4.5 Shareability
+
+- Add an OG image route (`pages/api/og/deprize/[id].tsx` with `@vercel/og`) rendering
+  title, top three competitors with percentages, prize pool, and closes date, so a
+  shared link previews live odds. Set it in `<Head>` via `competition.metaDescription`
+  plus an `og:image` URL.
+- Add a `Share` button (copies `/deprize/<slug>` when the race has a slug, else `/deprize/<id>`).
+
+---
+
+## Appendix A — Pitfalls checklist for the implementer
+
+- `market.outcomes` is index-aligned with the contract. **Never** sort it in place.
+  Sort a copy for display only.
+- `Bet.cost` already includes the 1% LMSR fee; `slice` is separate. Total spent =
+  `cost + slice`.
+- `AMMOutcomeTokenTrade.transactor` is the Mint for buys. Use `Bet` for identity of
+  buyers; use trade rows only for price reconstruction and for a user's sells.
+- All wei values are 18-decimal (`UNIT = 10n ** 18n`); divide with `Number(x) / Number(UNIT)`
+  only for display; do aggregation in `bigint` where sums can exceed 2^53 wei (they can).
+- `getContractEvents` returns `bigint` block numbers; `JSON.stringify` throws on bigint —
+  convert to string before caching.
+- Filter `Bet` by the `deprizeId` indexed topic; the Mint serves every DePrize on the chain.
+- Arbitrum blocks are ~0.25s; a naive `fromBlock: 0` scan will never finish. Fill
+  `DEPRIZE_EVENTS_FROM_BLOCK` with real values.
+- Do not re-introduce a uniform `1/n` sample after a traded sample (see the comments in
+  `recordOddsSample`); the rebuild makes those guards mostly moot but keep them.
+- Anything that fails in the events layer must degrade to `—`, never block the page.

--- a/ui/components/deprize/BetModal.tsx
+++ b/ui/components/deprize/BetModal.tsx
@@ -268,8 +268,9 @@ export default function BetModal({
             void/cancel; final resolution). Full detail in the DePrize Terms. */}
         <div className="text-amber-300/90 text-[11px] leading-snug space-y-1.5">
           <p>
-            You are buying outcome tokens for this team. If the team wins, they redeem for their
-            full share; if it loses, they are <span className="font-semibold">worth $0</span>. Only
+            You are buying outcome tokens for this competitor. If this competitor wins, they redeem
+            for their full share; if it loses, they are <span className="font-semibold">worth $0</span>.
+            Only
             bet what you can afford to lose. Read this DePrize&apos;s rules before betting —
             resolution is final and cannot be reversed.
           </p>

--- a/ui/components/deprize/DePrizePositionPanel.tsx
+++ b/ui/components/deprize/DePrizePositionPanel.tsx
@@ -1,0 +1,255 @@
+import type { ActivityRow, BetRow, SellRow } from '@/lib/deprize/activity-math'
+import { userActiveOutcomes, userActivity, userPosition, userSummary } from '@/lib/deprize/activity-math'
+import { fmt } from '@/lib/deprize/format'
+import type { Outcome } from '@/lib/deprize/useDePrizeMarket'
+import EthUsd from '@/components/deprize/EthUsd'
+
+type Props = {
+  outcomes: Outcome[]
+  labels: string[]
+  /** Color per outcome index (same source as the cards and the chart). */
+  colors: string[]
+  bets: BetRow[]
+  sells: SellRow[]
+  user: string
+  /** Live cash-out value per outcome index while trading. */
+  sellQuotes: Map<number, number>
+  /** Redeem value per outcome index once resolved. */
+  redeemValues?: Map<number, number>
+  resolved: boolean
+  isRefundVector: boolean
+  winningIndex: number
+  tradingHalted: boolean
+  explorerTxBase: string
+  onCashOut: (index: number) => void
+  loading: boolean
+}
+
+const CARD =
+  'p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg'
+
+function Mini({ label, title, children }: { label: string; title?: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className={`text-xs text-gray-400 ${title ? 'cursor-help' : ''}`} title={title}>
+        {label}
+      </p>
+      <p className="text-sm font-semibold text-white tabular-nums">{children}</p>
+    </div>
+  )
+}
+
+function fmtWhen(ms: number): string {
+  if (!Number.isFinite(ms)) return ''
+  return new Date(ms).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+/**
+ * The connected wallet's money on this prize, in one place: net result so far,
+ * spent / current value / cashed out / best-case payout, per-outcome rows with
+ * cash-out, and the on-chain activity feed. Renders nothing for wallets with no
+ * activity and no balance.
+ */
+export default function DePrizePositionPanel({
+  outcomes,
+  labels,
+  colors,
+  bets,
+  sells,
+  user,
+  sellQuotes,
+  redeemValues,
+  resolved,
+  isRefundVector,
+  winningIndex,
+  tradingHalted,
+  explorerTxBase,
+  onCashOut,
+  loading,
+}: Props) {
+  const active = userActiveOutcomes(bets, sells, user)
+  const heldIdx = outcomes.filter((o) => Number.isFinite(o.balance) && o.balance > 0).map((o) => o.index)
+  const rowsIdx = Array.from(new Set([...active, ...heldIdx])).sort((a, b) => a - b)
+  if (rowsIdx.length === 0) return null
+
+  const valueByIndex = new Map<number, number>()
+  for (const i of rowsIdx) {
+    const v = resolved ? redeemValues?.get(i) : sellQuotes.get(i)
+    if (v !== undefined && Number.isFinite(v)) valueByIndex.set(i, v)
+  }
+  const summary = userSummary(bets, sells, user, valueByIndex)
+  const valueKnown = rowsIdx.every((i) => {
+    const held = outcomes[i]?.balance ?? 0
+    return !(held > 0) || valueByIndex.has(i)
+  })
+
+  // Best case: the single largest held position pays 1 ETH per token.
+  const bestCase = heldIdx.reduce((m, i) => Math.max(m, outcomes[i]?.balance ?? 0), 0)
+  const positive = summary.netPnlEth >= 0
+
+  const rows = rowsIdx
+    .map((i) => ({
+      index: i,
+      pos: userPosition(bets, sells, user, i),
+      held: outcomes[i]?.balance ?? 0,
+      value: valueByIndex.get(i),
+    }))
+    .sort((a, b) => (b.value ?? 0) - (a.value ?? 0) || b.held - a.held)
+
+  const feed: ActivityRow[] = userActivity(bets, sells, user)
+
+  return (
+    <div className={CARD}>
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <p className="text-white font-semibold">Your position</p>
+        <div
+          className={`px-3 py-1 rounded-full text-sm font-semibold tabular-nums border ${
+            positive
+              ? 'bg-emerald-500/10 text-emerald-300 border-emerald-500/30'
+              : 'bg-rose-500/10 text-rose-300 border-rose-500/30'
+          } ${valueKnown ? '' : 'opacity-60'}`}
+          title="Current value of your shares plus what you've already cashed out, minus everything you've spent (including the 5% prize slice)."
+        >
+          {valueKnown || loading ? (
+            <>
+              <EthUsd eth={summary.netPnlEth} signed usdClassName="opacity-70 font-normal" />
+              <span className="ml-1.5 text-xs font-normal opacity-70">so far</span>
+            </>
+          ) : (
+            '…'
+          )}
+        </div>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <Mini label="Spent" title="Everything you've paid in, including the 5% that went to the prize pool.">
+          <EthUsd eth={summary.totalSpentEth} />
+        </Mini>
+        <Mini
+          label={resolved ? 'Claimable' : 'Current value'}
+          title={resolved ? 'What your shares redeem for now.' : 'What the market would pay you to sell everything right now.'}
+        >
+          {valueKnown ? <EthUsd eth={summary.currentValueEth} approx={!resolved} /> : '…'}
+        </Mini>
+        <Mini label="Cashed out">
+          <EthUsd eth={summary.realizedEth} />
+        </Mini>
+        <Mini
+          label={resolved ? 'Result' : 'If your pick wins'}
+          title={resolved ? undefined : 'Each share pays 1 ETH if its team is selected as the winner. Paid from the betting market, not the prize pool.'}
+        >
+          {resolved ? (
+            isRefundVector ? 'Refund' : heldIdx.includes(winningIndex) ? 'Won' : 'Lost'
+          ) : (
+            <span className="text-emerald-300">
+              <EthUsd eth={bestCase} usdClassName="text-emerald-300/70 font-normal" />
+            </span>
+          )}
+        </Mini>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-2">
+        {rows.map(({ index, pos, held, value }) => {
+          const canSell = !resolved && !tradingHalted && held > 0
+          return (
+            <div
+              key={index}
+              className="flex items-center justify-between gap-3 flex-wrap rounded-xl bg-white/[0.03] border border-white/[0.06] px-3 py-2.5"
+            >
+              <div className="flex items-center gap-2.5 min-w-0">
+                <span
+                  className="inline-block w-1.5 h-8 rounded-full shrink-0"
+                  style={{ background: colors[index % colors.length] }}
+                />
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-white truncate">{labels[index]}</p>
+                  <p className="text-xs text-gray-500 tabular-nums">
+                    {fmt(held, 4)} shares
+                    {pos.qtyBought > 0 && (
+                      <>
+                        {' · '}avg {fmt(pos.avgCostEth, 3)} ETH/share
+                      </>
+                    )}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <div className="text-right">
+                  <p className="text-[10px] uppercase tracking-wide text-gray-500">
+                    {resolved ? (isRefundVector ? 'Refund' : index === winningIndex ? 'Won' : 'Lost') : 'Now worth'}
+                  </p>
+                  <p className="text-sm font-semibold text-white tabular-nums">
+                    {held > 0 ? (
+                      value !== undefined ? (
+                        <EthUsd eth={value} approx={!resolved} />
+                      ) : (
+                        '…'
+                      )
+                    ) : (
+                      <span className="text-gray-500">sold</span>
+                    )}
+                  </p>
+                </div>
+                {canSell && (
+                  <button
+                    type="button"
+                    onClick={() => onCashOut(index)}
+                    disabled={value === undefined}
+                    className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-semibold uppercase tracking-wide bg-white/5 hover:bg-indigo-500/15 text-white border border-white/10 hover:border-indigo-400/35 transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Cash out
+                  </button>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {feed.length > 0 && (
+        <details className="mt-3 group">
+          <summary className="cursor-pointer list-none text-xs text-gray-400 hover:text-gray-300 flex items-center gap-1">
+            Activity
+            <span className="inline-block transition-transform group-open:rotate-180">▾</span>
+          </summary>
+          <ul className="mt-2 flex flex-col gap-1.5">
+            {feed.map((r) => (
+              <li
+                key={`${r.txHash}-${r.logIndex}`}
+                className="flex items-center justify-between gap-3 text-xs text-gray-300"
+              >
+                <span className="truncate">
+                  {r.kind === 'bet' ? (
+                    <>
+                      Backed <span className="text-white">{labels[r.outcomeIndex]}</span> ·{' '}
+                      <EthUsd eth={r.costEth + r.sliceEth} />
+                    </>
+                  ) : (
+                    <>
+                      Cashed out {fmt(r.qty, 4)} shares of{' '}
+                      <span className="text-white">{labels[r.outcomeIndex]}</span> ·{' '}
+                      <EthUsd eth={r.proceedsEth} signed />
+                    </>
+                  )}
+                </span>
+                <a
+                  href={`${explorerTxBase}${r.txHash}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="shrink-0 text-gray-500 hover:text-indigo-300 tabular-nums"
+                >
+                  {fmtWhen(r.timestampMs)} ↗
+                </a>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  )
+}

--- a/ui/components/deprize/DePrizePositionPanel.tsx
+++ b/ui/components/deprize/DePrizePositionPanel.tsx
@@ -28,6 +28,16 @@ type Props = {
 const CARD =
   'p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg'
 
+function PnlSuffix({ pnl }: { pnl: number | undefined }) {
+  if (pnl === undefined || !Number.isFinite(pnl)) return null
+  return (
+    <span className={`ml-1.5 font-medium ${pnl >= 0 ? 'text-emerald-400/80' : 'text-rose-400/80'}`}>
+      (
+      <EthUsd eth={pnl} signed usdClassName="opacity-80 font-normal" />)
+    </span>
+  )
+}
+
 function Mini({ label, title, children }: { label: string; title?: string; children: React.ReactNode }) {
   return (
     <div>
@@ -141,7 +151,7 @@ export default function DePrizePositionPanel({
         </Mini>
         <Mini
           label={resolved ? 'Result' : 'If your pick wins'}
-          title={resolved ? undefined : 'Each share pays 1 ETH if its team is selected as the winner. Paid from the betting market, not the prize pool.'}
+          title={resolved ? undefined : 'Each share pays 1 ETH if this competitor is selected as the winner. Paid from the betting market, not the prize pool.'}
         >
           {resolved ? (
             isRefundVector ? 'Refund' : heldIdx.includes(winningIndex) ? 'Won' : 'Lost'
@@ -168,11 +178,26 @@ export default function DePrizePositionPanel({
                 />
                 <div className="min-w-0">
                   <p className="text-sm font-semibold text-white truncate">{labels[index]}</p>
-                  <p className="text-xs text-gray-500 tabular-nums">
-                    {fmt(held, 4)} shares
-                    {pos.qtyBought > 0 && (
+                  <p className="text-xs text-gray-400 tabular-nums">
+                    {held > 0 && pos.heldCostEth > 0 ? (
                       <>
-                        {' · '}avg {fmt(pos.avgCostEth, 3)} ETH/share
+                        Your bet <EthUsd eth={pos.heldCostEth} />
+                        {value !== undefined && (
+                          <>
+                            {' · '}
+                            {resolved ? 'Claim' : 'Cash out'} <EthUsd eth={value} approx={!resolved} />
+                            <PnlSuffix pnl={value - pos.heldCostEth} />
+                          </>
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        {fmt(held, 4)} shares
+                        {pos.qtyBought > 0 && (
+                          <>
+                            {' · '}avg {fmt(pos.avgCostEth, 3)} ETH/share
+                          </>
+                        )}
                       </>
                     )}
                   </p>

--- a/ui/components/deprize/DePrizeQuestionCard.tsx
+++ b/ui/components/deprize/DePrizeQuestionCard.tsx
@@ -28,44 +28,38 @@ function CriteriaList({ criteria }: { criteria: CapabilityCriterion[] }) {
 }
 
 /**
- * What the prize is about, above the fold: the question, the one-paragraph
- * description, and the criteria a competitor must meet to win.
+ * One-line question above the fold. Description + win criteria sit in a
+ * single collapsed accordion so the odds chart and competitors stay visible.
  */
 export default function DePrizeQuestionCard({ tagline, description, criteria, moonbaseHref }: Props) {
   const hasCriteria = !!criteria && criteria.length > 0
-  // Taglines carry a trailing call to action ("Back a team — every bet grows
-  // the prize pool."). Only the question belongs here.
+  const hasDetails = !!description || hasCriteria
+  // Taglines carry a trailing call to action ("Back a competitor — every bet
+  // grows the prize pool."). Only the question belongs here.
   const q = tagline.indexOf('?')
   const question = q >= 0 ? tagline.slice(0, q + 1) : tagline
   return (
     <div className={CARD}>
       <p className="text-white text-base font-semibold leading-snug">{question}</p>
-      {description && <p className="text-gray-400 text-sm mt-2">{description}</p>}
 
-      {hasCriteria && (
-        <>
-          {/* Always expanded on sm+; collapsible on phones to keep odds in view. */}
-          <div className="hidden sm:block mt-4">
-            <p className="text-white text-sm font-semibold mb-2">What counts as winning</p>
-            <CriteriaList criteria={criteria!} />
+      {hasDetails && (
+        <details className="mt-3 group">
+          <summary className="cursor-pointer list-none text-sm font-semibold text-white flex items-center justify-between gap-3">
+            <span>{hasCriteria ? 'What counts as winning' : 'About this prize'}</span>
+            <span className="text-gray-500 text-xs font-normal shrink-0">
+              {hasCriteria ? `${criteria!.length} criteria` : null}
+              <span className="ml-1 inline-block transition-transform group-open:rotate-180">▾</span>
+            </span>
+          </summary>
+          <div className="mt-3 flex flex-col gap-3">
+            {description && <p className="text-gray-400 text-sm">{description}</p>}
+            {hasCriteria && <CriteriaList criteria={criteria!} />}
           </div>
-          <details className="sm:hidden mt-3 group">
-            <summary className="cursor-pointer list-none text-sm font-semibold text-white flex items-center justify-between">
-              What counts as winning
-              <span className="text-gray-500 text-xs font-normal">
-                {criteria!.length} criteria
-                <span className="ml-1 inline-block transition-transform group-open:rotate-180">▾</span>
-              </span>
-            </summary>
-            <div className="mt-2">
-              <CriteriaList criteria={criteria!} />
-            </div>
-          </details>
-        </>
+        </details>
       )}
 
       {moonbaseHref && (
-        <p className="mt-4 text-xs">
+        <p className="mt-3 text-xs">
           <Link
             href={moonbaseHref}
             className="text-indigo-300/90 underline-offset-2 hover:underline hover:text-indigo-200"

--- a/ui/components/deprize/DePrizeQuestionCard.tsx
+++ b/ui/components/deprize/DePrizeQuestionCard.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link'
+import type { CapabilityCriterion } from '@/lib/lunar-atlas/types'
+
+type Props = {
+  /** The market's question, e.g. "Which company lands on the Moon next?" */
+  tagline: string
+  description?: string
+  criteria?: CapabilityCriterion[]
+  /** Deep link into Moon Base Zero for this race. */
+  moonbaseHref?: string
+}
+
+const CARD =
+  'p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg'
+
+function CriteriaList({ criteria }: { criteria: CapabilityCriterion[] }) {
+  return (
+    <ol className="flex flex-col gap-2.5">
+      {criteria.map((c, i) => (
+        <li key={c.id} className="text-sm text-gray-300">
+          <span className="text-gray-500 mr-2 tabular-nums">{i + 1}</span>
+          {c.statement}
+          {c.threshold && <p className="text-xs text-gray-500 mt-0.5 pl-5">{c.threshold}</p>}
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+/**
+ * What the prize is about, above the fold: the question, the one-paragraph
+ * description, and the criteria a competitor must meet to win.
+ */
+export default function DePrizeQuestionCard({ tagline, description, criteria, moonbaseHref }: Props) {
+  const hasCriteria = !!criteria && criteria.length > 0
+  // Taglines carry a trailing call to action ("Back a team — every bet grows
+  // the prize pool."). Only the question belongs here.
+  const q = tagline.indexOf('?')
+  const question = q >= 0 ? tagline.slice(0, q + 1) : tagline
+  return (
+    <div className={CARD}>
+      <p className="text-white text-base font-semibold leading-snug">{question}</p>
+      {description && <p className="text-gray-400 text-sm mt-2">{description}</p>}
+
+      {hasCriteria && (
+        <>
+          {/* Always expanded on sm+; collapsible on phones to keep odds in view. */}
+          <div className="hidden sm:block mt-4">
+            <p className="text-white text-sm font-semibold mb-2">What counts as winning</p>
+            <CriteriaList criteria={criteria!} />
+          </div>
+          <details className="sm:hidden mt-3 group">
+            <summary className="cursor-pointer list-none text-sm font-semibold text-white flex items-center justify-between">
+              What counts as winning
+              <span className="text-gray-500 text-xs font-normal">
+                {criteria!.length} criteria
+                <span className="ml-1 inline-block transition-transform group-open:rotate-180">▾</span>
+              </span>
+            </summary>
+            <div className="mt-2">
+              <CriteriaList criteria={criteria!} />
+            </div>
+          </details>
+        </>
+      )}
+
+      {moonbaseHref && (
+        <p className="mt-4 text-xs">
+          <Link
+            href={moonbaseHref}
+            className="text-indigo-300/90 underline-offset-2 hover:underline hover:text-indigo-200"
+          >
+            See this race on Moon Base Zero →
+          </Link>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/ui/components/deprize/DePrizeTeamCard.tsx
+++ b/ui/components/deprize/DePrizeTeamCard.tsx
@@ -41,6 +41,13 @@ type DePrizeTeamCardProps = {
   hrefOverride?: string
   /** Atlas org display name, for competitors with no Team NFT. */
   nameOverride?: string
+  /** Vehicle / article shown under the org name (live prize page). */
+  vehicleLabel?: string
+  /**
+   * Live-page Back button copy, e.g. "Back Voyager Lunar Systems".
+   * Demo cards omit this and keep "Back this team".
+   */
+  backLabel?: string
   /** Atlas org logo. Suppressed when `unclaimed`. */
   imageOverride?: string
   /**
@@ -91,6 +98,8 @@ export default function DePrizeTeamCard({
   withdrawn = false,
   hrefOverride,
   nameOverride,
+  vehicleLabel,
+  backLabel,
   imageOverride,
   unclaimed = false,
   participation,
@@ -170,6 +179,9 @@ export default function DePrizeTeamCard({
             )}
           </div>
           {isField && <p className="text-xs text-gray-400 pl-12">Any other team</p>}
+          {!isField && vehicleLabel && (
+            <p className="text-xs text-gray-400 pl-12">{vehicleLabel}</p>
+          )}
           {withdrawn && !isField && (
             <p className="text-xs text-amber-400/90 pl-12">Withdrawn — sell only</p>
           )}
@@ -192,7 +204,9 @@ export default function DePrizeTeamCard({
             disabled={busy}
             className="rounded-xl shadow-purple-500/10"
           >
-            {!userConnected ? 'Connect to back' : isField ? 'Back the field' : 'Back this team'}
+            {!userConnected
+              ? 'Connect to back'
+              : backLabel ?? (isField ? 'Back the field' : 'Back this team')}
           </StandardButton>
         )}
       </div>

--- a/ui/components/deprize/DePrizeTeamCard.tsx
+++ b/ui/components/deprize/DePrizeTeamCard.tsx
@@ -14,18 +14,22 @@ type DePrizeTeamCardProps = {
   resolved: boolean
   isRefundVector: boolean
   isWinningSlot: boolean
-  // Value display (ETH). redeemValue set once resolved; sellQuote while trading.
+  /**
+   * Inline holdings (payout line + cash-out quote). Only rendered when
+   * `onCashOut` is provided — the live prize page shows holdings in the
+   * position panel instead and omits these.
+   */
   redeemValueEth?: number
   sellQuoteEth?: number
-  investedEth: number
+  investedEth?: number
+  onCashOut?: (index: number) => void
   // Actions + gating
   bettingOpen: boolean
   tradingHalted: boolean
   busy: boolean
   userConnected: boolean
   onBet: (index: number) => void
-  onCashOut: (index: number) => void
-  /** Open Field slot — render overrides + tooltip instead of a Team NFT. */
+  /** Open Field slot — render overrides instead of a Team NFT. */
   isField?: boolean
   /** Disclosure: competitor marked withdrawn on-chain. Slot stays tradable. */
   withdrawn?: boolean
@@ -76,7 +80,7 @@ export default function DePrizeTeamCard({
   isWinningSlot,
   redeemValueEth,
   sellQuoteEth,
-  investedEth,
+  investedEth = 0,
   bettingOpen,
   tradingHalted,
   busy,
@@ -92,37 +96,19 @@ export default function DePrizeTeamCard({
   participation,
 }: DePrizeTeamCardProps) {
   const holding = Number.isFinite(outcome.balance) && outcome.balance > 0
+  const showHoldings = !!onCashOut && holding
   const realizedValue = resolved ? redeemValueEth : sellQuoteEth
   const pnl =
-    realizedValue !== undefined && investedEth > 0
-      ? realizedValue - investedEth
-      : undefined
-  const canCashOut = holding && !tradingHalted && !resolved
-  const showWinSubtitle = holding && !resolved
-  const participationTone =
-    participation === 'official'
-      ? 'from-emerald-950/55 border-emerald-400/25'
-      : participation === 'unofficial'
-        ? 'from-zinc-950/80 border-zinc-400/20'
-        : 'from-slate-900/90 border-white/[0.08]'
+    realizedValue !== undefined && investedEth > 0 ? realizedValue - investedEth : undefined
+  const canCashOut = showHoldings && !tradingHalted && !resolved
 
   return (
     <div
-      className={`relative overflow-hidden p-4 sm:p-5 rounded-2xl bg-gradient-to-br via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border shadow-lg ${participationTone} ${
-        resolved && isWinningSlot
-          ? 'border-emerald-400/40 ring-1 ring-emerald-400/20'
-          : ''
+      className={`relative overflow-hidden p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg ${
+        resolved && isWinningSlot ? 'border-emerald-400/40 ring-1 ring-emerald-400/20' : ''
       }`}
     >
-      {participation && (
-        <span
-          aria-hidden
-          className={`absolute inset-y-0 left-0 w-1 ${
-            participation === 'official' ? 'bg-emerald-400' : 'bg-zinc-400'
-          }`}
-        />
-      )}
-      {/* Top row: chance/result · team (+ if-wins subtitle) · bet CTA */}
+      {/* Top row: chance/result · team · bet CTA */}
       <div className="flex items-center gap-4 flex-wrap">
         <div className="flex items-center gap-3 min-w-[96px]">
           <span
@@ -160,36 +146,39 @@ export default function DePrizeTeamCard({
         </div>
 
         <div className="flex-1 min-w-[150px] flex flex-col gap-1">
-          <DePrizeTeamLink
-            teamId={teamId}
-            teamContract={teamContract}
-            color={color}
-            size={40}
-            className="text-base font-semibold text-white hover:text-indigo-200"
-            nameOverride={isField ? 'Open Field' : nameOverride}
-            imageOverride={isField ? FIELD_AVATAR : imageOverride}
-            hrefOverride={isField ? '/deprize#open-field' : hrefOverride}
-            // The field slot is not an organization, so its own placeholder mark
-            // must survive the unclaimed logo suppression.
-            unclaimed={!isField && unclaimed}
-          />
-          {isField && (
-            <p
-              className="text-xs text-gray-400 pl-12"
-              title="Pays if any qualifying entrant not listed above is selected as the winner. The Senate names the entity; the admin Safe records the payout address in the same settlement batch."
-            >
-              Any qualifying entrant not listed above
-            </p>
-          )}
+          <div className="flex items-center gap-2 flex-wrap">
+            <DePrizeTeamLink
+              teamId={teamId}
+              teamContract={teamContract}
+              color={color}
+              size={40}
+              className="text-base font-semibold text-white hover:text-indigo-200"
+              nameOverride={isField ? 'Open Field' : nameOverride}
+              imageOverride={isField ? FIELD_AVATAR : imageOverride}
+              hrefOverride={isField ? '/deprize#open-field' : hrefOverride}
+              // The field slot is not an organization, so its own placeholder mark
+              // must survive the unclaimed logo suppression.
+              unclaimed={!isField && unclaimed}
+            />
+            {participation === 'unofficial' && !isField && (
+              <span
+                className="text-[10px] uppercase tracking-wide rounded-full px-2 py-0.5 border border-zinc-500/40 text-zinc-300"
+                title="Listed by MoonDAO; this organization has not confirmed participation."
+              >
+                Unconfirmed
+              </span>
+            )}
+          </div>
+          {isField && <p className="text-xs text-gray-400 pl-12">Any other team</p>}
           {withdrawn && !isField && (
-            <p className="text-xs text-amber-400/90 pl-12">
-              Withdrawn — you can still sell your position
-            </p>
+            <p className="text-xs text-amber-400/90 pl-12">Withdrawn — sell only</p>
           )}
-          {showWinSubtitle && (
-            // Align under the team name (avatar 40px + gap-2 8px).
-            <p className="text-xs text-gray-500 pl-12">
-              If wins ·{' '}
+          {showHoldings && !resolved && (
+            <p
+              className="text-xs text-gray-500 pl-12"
+              title="Each share you hold pays 1 ETH if this team is selected as the winner. Paid from the betting market, not from the prize pool."
+            >
+              Your payout if wins ·{' '}
               <span className="text-emerald-400/90 font-medium tabular-nums">
                 <EthUsd eth={outcome.balance} usdClassName="text-emerald-400/70 font-normal" />
               </span>
@@ -200,16 +189,15 @@ export default function DePrizeTeamCard({
         {bettingOpen && !tradingHalted && (
           <StandardButton
             onClick={() => onBet(outcome.index)}
-            disabled={busy || !userConnected}
+            disabled={busy}
             className="rounded-xl shadow-purple-500/10"
           >
-            {isField ? 'Back the field' : 'Back this team'}
+            {!userConnected ? 'Connect to back' : isField ? 'Back the field' : 'Back this team'}
           </StandardButton>
         )}
       </div>
 
-      {/* Single holdings line — one exit quote + action (Polymarket-style) */}
-      {holding && (
+      {showHoldings && (
         <div className="mt-4 flex items-center justify-between gap-3 flex-wrap rounded-xl bg-white/[0.03] border border-white/[0.06] px-3 py-2.5">
           <div className="min-w-0">
             <p className="text-[10px] uppercase tracking-wide text-gray-500">
@@ -240,7 +228,7 @@ export default function DePrizeTeamCard({
           {canCashOut && (
             <button
               type="button"
-              onClick={() => onCashOut(outcome.index)}
+              onClick={() => onCashOut?.(outcome.index)}
               disabled={busy || !userConnected || sellQuoteEth === undefined}
               className="shrink-0 px-4 py-2 rounded-lg text-xs font-semibold uppercase tracking-wide
                 bg-white/5 hover:bg-indigo-500/15 text-white border border-white/10 hover:border-indigo-400/35

--- a/ui/components/deprize/DePrizeTeamCard.tsx
+++ b/ui/components/deprize/DePrizeTeamCard.tsx
@@ -188,7 +188,7 @@ export default function DePrizeTeamCard({
           {showHoldings && !resolved && (
             <p
               className="text-xs text-gray-500 pl-12"
-              title="Each share you hold pays 1 ETH if this team is selected as the winner. Paid from the betting market, not from the prize pool."
+              title="Each share you hold pays 1 ETH if this competitor is selected as the winner. Paid from the betting market, not from the prize pool."
             >
               Your payout if wins ·{' '}
               <span className="text-emerald-400/90 font-medium tabular-nums">

--- a/ui/components/deprize/OddsHistoryChart.tsx
+++ b/ui/components/deprize/OddsHistoryChart.tsx
@@ -19,7 +19,7 @@ import {
 
 export type { OddsSample }
 
-export type OddsMarker = { t: number; index: number }
+export type OddsMarker = { t: number; index: number; buy?: boolean }
 
 type Props = {
   history: OddsSample[]
@@ -53,7 +53,7 @@ export default function OddsHistoryChart({
         tMax: 0,
         ticks: [] as number[],
         spanMs: 0,
-        dots: [] as { t: number; v: number; index: number }[],
+        dots: [] as { t: number; v: number; index: number; buy: boolean }[],
       }
     }
 
@@ -67,7 +67,8 @@ export default function OddsHistoryChart({
     })
 
     // Marker y-value = the traded outcome's probability right after the trade
-    // (the latest sample at or before the marker time).
+    // (the latest sample at or before the marker time). Buys render filled;
+    // cash-outs render hollow so sells read differently from bets.
     const sorted = [...history].sort((a, b) => a.t - b.t)
     const dots = markers
       .map((m) => {
@@ -78,9 +79,9 @@ export default function OddsHistoryChart({
         }
         return v === undefined || !Number.isFinite(v)
           ? null
-          : { t: Math.max(m.t, domain.tMin), v, index: m.index }
+          : { t: Math.max(m.t, domain.tMin), v, index: m.index, buy: m.buy !== false }
       })
-      .filter((d): d is { t: number; v: number; index: number } => d !== null)
+      .filter((d): d is { t: number; v: number; index: number; buy: boolean } => d !== null)
 
     return { data: rows, dots, ...domain }
   }, [history, outcomeCount, domainStartMs, markers])
@@ -153,8 +154,8 @@ export default function OddsHistoryChart({
             x={d.t}
             y={d.v}
             r={3.5}
-            fill={colors[d.index % colors.length]}
-            stroke="#0b1220"
+            fill={d.buy ? colors[d.index % colors.length] : '#0b1220'}
+            stroke={colors[d.index % colors.length]}
             strokeWidth={1.5}
             isFront
           />

--- a/ui/components/deprize/OddsHistoryChart.tsx
+++ b/ui/components/deprize/OddsHistoryChart.tsx
@@ -3,6 +3,7 @@ import {
   CartesianGrid,
   Line,
   LineChart,
+  ReferenceDot,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -18,6 +19,8 @@ import {
 
 export type { OddsSample }
 
+export type OddsMarker = { t: number; index: number }
+
 type Props = {
   history: OddsSample[]
   labels: string[]
@@ -25,6 +28,10 @@ type Props = {
   height?: number
   /** Anchor the X domain to the market open time (ms since epoch). */
   domainStartMs?: number
+  /** One dot per on-chain trade, drawn on the traded outcome's line. */
+  markers?: OddsMarker[]
+  /** True while the on-chain history is still loading. */
+  loading?: boolean
 }
 
 export default function OddsHistoryChart({
@@ -33,10 +40,12 @@ export default function OddsHistoryChart({
   colors,
   height = 220,
   domainStartMs,
+  markers = [],
+  loading = false,
 }: Props) {
   const outcomeCount = labels.length
 
-  const { data, tMin, tMax, ticks, spanMs } = useMemo(() => {
+  const { data, tMin, tMax, ticks, spanMs, dots } = useMemo(() => {
     if (!history.length) {
       return {
         data: [] as Record<string, number>[],
@@ -44,6 +53,7 @@ export default function OddsHistoryChart({
         tMax: 0,
         ticks: [] as number[],
         spanMs: 0,
+        dots: [] as { t: number; v: number; index: number }[],
       }
     }
 
@@ -56,8 +66,24 @@ export default function OddsHistoryChart({
       return row
     })
 
-    return { data: rows, ...domain }
-  }, [history, outcomeCount, domainStartMs])
+    // Marker y-value = the traded outcome's probability right after the trade
+    // (the latest sample at or before the marker time).
+    const sorted = [...history].sort((a, b) => a.t - b.t)
+    const dots = markers
+      .map((m) => {
+        let v: number | undefined
+        for (const s of sorted) {
+          if (s.t <= m.t) v = s.p[m.index]
+          else break
+        }
+        return v === undefined || !Number.isFinite(v)
+          ? null
+          : { t: Math.max(m.t, domain.tMin), v, index: m.index }
+      })
+      .filter((d): d is { t: number; v: number; index: number } => d !== null)
+
+    return { data: rows, dots, ...domain }
+  }, [history, outcomeCount, domainStartMs, markers])
 
   if (data.length < 2) {
     return (
@@ -65,8 +91,7 @@ export default function OddsHistoryChart({
         className="flex items-center justify-center text-gray-500 text-xs text-center px-4"
         style={{ height }}
       >
-        Odds history will plot here as the market moves. Samples persist across
-        visits, so the line grows from market open to now.
+        {loading ? 'Loading odds…' : 'No trades yet.'}
       </div>
     )
   }
@@ -120,6 +145,18 @@ export default function OddsHistoryChart({
             dot={false}
             isAnimationActive={false}
             connectNulls
+          />
+        ))}
+        {dots.map((d, i) => (
+          <ReferenceDot
+            key={`m${i}`}
+            x={d.t}
+            y={d.v}
+            r={3.5}
+            fill={colors[d.index % colors.length]}
+            stroke="#0b1220"
+            strokeWidth={1.5}
+            isFront
           />
         ))}
       </LineChart>

--- a/ui/const/config.ts
+++ b/ui/const/config.ts
@@ -480,6 +480,13 @@ export const DEPRIZE_REGISTRY_ADDRESSES: Index = {
   'arbitrum-sepolia': '',
   arbitrum: '0xf8B2244634c6eCeF32de10BFe0D7436413A59924',
 }
+// First block worth scanning for DePrize events per chain: the block in which
+// DePrizeRegistry was deployed (Etherscan `getcontractcreation`). Every DePrize
+// mint router, market and trade was created after this block.
+export const DEPRIZE_EVENTS_FROM_BLOCK: Record<string, number> = {
+  sepolia: 11068914,
+  arbitrum: 495964196,
+}
 // DePrizeMint bet router (5% JB prize slice + 95% CTF/LMSR collateral). Populate
 // per chain once `script/deprize/DePrizeMint.s.sol` has deployed the router and
 // `setMarket(deprizeId, lmsr)` has bound the market. Empty until then — the

--- a/ui/cypress/e2e/onramp/create-citizen-onramp.cy.tsx
+++ b/ui/cypress/e2e/onramp/create-citizen-onramp.cy.tsx
@@ -62,17 +62,16 @@ describe('CreateCitizen Onramp E2E Flow', () => {
       },
     })
 
-    cy.get('#app-layout', { timeout: 60000 }).should('exist')
+    cy.get('#app-layout', { timeout: 120000 }).should('exist')
 
-    // Verify cache still exists (should be restored by the component)
-    cy.window().then((win) => {
+    // Retryable: the app hydrates and restores asynchronously (Privy, JWT
+    // effects) after first paint, so a one-shot read can race the lifecycle.
+    cy.window({ timeout: 15000 }).should((win) => {
       const restored = win.localStorage.getItem(cacheKey)
-      expect(restored).to.not.be.null
-      if (restored) {
-        const cache = JSON.parse(restored)
-        expect(cache.formData.citizenData.name).to.equal('Test Citizen')
-        expect(cache.stage).to.equal(2)
-      }
+      expect(restored, 'form cache present in localStorage').to.not.be.null
+      const cache = JSON.parse(restored as string)
+      expect(cache.formData.citizenData.name).to.equal('Test Citizen')
+      expect(cache.stage).to.equal(2)
     })
 
     // JWT verification may or may not be called depending on component state
@@ -101,12 +100,12 @@ describe('CreateCitizen Onramp E2E Flow', () => {
       },
     })
 
-    cy.get('#app-layout', { timeout: 60000 }).should('exist')
+    cy.get('#app-layout', { timeout: 120000 }).should('exist')
 
-    // Cache should still exist even without JWT
-    cy.window().then((win) => {
+    // Retryable for the same async-hydration reason as above.
+    cy.window({ timeout: 15000 }).should((win) => {
       const restored = win.localStorage.getItem(cacheKey)
-      expect(restored).to.not.be.null
+      expect(restored, 'form cache present in localStorage').to.not.be.null
     })
   })
 
@@ -131,27 +130,16 @@ describe('CreateCitizen Onramp E2E Flow', () => {
       },
     })
 
-    cy.get('#app-layout', { timeout: 60000 }).should('exist')
-    // Allow client some time to run restoreCache / expiry handling.
-    // Note: this uses a fixed delay and is therefore not fully deterministic.
-    cy.wait(1500)
+    cy.get('#app-layout', { timeout: 120000 }).should('exist')
 
-    // Verify expired cache behavior
-    // restoreCache() should return null for expired cache and clear it
-    cy.window().then((win) => {
-      const restored = win.localStorage.getItem(cacheKey)
-      const CACHE_EXPIRY_MS = 24 * 60 * 60 * 1000 // 24 hours
-      
-      if (restored) {
-        const cache = JSON.parse(restored)
-        const now = Date.now()
-        const cacheAge = now - cache.timestamp
-        // Verify cache is expired
-        expect(cacheAge).to.be.greaterThan(CACHE_EXPIRY_MS)
-        // When restoreCache() is called, it should detect expiry and clear the cache
-        // The cache may still exist if restoreCache hasn't been called yet in the component lifecycle
-      }
-      // If cache was already cleared by restoreCache(), that's the expected behavior
+    // Deterministic: the app clears expired caches on mount (restoreCache and
+    // the expiry sweep effect), so poll until the key is gone instead of
+    // sleeping a fixed delay and asserting conditionally.
+    cy.window({ timeout: 15000 }).should((win) => {
+      expect(
+        win.localStorage.getItem(cacheKey),
+        'expired form cache cleared'
+      ).to.be.null
     })
   })
 })

--- a/ui/cypress/integration/lib/deprize/activity-math.cy.ts
+++ b/ui/cypress/integration/lib/deprize/activity-math.cy.ts
@@ -23,7 +23,9 @@ function bet(p: Partial<BetRow> & { bettor: string; outcomeIndex: number; qty: n
     ...p,
   }
 }
-function sell(p: Partial<SellRow> & { seller: string; outcomeIndex: number; qty: number }): SellRow {
+function sell(
+  p: Partial<SellRow> & { seller: string; outcomeIndex: number; qty: number }
+): SellRow {
   return {
     proceedsEth: 0,
     blockNumber: 2n,
@@ -43,7 +45,10 @@ describe('deprize activity math', () => {
   ]
 
   it('counts unique backers case-insensitively', () => {
-    const mixed = [...bets, bet({ bettor: A.toUpperCase().replace('0X', '0x'), outcomeIndex: 0, qty: 1 })]
+    const mixed = [
+      ...bets,
+      bet({ bettor: A.toUpperCase().replace('0X', '0x'), outcomeIndex: 0, qty: 1 }),
+    ]
     expect(uniqueBackers(mixed)).to.equal(2)
   })
 
@@ -84,8 +89,20 @@ describe('deprize activity math', () => {
     expect(s.netPnlEth).to.be.closeTo(3.0 + 0.9 - 3.5, 1e-12)
   })
 
+  it('userSummary includes on-chain holdings that never appear in events', () => {
+    const value = new Map<number, number>([[4, 1.25]])
+    const s = userSummary([], [], A, value)
+    expect(s.totalSpentEth).to.equal(0)
+    expect(s.realizedEth).to.equal(0)
+    expect(s.heldCostEth).to.equal(0)
+    expect(s.currentValueEth).to.equal(1.25)
+    expect(s.netPnlEth).to.equal(1.25)
+  })
+
   it('userSummary is negative after a losing cash-out', () => {
-    const only: BetRow[] = [bet({ bettor: A, outcomeIndex: 0, qty: 1, costEth: 0.95, sliceEth: 0.05 })]
+    const only: BetRow[] = [
+      bet({ bettor: A, outcomeIndex: 0, qty: 1, costEth: 0.95, sliceEth: 0.05 }),
+    ]
     const sells: SellRow[] = [sell({ seller: A, outcomeIndex: 0, qty: 1, proceedsEth: 0.7 })]
     const s = userSummary(only, sells, A, new Map())
     expect(s.netPnlEth).to.be.closeTo(-0.3, 1e-12)

--- a/ui/cypress/integration/lib/deprize/activity-math.cy.ts
+++ b/ui/cypress/integration/lib/deprize/activity-math.cy.ts
@@ -1,0 +1,105 @@
+import {
+  totalStaked,
+  uniqueBackers,
+  userActiveOutcomes,
+  userActivity,
+  userPosition,
+  userSummary,
+  type BetRow,
+  type SellRow,
+} from '@/lib/deprize/activity-math'
+
+const A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+function bet(p: Partial<BetRow> & { bettor: string; outcomeIndex: number; qty: number }): BetRow {
+  return {
+    costEth: 0,
+    sliceEth: 0,
+    blockNumber: 1n,
+    logIndex: 0,
+    txHash: '0x1',
+    timestampMs: 1,
+    ...p,
+  }
+}
+function sell(p: Partial<SellRow> & { seller: string; outcomeIndex: number; qty: number }): SellRow {
+  return {
+    proceedsEth: 0,
+    blockNumber: 2n,
+    logIndex: 0,
+    txHash: '0x2',
+    timestampMs: 2,
+    ...p,
+  }
+}
+
+describe('deprize activity math', () => {
+  const bets: BetRow[] = [
+    bet({ bettor: A, outcomeIndex: 0, qty: 2, costEth: 0.95, sliceEth: 0.05 }),
+    bet({ bettor: A, outcomeIndex: 0, qty: 2, costEth: 1.9, sliceEth: 0.1, blockNumber: 3n }),
+    bet({ bettor: A, outcomeIndex: 1, qty: 1, costEth: 0.475, sliceEth: 0.025 }),
+    bet({ bettor: B, outcomeIndex: 2, qty: 5, costEth: 0.19, sliceEth: 0.01 }),
+  ]
+
+  it('counts unique backers case-insensitively', () => {
+    const mixed = [...bets, bet({ bettor: A.toUpperCase().replace('0X', '0x'), outcomeIndex: 0, qty: 1 })]
+    expect(uniqueBackers(mixed)).to.equal(2)
+  })
+
+  it('total staked sums the market-side cost only (not the prize slice)', () => {
+    expect(totalStaked(bets)).to.be.closeTo(0.95 + 1.9 + 0.475 + 0.19, 1e-12)
+  })
+
+  it('userPosition uses average all-in cost (cost + slice) for held tokens', () => {
+    const sells: SellRow[] = [sell({ seller: A, outcomeIndex: 0, qty: 1, proceedsEth: 0.9 })]
+    const p = userPosition(bets, sells, A, 0)
+    expect(p.qtyBought).to.equal(4)
+    expect(p.qtySold).to.equal(1)
+    expect(p.qtyHeld).to.equal(3)
+    expect(p.spentEth).to.be.closeTo(3.0, 1e-12) // 1.0 + 2.0 all-in
+    expect(p.avgCostEth).to.be.closeTo(0.75, 1e-12)
+    expect(p.heldCostEth).to.be.closeTo(2.25, 1e-12)
+    expect(p.proceedsEth).to.equal(0.9)
+  })
+
+  it('userActiveOutcomes lists every outcome touched, sorted', () => {
+    const sells: SellRow[] = [sell({ seller: A, outcomeIndex: 3, qty: 1 })]
+    expect(userActiveOutcomes(bets, sells, A)).to.deep.equal([0, 1, 3])
+    expect(userActiveOutcomes(bets, sells, B)).to.deep.equal([2])
+  })
+
+  it('userSummary nets current value + realized against everything spent', () => {
+    const sells: SellRow[] = [sell({ seller: A, outcomeIndex: 0, qty: 1, proceedsEth: 0.9 })]
+    const value = new Map<number, number>([
+      [0, 2.4], // 3 held tokens on outcome 0
+      [1, 0.6],
+    ])
+    const s = userSummary(bets, sells, A, value)
+    expect(s.totalSpentEth).to.be.closeTo(3.5, 1e-12)
+    expect(s.realizedEth).to.equal(0.9)
+    expect(s.currentValueEth).to.equal(3.0)
+    expect(s.heldCostEth).to.be.closeTo(2.25 + 0.5, 1e-12)
+    expect(s.unrealizedPnlEth).to.be.closeTo(3.0 - 2.75, 1e-12)
+    expect(s.netPnlEth).to.be.closeTo(3.0 + 0.9 - 3.5, 1e-12)
+  })
+
+  it('userSummary is negative after a losing cash-out', () => {
+    const only: BetRow[] = [bet({ bettor: A, outcomeIndex: 0, qty: 1, costEth: 0.95, sliceEth: 0.05 })]
+    const sells: SellRow[] = [sell({ seller: A, outcomeIndex: 0, qty: 1, proceedsEth: 0.7 })]
+    const s = userSummary(only, sells, A, new Map())
+    expect(s.netPnlEth).to.be.closeTo(-0.3, 1e-12)
+    expect(s.heldCostEth).to.equal(0)
+  })
+
+  it('userActivity is reverse-chronological by block then log index', () => {
+    const sells: SellRow[] = [sell({ seller: A, outcomeIndex: 0, qty: 1, blockNumber: 2n })]
+    const rows = userActivity(bets, sells, A)
+    expect(rows.map((r) => `${r.kind}@${r.blockNumber}`)).to.deep.equal([
+      'bet@3',
+      'sell@2',
+      'bet@1',
+      'bet@1',
+    ])
+  })
+})

--- a/ui/cypress/integration/lib/deprize/competitions.cy.ts
+++ b/ui/cypress/integration/lib/deprize/competitions.cy.ts
@@ -112,6 +112,14 @@ describe('deprize competitions registry', () => {
       601, 602, 603, 604, 605, 24,
     ])
     expect(binding!.outcomes[5].field).to.equal(true)
+    expect(binding!.outcomes.map((o) => o.vehicleLabel)).to.deep.equal([
+      'Griffin Mission One',
+      'Nova-C IM-3',
+      'Blue Ghost M2',
+      'Blue Moon MK1',
+      "Chang'e-7",
+      undefined,
+    ])
   })
 
   it('registers Sepolia DePrize 20 as the unbound Harsh Mistress featured prize', () => {

--- a/ui/cypress/integration/lib/deprize/lmsr-history.cy.ts
+++ b/ui/cypress/integration/lib/deprize/lmsr-history.cy.ts
@@ -1,0 +1,101 @@
+import {
+  lmsrMarginalPrices,
+  maxProbDelta,
+  rebuildOddsHistory,
+} from '@/lib/deprize/lmsr-history'
+
+const sum = (xs: number[]) => xs.reduce((s, x) => s + x, 0)
+
+describe('deprize LMSR history reconstruction', () => {
+  describe('lmsrMarginalPrices', () => {
+    it('is uniform with no trades', () => {
+      expect(lmsrMarginalPrices([0, 0, 0], 0.03)).to.deep.equal([100 / 3, 100 / 3, 100 / 3])
+    })
+
+    it('raises the bought outcome, lowers the rest, still sums to 100', () => {
+      const p = lmsrMarginalPrices([0.01, 0, 0], 0.03)
+      expect(p[0]).to.be.greaterThan(100 / 3)
+      expect(p[1]).to.be.lessThan(100 / 3)
+      expect(p[1]).to.be.closeTo(p[2], 1e-12)
+      expect(sum(p)).to.be.closeTo(100, 1e-9)
+    })
+
+    it('matches the closed form exp(q/b)/Σexp(q/b)', () => {
+      const q = [0.004, -0.001, 0.002]
+      const funding = 0.03
+      const b = funding / Math.log(3)
+      const e = q.map((x) => Math.exp(x / b))
+      const expected = e.map((x) => (100 * x) / sum(e))
+      const got = lmsrMarginalPrices(q, funding)
+      for (let i = 0; i < 3; i++) expect(got[i]).to.be.closeTo(expected[i], 1e-9)
+    })
+
+    it('does not overflow on large positions', () => {
+      const p = lmsrMarginalPrices([50, 0, 0], 0.03)
+      expect(p[0]).to.be.closeTo(100, 1e-9)
+      expect(Number.isFinite(p[1])).to.equal(true)
+    })
+  })
+
+  describe('rebuildOddsHistory', () => {
+    const open = Date.UTC(2026, 8, 1)
+
+    it('starts at the uniform prior on market open and steps after each trade', () => {
+      const { history, markers } = rebuildOddsHistory({
+        marketStartMs: open,
+        initialFundingEth: 0.06,
+        numOutcomes: 6,
+        trades: [
+          { timestampMs: open + 1000, amounts: [0.004, 0, 0, 0, 0, 0] },
+          { timestampMs: open + 2000, amounts: [-0.002, 0, 0, 0, 0, 0] },
+        ],
+      })
+      expect(history).to.have.length(3)
+      expect(history[0].t).to.equal(open)
+      for (const p of history[0].p) expect(p).to.be.closeTo(100 / 6, 1e-9)
+      expect(history[1].p[0]).to.be.greaterThan(history[0].p[0])
+      expect(history[2].p[0]).to.be.lessThan(history[1].p[0])
+      expect(history[2].p[0]).to.be.greaterThan(history[0].p[0])
+      expect(markers).to.deep.equal([
+        { t: open + 1000, index: 0, buy: true },
+        { t: open + 2000, index: 0, buy: false },
+      ])
+    })
+
+    it('applies funding changes in time order', () => {
+      const trade = { timestampMs: open + 5000, amounts: [0.01, 0, 0] }
+      const before = rebuildOddsHistory({
+        marketStartMs: open,
+        initialFundingEth: 0.03,
+        numOutcomes: 3,
+        trades: [trade],
+      })
+      const after = rebuildOddsHistory({
+        marketStartMs: open,
+        initialFundingEth: 0.03,
+        numOutcomes: 3,
+        trades: [trade],
+        fundingChanges: [{ timestampMs: open + 1000, deltaEth: 0.03 }],
+      })
+      // More liquidity → the same trade moves the price less.
+      expect(after.history.at(-1)!.p[0]).to.be.lessThan(before.history.at(-1)!.p[0])
+    })
+
+    it('never emits a sample before market open', () => {
+      const { history } = rebuildOddsHistory({
+        marketStartMs: open,
+        initialFundingEth: 0.03,
+        numOutcomes: 3,
+        trades: [{ timestampMs: open - 10, amounts: [0.001, 0, 0] }],
+      })
+      expect(history[1].t).to.equal(open)
+    })
+  })
+
+  describe('maxProbDelta', () => {
+    it('reports the largest per-outcome gap and Infinity on NaN', () => {
+      expect(maxProbDelta([10, 20, 70], [10.4, 19.6, 70])).to.be.closeTo(0.4, 1e-12)
+      expect(maxProbDelta([10, NaN], [10, 20])).to.equal(Infinity)
+    })
+  })
+})

--- a/ui/cypress/integration/lib/deprize/rank-outcomes.cy.ts
+++ b/ui/cypress/integration/lib/deprize/rank-outcomes.cy.ts
@@ -1,0 +1,42 @@
+import { rankOutcomes } from '@/lib/deprize/rank-outcomes'
+
+const o = (index: number, probability: number) => ({ index, probability })
+const noField = () => false
+
+describe('deprize rankOutcomes', () => {
+  it('orders by implied chance, highest first', () => {
+    const ranked = rankOutcomes([o(0, 15), o(1, 60), o(2, 25)], { isField: noField })
+    expect(ranked.map((x) => x.index)).to.deep.equal([1, 2, 0])
+  })
+
+  it('keeps registry order on ties', () => {
+    const ranked = rankOutcomes([o(0, 20), o(1, 20), o(2, 60), o(3, 20)], { isField: noField })
+    expect(ranked.map((x) => x.index)).to.deep.equal([2, 0, 1, 3])
+  })
+
+  it('sinks NaN below numbers but keeps them above the field', () => {
+    const ranked = rankOutcomes([o(0, NaN), o(1, 10), o(2, NaN)], {
+      isField: (i) => i === 2,
+    })
+    expect(ranked.map((x) => x.index)).to.deep.equal([1, 0, 2])
+  })
+
+  it('pins the Open Field last even when it has the highest chance', () => {
+    const ranked = rankOutcomes([o(0, 10), o(1, 80), o(2, 10)], { isField: (i) => i === 1 })
+    expect(ranked.map((x) => x.index)).to.deep.equal([0, 2, 1])
+  })
+
+  it('puts the winner first once resolved, field still last', () => {
+    const ranked = rankOutcomes([o(0, 10), o(1, 70), o(2, 20)], {
+      isField: (i) => i === 2,
+      winningIndex: 0,
+    })
+    expect(ranked.map((x) => x.index)).to.deep.equal([0, 1, 2])
+  })
+
+  it('does not mutate the input', () => {
+    const input = [o(0, 15), o(1, 60)]
+    rankOutcomes(input, { isField: noField })
+    expect(input.map((x) => x.index)).to.deep.equal([0, 1])
+  })
+})

--- a/ui/lib/deprize/activity-fetch.ts
+++ b/ui/lib/deprize/activity-fetch.ts
@@ -146,16 +146,20 @@ export function fetchDePrizeBets(args: {
  * All LMSR trades (buys routed through the mint + direct sells) and funding
  * changes for one market. `fromBlock` should be the first Bet block for the
  * DePrize when known (trades cannot precede the first bet), else the registry
- * deploy block.
+ * deploy block. Funding changes are scanned from `fundingFromBlock` (defaults
+ * to `fromBlock`): seed funding lands at market creation, before the first
+ * bet, so funding must start at deployment to catch early changes.
  */
 export function fetchMarketTrades(args: {
   chain: Chain
   marketAddress: string
   fromBlock: bigint
+  fundingFromBlock?: bigint
   gen: number
 }): Promise<MarketTrades> {
   const { chain, marketAddress, fromBlock, gen } = args
-  const key = `trades:${chain.id}:${marketAddress.toLowerCase()}`
+  const fundingFrom = args.fundingFromBlock ?? fromBlock
+  const key = `trades:${chain.id}:${marketAddress.toLowerCase()}:${fromBlock}:${fundingFrom}`
   return cached(key, gen, async () => {
     const [tradeLogs, fundingLogs] = await Promise.all([
       fetchLogs<TradeArgs>({
@@ -173,7 +177,7 @@ export function fetchMarketTrades(args: {
         abi: LMSRWithTWAP.abi,
         signature: FUNDING_EVENT_SIGNATURE,
         event: fundingEvent(),
-        fromBlock,
+        fromBlock: fundingFrom,
         gen,
       }).catch(() => [] as RawLog<FundingArgs>[]),
     ])

--- a/ui/lib/deprize/activity-fetch.ts
+++ b/ui/lib/deprize/activity-fetch.ts
@@ -1,0 +1,230 @@
+// Typed, timestamped DePrize activity rows built from on-chain logs. Shared by
+// `useDePrizeActivity` (backers / positions) and `useOddsHistory` (odds
+// rebuild), with a session cache so both read one fetch.
+
+import DePrizeMintABI from 'const/abis/DePrizeMint.json'
+import LMSRWithTWAP from 'const/abis/LMSRWithTWAP.json'
+import { DEPRIZE_EVENTS_FROM_BLOCK, DEPRIZE_MINT_ADDRESSES } from 'const/config'
+import { getContract, type Chain } from 'thirdweb'
+import type { BetRow, SellRow } from './activity-math'
+import { UNIT } from './constants'
+import {
+  BET_EVENT_SIGNATURE,
+  FUNDING_EVENT_SIGNATURE,
+  TRADE_EVENT_SIGNATURE,
+  betEvent,
+  cached,
+  fetchEventsChunked,
+  fetchEventsViaExplorer,
+  fundingEvent,
+  latestBlock,
+  tradeEvent,
+  withTimestamps,
+  type RawLog,
+} from './events'
+import type { FundingLike } from './lmsr-history'
+import { deprizeReadChain, deprizeReadClient } from './read'
+
+export type TradeRow = {
+  transactor: string // lowercase
+  /** Signed outcome-token deltas in ETH units (positive = bought from the AMM). */
+  amounts: number[]
+  netCostEth: number
+  feesEth: number
+  blockNumber: bigint
+  logIndex: number
+  txHash: string
+  timestampMs: number
+}
+
+export type MarketTrades = {
+  trades: TradeRow[]
+  fundingChanges: FundingLike[]
+}
+
+const toEth = (v: bigint) => Number(v) / Number(UNIT)
+
+export function eventsFromBlock(chainSlug: string): bigint {
+  return BigInt(DEPRIZE_EVENTS_FROM_BLOCK[chainSlug] ?? 0)
+}
+
+type BetArgs = {
+  deprizeId: bigint
+  bettor: string
+  outcomeIndex: bigint
+  outcomeTokenAmount: bigint
+  cost: bigint
+  slice: bigint
+}
+type TradeArgs = {
+  transactor: string
+  outcomeTokenAmounts: readonly bigint[]
+  outcomeTokenNetCost: bigint
+  marketFees: bigint
+}
+type FundingArgs = { fundingChange: bigint }
+
+/** Explorer API first (one call, timestamps included); RPC chunks as fallback. */
+async function fetchLogs<T>(args: {
+  chain: Chain
+  address: string
+  abi: any
+  signature: string
+  event: any
+  fromBlock: bigint
+  topic1?: bigint
+  gen: number
+}): Promise<RawLog<T>[]> {
+  const readChain = deprizeReadChain(args.chain.id)
+  try {
+    return await fetchEventsViaExplorer<T>({
+      chainId: args.chain.id,
+      address: args.address,
+      signature: args.signature,
+      fromBlock: args.fromBlock,
+      topic1: args.topic1,
+      gen: args.gen,
+    })
+  } catch (e) {
+    console.warn('[deprize] explorer logs unavailable, falling back to RPC', e)
+  }
+  const contract = getContract({
+    client: deprizeReadClient,
+    chain: readChain,
+    address: args.address,
+    abi: args.abi,
+  })
+  const toBlock = await latestBlock(readChain)
+  const logs = await fetchEventsChunked<T>({
+    contract,
+    events: [args.event],
+    fromBlock: args.fromBlock,
+    toBlock,
+  })
+  return withTimestamps(readChain, logs)
+}
+
+/** All `Bet` events for one DePrize (indexed filter — never scans other prizes). */
+export function fetchDePrizeBets(args: {
+  chain: Chain
+  chainSlug: string
+  deprizeId: number
+  gen: number
+}): Promise<BetRow[]> {
+  const { chain, chainSlug, deprizeId, gen } = args
+  const mintAddress = DEPRIZE_MINT_ADDRESSES[chainSlug] ?? ''
+  if (!mintAddress) return Promise.resolve([])
+  const key = `bets:${chain.id}:${mintAddress}:${deprizeId}`
+  return cached(key, gen, async () => {
+    const logs = await fetchLogs<BetArgs>({
+      chain,
+      address: mintAddress,
+      abi: DePrizeMintABI,
+      signature: BET_EVENT_SIGNATURE,
+      event: betEvent(BigInt(deprizeId)),
+      fromBlock: eventsFromBlock(chainSlug),
+      topic1: BigInt(deprizeId),
+      gen,
+    })
+    return logs
+      .filter((l) => BigInt(l.args.deprizeId) === BigInt(deprizeId))
+      .map((l) => ({
+        bettor: l.args.bettor.toLowerCase(),
+        outcomeIndex: Number(l.args.outcomeIndex),
+        qty: toEth(l.args.outcomeTokenAmount),
+        costEth: toEth(l.args.cost),
+        sliceEth: toEth(l.args.slice),
+        blockNumber: l.blockNumber,
+        logIndex: l.logIndex,
+        txHash: l.transactionHash,
+        timestampMs: l.timestampMs,
+      }))
+  })
+}
+
+/**
+ * All LMSR trades (buys routed through the mint + direct sells) and funding
+ * changes for one market. `fromBlock` should be the first Bet block for the
+ * DePrize when known (trades cannot precede the first bet), else the registry
+ * deploy block.
+ */
+export function fetchMarketTrades(args: {
+  chain: Chain
+  marketAddress: string
+  fromBlock: bigint
+  gen: number
+}): Promise<MarketTrades> {
+  const { chain, marketAddress, fromBlock, gen } = args
+  const key = `trades:${chain.id}:${marketAddress.toLowerCase()}`
+  return cached(key, gen, async () => {
+    const [tradeLogs, fundingLogs] = await Promise.all([
+      fetchLogs<TradeArgs>({
+        chain,
+        address: marketAddress,
+        abi: LMSRWithTWAP.abi,
+        signature: TRADE_EVENT_SIGNATURE,
+        event: tradeEvent(),
+        fromBlock,
+        gen,
+      }),
+      fetchLogs<FundingArgs>({
+        chain,
+        address: marketAddress,
+        abi: LMSRWithTWAP.abi,
+        signature: FUNDING_EVENT_SIGNATURE,
+        event: fundingEvent(),
+        fromBlock,
+        gen,
+      }).catch(() => [] as RawLog<FundingArgs>[]),
+    ])
+    const trades: TradeRow[] = tradeLogs.map((l) => ({
+      transactor: l.args.transactor.toLowerCase(),
+      amounts: l.args.outcomeTokenAmounts.map((a) => toEth(a)),
+      netCostEth: toEth(l.args.outcomeTokenNetCost),
+      feesEth: toEth(l.args.marketFees),
+      blockNumber: l.blockNumber,
+      logIndex: l.logIndex,
+      txHash: l.transactionHash,
+      timestampMs: l.timestampMs,
+    }))
+    const fundingChanges: FundingLike[] = fundingLogs.map((l) => ({
+      timestampMs: l.timestampMs,
+      deltaEth: toEth(l.args.fundingChange),
+    }))
+    return { trades, fundingChanges }
+  })
+}
+
+/**
+ * Cash-outs: trades where the transactor is a wallet (not the mint router) and
+ * tokens flowed back to the AMM. One outcome per sell in our UI; pick the most
+ * negative leg.
+ */
+export function sellsFromTrades(trades: TradeRow[], mintAddress: string | undefined): SellRow[] {
+  const mint = (mintAddress ?? '').toLowerCase()
+  const out: SellRow[] = []
+  for (const t of trades) {
+    if (mint && t.transactor === mint) continue
+    let idx = -1
+    let most = 0
+    t.amounts.forEach((a, i) => {
+      if (a < most) {
+        most = a
+        idx = i
+      }
+    })
+    if (idx < 0) continue
+    out.push({
+      seller: t.transactor,
+      outcomeIndex: idx,
+      qty: -most,
+      // netCost is negative for a sell (AMM pays out); fees are deducted.
+      proceedsEth: -t.netCostEth - t.feesEth,
+      blockNumber: t.blockNumber,
+      logIndex: t.logIndex,
+      txHash: t.txHash,
+      timestampMs: t.timestampMs,
+    })
+  }
+  return out
+}

--- a/ui/lib/deprize/activity-math.ts
+++ b/ui/lib/deprize/activity-math.ts
@@ -1,0 +1,156 @@
+// Pure aggregation over DePrize on-chain activity (Bet events from DePrizeMint,
+// sell trades from the LMSR). No React / thirdweb imports so `yarn test:deprize`
+// can cover it.
+//
+// Money model (see docs/DEPRIZE_DETAIL_PAGE_PLAN.md §0.1–0.2):
+//   bet.costEth   — what went into the betting market (LMSR net cost + 1% fee)
+//   bet.sliceEth  — the 5% prize slice paid to the Juicebox prize pool
+//   total spent   — costEth + sliceEth (both are real money the bettor paid)
+//   sell.proceeds — ETH returned to the seller net of the LMSR fee
+
+export type BetRow = {
+  bettor: string // lowercase
+  outcomeIndex: number
+  qty: number // outcome tokens (1 token pays 1 ETH if the outcome wins)
+  costEth: number
+  sliceEth: number
+  blockNumber: bigint
+  logIndex: number
+  txHash: string
+  timestampMs: number
+}
+
+export type SellRow = {
+  seller: string // lowercase
+  outcomeIndex: number
+  qty: number // positive number of tokens sold
+  proceedsEth: number
+  blockNumber: bigint
+  logIndex: number
+  txHash: string
+  timestampMs: number
+}
+
+export type ActivityRow =
+  | ({ kind: 'bet' } & BetRow)
+  | ({ kind: 'sell' } & SellRow)
+
+export type OutcomePosition = {
+  outcomeIndex: number
+  qtyBought: number
+  qtySold: number
+  qtyHeld: number
+  /** Total paid for every token ever bought on this outcome (cost + slice). */
+  spentEth: number
+  /** Average all-in cost per token bought. */
+  avgCostEth: number
+  /** Cost basis attributed to tokens still held (average-cost method). */
+  heldCostEth: number
+  proceedsEth: number
+}
+
+export type UserSummary = {
+  totalSpentEth: number
+  realizedEth: number
+  currentValueEth: number
+  heldCostEth: number
+  unrealizedPnlEth: number
+  netPnlEth: number
+}
+
+export function totalBet(bets: BetRow[]): number {
+  return bets.reduce((s, b) => s + b.costEth, 0)
+}
+
+export function uniqueBackers(bets: BetRow[]): number {
+  return new Set(bets.map((b) => b.bettor.toLowerCase())).size
+}
+
+/** Total ETH bettors have put into the market side (costEth only; the slice is prize pool). */
+export function totalStaked(bets: BetRow[]): number {
+  return totalBet(bets)
+}
+
+export function userPosition(
+  bets: BetRow[],
+  sells: SellRow[],
+  user: string,
+  outcomeIndex: number,
+): OutcomePosition {
+  const u = user.toLowerCase()
+  let qtyBought = 0
+  let spentEth = 0
+  for (const b of bets) {
+    if (b.bettor !== u || b.outcomeIndex !== outcomeIndex) continue
+    qtyBought += b.qty
+    spentEth += b.costEth + b.sliceEth
+  }
+  let qtySold = 0
+  let proceedsEth = 0
+  for (const s of sells) {
+    if (s.seller !== u || s.outcomeIndex !== outcomeIndex) continue
+    qtySold += s.qty
+    proceedsEth += s.proceedsEth
+  }
+  const qtyHeld = Math.max(0, qtyBought - qtySold)
+  const avgCostEth = qtyBought > 0 ? spentEth / qtyBought : 0
+  return {
+    outcomeIndex,
+    qtyBought,
+    qtySold,
+    qtyHeld,
+    spentEth,
+    avgCostEth,
+    heldCostEth: avgCostEth * qtyHeld,
+    proceedsEth,
+  }
+}
+
+/** Outcome indices where the user has ever bought or sold. */
+export function userActiveOutcomes(bets: BetRow[], sells: SellRow[], user: string): number[] {
+  const u = user.toLowerCase()
+  const set = new Set<number>()
+  for (const b of bets) if (b.bettor === u) set.add(b.outcomeIndex)
+  for (const s of sells) if (s.seller === u) set.add(s.outcomeIndex)
+  return Array.from(set).sort((a, b) => a - b)
+}
+
+/**
+ * Wallet-level summary. `currentValueByIndex` is what the user's held tokens
+ * are worth right now (live sell quote while trading, redeem value once
+ * resolved). Outcomes missing from the map contribute 0 current value.
+ */
+export function userSummary(
+  bets: BetRow[],
+  sells: SellRow[],
+  user: string,
+  currentValueByIndex: Map<number, number>,
+): UserSummary {
+  let totalSpentEth = 0
+  let realizedEth = 0
+  let heldCostEth = 0
+  let currentValueEth = 0
+  for (const idx of userActiveOutcomes(bets, sells, user)) {
+    const p = userPosition(bets, sells, user, idx)
+    totalSpentEth += p.spentEth
+    realizedEth += p.proceedsEth
+    heldCostEth += p.heldCostEth
+    const v = currentValueByIndex.get(idx)
+    if (v !== undefined && Number.isFinite(v)) currentValueEth += v
+  }
+  const unrealizedPnlEth = currentValueEth - heldCostEth
+  const netPnlEth = currentValueEth + realizedEth - totalSpentEth
+  return { totalSpentEth, realizedEth, currentValueEth, heldCostEth, unrealizedPnlEth, netPnlEth }
+}
+
+/** Reverse-chronological feed of one wallet's bets and sells. */
+export function userActivity(bets: BetRow[], sells: SellRow[], user: string): ActivityRow[] {
+  const u = user.toLowerCase()
+  const rows: ActivityRow[] = []
+  for (const b of bets) if (b.bettor === u) rows.push({ kind: 'bet', ...b })
+  for (const s of sells) if (s.seller === u) rows.push({ kind: 'sell', ...s })
+  return rows.sort((a, b) => {
+    if (a.blockNumber !== b.blockNumber) return a.blockNumber > b.blockNumber ? -1 : 1
+    return b.logIndex - a.logIndex
+  })
+}

--- a/ui/lib/deprize/activity-math.ts
+++ b/ui/lib/deprize/activity-math.ts
@@ -31,9 +31,7 @@ export type SellRow = {
   timestampMs: number
 }
 
-export type ActivityRow =
-  | ({ kind: 'bet' } & BetRow)
-  | ({ kind: 'sell' } & SellRow)
+export type ActivityRow = ({ kind: 'bet' } & BetRow) | ({ kind: 'sell' } & SellRow)
 
 export type OutcomePosition = {
   outcomeIndex: number
@@ -75,7 +73,7 @@ export function userPosition(
   bets: BetRow[],
   sells: SellRow[],
   user: string,
-  outcomeIndex: number,
+  outcomeIndex: number
 ): OutcomePosition {
   const u = user.toLowerCase()
   let qtyBought = 0
@@ -118,19 +116,22 @@ export function userActiveOutcomes(bets: BetRow[], sells: SellRow[], user: strin
 /**
  * Wallet-level summary. `currentValueByIndex` is what the user's held tokens
  * are worth right now (live sell quote while trading, redeem value once
- * resolved). Outcomes missing from the map contribute 0 current value.
+ * resolved). Map keys are included even with no Bet/sell events (transfers,
+ * missed logs). Outcomes missing from the map contribute 0 current value.
  */
 export function userSummary(
   bets: BetRow[],
   sells: SellRow[],
   user: string,
-  currentValueByIndex: Map<number, number>,
+  currentValueByIndex: Map<number, number>
 ): UserSummary {
   let totalSpentEth = 0
   let realizedEth = 0
   let heldCostEth = 0
   let currentValueEth = 0
-  for (const idx of userActiveOutcomes(bets, sells, user)) {
+  const indexes = new Set(userActiveOutcomes(bets, sells, user))
+  for (const idx of currentValueByIndex.keys()) indexes.add(idx)
+  for (const idx of indexes) {
     const p = userPosition(bets, sells, user, idx)
     totalSpentEth += p.spentEth
     realizedEth += p.proceedsEth

--- a/ui/lib/deprize/competitions.ts
+++ b/ui/lib/deprize/competitions.ts
@@ -88,9 +88,9 @@ export type DePrizeCompetition = {
 
 export const GENERIC_DEPRIZE_COMPETITION: DePrizeCompetition = {
   title: 'DePrize',
-  tagline: 'Back the team you think will win — live odds, payout when a winner is declared.',
+  tagline: 'Back the competitor you think will win — live odds, payout when a winner is declared.',
   metaDescription:
-    'Back the team you think will win — live odds, payout when a winner is declared.',
+    'Back the competitor you think will win — live odds, payout when a winner is declared.',
 }
 
 /** Stable prize-page path for a Moon Base Zero race. Resolves live or atlas. */
@@ -108,7 +108,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     1: {
       title: 'The Moon Is A Harsh Mistress',
       tagline:
-        'Which team posts “The Moon is a harsh mistress” first? Back a team — every bet grows the prize pool.',
+        'Which team posts “The Moon is a harsh mistress” first? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Arbitrum DePrize: back the MoonDAO team you think will post “The Moon is a harsh mistress” first. Live LMSR odds, and every bet funds the prize pool.',
       questionId: '0xc3efda478f2465a1d402bfe9bc43fd04660daa72d0a71031594b341f2718adb9',
@@ -150,7 +150,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     10: {
       title: 'First commercial crewed lunar landing',
       tagline:
-        'Which crewed lander puts astronauts on the lunar surface first? Back a team — every bet grows the prize pool.',
+        'Which crewed lander puts astronauts on the lunar surface first? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Sepolia DePrize for the first commercial crewed lunar landing. SpaceX Starship HLS vs Blue Origin Blue Moon MK2.',
       sharedGoalId: 'shared-crewed-lander',
@@ -164,7 +164,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     12: {
       title: 'First crewed lunar terrain vehicle in service',
       tagline:
-        'Which LTV is driving on the lunar surface first? Back a team — every bet grows the prize pool.',
+        'Which LTV is driving on the lunar surface first? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Sepolia DePrize for the first crewed lunar terrain vehicle. Astrolab, Lunar Outpost, and Intuitive Machines.',
       sharedGoalId: 'shared-lunar-rover',
@@ -179,7 +179,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     15: {
       title: 'First sustained oxygen and metals from lunar regolith',
       tagline:
-        'Which ISRU plant makes oxygen from regolith first? Back a team — every bet grows the prize pool.',
+        'Which ISRU plant makes oxygen from regolith first? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Sepolia DePrize for the first sustained lunar ISRU plant. Blue Alchemist, Sierra Space, Lunar Resources, and Cislune.',
       sharedGoalId: 'shared-isru-oxygen',
@@ -195,7 +195,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     17: {
       title: 'First demonstrated lunar landing-pad construction system',
       tagline:
-        'Which team hardens a lunar landing pad first? Back a team — every bet grows the prize pool.',
+        'Which team hardens a lunar landing pad first? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Sepolia DePrize for the first demonstrated lunar landing-pad construction system. ICON, Redwire, Astroport, AI SpaceFactory, and Astrobotic.',
       questionId: '0x8cea9bc514c3b1f069f68b62046ab8679c2d8aaffcf91fdfd071b40399c1ab9b',
@@ -213,7 +213,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     18: {
       title: 'First pressurized habitat occupied on the lunar surface',
       tagline:
-        'Which habitat houses crew on the Moon first? Back a team — every bet grows the prize pool.',
+        'Which habitat houses crew on the Moon first? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Sepolia DePrize for the first pressurized lunar habitat. Artemis Base Camp, ILRS, Thales MPH, Sierra Space LIFE, and JAXA Lunar Cruiser.',
       questionId: '0xb450b8b519b564b86a2ded23034b5e808080705e2567f0fc947676cb39cebc72',
@@ -231,7 +231,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     19: {
       title: 'First operational lunar communications and navigation service',
       tagline:
-        'Which network sells lunar comms first? Back a team — every bet grows the prize pool.',
+        'Which network sells lunar comms first? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Sepolia DePrize for the first operational lunar communications and navigation service. Modul8, Intuitive Machines, ESA Moonlight, Crescent Parsec, and Solstar.',
       questionId: '0xb97bc9385d44cda940b222c2027923496c034d44348931be525acf34970db986',
@@ -251,7 +251,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     20: {
       title: 'The Moon Is A Harsh Mistress',
       tagline:
-        'Which team posts “The Moon is a harsh mistress” first? Back a team — every bet grows the prize pool.',
+        'Which team posts “The Moon is a harsh mistress” first? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Sepolia DePrize: back the MoonDAO team you think will post “The Moon is a harsh mistress” first. Live LMSR odds, and every bet funds the prize pool.',
       questionId: '0xe6430ff8d51a6e5389d1c23cfa5dcab4682407f866a208ef3ea60120b271d5cf',

--- a/ui/lib/deprize/competitions.ts
+++ b/ui/lib/deprize/competitions.ts
@@ -48,6 +48,12 @@ export type DePrizeRaceOutcome = {
    * `fieldOdds`, never in `oddsByProjectId`.
    */
   field?: boolean
+  /**
+   * Optional vehicle / article name shown under the org on the live prize
+   * page (e.g. "Griffin Mission One"). Atlas `project.name` is often a
+   * family label ("Peregrine & Griffin Landers") and is the wrong line here.
+   */
+  vehicleLabel?: string
 }
 
 export type DePrizeRaceBinding = {
@@ -256,7 +262,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     21: {
       title: 'Touchdown',
       tagline:
-        'Which landing-vehicle operator lands upright on the Moon next and returns 24 hours of surface data? Back a team — every bet grows the prize pool.',
+        'Which landing-vehicle operator lands upright on the Moon next and returns 24 hours of surface data? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Sepolia DePrize for the next successful lunar landing. Astrobotic Griffin, Intuitive Machines, Firefly Blue Ghost, Blue Origin Blue Moon MK1, CNSA Chang’e-7, and the Open Field.',
       questionId: '0x18f9e4f8e5b291580b00bd23299194b169a66c3513229c5e16240e05d8520f17',
@@ -264,11 +270,11 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
       raceLabel: 'Next lunar landing',
       supersededBy: 22,
       outcomes: [
-        { projectId: 'astrobotic-griffin', teamId: 601 },
-        { projectId: 'im-nova-c', teamId: 602 },
-        { projectId: 'firefly-blue-ghost', teamId: 603 },
-        { projectId: 'blue-origin-blue-moon-mk1', teamId: 604 },
-        { projectId: 'cnsa-change-7', teamId: 605 },
+        { projectId: 'astrobotic-griffin', teamId: 601, vehicleLabel: 'Griffin Mission One' },
+        { projectId: 'im-nova-c', teamId: 602, vehicleLabel: 'Nova-C IM-3' },
+        { projectId: 'firefly-blue-ghost', teamId: 603, vehicleLabel: 'Blue Ghost M2' },
+        { projectId: 'blue-origin-blue-moon-mk1', teamId: 604, vehicleLabel: 'Blue Moon MK1' },
+        { projectId: 'cnsa-change-7', teamId: 605, vehicleLabel: "Chang'e-7" },
         { projectId: OPEN_FIELD_PROJECT_ID, teamId: 24, field: true },
       ],
     },
@@ -277,7 +283,7 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
     22: {
       title: 'Touchdown',
       tagline:
-        'Which landing-vehicle operator lands upright on the Moon next and returns 24 hours of surface data? Back a team — every bet grows the prize pool.',
+        'Which landing-vehicle operator lands upright on the Moon next and returns 24 hours of surface data? Back a competitor — every bet grows the prize pool.',
       metaDescription:
         'Sepolia DePrize for the next successful lunar landing. Astrobotic Griffin, Intuitive Machines, Firefly Blue Ghost, Blue Origin Blue Moon MK1, CNSA Chang’e-7, and the Open Field.',
       questionId: '0x1ba1808c0a0d8a2bbc48462cd3a490e306695713e0cafd362d365c9db3f43513',
@@ -285,11 +291,11 @@ const DEPRIZE_COMPETITIONS: Record<string, Record<number, DePrizeCompetition>> =
       raceLabel: 'Next lunar landing',
       supersedes: 21,
       outcomes: [
-        { projectId: 'astrobotic-griffin', teamId: 601 },
-        { projectId: 'im-nova-c', teamId: 602 },
-        { projectId: 'firefly-blue-ghost', teamId: 603 },
-        { projectId: 'blue-origin-blue-moon-mk1', teamId: 604 },
-        { projectId: 'cnsa-change-7', teamId: 605 },
+        { projectId: 'astrobotic-griffin', teamId: 601, vehicleLabel: 'Griffin Mission One' },
+        { projectId: 'im-nova-c', teamId: 602, vehicleLabel: 'Nova-C IM-3' },
+        { projectId: 'firefly-blue-ghost', teamId: 603, vehicleLabel: 'Blue Ghost M2' },
+        { projectId: 'blue-origin-blue-moon-mk1', teamId: 604, vehicleLabel: 'Blue Moon MK1' },
+        { projectId: 'cnsa-change-7', teamId: 605, vehicleLabel: "Chang'e-7" },
         { projectId: OPEN_FIELD_PROJECT_ID, teamId: 24, field: true },
       ],
     },

--- a/ui/lib/deprize/events.ts
+++ b/ui/lib/deprize/events.ts
@@ -75,7 +75,12 @@ export async function fetchEventsViaExplorer<T>(args: {
     const body = await r.json().catch(() => ({}))
     throw new Error(body?.error || `logs api ${r.status}`)
   }
-  const { logs } = (await r.json()) as { logs: ExplorerLog[] }
+  const { logs, truncated } = (await r.json()) as { logs: ExplorerLog[]; truncated?: boolean }
+  if (truncated) {
+    console.warn(
+      `[deprize] explorer logs truncated at ${logs.length} rows; history is partial and snaps to live`
+    )
+  }
   const out: RawLog<T>[] = []
   for (const l of logs) {
     try {

--- a/ui/lib/deprize/events.ts
+++ b/ui/lib/deprize/events.ts
@@ -1,0 +1,251 @@
+// On-chain event access for DePrize pages: DePrizeMint `Bet` logs (who backed
+// what) and LMSR `AMMOutcomeTokenTrade` logs (how prices moved, cash-outs).
+//
+// Primary source is `/api/deprize/logs` (Etherscan V2 behind a server key):
+// one request covers the whole range since deployment and includes block
+// timestamps. Fallback is chunked `eth_getLogs` through thirdweb when the API
+// route is unavailable (no key, explorer outage). Results are cached per
+// session so navigating between pages doesn't refetch.
+
+import { getContractEvents, prepareEvent, type Chain, type ThirdwebContract } from 'thirdweb'
+import { eth_blockNumber, eth_getBlockByNumber, getRpcClient } from 'thirdweb/rpc'
+import { decodeEventLog, parseAbiItem, toEventSelector, type Hex } from 'viem'
+import { deprizeReadClient } from './read'
+
+export const BET_EVENT_SIGNATURE =
+  'event Bet(uint256 indexed deprizeId, address indexed bettor, uint256 outcomeIndex, uint256 outcomeTokenAmount, uint256 cost, uint256 slice)' as const
+export const TRADE_EVENT_SIGNATURE =
+  'event AMMOutcomeTokenTrade(address indexed transactor, int256[] outcomeTokenAmounts, int256 outcomeTokenNetCost, uint256 marketFees)' as const
+export const FUNDING_EVENT_SIGNATURE = 'event AMMFundingChanged(int256 fundingChange)' as const
+
+export function betEvent(deprizeId: bigint) {
+  return prepareEvent({ signature: BET_EVENT_SIGNATURE, filters: { deprizeId } })
+}
+export const tradeEvent = () => prepareEvent({ signature: TRADE_EVENT_SIGNATURE })
+export const fundingEvent = () => prepareEvent({ signature: FUNDING_EVENT_SIGNATURE })
+
+export type RawLog<TArgs> = {
+  args: TArgs
+  blockNumber: bigint
+  logIndex: number
+  transactionHash: string
+  /** Unix ms when known from the source (explorer API); NaN otherwise. */
+  timestampMs: number
+}
+
+// ---- Explorer-backed fetch ------------------------------------------------
+
+type ExplorerLog = {
+  topics: string[]
+  data: string
+  blockNumber: string
+  timeStamp: string
+  logIndex: string
+  transactionHash: string
+}
+
+const pad32 = (v: bigint): Hex => `0x${v.toString(16).padStart(64, '0')}`
+
+/**
+ * Fetch and decode one event type from the explorer-backed API route.
+ * `topic1` filters on the first indexed argument. Throws on any failure so the
+ * caller can fall back to RPC.
+ */
+export async function fetchEventsViaExplorer<T>(args: {
+  chainId: number
+  address: string
+  signature: string
+  fromBlock: bigint
+  topic1?: bigint
+  gen?: number
+}): Promise<RawLog<T>[]> {
+  if (typeof window === 'undefined') throw new Error('explorer fetch is browser-only')
+  const abiItem = parseAbiItem(args.signature)
+  const topic0 = toEventSelector(abiItem as any)
+  const q = new URLSearchParams({
+    chainId: String(args.chainId),
+    address: args.address,
+    fromBlock: args.fromBlock.toString(),
+    topic0,
+  })
+  if (args.topic1 !== undefined) q.set('topic1', pad32(args.topic1))
+  if (args.gen) q.set('gen', String(args.gen))
+  const r = await fetch(`/api/deprize/logs?${q.toString()}`)
+  if (!r.ok) {
+    const body = await r.json().catch(() => ({}))
+    throw new Error(body?.error || `logs api ${r.status}`)
+  }
+  const { logs } = (await r.json()) as { logs: ExplorerLog[] }
+  const out: RawLog<T>[] = []
+  for (const l of logs) {
+    try {
+      const decoded = decodeEventLog({
+        abi: [abiItem as any],
+        data: l.data as Hex,
+        topics: l.topics as [Hex, ...Hex[]],
+      }) as { args: unknown }
+      out.push({
+        args: decoded.args as T,
+        blockNumber: BigInt(l.blockNumber),
+        logIndex: l.logIndex && l.logIndex !== '0x' ? Number(BigInt(l.logIndex)) : 0,
+        transactionHash: l.transactionHash,
+        timestampMs: Number(BigInt(l.timeStamp)) * 1000,
+      })
+    } catch {
+      /* skip undecodable rows */
+    }
+  }
+  return sortLogs(out)
+}
+
+// ---- RPC fallback ---------------------------------------------------------
+
+const MIN_CHUNK = 2_000n
+
+function isRangeError(e: unknown): boolean {
+  const msg = `${(e as any)?.message ?? ''} ${(e as any)?.shortMessage ?? ''} ${(e as any)?.details ?? ''}`.toLowerCase()
+  return (
+    msg.includes('range') ||
+    msg.includes('limit') ||
+    msg.includes('too many') ||
+    msg.includes('10000') ||
+    msg.includes('exceed') ||
+    msg.includes('timeout') ||
+    msg.includes('too large') ||
+    msg.includes('429')
+  )
+}
+
+/**
+ * Fetch logs for `events` between `fromBlock` and `toBlock` inclusive over RPC.
+ * Tries the whole range in one request; on a range-style error splits into
+ * chunks and halves the chunk size on further errors down to MIN_CHUNK.
+ */
+export async function fetchEventsChunked<T>(args: {
+  contract: ThirdwebContract
+  events: any[]
+  fromBlock: bigint
+  toBlock: bigint
+  initialChunk?: bigint
+}): Promise<RawLog<T>[]> {
+  const { contract, events, fromBlock, toBlock } = args
+  if (toBlock < fromBlock) return []
+
+  const normalize = (logs: any[]): RawLog<T>[] =>
+    logs.map((l) => ({
+      args: l.args as T,
+      blockNumber: BigInt(l.blockNumber ?? 0),
+      logIndex: Number(l.logIndex ?? 0),
+      transactionHash: String(l.transactionHash ?? ''),
+      timestampMs: NaN,
+    }))
+
+  try {
+    const logs = await getContractEvents({ contract, events, fromBlock, toBlock, useIndexer: false })
+    return sortLogs(normalize(logs as any[]))
+  } catch (e) {
+    if (!isRangeError(e)) throw e
+  }
+
+  const out: RawLog<T>[] = []
+  let chunk = args.initialChunk ?? 9_000n
+  let from = fromBlock
+  while (from <= toBlock) {
+    const to = from + chunk - 1n > toBlock ? toBlock : from + chunk - 1n
+    try {
+      const logs = await getContractEvents({
+        contract,
+        events,
+        fromBlock: from,
+        toBlock: to,
+        useIndexer: false,
+      })
+      out.push(...normalize(logs as any[]))
+      from = to + 1n
+    } catch (e) {
+      if (!isRangeError(e) || chunk <= MIN_CHUNK) throw e
+      chunk = chunk / 2n < MIN_CHUNK ? MIN_CHUNK : chunk / 2n
+    }
+  }
+  return sortLogs(out)
+}
+
+function sortLogs<T>(logs: RawLog<T>[]): RawLog<T>[] {
+  return logs.sort((a, b) => {
+    if (a.blockNumber !== b.blockNumber) return a.blockNumber < b.blockNumber ? -1 : 1
+    return a.logIndex - b.logIndex
+  })
+}
+
+export async function latestBlock(chain: Chain): Promise<bigint> {
+  return eth_blockNumber(getRpcClient({ client: deprizeReadClient, chain }))
+}
+
+const tsCache = new Map<string, number>()
+
+/** Block number → unix ms for a set of blocks (deduped, cached, 6 in flight). */
+export async function fetchBlockTimestamps(
+  chain: Chain,
+  blocks: bigint[],
+): Promise<Map<bigint, number>> {
+  const rpc = getRpcClient({ client: deprizeReadClient, chain })
+  const unique = Array.from(new Set(blocks.map((b) => b.toString()))).map((s) => BigInt(s))
+  const result = new Map<bigint, number>()
+  const pending: bigint[] = []
+  for (const b of unique) {
+    const hit = tsCache.get(`${chain.id}:${b}`)
+    if (hit !== undefined) result.set(b, hit)
+    else pending.push(b)
+  }
+  for (let i = 0; i < pending.length; i += 6) {
+    const slice = pending.slice(i, i + 6)
+    const got = await Promise.all(
+      slice.map(async (b) => {
+        try {
+          const block = await eth_getBlockByNumber(rpc, { blockNumber: b })
+          return [b, Number(block.timestamp) * 1000] as const
+        } catch {
+          return [b, NaN] as const
+        }
+      }),
+    )
+    for (const [b, ts] of got) {
+      if (Number.isFinite(ts)) {
+        tsCache.set(`${chain.id}:${b}`, ts)
+        result.set(b, ts)
+      }
+    }
+  }
+  return result
+}
+
+/** Fill in NaN timestamps from RPC block headers. */
+export async function withTimestamps<T>(chain: Chain, logs: RawLog<T>[]): Promise<RawLog<T>[]> {
+  const missing = logs.filter((l) => !Number.isFinite(l.timestampMs)).map((l) => l.blockNumber)
+  if (!missing.length) return logs
+  const ts = await fetchBlockTimestamps(chain, missing)
+  return logs.map((l) =>
+    Number.isFinite(l.timestampMs) ? l : { ...l, timestampMs: ts.get(l.blockNumber) ?? NaN },
+  )
+}
+
+// ---- Session cache -------------------------------------------------------
+const sessionCache = new Map<string, { gen: number; promise: Promise<unknown> }>()
+
+/**
+ * Memoize an async fetch for this browser session. `gen` is a monotonically
+ * increasing refresh generation (e.g. the page's refreshNonce): an entry is
+ * reused only if it was fetched at that generation or later, so several hooks
+ * bumping the same generation share one refetch.
+ */
+export function cached<T>(key: string, gen: number, fn: () => Promise<T>): Promise<T> {
+  const hit = sessionCache.get(key)
+  if (hit && hit.gen >= gen) return hit.promise as Promise<T>
+  const promise = fn().catch((e) => {
+    const cur = sessionCache.get(key)
+    if (cur?.promise === promise) sessionCache.delete(key)
+    throw e
+  })
+  sessionCache.set(key, { gen, promise })
+  return promise
+}

--- a/ui/lib/deprize/lmsr-history.ts
+++ b/ui/lib/deprize/lmsr-history.ts
@@ -1,0 +1,97 @@
+// Pure LMSR odds-history reconstruction from trade events. No React / thirdweb
+// imports so `yarn test:deprize` can cover it.
+//
+// Gnosis LMSR marginal price:
+//   b   = funding / ln(n)
+//   q_i = net outcome tokens sold for i (cumulative Σ outcomeTokenAmounts[i])
+//   p_i = exp(q_i/b) / Σ_j exp(q_j/b)  ==  1 / Σ_j exp((q_j - q_i)/b)
+// The second form never overflows.
+
+import type { OddsSample } from './odds-chart'
+
+export type TradeLike = {
+  timestampMs: number
+  /** Signed outcome-token deltas in ETH units (positive = bought from the AMM). */
+  amounts: number[]
+}
+
+export type FundingLike = { timestampMs: number; deltaEth: number }
+
+export type TradeMarker = {
+  t: number
+  /** Outcome the trade was mostly about (largest |amount|). */
+  index: number
+  /** True when the AMM sold tokens (a bet), false for a cash-out. */
+  buy: boolean
+}
+
+/** Marginal prices in percent (sum ≈ 100). */
+export function lmsrMarginalPrices(qEth: number[], fundingEth: number): number[] {
+  const n = qEth.length
+  if (n === 0) return []
+  if (n === 1) return [100]
+  if (!(fundingEth > 0)) return qEth.map(() => 100 / n)
+  const b = fundingEth / Math.log(n)
+  return qEth.map((qi) => {
+    let denom = 0
+    for (const qj of qEth) denom += Math.exp((qj - qi) / b)
+    return 100 / denom
+  })
+}
+
+/**
+ * Rebuild the odds series from market open: first sample at `marketStartMs`
+ * (uniform prior), then one sample after every trade. Trades and funding
+ * changes are merged chronologically.
+ */
+export function rebuildOddsHistory(args: {
+  marketStartMs: number
+  initialFundingEth: number
+  trades: TradeLike[]
+  fundingChanges?: FundingLike[]
+  numOutcomes: number
+}): { history: OddsSample[]; markers: TradeMarker[] } {
+  const { marketStartMs, initialFundingEth, trades, fundingChanges = [], numOutcomes } = args
+  const q = Array.from({ length: numOutcomes }, () => 0)
+  let funding = initialFundingEth
+
+  type Ev = { t: number; trade?: TradeLike; funding?: FundingLike }
+  const events: Ev[] = [
+    ...trades.map((tr) => ({ t: tr.timestampMs, trade: tr })),
+    ...fundingChanges.map((fc) => ({ t: fc.timestampMs, funding: fc })),
+  ].sort((a, b) => a.t - b.t)
+
+  const history: OddsSample[] = [
+    { t: marketStartMs, p: lmsrMarginalPrices(q, funding) },
+  ]
+  const markers: TradeMarker[] = []
+
+  for (const ev of events) {
+    if (ev.funding) funding += ev.funding.deltaEth
+    if (ev.trade) {
+      const a = ev.trade.amounts
+      let best = 0
+      for (let i = 0; i < Math.min(a.length, numOutcomes); i++) {
+        q[i] += a[i] ?? 0
+        if (Math.abs(a[i] ?? 0) > Math.abs(a[best] ?? 0)) best = i
+      }
+      markers.push({ t: ev.t, index: best, buy: (a[best] ?? 0) > 0 })
+    }
+    // Never emit a sample before market open (clock skew / same-block trades).
+    const t = Math.max(ev.t, marketStartMs)
+    history.push({ t, p: lmsrMarginalPrices(q, funding) })
+  }
+  return { history, markers }
+}
+
+/** Max absolute difference (percentage points) between two probability vectors. */
+export function maxProbDelta(a: number[], b: number[]): number {
+  let d = 0
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i]
+    const y = b[i]
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return Infinity
+    d = Math.max(d, Math.abs(x - y))
+  }
+  return d
+}

--- a/ui/lib/deprize/rank-outcomes.ts
+++ b/ui/lib/deprize/rank-outcomes.ts
@@ -1,0 +1,30 @@
+// Pure display ordering for DePrize outcomes. Dependency-free so the mocha
+// unit runner can cover it without React.
+
+export type RankableOutcome = { index: number; probability: number }
+
+/**
+ * Order outcomes for display: highest implied chance first. Ties (and NaN)
+ * keep registry order. Outcomes flagged by `isField` (Open Field) are always
+ * pinned to the end regardless of chance. When `winningIndex` is provided
+ * (market resolved), that outcome is moved to the very top.
+ *
+ * Never sort `market.outcomes` in place — indices must stay contract-aligned.
+ */
+export function rankOutcomes<T extends RankableOutcome>(
+  outcomes: T[],
+  opts: { isField: (index: number) => boolean; winningIndex?: number },
+): T[] {
+  const score = (o: T) => (Number.isFinite(o.probability) ? o.probability : -1)
+  return [...outcomes].sort((a, b) => {
+    if (opts.winningIndex !== undefined) {
+      if (a.index === opts.winningIndex) return -1
+      if (b.index === opts.winningIndex) return 1
+    }
+    const af = opts.isField(a.index)
+    const bf = opts.isField(b.index)
+    if (af !== bf) return af ? 1 : -1
+    const d = score(b) - score(a)
+    return d !== 0 ? d : a.index - b.index
+  })
+}

--- a/ui/lib/deprize/useDePrizeActivity.tsx
+++ b/ui/lib/deprize/useDePrizeActivity.tsx
@@ -1,10 +1,15 @@
 import { DEPRIZE_MINT_ADDRESSES } from 'const/config'
 import { useEffect, useMemo, useState } from 'react'
 import type { Chain } from 'thirdweb'
-import { fetchDePrizeBets, fetchMarketTrades, sellsFromTrades, type TradeRow } from './activity-fetch'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+import {
+  fetchDePrizeBets,
+  fetchMarketTrades,
+  sellsFromTrades,
+  type TradeRow,
+} from './activity-fetch'
 import { totalStaked, uniqueBackers, type BetRow, type SellRow } from './activity-math'
 import type { FundingLike } from './lmsr-history'
-import { getChainSlug } from '@/lib/thirdweb/chain'
 
 export type DePrizeActivity = {
   bets: BetRow[]
@@ -42,12 +47,20 @@ export function useDePrizeActivity(args: {
   const chainSlug = getChainSlug(chain)
   const mintAddress = DEPRIZE_MINT_ADDRESSES[chainSlug]
   const [data, setData] = useState<Omit<DePrizeActivity, 'loading' | 'error'>>(EMPTY)
-  const [loading, setLoading] = useState(false)
+  const [dataKey, setDataKey] = useState('')
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | undefined>()
+  const requestKey =
+    deprizeId !== undefined && marketAddress && !/^0x0+$/.test(marketAddress)
+      ? `${chain.id}:${deprizeId}:${marketAddress.toLowerCase()}`
+      : ''
 
   useEffect(() => {
     if (deprizeId === undefined || !marketAddress || /^0x0+$/.test(marketAddress)) {
       setData(EMPTY)
+      setDataKey('')
+      setLoading(true)
+      setError(undefined)
       return
     }
     let cancelled = false
@@ -75,9 +88,12 @@ export function useDePrizeActivity(args: {
           backers: uniqueBackers(bets),
           totalStakedEth: totalStaked(bets),
         })
+        setDataKey(requestKey)
       } catch (e: any) {
         if (cancelled) return
         console.warn('[deprize] activity load failed', e)
+        setData(EMPTY)
+        setDataKey(requestKey)
         setError(e?.shortMessage || e?.message || 'Failed to load activity')
       } finally {
         if (!cancelled) setLoading(false)
@@ -86,7 +102,15 @@ export function useDePrizeActivity(args: {
     return () => {
       cancelled = true
     }
-  }, [deprizeId, marketAddress, chain, chainSlug, mintAddress, refreshNonce])
+  }, [requestKey, deprizeId, marketAddress, chain, chainSlug, mintAddress, refreshNonce])
 
-  return useMemo(() => ({ ...data, loading, error }), [data, loading, error])
+  const stale = dataKey !== requestKey
+  return useMemo(
+    () => ({
+      ...(stale ? EMPTY : data),
+      loading: loading || stale,
+      error: stale ? undefined : error,
+    }),
+    [data, loading, error, stale]
+  )
 }

--- a/ui/lib/deprize/useDePrizeActivity.tsx
+++ b/ui/lib/deprize/useDePrizeActivity.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 import type { Chain } from 'thirdweb'
 import { getChainSlug } from '@/lib/thirdweb/chain'
 import {
+  eventsFromBlock,
   fetchDePrizeBets,
   fetchMarketTrades,
   sellsFromTrades,
@@ -76,6 +77,7 @@ export function useDePrizeActivity(args: {
               chain,
               marketAddress,
               fromBlock: firstBetBlock,
+              fundingFromBlock: eventsFromBlock(chainSlug),
               gen: refreshNonce,
             })
           : { trades: [] as TradeRow[], fundingChanges: [] as FundingLike[] }

--- a/ui/lib/deprize/useDePrizeActivity.tsx
+++ b/ui/lib/deprize/useDePrizeActivity.tsx
@@ -1,0 +1,92 @@
+import { DEPRIZE_MINT_ADDRESSES } from 'const/config'
+import { useEffect, useMemo, useState } from 'react'
+import type { Chain } from 'thirdweb'
+import { fetchDePrizeBets, fetchMarketTrades, sellsFromTrades, type TradeRow } from './activity-fetch'
+import { totalStaked, uniqueBackers, type BetRow, type SellRow } from './activity-math'
+import type { FundingLike } from './lmsr-history'
+import { getChainSlug } from '@/lib/thirdweb/chain'
+
+export type DePrizeActivity = {
+  bets: BetRow[]
+  sells: SellRow[]
+  trades: TradeRow[]
+  fundingChanges: FundingLike[]
+  backers: number
+  totalStakedEth: number
+  loading: boolean
+  error: string | undefined
+}
+
+const EMPTY: Omit<DePrizeActivity, 'loading' | 'error'> = {
+  bets: [],
+  sells: [],
+  trades: [],
+  fundingChanges: [],
+  backers: 0,
+  totalStakedEth: 0,
+}
+
+/**
+ * On-chain activity for one DePrize: every `Bet` (who backed what, for how
+ * much) and every LMSR trade (price moves, cash-outs). Re-fetches when
+ * `refreshNonce` changes; the underlying fetches are session-cached so the
+ * market hook's odds rebuild shares the same requests.
+ */
+export function useDePrizeActivity(args: {
+  deprizeId: number | undefined
+  marketAddress: string | undefined
+  chain: Chain
+  refreshNonce?: number
+}): DePrizeActivity {
+  const { deprizeId, marketAddress, chain, refreshNonce = 0 } = args
+  const chainSlug = getChainSlug(chain)
+  const mintAddress = DEPRIZE_MINT_ADDRESSES[chainSlug]
+  const [data, setData] = useState<Omit<DePrizeActivity, 'loading' | 'error'>>(EMPTY)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+
+  useEffect(() => {
+    if (deprizeId === undefined || !marketAddress || /^0x0+$/.test(marketAddress)) {
+      setData(EMPTY)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setError(undefined)
+    ;(async () => {
+      try {
+        const bets = await fetchDePrizeBets({ chain, chainSlug, deprizeId, gen: refreshNonce })
+        if (cancelled) return
+        const firstBetBlock = bets.length ? bets[0].blockNumber : undefined
+        const { trades, fundingChanges } = firstBetBlock
+          ? await fetchMarketTrades({
+              chain,
+              marketAddress,
+              fromBlock: firstBetBlock,
+              gen: refreshNonce,
+            })
+          : { trades: [] as TradeRow[], fundingChanges: [] as FundingLike[] }
+        if (cancelled) return
+        setData({
+          bets,
+          sells: sellsFromTrades(trades, mintAddress),
+          trades,
+          fundingChanges,
+          backers: uniqueBackers(bets),
+          totalStakedEth: totalStaked(bets),
+        })
+      } catch (e: any) {
+        if (cancelled) return
+        console.warn('[deprize] activity load failed', e)
+        setError(e?.shortMessage || e?.message || 'Failed to load activity')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [deprizeId, marketAddress, chain, chainSlug, mintAddress, refreshNonce])
+
+  return useMemo(() => ({ ...data, loading, error }), [data, loading, error])
+}

--- a/ui/lib/deprize/useDePrizeMarket.tsx
+++ b/ui/lib/deprize/useDePrizeMarket.tsx
@@ -55,6 +55,8 @@ export type UseDePrizeMarketResult = {
   isRefundVector: boolean
   /** LMSR market open time (ms), when available — anchors the odds chart domain. */
   marketStartMs: number | undefined
+  /** LMSR `funding()` in ETH — the liquidity parameter behind marginal prices. */
+  fundingEth: number | undefined
   oddsHistory: OddsSample[]
   loading: boolean
   error: string | undefined
@@ -317,8 +319,10 @@ export function useDePrizeMarket(params: {
     positionIds: bigint[]
     feePct?: number
     marketStartMs?: number
+    fundingEth?: number
   } | null>(null)
   const [marketStartMs, setMarketStartMs] = useState<number | undefined>()
+  const [fundingEth, setFundingEth] = useState<number | undefined>()
   // Bumped whenever the bound market changes so in-flight loads/polls from a
   // prior navigation cannot overwrite the current market's state.
   const loadGenRef = useRef(0)
@@ -381,6 +385,14 @@ export function useDePrizeMarket(params: {
         })
           .then((v) => Number(v))
           .catch(() => 0)
+        // LMSR liquidity parameter; needed to rebuild odds history from trades.
+        const funding = await rpcRead<bigint>({
+          contract: lmsr,
+          method: 'funding' as string,
+          params: [],
+        })
+          .then((v) => Number(v) / Number(UNIT))
+          .catch(() => undefined)
         if (loadGenRef.current !== gen) return
         const startMs = Number.isFinite(startSec) && startSec > 0 ? startSec * 1000 : undefined
         staticRef.current = {
@@ -388,12 +400,14 @@ export function useDePrizeMarket(params: {
           positionIds: ids,
           feePct: fee,
           marketStartMs: startMs,
+          fundingEth: funding,
         }
         startTransition(() => {
           if (loadGenRef.current !== gen) return
           setPositionIds(ids)
           setFeePct(fee)
           setMarketStartMs(startMs)
+          setFundingEth(funding)
         })
       }
       const { conditionId: cond, positionIds: ids } = staticRef.current
@@ -581,6 +595,7 @@ export function useDePrizeMarket(params: {
     winningIndex,
     isRefundVector,
     marketStartMs: marketStartMs ?? staticRef.current?.marketStartMs,
+    fundingEth: fundingEth ?? staticRef.current?.fundingEth,
     oddsHistory,
     loading,
     error,

--- a/ui/lib/deprize/useOddsHistory.tsx
+++ b/ui/lib/deprize/useOddsHistory.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from 'react'
+import type { DePrizeActivity } from './useDePrizeActivity'
+import type { UseDePrizeMarketResult } from './useDePrizeMarket'
+import { maxProbDelta, rebuildOddsHistory, type TradeMarker } from './lmsr-history'
+import type { OddsSample } from './odds-chart'
+
+/** Live-vs-rebuilt divergence (percentage points) above which we trust live. */
+const LIVE_SNAP_PT = 0.5
+
+/**
+ * Odds history for the chart, identical on every device: rebuilt from the
+ * market's on-chain trades (via `useDePrizeActivity`) and the LMSR funding
+ * parameter, then finished with the live poll's current prices. Falls back to
+ * the market hook's per-browser samples while activity is loading or when the
+ * chain data is unavailable.
+ */
+export function useOddsHistory(args: {
+  market: UseDePrizeMarketResult
+  activity: DePrizeActivity
+}): { history: OddsSample[]; markers: TradeMarker[]; loading: boolean; fromChain: boolean } {
+  const { market, activity } = args
+  const live = useMemo(
+    () => market.outcomes.map((o) => o.probability),
+    [market.outcomes],
+  )
+  const liveValid = live.length > 0 && live.every((p) => Number.isFinite(p))
+
+  return useMemo(() => {
+    const canRebuild =
+      !activity.loading &&
+      !activity.error &&
+      market.marketStartMs !== undefined &&
+      market.fundingEth !== undefined &&
+      market.fundingEth > 0 &&
+      market.outcomes.length > 0
+
+    if (!canRebuild) {
+      return {
+        history: market.oddsHistory,
+        markers: [],
+        loading: activity.loading,
+        fromChain: false,
+      }
+    }
+
+    const trades = activity.trades
+      .filter((t) => Number.isFinite(t.timestampMs))
+      .map((t) => ({ timestampMs: t.timestampMs, amounts: t.amounts }))
+    const fundingChanges = activity.fundingChanges.filter((f) => Number.isFinite(f.timestampMs))
+    const { history, markers } = rebuildOddsHistory({
+      marketStartMs: market.marketStartMs as number,
+      initialFundingEth: market.fundingEth as number,
+      trades,
+      fundingChanges,
+      numOutcomes: market.outcomes.length,
+    })
+
+    // Finish with the live prices when they differ from the reconstruction
+    // (trades we couldn't see, rounding, or a resolved payout vector).
+    if (liveValid && !market.resolved) {
+      const last = history[history.length - 1]
+      const delta = maxProbDelta(last.p, live)
+      if (delta > LIVE_SNAP_PT) {
+        console.warn(`[deprize] rebuilt odds differ from live by ${delta.toFixed(2)} pt`)
+      }
+      if (delta > 0.05) history.push({ t: Date.now(), p: [...live] })
+    } else if (market.resolved && liveValid) {
+      history.push({ t: Date.now(), p: [...live] })
+    }
+
+    return { history, markers, loading: false, fromChain: true }
+  }, [
+    activity.loading,
+    activity.error,
+    activity.trades,
+    activity.fundingChanges,
+    market.marketStartMs,
+    market.fundingEth,
+    market.outcomes.length,
+    market.oddsHistory,
+    market.resolved,
+    live,
+    liveValid,
+  ])
+}

--- a/ui/lib/deprize/useOddsHistory.tsx
+++ b/ui/lib/deprize/useOddsHistory.tsx
@@ -47,9 +47,14 @@ export function useOddsHistory(args: {
       .filter((t) => Number.isFinite(t.timestampMs))
       .map((t) => ({ timestampMs: t.timestampMs, amounts: t.amounts }))
     const fundingChanges = activity.fundingChanges.filter((f) => Number.isFinite(f.timestampMs))
+    // `market.fundingEth` is the funding *now*. The replayed changes are the
+    // ones inside the scanned window, so back them out to get the funding at
+    // the start of the window; otherwise each change would count twice.
+    const replayedDelta = fundingChanges.reduce((s, f) => s + f.deltaEth, 0)
+    const initialFundingEth = Math.max(0, (market.fundingEth as number) - replayedDelta)
     const { history, markers } = rebuildOddsHistory({
       marketStartMs: market.marketStartMs as number,
-      initialFundingEth: market.fundingEth as number,
+      initialFundingEth,
       trades,
       fundingChanges,
       numOutcomes: market.outcomes.length,

--- a/ui/pages/api/deprize/logs.ts
+++ b/ui/pages/api/deprize/logs.ts
@@ -11,7 +11,9 @@ import type { NextApiRequest, NextApiResponse } from 'next'
  * 1000 logs and includes block timestamps.
  *
  * GET /api/deprize/logs?chainId=11155111&address=0x…&fromBlock=N&topic0=0x…[&topic1=0x…]
- * → { logs: [{ address, topics, data, blockNumber, timeStamp, logIndex, transactionHash }] }
+ * → { logs: [{ address, topics, data, blockNumber, timeStamp, logIndex, transactionHash }], truncated: boolean }
+ * `truncated` is true when the result hit the page cap (MAX_PAGES full pages),
+ * so the chart treats the rebuilt history as partial and snaps to live prices.
  */
 
 export type EtherscanLog = {
@@ -55,6 +57,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const logs: EtherscanLog[] = []
+  let truncated = false
   for (let page = 1; page <= MAX_PAGES; page++) {
     const params = new URLSearchParams({
       chainid: String(chainId),
@@ -87,12 +90,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const batch = Array.isArray(json.result) ? (json.result as EtherscanLog[]) : []
     logs.push(...batch)
     if (batch.length < PAGE) break
+    if (page === MAX_PAGES) truncated = true
   }
 
   // Short CDN cache: the page refetches after its own transactions with a
   // cache-busting `gen` query param, so a brief TTL is safe.
   setCDNCacheHeaders(res, 15, 60)
-  return res.status(200).json({ logs })
+  return res.status(200).json({ logs, truncated })
 }
 
 export default withMiddleware(handler, rateLimit)

--- a/ui/pages/api/deprize/logs.ts
+++ b/ui/pages/api/deprize/logs.ts
@@ -1,0 +1,98 @@
+import { setCDNCacheHeaders } from 'middleware/cacheHeaders'
+import { rateLimit } from 'middleware/rateLimit'
+import withMiddleware from 'middleware/withMiddleware'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+/**
+ * Raw event logs for one contract via the Etherscan V2 API (one key, every
+ * chain). The DePrize pages need every `Bet` / `AMMOutcomeTokenTrade` since
+ * deployment; RPC `eth_getLogs` is capped at ~10k blocks per call, which is
+ * unusable on Arbitrum. Etherscan returns the full range in one page of up to
+ * 1000 logs and includes block timestamps.
+ *
+ * GET /api/deprize/logs?chainId=11155111&address=0x…&fromBlock=N&topic0=0x…[&topic1=0x…]
+ * → { logs: [{ address, topics, data, blockNumber, timeStamp, logIndex, transactionHash }] }
+ */
+
+export type EtherscanLog = {
+  address: string
+  topics: string[]
+  data: string
+  blockNumber: string // hex
+  timeStamp: string // hex seconds
+  logIndex: string // hex
+  transactionHash: string
+}
+
+const SUPPORTED_CHAINS = new Set([1, 11155111, 42161, 421614])
+const PAGE = 1000
+const MAX_PAGES = 10
+
+function isHex(v: unknown): v is string {
+  return typeof v === 'string' && /^0x[0-9a-fA-F]*$/.test(v)
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  const apiKey =
+    process.env.ETHERSCAN_API_KEY ||
+    process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY ||
+    process.env.ARBISCAN_API_KEY
+  if (!apiKey) return res.status(503).json({ error: 'Explorer API key not configured' })
+
+  const chainId = Number(req.query.chainId)
+  const address = req.query.address
+  const fromBlock = Number(req.query.fromBlock ?? 0)
+  const topic0 = req.query.topic0
+  const topic1 = req.query.topic1
+  if (!SUPPORTED_CHAINS.has(chainId)) return res.status(400).json({ error: 'Unsupported chainId' })
+  if (!isHex(address) || address.length !== 42) return res.status(400).json({ error: 'Bad address' })
+  if (!Number.isFinite(fromBlock) || fromBlock < 0) return res.status(400).json({ error: 'Bad fromBlock' })
+  if (!isHex(topic0) || topic0.length !== 66) return res.status(400).json({ error: 'Bad topic0' })
+  if (topic1 !== undefined && (!isHex(topic1) || topic1.length !== 66)) {
+    return res.status(400).json({ error: 'Bad topic1' })
+  }
+
+  const logs: EtherscanLog[] = []
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const params = new URLSearchParams({
+      chainid: String(chainId),
+      module: 'logs',
+      action: 'getLogs',
+      address,
+      fromBlock: String(fromBlock),
+      toBlock: 'latest',
+      topic0,
+      page: String(page),
+      offset: String(PAGE),
+      apikey: apiKey,
+    })
+    if (topic1) {
+      params.set('topic0_1_opr', 'and')
+      params.set('topic1', topic1)
+    }
+    let json: any
+    try {
+      const r = await fetch(`https://api.etherscan.io/v2/api?${params.toString()}`)
+      json = await r.json()
+    } catch (e: any) {
+      return res.status(502).json({ error: `Explorer request failed: ${e?.message ?? e}` })
+    }
+    // status "0" + "No records found" is an empty result, not an error.
+    if (json?.status !== '1') {
+      if (typeof json?.message === 'string' && /no records/i.test(json.message)) break
+      return res.status(502).json({ error: json?.result || json?.message || 'Explorer error' })
+    }
+    const batch = Array.isArray(json.result) ? (json.result as EtherscanLog[]) : []
+    logs.push(...batch)
+    if (batch.length < PAGE) break
+  }
+
+  // Short CDN cache: the page refetches after its own transactions with a
+  // cache-busting `gen` query param, so a brief TTL is safe.
+  setCDNCacheHeaders(res, 15, 60)
+  return res.status(200).json({ logs })
+}
+
+export default withMiddleware(handler, rateLimit)

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -325,10 +325,12 @@ function DePrizeDetailContent() {
             // read fails, fall back to the net-only quote rather than no quote.
             let fee = 0n
             try {
+              // calcMarketFee is uint256(|net|); a signed sell net is out of range.
+              const absNet = net < 0n ? -net : net
               fee = await rpcRead<bigint>({
                 contract: lmsrRead,
                 method: 'calcMarketFee' as string,
-                params: [net],
+                params: [absNet],
               })
             } catch {
               fee = 0n

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -320,7 +320,20 @@ function DePrizeDetailContent() {
               method: 'calcNetCost' as string,
               params: [amounts],
             })
-            return [o.index, Number(-net) / Number(UNIT)] as [number, number]
+            // Net cost excludes the market-maker fee; realized sells record
+            // proceeds as -netCost - fees, so quote the same here. If the fee
+            // read fails, fall back to the net-only quote rather than no quote.
+            let fee = 0n
+            try {
+              fee = await rpcRead<bigint>({
+                contract: lmsrRead,
+                method: 'calcMarketFee' as string,
+                params: [net],
+              })
+            } catch {
+              fee = 0n
+            }
+            return [o.index, Number(-net - fee) / Number(UNIT)] as [number, number]
           } catch {
             return null
           }

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -36,15 +36,17 @@ import {
   shouldSurfaceResolution,
   UNIT,
 } from '@/lib/deprize/constants'
-import { fmt } from '@/lib/deprize/format'
 import { spendableFromBalanceEth } from '@/lib/deprize/gas-reserve'
 import { buildAmounts } from '@/lib/deprize/quote'
+import { rankOutcomes } from '@/lib/deprize/rank-outcomes'
 import { deprizeReadChain, deprizeReadClient, rpcRead } from '@/lib/deprize/read'
 import { formatBettingCloses, isMintConfigured, reconcileBettingStatus } from '@/lib/deprize/status'
 import { useDePrize } from '@/lib/deprize/useDePrize'
+import { useDePrizeActivity } from '@/lib/deprize/useDePrizeActivity'
 import { useDePrizeLaunchpadToken } from '@/lib/deprize/useDePrizeLaunchpad'
-import EthUsd from '@/components/deprize/EthUsd'
 import { useDePrizeMarket } from '@/lib/deprize/useDePrizeMarket'
+import { useOddsHistory } from '@/lib/deprize/useOddsHistory'
+import EthUsd from '@/components/deprize/EthUsd'
 import useRegionRestriction from '@/lib/geo/useRegionRestriction'
 import useTotalFunding from '@/lib/juicebox/useTotalFunding'
 import { getChainSlug } from '@/lib/thirdweb/chain'
@@ -56,6 +58,8 @@ import { NoticeFooter } from '@/components/layout/NoticeFooter'
 import BetModal from '@/components/deprize/BetModal'
 import ClaimPanel from '@/components/deprize/ClaimPanel'
 import DePrizeAdminPanel from '@/components/deprize/DePrizeAdminPanel'
+import DePrizePositionPanel from '@/components/deprize/DePrizePositionPanel'
+import DePrizeQuestionCard from '@/components/deprize/DePrizeQuestionCard'
 import DePrizeTeamCard from '@/components/deprize/DePrizeTeamCard'
 import DePrizeTeamLink, {
   useDePrizeTeamName,
@@ -66,6 +70,15 @@ import ExitPositionModal from '@/components/deprize/ExitPositionModal'
 const OddsHistoryChart = dynamic(() => import('@/components/deprize/OddsHistoryChart'), {
   ssr: false,
 })
+
+const CARD =
+  'p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg'
+
+const EXPLORER_TX: Record<string, string> = {
+  sepolia: 'https://sepolia.etherscan.io/tx/',
+  arbitrum: 'https://arbiscan.io/tx/',
+  'arbitrum-sepolia': 'https://sepolia.arbiscan.io/tx/',
+}
 
 function outcomeDisplayName(
   index: number,
@@ -133,13 +146,7 @@ function DePrizeDetailContent() {
   // build-time default — otherwise switching networks never re-queries DePrize.
   const competition = getDePrizeCompetition(chainSlug, deprizeId)
   const raceBinding = getDePrizeRaceBinding(chainSlug, deprizeId)
-  const namedRaceOutcomes = raceBinding?.outcomes.filter((o) => !o.field) ?? []
-  const anyOfficialCompetitor = namedRaceOutcomes.some((o) =>
-    isCompetitorClaimed(o)
-  )
-  const anyUnofficialCompetitor = namedRaceOutcomes.some(
-    (o) => !isCompetitorClaimed(o)
-  )
+  const raceGoal = raceBinding ? sharedGoalById(SEED_ATLAS, raceBinding.sharedGoalId) : undefined
   const generationNumber = getDePrizeGenerationNumber(chainSlug, deprizeId)
   const knownCompetition = isKnownDePrizeCompetition(chainSlug, deprizeId)
   const account = useActiveAccount()
@@ -164,6 +171,15 @@ function DePrizeDetailContent() {
     registryState: deprize?.state,
   })
 
+  const [refreshNonce, setRefreshNonce] = useState(0)
+  const activity = useDePrizeActivity({
+    deprizeId,
+    marketAddress: market.marketAddress,
+    chain,
+    refreshNonce,
+  })
+  const odds = useOddsHistory({ market, activity })
+
   const region = useRegionRestriction()
   // Pass a plain number: useRead JSON.stringify's its params for memoization,
   // which throws on bigint. JB project ids are small, so Number() is safe.
@@ -177,10 +193,8 @@ function DePrizeDetailContent() {
 
   const mintAddress = DEPRIZE_MINT_ADDRESSES[chainSlug] ?? ''
 
-  const [refreshNonce, setRefreshNonce] = useState(0)
   const [nativeBalance, setNativeBalance] = useState<number | undefined>()
   const [sellQuotes, setSellQuotes] = useState<Map<number, number>>(new Map())
-  const [costBasis, setCostBasis] = useState<Record<number, number>>({})
   const [betIndex, setBetIndex] = useState<number | null>(null)
   const [exitIndex, setExitIndex] = useState<number | null>(null)
 
@@ -271,78 +285,16 @@ function DePrizeDetailContent() {
     }
   }, [userAddress, readChain, refreshNonce])
 
-  // Cost basis (per market + wallet) for profit display.
-  const costStorageKey = useMemo(
-    () =>
-      market.marketAddress && userAddress
-        ? `deprize:costBasis:v1:${market.marketAddress}:${userAddress}`
-        : null,
-    [market.marketAddress, userAddress],
-  )
-  useEffect(() => {
-    if (!costStorageKey || typeof window === 'undefined') {
-      setCostBasis({})
-      return
-    }
-    try {
-      const raw = window.localStorage.getItem(costStorageKey)
-      setCostBasis(raw ? (JSON.parse(raw) as Record<number, number>) : {})
-    } catch {
-      setCostBasis({})
-    }
-  }, [costStorageKey])
-  const persistCostBasis = useCallback(
-    (next: Record<number, number>) => {
-      if (costStorageKey && typeof window !== 'undefined') {
-        try {
-          window.localStorage.setItem(costStorageKey, JSON.stringify(next))
-        } catch {
-          /* ignore */
-        }
-      }
-    },
-    [costStorageKey],
-  )
-  const addCostBasis = useCallback(
-    (index: number, deltaEth: number) => {
-      setCostBasis((prev) => {
-        const next = { ...prev, [index]: Math.max(0, (prev[index] ?? 0) + deltaEth) }
-        persistCostBasis(next)
-        return next
-      })
-    },
-    [persistCostBasis],
-  )
-  const resetCostBasis = useCallback(
-    (index: number) => {
-      setCostBasis((prev) => {
-        const next = { ...prev, [index]: 0 }
-        persistCostBasis(next)
-        return next
-      })
-    },
-    [persistCostBasis],
-  )
-  const clearCostBasis = useCallback(() => {
-    setCostBasis({})
-    if (costStorageKey && typeof window !== 'undefined') {
-      try {
-        window.localStorage.removeItem(costStorageKey)
-      } catch {
-        /* ignore */
-      }
-    }
-  }, [costStorageKey])
-
+  // After a tx, events land a block or two later: refresh now, soon, and later.
   const refreshAll = useCallback(() => {
-    market.refresh()
-    refreshRegistry()
-    setRefreshNonce((n) => n + 1)
-    setTimeout(() => {
+    const tick = () => {
       market.refresh()
       refreshRegistry()
       setRefreshNonce((n) => n + 1)
-    }, 2500)
+    }
+    tick()
+    setTimeout(tick, 2500)
+    setTimeout(tick, 8000)
   }, [market, refreshRegistry])
 
   // Live sell quotes for held outcomes while the market is trading.
@@ -404,20 +356,39 @@ function DePrizeDetailContent() {
     !tradingHalted &&
     market.stage === MarketStage.Running
 
-  // Moon Base Zero "Back this team" deep-links here with ?outcome=N.
+  // The Back button is also the connect entry point.
+  const handleBet = useCallback(
+    (index: number) => {
+      if (!userAddress) {
+        login()
+        return
+      }
+      setBetIndex(index)
+    },
+    [userAddress, login],
+  )
+
+  // Moon Base Zero "Back this team" deep-links here with ?outcome=N. Wait for
+  // the market + chart to settle so the layout above the card stops shifting.
+  const [deepLinkHandled, setDeepLinkHandled] = useState(false)
   useEffect(() => {
-    if (!router.isReady || numOutcomes <= 0) return
+    if (deepLinkHandled || !router.isReady || numOutcomes <= 0) return
+    if (market.loading || odds.loading) return
     const raw = router.query.outcome
     if (typeof raw !== 'string' || !/^\d+$/.test(raw)) return
     const idx = Number(raw)
     if (idx < 0 || idx >= numOutcomes) return
+    setDeepLinkHandled(true)
     const el = document.getElementById(`deprize-outcome-${idx}`)
     el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
     if (userAddress && bettingAllowed) setBetIndex(idx)
   }, [
+    deepLinkHandled,
     router.isReady,
     router.query.outcome,
     numOutcomes,
+    market.loading,
+    odds.loading,
     userAddress,
     bettingAllowed,
   ])
@@ -434,7 +405,7 @@ function DePrizeDetailContent() {
     })
   const showRefundVector = showResolved && market.isRefundVector
 
-  const { effectiveDescription, statusLabelOverride } = deprize
+  const { bettingBlockedReason, statusLabelOverride } = deprize
     ? reconcileBettingStatus({
         bettingOpen: deprize.bettingOpen,
         marketStage: market.stage,
@@ -442,7 +413,7 @@ function DePrizeDetailContent() {
         registryState: deprize.state,
         marketBound,
       })
-    : { effectiveDescription: undefined, statusLabelOverride: undefined }
+    : { bettingBlockedReason: undefined, statusLabelOverride: undefined }
 
   // Prefer the registry's winning team id (NFT id); fall back to the CTF
   // payout slot → teamIds mapping once resolution is surfaced.
@@ -462,6 +433,52 @@ function DePrizeDetailContent() {
     if (!bound.startsWith('Team #')) return bound
     return rosterNames[o.index] || bound
   })
+
+  // One color per outcome, shared by cards, chart lines and the position panel.
+  // Claimed listings get their brand color; everything else gets a distinct
+  // palette color (consent gates branding, not legibility — the cards are the
+  // chart's legend).
+  const outcomeColors = useMemo(
+    () =>
+      Array.from({ length: numOutcomes }, (_, i) => {
+        const binding = raceBinding?.outcomes[i]
+        const fallback = OUTCOME_COLORS[i % OUTCOME_COLORS.length]
+        if (binding?.field || !binding || !isCompetitorClaimed(binding)) return fallback
+        const project = binding.projectId ? projectById(SEED_ATLAS, binding.projectId) : undefined
+        const org = project ? orgById(SEED_ATLAS, project.orgId) : undefined
+        return orgColor(org) || fallback
+      }),
+    [numOutcomes, raceBinding],
+  )
+
+  // Display order only — `market.outcomes` stays contract-index aligned.
+  const rankedOutcomes = useMemo(
+    () =>
+      rankOutcomes(market.outcomes, {
+        isField: (i) => !!raceBinding?.outcomes[i]?.field,
+        winningIndex: showResolved && market.winningIndex >= 0 ? market.winningIndex : undefined,
+      }),
+    [market.outcomes, raceBinding, showResolved, market.winningIndex],
+  )
+
+  const redeemValues = useMemo(() => {
+    const m = new Map<number, number>()
+    if (!showResolved) return m
+    for (const o of market.outcomes) {
+      if (o.balanceWei === undefined) continue
+      m.set(
+        o.index,
+        Number(
+          positionRedeemValue(
+            o.balanceWei,
+            market.payoutNums[o.index] ?? 0n,
+            market.payoutDen ?? 0n,
+          ),
+        ) / Number(UNIT),
+      )
+    }
+    return m
+  }, [showResolved, market.outcomes, market.payoutNums, market.payoutDen])
 
   const shellTitle =
     knownCompetition && deprizeId !== undefined
@@ -527,43 +544,56 @@ function DePrizeDetailContent() {
     )
   }
 
+  // "Open" next to a live market says nothing; badge only when something is off.
+  const abnormalStatus = !!bettingBlockedReason && !bettingBlockedReason.startsWith('Loading')
+  const showBadge = abnormalStatus || deprize.state !== DePrizeState.OPEN
+  const explorerTxBase = EXPLORER_TX[chainSlug] ?? 'https://etherscan.io/tx/'
+  const hasLineage =
+    deprize.state === DePrizeState.SUPERSEDED || competition.supersedes !== undefined
+
   return (
     <Shell title={shellTitle} description={competition.metaDescription}>
       <div className="flex flex-col gap-4 w-full max-w-[860px] mx-auto">
-        {/* Compact header — title + prize stats only. Copy lives below the fold. */}
-        <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
+        {/* Header — name, id, status only when it isn't the normal OPEN state, stats. */}
+        <div className={CARD}>
           <div className="flex items-center justify-between gap-3 flex-wrap">
             <div className="flex items-center gap-2 sm:gap-3 flex-wrap min-w-0">
               <h1 className="text-white font-GoodTimes text-lg sm:text-xl">
-                {knownCompetition
-                  ? `DePrize #${deprizeId} — ${competition.title}`
-                  : `DePrize #${deprizeId}`}
+                {knownCompetition ? competition.title : `DePrize #${deprizeId}`}
               </h1>
-              {deprize && (
+              {knownCompetition && (
+                <span className="text-xs font-mono text-gray-500">#{deprizeId}</span>
+              )}
+              {showBadge && (
                 <StateBadge
                   state={deprize.state}
-                  labelOverride={statusLabelOverride}
-                  toneOverride={statusLabelOverride ? 'amber' : undefined}
+                  labelOverride={abnormalStatus ? statusLabelOverride : undefined}
+                  toneOverride={abnormalStatus ? 'amber' : undefined}
                 />
               )}
-              {knownCompetition && generationNumber > 1 && (
-                <span className="px-3 py-1 rounded-full text-xs font-medium border bg-white/10 text-gray-200 border-white/20">
-                  Generation {generationNumber}
-                </span>
-              )}
             </div>
-            <Link
-              href="/deprize"
-              className="shrink-0 text-sm text-indigo-300/90 hover:text-indigo-200 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/50 rounded"
-            >
-              ← All prizes
-            </Link>
+            <div className="flex items-center gap-4 shrink-0 text-sm">
+              {raceGoal && (
+                <Link
+                  href={`/moonbase?race=${raceGoal.id}`}
+                  className="text-indigo-300/90 hover:text-indigo-200 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/50 rounded"
+                >
+                  Open in Moon Base Zero
+                </Link>
+              )}
+              <Link
+                href="/deprize"
+                className="text-indigo-300/90 hover:text-indigo-200 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/50 rounded"
+              >
+                ← All prizes
+              </Link>
+            </div>
           </div>
-          <div className="mt-3 grid grid-cols-3 gap-3">
+          <div className="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3">
             <Stat
-              label="Prize pool"
+              label="Prize pool · to winner"
               href={launchpad.missionHref}
-              title={launchpad.missionHref ? 'Open the launchpad prize pool' : undefined}
+              title="Paid to the winning team when the race settles. Separate from what bettors win — bettor payouts come from the betting market."
             >
               {jbProjectId !== undefined && !isLoadingFunding ? (
                 <EthUsd eth={Number(totalFunding) / Number(UNIT)} prize />
@@ -571,12 +601,39 @@ function DePrizeDetailContent() {
                 '—'
               )}
             </Stat>
-            <Stat label="Providers">{numOutcomes || '—'}</Stat>
+            <Stat
+              label="Total staked"
+              title="ETH bettors have put into the market. Winning shares are paid from this plus the market's seed funding."
+            >
+              {activity.loading && !activity.bets.length ? (
+                '…'
+              ) : activity.error ? (
+                '—'
+              ) : (
+                <EthUsd eth={activity.totalStakedEth} approx />
+              )}
+            </Stat>
+            <Stat label="Backers" title="Unique wallets that have backed a team.">
+              {activity.loading && !activity.bets.length ? (
+                '…'
+              ) : activity.error ? (
+                '—'
+              ) : (
+                <>
+                  {activity.backers}
+                  {activity.bets.length > 0 && (
+                    <span className="ml-1.5 text-xs font-normal text-gray-500">
+                      · {activity.bets.length} {activity.bets.length === 1 ? 'bet' : 'bets'}
+                    </span>
+                  )}
+                </>
+              )}
+            </Stat>
             <Stat
               label="Betting closes"
               title="After this time the market can be locked and moved to winner determination. Until then, betting stays open."
             >
-              {deprize && deprize.sunset > 0n ? formatBettingCloses(deprize.sunset) : '—'}
+              {deprize.sunset > 0n ? formatBettingCloses(deprize.sunset) : '—'}
             </Stat>
           </div>
           {winningTeamId > 0n && (
@@ -607,79 +664,61 @@ function DePrizeDetailContent() {
             )}
         </div>
 
-        {deprize?.cancellationPending && (
-          <Notice tone="red">
-            A cancellation has been announced for this DePrize. New bets are paused during the 7-day
-            notice window. If the cancellation goes through, all positions are refunded.
-          </Notice>
+        {/* Actionable status only (paused / no market / cancelling). */}
+        {bettingBlockedReason && !bettingBlockedReason.startsWith('Loading') && (
+          <Notice tone="amber">{bettingBlockedReason}</Notice>
         )}
 
-        {market.error && (
-          <Notice tone="red">
-            Couldn&apos;t fully load market data: {market.error}. Reload the page and try again.
-          </Notice>
+        {market.error && <Notice tone="red">Couldn&apos;t load market data — reload.</Notice>}
+
+        <DePrizeQuestionCard
+          tagline={competition.tagline}
+          description={raceGoal?.description}
+          criteria={raceGoal?.criteria}
+          moonbaseHref={raceGoal ? `/moonbase?race=${raceGoal.id}` : undefined}
+        />
+
+        {userAddress && numOutcomes > 0 && (
+          <DePrizePositionPanel
+            outcomes={market.outcomes}
+            labels={predictionLabels}
+            colors={outcomeColors}
+            bets={activity.bets}
+            sells={activity.sells}
+            user={userAddress}
+            sellQuotes={sellQuotes}
+            redeemValues={redeemValues}
+            resolved={showResolved}
+            isRefundVector={showRefundVector}
+            winningIndex={market.winningIndex}
+            tradingHalted={tradingHalted}
+            explorerTxBase={explorerTxBase}
+            onCashOut={(i) => setExitIndex(i)}
+            loading={activity.loading}
+          />
         )}
 
-        {/* Predictions — first thing after the title so the history is above the fold. */}
+        {/* Odds — the ranked cards below are the legend (same colors). */}
         {numOutcomes > 0 && (
-          <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
-            <div className="flex items-center justify-between gap-3 flex-wrap mb-3">
-              <div>
-                <p className="text-white font-semibold">Predictions</p>
-                <p className="text-gray-500 text-xs">
-                  Implied chance since the market opened
-                  {market.marketStartMs !== undefined
-                    ? ` (${new Date(market.marketStartMs).toLocaleDateString()})`
-                    : ''}
-                </p>
-              </div>
-              <div className="flex items-center gap-3 flex-wrap">
-                {market.outcomes.map((o) => (
-                  <div key={o.index} className="flex items-center gap-1.5">
-                    <span
-                      className="inline-block w-2.5 h-2.5 rounded-full"
-                      style={{ background: OUTCOME_COLORS[o.index % OUTCOME_COLORS.length] }}
-                    />
-                    <span className="text-gray-300 text-xs">
-                      {predictionLabels[o.index]}
-                      {Number.isNaN(o.probability) ? '' : ` · ${fmt(o.probability, 0)}%`}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
+          <div className={CARD}>
+            <p className="text-white font-semibold mb-3">Odds</p>
             <OddsHistoryChart
-              history={market.oddsHistory}
+              history={odds.history}
               labels={predictionLabels}
-              colors={OUTCOME_COLORS}
+              colors={outcomeColors}
               domainStartMs={market.marketStartMs}
+              markers={odds.markers}
+              loading={odds.loading}
             />
           </div>
         )}
 
-        {/* Competitors */}
+        {/* Competitors, ranked by chance; Open Field last. */}
         {numOutcomes > 0 && (
           <div className="flex flex-col gap-3">
             <h3 className="title-text-colors text-lg font-GoodTimes">Competitors</h3>
-            {(anyOfficialCompetitor || anyUnofficialCompetitor) && (
-              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 -mt-1">
-                {anyOfficialCompetitor && (
-                  <span className="inline-flex items-center gap-1.5">
-                    <span className="h-3 w-1 rounded-full bg-emerald-400" />
-                    Official participant
-                  </span>
-                )}
-                {anyUnofficialCompetitor && (
-                  <span className="inline-flex items-center gap-1.5">
-                    <span className="h-3 w-1 rounded-full bg-zinc-400" />
-                    Unofficial — not confirmed
-                  </span>
-                )}
-              </div>
-            )}
-            {market.outcomes.map((o) => {
-              const teamId = deprize?.teamIds[o.index] ?? 0n
-              const invested = costBasis[o.index] ?? 0
+            {rankedOutcomes.map((o) => {
+              const teamId = deprize.teamIds[o.index] ?? 0n
               const outcomeBinding = raceBinding?.outcomes[o.index]
               const isField = !!outcomeBinding?.field
               const atlasProject =
@@ -690,129 +729,50 @@ function DePrizeDetailContent() {
                 ? orgById(SEED_ATLAS, atlasProject.orgId)
                 : undefined
               const claimed = isCompetitorClaimed(outcomeBinding)
-              const redeemValueEth =
-                showResolved && o.balanceWei !== undefined
-                  ? Number(
-                      positionRedeemValue(
-                        o.balanceWei,
-                        market.payoutNums[o.index] ?? 0n,
-                        market.payoutDen ?? 0n,
-                      ),
-                    ) / Number(UNIT)
-                  : undefined
               return (
                 <div id={`deprize-outcome-${o.index}`} key={o.index}>
-                <DePrizeTeamCard
-                  outcome={o}
-                  teamId={teamId}
-                  teamContract={teamContract}
-                  color={
-                    isField
-                      ? OUTCOME_COLORS[o.index % OUTCOME_COLORS.length]
-                      : claimed
-                        ? orgColor(atlasOrg)
-                        : '#9ca3af'
-                  }
-                  loading={market.loading}
-                  resolved={showResolved}
-                  isRefundVector={showRefundVector}
-                  isWinningSlot={showResolved && o.index === market.winningIndex}
-                  redeemValueEth={redeemValueEth}
-                  sellQuoteEth={sellQuotes.get(o.index)}
-                  investedEth={invested}
-                  bettingOpen={bettingAllowed}
-                  tradingHalted={tradingHalted}
-                  busy={false}
-                  userConnected={!!userAddress}
-                  onBet={(i) => setBetIndex(i)}
-                  onCashOut={(i) => setExitIndex(i)}
-                  isField={isField}
-                  withdrawn={!!withdrawnByTeamId[teamId.toString()]}
-                  hrefOverride={
-                    outcomeBinding?.projectId
-                      ? `/moonbase/${outcomeBinding.projectId}`
-                      : undefined
-                  }
-                  nameOverride={atlasOrg?.name || atlasProject?.name}
-                  imageOverride={claimed ? atlasOrg?.logoURI : undefined}
-                  unclaimed={!isField && !!outcomeBinding && !claimed}
-                  participation={
-                    isField || !outcomeBinding
-                      ? undefined
-                      : claimed
-                        ? 'official'
-                        : 'unofficial'
-                  }
-                />
+                  <DePrizeTeamCard
+                    outcome={o}
+                    teamId={teamId}
+                    teamContract={teamContract}
+                    color={outcomeColors[o.index]}
+                    loading={market.loading}
+                    resolved={showResolved}
+                    isRefundVector={showRefundVector}
+                    isWinningSlot={showResolved && o.index === market.winningIndex}
+                    bettingOpen={bettingAllowed}
+                    tradingHalted={tradingHalted}
+                    busy={false}
+                    userConnected={!!userAddress}
+                    onBet={handleBet}
+                    isField={isField}
+                    withdrawn={!!withdrawnByTeamId[teamId.toString()]}
+                    hrefOverride={
+                      outcomeBinding?.projectId
+                        ? `/moonbase/${outcomeBinding.projectId}`
+                        : undefined
+                    }
+                    nameOverride={atlasOrg?.name || atlasProject?.name}
+                    imageOverride={claimed ? atlasOrg?.logoURI : undefined}
+                    unclaimed={!isField && !!outcomeBinding && !claimed}
+                    participation={
+                      isField || !outcomeBinding
+                        ? undefined
+                        : claimed
+                          ? 'official'
+                          : 'unofficial'
+                    }
+                  />
                 </div>
               )
             })}
           </div>
         )}
 
-        {/* Description — below the predictions and competitors. */}
-        <div className="p-4 sm:p-5 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/70 to-indigo-950/40 backdrop-blur-xl border border-white/[0.08] shadow-lg">
-          <p className="text-gray-300 text-sm">{competition.tagline}</p>
-          {effectiveDescription && (
-            <p className="text-gray-500 text-sm mt-2">{effectiveDescription}</p>
-          )}
-          {deprize?.state === DePrizeState.SUPERSEDED && (
-            <p className="text-amber-200/90 text-sm mt-2">
-              This generation was superseded
-              {competition.supersededBy
-                ? ` by DePrize #${competition.supersededBy}`
-                : ''}
-              . New bets are closed; you can still sell your position at the market price. Odds for
-              this race live on the current generation.
-              {competition.supersededBy && (
-                <>
-                  {' '}
-                  <Link
-                    href={`/deprize/${competition.supersededBy}`}
-                    className="underline underline-offset-2 hover:text-amber-100"
-                  >
-                    Open generation {generationNumber + 1}
-                  </Link>
-                </>
-              )}
-            </p>
-          )}
-          {competition.supersedes !== undefined && deprize?.state !== DePrizeState.SUPERSEDED && (
-            <p className="text-gray-500 text-xs mt-2">
-              Continues from{' '}
-              <Link
-                href={`/deprize/${competition.supersedes}`}
-                className="text-indigo-300/90 underline underline-offset-2 hover:text-indigo-200"
-              >
-                generation {generationNumber - 1} (DePrize #{competition.supersedes})
-              </Link>
-              . Legacy positions remain sellable there until the race settles.
-            </p>
-          )}
-          {isRaceBindingComplete(raceBinding?.outcomes) && (
-            <p className="text-gray-500 text-xs leading-relaxed mt-3">{ROSTER_DISCLAIMER}</p>
-          )}
-        </div>
-
         {(region.isRestricted || (!region.isLoading && !region.isError && !region.country)) && (
           <Notice tone="amber">
-            Betting isn&apos;t available in your region. You can still view live odds and, if you
-            hold a position, claim or cash out.
+            Betting isn&apos;t available in your region. You can view odds, cash out and claim.
           </Notice>
-        )}
-
-        {!userAddress && bettingAllowed && (
-          <div className="p-4 sm:p-5 rounded-2xl bg-indigo-500/10 border border-indigo-500/30 flex items-center justify-between gap-3 flex-wrap">
-            <p className="text-indigo-100 text-sm font-medium">
-              Connect a wallet to back a team, cash out, or claim.
-            </p>
-            <button
-              onClick={() => login()}
-              className="px-5 py-2.5 rounded-full bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 text-white text-sm font-semibold transition-all"
-            >
-              Connect Wallet
-            </button>
-          </div>
         )}
 
         {/* Claim / refund */}
@@ -824,36 +784,68 @@ function DePrizeDetailContent() {
             resolved={showResolved}
             isRefundVector={showRefundVector}
             winningTeamName={winningTeamName || undefined}
-            jbProjectId={deprize?.jbProjectId}
+            jbProjectId={deprize.jbProjectId}
             refreshNonce={refreshNonce}
-            onDone={() => {
-              clearCostBasis()
-              refreshAll()
-            }}
+            onDone={refreshAll}
           />
         )}
 
-        {/* Admin */}
-        {deprize && (
-          <DePrizeAdminPanel
-            deprizeId={deprizeId}
-            chain={chain}
-            account={account}
-            state={deprize.state}
-            teamIds={deprize.teamIds}
-            cancellationPending={deprize.cancellationPending}
-            marketAddress={market.marketAddress}
-            numOutcomes={numOutcomes}
-            stage={market.stage}
-            resolved={market.resolved}
-            marketFeesWei={market.marketFeesWei}
-            onDone={refreshAll}
-          />
+        {/* Admin (renders nothing for non-admins) */}
+        <DePrizeAdminPanel
+          deprizeId={deprizeId}
+          chain={chain}
+          account={account}
+          state={deprize.state}
+          teamIds={deprize.teamIds}
+          cancellationPending={deprize.cancellationPending}
+          marketAddress={market.marketAddress}
+          numOutcomes={numOutcomes}
+          stage={market.stage}
+          resolved={market.resolved}
+          marketFeesWei={market.marketFeesWei}
+          onDone={refreshAll}
+        />
+
+        {/* Lineage + roster footnote */}
+        {(hasLineage || isRaceBindingComplete(raceBinding?.outcomes)) && (
+          <div className="flex flex-col gap-1.5 px-1">
+            {deprize.state === DePrizeState.SUPERSEDED && (
+              <p className="text-xs text-amber-200/90">
+                Superseded
+                {competition.supersededBy ? (
+                  <>
+                    {' '}by{' '}
+                    <Link
+                      href={`/deprize/${competition.supersededBy}`}
+                      className="underline underline-offset-2 hover:text-amber-100"
+                    >
+                      DePrize #{competition.supersededBy}
+                    </Link>
+                  </>
+                ) : null}
+                {' '}— new bets happen there. You can still sell here.
+              </p>
+            )}
+            {competition.supersedes !== undefined && deprize.state !== DePrizeState.SUPERSEDED && (
+              <p className="text-xs text-gray-500">
+                Generation {generationNumber} · continues from{' '}
+                <Link
+                  href={`/deprize/${competition.supersedes}`}
+                  className="text-indigo-300/90 underline underline-offset-2 hover:text-indigo-200"
+                >
+                  #{competition.supersedes}
+                </Link>
+              </p>
+            )}
+            {isRaceBindingComplete(raceBinding?.outcomes) && (
+              <p className="text-[11px] text-gray-600 leading-relaxed">{ROSTER_DISCLAIMER}</p>
+            )}
+          </div>
         )}
       </div>
 
       {/* Bet modal */}
-      {betIndex !== null && deprize && market.marketAddress && account && (
+      {betIndex !== null && market.marketAddress && account && (
         <BetModal
           deprizeId={deprizeId}
           outcomeIndex={betIndex}
@@ -867,10 +859,7 @@ function DePrizeDetailContent() {
           account={account}
           spendableEth={spendable}
           onClose={() => setBetIndex(null)}
-          onDone={(index, costEth) => {
-            addCostBasis(index, costEth)
-            refreshAll()
-          }}
+          onDone={refreshAll}
         />
       )}
 
@@ -887,10 +876,7 @@ function DePrizeDetailContent() {
           chain={chain}
           account={account}
           onClose={() => setExitIndex(null)}
-          onDone={() => {
-            resetCostBasis(exitIndex)
-            refreshAll()
-          }}
+          onDone={refreshAll}
         />
       )}
     </Shell>

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -597,7 +597,7 @@ function DePrizeDetailContent() {
             <Stat
               label="Prize pool · to winner"
               href={launchpad.missionHref}
-              title="Paid to the winning team when the race settles. Separate from what bettors win — bettor payouts come from the betting market."
+              title="Paid to the winning competitor when the race settles. Separate from what bettors win — bettor payouts come from the betting market."
             >
               {jbProjectId !== undefined && !isLoadingFunding ? (
                 <EthUsd eth={Number(totalFunding) / Number(UNIT)} prize />
@@ -617,7 +617,7 @@ function DePrizeDetailContent() {
                 <EthUsd eth={activity.totalStakedEth} approx />
               )}
             </Stat>
-            <Stat label="Backers" title="Unique wallets that have backed a team.">
+            <Stat label="Backers" title="Unique wallets that have backed a competitor.">
               {activity.loading && !activity.bets.length ? (
                 '…'
               ) : activity.error ? (
@@ -705,7 +705,11 @@ function DePrizeDetailContent() {
         {/* Odds — the ranked cards below are the legend (same colors). */}
         {numOutcomes > 0 && (
           <div className={CARD}>
-            <p className="text-white font-semibold mb-3">Odds</p>
+            <p className="text-white font-semibold mb-3">
+              {!activity.loading && !activity.error && activity.bets.length === 0
+                ? 'Starting odds — no bets yet'
+                : 'Odds'}
+            </p>
             <OddsHistoryChart
               history={odds.history}
               labels={predictionLabels}
@@ -757,6 +761,14 @@ function DePrizeDetailContent() {
                         : undefined
                     }
                     nameOverride={atlasOrg?.name || atlasProject?.name}
+                    vehicleLabel={outcomeBinding?.vehicleLabel}
+                    backLabel={
+                      isField
+                        ? 'Back the field'
+                        : atlasOrg?.name || atlasProject?.name
+                          ? `Back ${atlasOrg?.name || atlasProject?.name}`
+                          : undefined
+                    }
                     imageOverride={claimed ? atlasOrg?.logoURI : undefined}
                     unclaimed={!isField && !!outcomeBinding && !claimed}
                     participation={

--- a/ui/pages/deprize/[id].tsx
+++ b/ui/pages/deprize/[id].tsx
@@ -378,10 +378,14 @@ function DePrizeDetailContent() {
     if (typeof raw !== 'string' || !/^\d+$/.test(raw)) return
     const idx = Number(raw)
     if (idx < 0 || idx >= numOutcomes) return
+    // Wallet hydrate and the geo check usually finish after the chart. Latch
+    // only once those gates can open the modal; otherwise a later ready pass
+    // would no-op and `?outcome=N` would scroll without auto-opening.
+    if (!userAddress || !bettingAllowed) return
     setDeepLinkHandled(true)
     const el = document.getElementById(`deprize-outcome-${idx}`)
     el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-    if (userAddress && bettingAllowed) setBetIndex(idx)
+    setBetIndex(idx)
   }, [
     deepLinkHandled,
     router.isReady,


### PR DESCRIPTION
Implements `docs/DEPRIZE_DETAIL_PAGE_PLAN.md` (included) against the live Sepolia prize **#22 Touchdown** (`/deprize/22`, `/deprize/shared-next-landing`).

## What changed on the page

Addresses the six feedback points on the individual prize page:

| # | Feedback | Fix |
|---|---|---|
| 1 | Criteria/description above the fold | New `DePrizeQuestionCard` right under the header: question, atlas description, "What counts as winning" criteria, Moon Base Zero link |
| 2 | Total number of backers | Header stat **Backers · N bets** from on-chain `Bet` events, plus **Total staked** |
| 3 | My activity / total won or lost | New `DePrizePositionPanel`: net result so far, spent / current value / cashed out / if-your-pick-wins, per-outcome rows with cash-out, on-chain activity feed with explorer links. Replaces the localStorage cost basis |
| 4 | Graph doesn't change over time | Odds series rebuilt from `AMMOutcomeTokenTrade` + funding events with the LMSR marginal-price formula — identical on every device, one dot per trade, finished with live prices |
| 5 | Rank competitors | Sorted by chance, **Open Field pinned last**, winner first once resolved (`rank-outcomes.ts`) |
| 6 | Prize pool vs "If wins" confusion | Labels: **Prize pool · to winner** vs **Your payout if wins**, with tooltips stating which pot pays whom |

Cut list applied: status badge only when something is off (no "Open" next to a live market), no generation chip, no duplicated description card, no chart legend (the ranked cards are the legend), notices only when actionable, single lineage footnote. Back button doubles as connect; `?outcome=N` deep-links scroll to the card.

## Data layer

- `pages/api/deprize/logs.ts` — Etherscan V2 logs proxy behind a server key. The app's RPC proxy caps `eth_getLogs` at 10k blocks, which makes scanning from deploy impractical (Arbitrum ≈ 25M blocks). **Deployment needs `ETHERSCAN_API_KEY`** (falls back to `NEXT_PUBLIC_ETHERSCAN_API_KEY` / `ARBISCAN_API_KEY`).
- `lib/deprize/events.ts` — explorer fetch + chunked RPC fallback + per-session cache keyed by refresh generation.
- `lib/deprize/activity-fetch.ts`, `activity-math.ts`, `useDePrizeActivity.tsx` — typed Bet/trade rows, backers, staked, positions, wallet summary, feed.
- `lib/deprize/lmsr-history.ts`, `useOddsHistory.tsx` — pure LMSR reconstruction; `useDePrizeMarket` now exposes `funding()`.
- `DEPRIZE_EVENTS_FROM_BLOCK` in `const/config.ts` (registry creation blocks from Etherscan: Sepolia 11068914, Arbitrum 495964196).

## Verification

- `yarn test:deprize` — 147 passing (new: `rank-outcomes`, `activity-math`, `lmsr-history`)
- `tsc` clean for touched files; `next lint` clean
- Browser check on Sepolia `/deprize/22`: stats show 1 backer / 1 bet / ≈0.0038 ETH staked, chart rebuilt from chain with the trade marker, cards ranked with Open Field last, `?outcome=2` scrolls to the card.
- Not exercised in the browser: the position panel with a connected wallet (no wallet in the headless tab) — covered by the `activity-math` unit tests.

## Sepolia launch (Phase 0)

#22 is already live and verified on-chain (state OPEN, betting open, market bound). Launch checklist and re-provisioning steps are in the plan doc.

Made with [Cursor](https://cursor.com)