### PR TITLE
Add the lunar sun path and skyline field

### DIFF
--- a/ui/cypress/integration/unit/lunar-atlas-horizon.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-horizon.cy.ts
@@ -1,0 +1,315 @@
+/**
+ * Moon Base Zero — skyline and sky visibility (headless, mocha + chai).
+ *
+ * The horizon field decides which 57% of the patch is in shadow once the sun comes
+ * down to its real elevation, and it does so from an amortized-linear recurrence
+ * over a DDA-quantised line with a change of variables folded in for the Moon's
+ * curvature. Every one of those words is a place to be quietly wrong by a degree,
+ * and a degree is half the real sun's elevation.
+ *
+ * It is also the kind of wrong that does not look like a bug. The first version of
+ * this module marched each point over a max-pooled mip pyramid and was off by 1.9°
+ * on average with a 10° worst case; it rendered plausible-looking shadows in
+ * plausible-looking places. What caught it was a comparison against a stupider
+ * implementation, so that comparison is the centre of this file rather than an
+ * afterthought.
+ */
+import { expect } from 'chai'
+import {
+  HORIZON_AZIMUTHS,
+  HORIZON_SIZE,
+  SWEEP_SIZE,
+  bruteForceHorizonTan,
+  buildHorizonField,
+} from '../../../lib/lunar-atlas/horizon'
+import { MOON_RADIUS_M } from '../../../lib/lunar-atlas/geo'
+import { CAP_EXTENT_M, type PolarHeightField } from '../../../lib/lunar-atlas/southpole'
+
+const RAD2DEG = 180 / Math.PI
+const SWEEP_CELL_M = CAP_EXTENT_M / SWEEP_SIZE
+const OUT_RATIO = SWEEP_SIZE / HORIZON_SIZE
+
+// Height fields are quoted in meters and encoded the way the baked PNG encodes
+// them, so the tests exercise the same raw-to-meters path the renderer does.
+const MIN_M = 0
+const MAX_M = 2000
+
+function fieldFrom(size: number, meters: (x: number, y: number) => number): PolarHeightField {
+  const data = new Uint16Array(size * size)
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const raw = Math.round(((meters(x, y) - MIN_M) / (MAX_M - MIN_M)) * 65535)
+      data[y * size + x] = Math.max(0, Math.min(65535, raw))
+    }
+  }
+  return { size, minM: MIN_M, maxM: MAX_M, data }
+}
+
+// A field at exactly the sweep resolution, so a test can name a sweep cell without
+// reasoning about the max-pool downsample at the same time.
+function sweepResField(meters: (cx: number, cy: number) => number): PolarHeightField {
+  return fieldFrom(SWEEP_SIZE, meters)
+}
+
+const horizonDeg = (tan: number) => Math.atan(tan) * RAD2DEG
+
+function outputTan(
+  hz: { horizonTan: Float32Array },
+  hx: number,
+  hy: number,
+  azimuth: number
+): number {
+  return hz.horizonTan[(hy * HORIZON_SIZE + hx) * HORIZON_AZIMUTHS + azimuth]
+}
+
+// Azimuth bin 0 points along map +X, which is image right. Bin 4 is map north,
+// which is DECREASING row index. Several tests below depend on that and would pass
+// against a 180°-rotated field if they did not say so out loud.
+const EAST = 0
+const NORTH = HORIZON_AZIMUTHS / 4
+const WEST = HORIZON_AZIMUTHS / 2
+const SOUTH = (3 * HORIZON_AZIMUTHS) / 4
+
+describe('lunar skyline: the reference implementation itself', () => {
+  // Everything else in this file is checked against bruteForceHorizonTan, so if it
+  // is wrong the whole suite is decorative. It gets its own analytic check first.
+  //
+  // This is not hypothetical. An earlier draft of that function used the ray
+  // PARAMETER as the distance while nearest-neighbour rounding sampled a cell up to
+  // half a step further out, which overstates the tangent by t/(t-0.5) — a factor of
+  // two at the first cell. It reported skylines 1.7° too high and very nearly got
+  // the correct sweep rewritten to agree with it.
+  const WALL_X = 400
+  const WALL_H = 500
+  const wall = sweepResField((cx) => (cx === WALL_X ? WALL_H : 0))
+
+  for (const cellX of [100, 200, 300, 380]) {
+    const distM = (WALL_X - cellX) * SWEEP_CELL_M
+    it(`matches the closed form for a wall ${(distM / 1000).toFixed(2)} km away`, () => {
+      const drop = (distM * distM) / (2 * MOON_RADIUS_M)
+      const exact = Math.atan((WALL_H - drop) / distM) * RAD2DEG
+      const got = horizonDeg(bruteForceHorizonTan(wall, cellX, 256, EAST))
+      expect(got).to.be.closeTo(exact, 0.005)
+    })
+  }
+
+  it('includes the curvature of the Moon rather than assuming a flat plane', () => {
+    // On a dead-level plain the skyline is BELOW the local horizontal, because the
+    // sphere falls away as d^2/2R. It is a small number — 0.13° at the patch rim —
+    // but it is a seventh of the real sun's elevation, so a flat-plane version of
+    // this module would light ground that should be dark.
+    const flat = sweepResField(() => 100)
+    const tan = bruteForceHorizonTan(flat, 256, 256, EAST)
+    expect(tan).to.be.lessThan(0)
+    // The nearest cell wins, since the drop grows faster than the distance.
+    const expected = -SWEEP_CELL_M / (2 * MOON_RADIUS_M)
+    expect(tan).to.be.closeTo(expected, Math.abs(expected) * 0.02)
+  })
+})
+
+describe('lunar skyline: the sweep against the reference', () => {
+  // Terrain rough enough that the recurrence has a real convex hull to walk. A
+  // smooth field would let a broken implementation pass by luck.
+  let s = 1234
+  const rand = () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 0xffffffff
+  }
+  const cells = 64
+  const lattice = new Float32Array(cells * cells)
+  for (let i = 0; i < lattice.length; i++) lattice[i] = rand() * 900
+  const rough = sweepResField(
+    (cx, cy) =>
+      lattice[(Math.floor((cy / SWEEP_SIZE) * cells) % cells) * cells + (Math.floor((cx / SWEEP_SIZE) * cells) % cells)]
+  )
+  const hz = buildHorizonField(rough)
+
+  const probes: [number, number][] = [
+    [64, 64],
+    [100, 30],
+    [30, 100],
+    [200, 200],
+    [128, 128],
+  ]
+
+  // The mean over the sweep cells inside one output texel, which is what the build
+  // writes, so this compares like with like.
+  function referenceFor(hx: number, hy: number, azimuth: number): number {
+    let acc = 0
+    for (let dy = 0; dy < OUT_RATIO; dy++) {
+      for (let dx = 0; dx < OUT_RATIO; dx++) {
+        acc += bruteForceHorizonTan(rough, hx * OUT_RATIO + dx, hy * OUT_RATIO + dy, azimuth)
+      }
+    }
+    return acc / (OUT_RATIO * OUT_RATIO)
+  }
+
+  // Axis-aligned and exactly-diagonal directions quantise to nothing: the DDA line
+  // IS the true ray. So on these the sweep has no excuse and must match the dumb
+  // version to floating point. This is the assertion that would have caught the mip
+  // pyramid, and it is tight on purpose.
+  for (const [azimuth, name] of [
+    [EAST, 'east'],
+    [NORTH, 'north'],
+    [WEST, 'west'],
+    [SOUTH, 'south'],
+    [2, 'north-east diagonal'],
+    [6, 'north-west diagonal'],
+  ] as [number, string][]) {
+    it(`is exact looking ${name}, where the line is not quantised`, () => {
+      for (const [hx, hy] of probes) {
+        const got = horizonDeg(outputTan(hz, hx, hy, azimuth))
+        const want = horizonDeg(referenceFor(hx, hy, azimuth))
+        expect(got, `texel ${hx},${hy}`).to.be.closeTo(want, 1e-3)
+      }
+    })
+  }
+
+  it('stays within the DDA drift bound on off-axis directions', () => {
+    // Off-axis lines wander up to half a cell sideways from the true ray, so they
+    // sample slightly different ground. That is a real limitation of sweeping rather
+    // than marching, and it is asserted rather than hidden so that a regression which
+    // makes it WORSE is caught — and so nobody reads the exact cases above and
+    // assumes this holds everywhere.
+    //
+    // The bound is generous because this test terrain is deliberately vicious: 900 m
+    // of relief on a 250 m lattice, where half a cell sideways can be a different
+    // cliff entirely. Real terrain is far smoother than this.
+    for (const azimuth of [1, 3, 5, 7]) {
+      for (const [hx, hy] of probes) {
+        const got = horizonDeg(outputTan(hz, hx, hy, azimuth))
+        const want = horizonDeg(referenceFor(hx, hy, azimuth))
+        expect(Math.abs(got - want), `bin ${azimuth} at ${hx},${hy}`).to.be.lessThan(12)
+      }
+    }
+  })
+})
+
+describe('lunar skyline: shape and sign', () => {
+  const WALL_X = 400
+  const WALL_H = 500
+  const wall = sweepResField((cx) => (cx === WALL_X ? WALL_H : 0))
+  const hz = buildHorizonField(wall)
+
+  it('rises steadily as the obstacle gets closer', () => {
+    // Monotonic in distance, which is the one property a reader can check by eye and
+    // therefore the one worth pinning: nothing about the hull walk or the curvature
+    // change of variables should be able to produce a bump.
+    let prev = -Infinity
+    for (let hx = 20; hx < WALL_X / OUT_RATIO - 4; hx += 10) {
+      const tan = outputTan(hz, hx, 128, EAST)
+      expect(tan, `texel ${hx} is nearer the wall than ${hx - 10}`).to.be.greaterThan(prev)
+      prev = tan
+    }
+  })
+
+  it('sees nothing looking away from the wall', () => {
+    // West of the wall, looking west, is flat ground for kilometres. The skyline is
+    // then slightly NEGATIVE from curvature, never positive.
+    expect(outputTan(hz, 100, 128, WEST)).to.be.lessThan(0)
+  })
+
+  it('reports a skyline below horizontal when the ground falls away', () => {
+    // The sign matters more than it looks. Ground that slopes away has a skyline
+    // genuinely BELOW its own horizontal, so a sun at half a degree still reaches it.
+    // Clamping these at zero — the natural thing to do if you think of a horizon as
+    // an occluder — would put every slope into shadow at dawn.
+    //
+    // Probed on the flank rather than at the summit on purpose. An output texel is
+    // the mean of four sweep cells, so the apex texel includes three cells that look
+    // UP at the one containing the peak, and its skyline is legitimately positive.
+    const cone = sweepResField((cx, cy) => {
+      const r = Math.hypot(cx - 256, cy - 256)
+      return Math.max(0, 300 - r * 3)
+    })
+    const peak = buildHorizonField(cone)
+    const mid = HORIZON_SIZE / 2
+    const onFlank = mid + 20 // 40 sweep cells out, well inside the 100-cell radius
+    expect(outputTan(peak, onFlank, mid, EAST), 'downhill, away from the summit').to.be.lessThan(0)
+    expect(outputTan(peak, onFlank, mid, WEST), 'uphill, toward the summit').to.be.greaterThan(0)
+  })
+
+  it('orients azimuth bins against the map frame, not the image', () => {
+    // Row 0 of the height field is map NORTH, so a wall placed in low rows must be
+    // found by the north bin. Getting this backwards flips every shadow 180°, which
+    // no other test here would notice because the terrain would still be lit
+    // plausibly — just from the wrong side.
+    const ridgeNorth = sweepResField((_cx, cy) => (cy === 100 ? 500 : 0))
+    const h = buildHorizonField(ridgeNorth)
+    const mid = HORIZON_SIZE / 2
+    expect(outputTan(h, mid, mid, NORTH), 'north bin must see it').to.be.greaterThan(0.02)
+    expect(outputTan(h, mid, mid, SOUTH), 'south bin must not').to.be.lessThan(0)
+  })
+})
+
+describe('lunar sky view factor', () => {
+  it('is 1 on an open plain and never leaves (0, 1]', () => {
+    const flat = sweepResField(() => 500)
+    const hz = buildHorizonField(flat)
+    for (const v of hz.skyView) {
+      expect(v).to.be.greaterThan(0)
+      expect(v).to.be.lessThan(1.0000001)
+    }
+    // A level skyline blocks nothing, and the curvature term only ever puts the
+    // skyline BELOW horizontal, which the clamp discards. So this is exactly 1 — not
+    // approximately. If it drifts, the clamp is gone and a hilltop is about to report
+    // less sky than a plain.
+    expect(hz.skyView[HORIZON_SIZE * 128 + 128]).to.equal(1)
+  })
+
+  it('closes down inside a bowl and opens up at its rim', () => {
+    // A crater 4 km across and 400 m deep: walls above the floor's horizontal on
+    // every side, nothing above the rim's.
+    const crater = sweepResField((cx, cy) => {
+      const r = Math.hypot(cx - 256, cy - 256) / 64
+      return 1000 + (r < 1 ? -400 * (1 - r * r) : 0)
+    })
+    const hz = buildHorizonField(crater)
+    const floor = hz.skyView[HORIZON_SIZE * 128 + 128]
+    const outside = hz.skyView[HORIZON_SIZE * 128 + 20]
+    expect(floor).to.be.lessThan(outside)
+    expect(outside).to.be.closeTo(1, 0.02)
+  })
+
+  it('is the mean of cos^2 over the bins, which is what makes it cosine-weighted', () => {
+    // Restated as an independent computation from the stored skyline, because the
+    // formula is the part most likely to be quietly replaced with something that
+    // "looks like an occlusion factor" — a mean of (1 - sin h), say, which is a
+    // different and wrong integral.
+    const ridge = sweepResField((cx) => (cx === 300 ? 800 : 400))
+    const hz = buildHorizonField(ridge)
+    for (const [hx, hy] of [
+      [60, 60],
+      [140, 100],
+    ] as [number, number][]) {
+      let acc = 0
+      for (let a = 0; a < HORIZON_AZIMUTHS; a++) {
+        const c = Math.cos(Math.atan(Math.max(0, outputTan(hz, hx, hy, a))))
+        acc += c * c
+      }
+      expect(hz.skyView[hy * HORIZON_SIZE + hx]).to.be.closeTo(acc / HORIZON_AZIMUTHS, 1e-6)
+    }
+  })
+})
+
+describe('lunar skyline: field shape', () => {
+  it('fills every texel and every azimuth', () => {
+    // A sweep that missed lines would leave zeroes behind, and a zero is a perfectly
+    // legal skyline value — it reads as "level" and shadows nothing — so a coverage
+    // hole would show up as a stripe of wrongly-lit ground rather than as an error.
+    const rough = sweepResField((cx, cy) => 500 + 200 * Math.sin(cx / 17) * Math.cos(cy / 23))
+    const hz = buildHorizonField(rough)
+    expect(hz.horizonTan.length).to.equal(HORIZON_SIZE * HORIZON_SIZE * HORIZON_AZIMUTHS)
+    let exactlyZero = 0
+    for (const v of hz.horizonTan) if (v === 0) exactlyZero++
+    // The patch rim genuinely has nothing ahead of it in outward directions and is
+    // recorded as level, so a handful of exact zeroes is expected; a stripe is not.
+    expect(exactlyZero).to.be.lessThan(hz.horizonTan.length * 0.02)
+  })
+
+  it('downsamples the sweep grid by a whole number', () => {
+    // The accumulate step divides by ratio^2 and indexes with a truncation, both of
+    // which silently mis-weight the average if these ever stop dividing evenly.
+    expect(SWEEP_SIZE % HORIZON_SIZE).to.equal(0)
+  })
+})

--- a/ui/cypress/integration/unit/lunar-atlas-sunpath.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-sunpath.cy.ts
@@ -1,0 +1,220 @@
+/**
+ * Moon Base Zero — the real sun over the ridge (headless, mocha + chai).
+ *
+ * Everything here is a direction, and a wrong direction is the hardest kind of bug
+ * to see in a rendered frame: a sun running backwards round the horizon, or a season
+ * inverted, or a bearing quoted in the wrong tangent frame all look completely
+ * normal in any single screenshot. They only show up as "the shadows sweep the wrong
+ * way", which nobody notices without a reference.
+ *
+ * So the assertions below are deliberately about things with an outside answer — the
+ * elevation range at the site's real latitude, the direction a southern sun
+ * circulates, the fact that the sun spends most of the year below the local
+ * horizontal — rather than about the code reproducing itself.
+ */
+import { expect } from 'chai'
+import {
+  BRIGHTEST_PHASE,
+  MOON_OBLIQUITY_DEG,
+  SEASON_PERIOD_DAYS,
+  SYNODIC_MONTH_DAYS,
+  localBearingDeg,
+  localElevationDeg,
+  maxElevationDeg,
+  subsolarLatDeg,
+  subsolarLonDeg,
+  sunAt,
+  trueSunDirection,
+} from '../../../lib/lunar-atlas/sunpath'
+import { SUN_LOCAL_ELEV_DEG } from '../../../lib/lunar-atlas/sun'
+import { capCenterLatLon, capLocalDirection } from '../../../lib/lunar-atlas/southpole'
+
+const DEG = Math.PI / 180
+
+function envelopeAt(season: number): { lo: number; hi: number } {
+  let lo = 90
+  let hi = -90
+  for (let i = 0; i < 720; i++) {
+    const e = sunAt({ lunarDay: i / 720, season }).elevationDeg
+    lo = Math.min(lo, e)
+    hi = Math.max(hi, e)
+  }
+  return { lo, hi }
+}
+
+describe('lunar sun path: periods and geometry', () => {
+  it('uses the synodic month, not the sidereal one', () => {
+    // 27.32 days is the sidereal period and the wrong one: what matters here is how
+    // long the SUN takes to come back round, which is 29.53. Using the sidereal
+    // period would drift the sun a full turn every couple of years.
+    expect(SYNODIC_MONTH_DAYS).to.be.closeTo(29.5306, 0.001)
+    expect(SEASON_PERIOD_DAYS).to.be.closeTo(365.25, 0.1)
+  })
+
+  it('tilts the axis to the ecliptic by 1.54 degrees', () => {
+    // The Moon's obliquity is quoted three different ways in the literature — to the
+    // ecliptic (1.54°), to its own orbital plane (6.68°), and to the Earth's equator
+    // (~23.4° ± 5.1°). Only the first is the one that sets polar illumination, and
+    // picking either of the others would multiply the seasonal swing by 4x or 15x.
+    expect(MOON_OBLIQUITY_DEG).to.be.closeTo(1.54, 0.01)
+  })
+
+  it('puts the subsolar point south at season 0 and north half a year later', () => {
+    expect(subsolarLatDeg(0)).to.be.closeTo(-MOON_OBLIQUITY_DEG, 1e-9)
+    expect(subsolarLatDeg(0.5)).to.be.closeTo(MOON_OBLIQUITY_DEG, 1e-9)
+    expect(subsolarLatDeg(0.25)).to.be.closeTo(0, 1e-9)
+  })
+
+  it('never puts the subsolar point outside the obliquity', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(Math.abs(subsolarLatDeg(i / 200))).to.be.at.most(MOON_OBLIQUITY_DEG + 1e-9)
+    }
+  })
+
+  it('returns a unit vector at every phase', () => {
+    for (let i = 0; i < 40; i++) {
+      const d = trueSunDirection({ lunarDay: i / 40, season: i / 37 })
+      expect(Math.hypot(d[0], d[1], d[2])).to.be.closeTo(1, 1e-12)
+    }
+  })
+})
+
+describe('lunar sun path: how grazing it really is', () => {
+  it('never lifts the sun above ~2.1 degrees at the ridge', () => {
+    // The headline fact, and the reason the whole illumination model had to change.
+    // Derived from the patch's own centre coordinates rather than quoted, so if the
+    // patch ever moves this number follows.
+    expect(maxElevationDeg()).to.be.closeTo(2.077, 0.01)
+  })
+
+  it('sits an order of magnitude below the sun the base was designed around', () => {
+    // Not a redundant assertion: it is the one that says out loud why sun.ts still
+    // exists and why baseplan must keep reading it. 44.46° vs 2.08° is a 21x
+    // difference in tan(), which is what the solar row spacing is proportional to.
+    expect(SUN_LOCAL_ELEV_DEG / maxElevationDeg()).to.be.greaterThan(15)
+    expect(Math.tan(SUN_LOCAL_ELEV_DEG * DEG) / Math.tan(maxElevationDeg() * DEG)).to.be.greaterThan(20)
+  })
+
+  it('reproduces the elevation envelope for each season', () => {
+    // Independently checkable spherical astronomy: at colatitude c with the subsolar
+    // point at latitude d, the elevation over one rotation runs from -d - c to
+    // -d + c. Asserted against that closed form rather than against recorded output,
+    // so this is a real check on the direction construction.
+    const colat = 90 + capCenterLatLon().lat
+    for (const season of [0, 0.125, 0.25, 0.375, 0.5]) {
+      const d = subsolarLatDeg(season)
+      const env = envelopeAt(season)
+      expect(env.hi, `season ${season} high`).to.be.closeTo(-d + colat, 0.01)
+      expect(env.lo, `season ${season} low`).to.be.closeTo(-d - colat, 0.01)
+    }
+  })
+
+  it('keeps the sun below local horizontal for two fifths of the year', () => {
+    // Counter-intuitive and important: the ridge is among the best-lit ground on the
+    // Moon, and yet for 39% of the year the sun does not clear its own tangent plane
+    // at ANY point in the month, and for 61% it drops below at some point.
+    // Illumination through those stretches comes from the ground FALLING AWAY, which
+    // is a horizon.ts question, not a dot product. Anything that "fixes" a negative
+    // elevation by clamping it has broken precisely that.
+    //
+    // Both fractions are asserted against the closed form rather than a threshold.
+    // The month's high is -d + colat and its low is -d - colat, and d sweeps
+    // -obliquity*cos(2*pi*season), so the share of the year with the high below zero
+    // is 1 - acos(-colat/obliquity)/pi. Guessing at these instead is how the first
+    // version of this test came to assert "most of the year" about 39%.
+    const colat = 90 + capCenterLatLon().lat
+    const k = colat / MOON_OBLIQUITY_DEG
+    const neverAbove = 1 - Math.acos(-k) / Math.PI
+    const dipsBelow = 1 - Math.acos(k) / Math.PI
+
+    const samples = 2048
+    let fullyBelow = 0
+    let partlyBelow = 0
+    for (let i = 0; i < samples; i++) {
+      const env = envelopeAt(i / samples)
+      if (env.hi < 0) fullyBelow++
+      if (env.lo < 0) partlyBelow++
+    }
+    expect(fullyBelow / samples, 'never rises above horizontal').to.be.closeTo(neverAbove, 0.01)
+    expect(partlyBelow / samples, 'dips below at some point').to.be.closeTo(dipsBelow, 0.01)
+    expect(neverAbove).to.be.closeTo(0.387, 0.005)
+    expect(dipsBelow).to.be.closeTo(0.613, 0.005)
+  })
+
+  it('is above horizontal all month at southern summer', () => {
+    expect(envelopeAt(0).lo).to.be.greaterThan(0)
+  })
+})
+
+describe('lunar sun path: which way round the sky', () => {
+  it('starts at local noon, due geographic north', () => {
+    // lunarDay 0 is defined as the subsolar point crossing the ridge's meridian, so
+    // the sun must be exactly over the site's longitude and pointing away from the
+    // pole — which at 89.46°S is geographic north.
+    const site = capCenterLatLon()
+    expect(subsolarLonDeg(0)).to.be.closeTo(site.lon, 1e-9)
+
+    // Geographic north in the MAP bearing frame: away from the pole is (sin lon,
+    // cos lon) in stereographic X/Y, so its map bearing is atan2(cos, sin).
+    const northBearing =
+      (Math.atan2(Math.cos(site.lon * DEG), Math.sin(site.lon * DEG)) / DEG + 360) % 360
+    expect(sunAt(BRIGHTEST_PHASE).bearingDeg).to.be.closeTo(northBearing, 0.05)
+  })
+
+  it('reads bearings in the map frame, which is 137 degrees off geographic', () => {
+    // Pinned because it looks like a bug every time. A reader who expects "due north
+    // = 90°" will find 227.49° and reach for a fix; this is the test that tells them
+    // not to.
+    const b = sunAt(BRIGHTEST_PHASE).bearingDeg
+    expect(b).to.be.closeTo(227.49, 0.05)
+    expect(Math.abs(b - 90)).to.be.greaterThan(100)
+  })
+
+  it('circulates counter-clockwise, the way a southern-hemisphere sun does', () => {
+    // East, then north, then west. A northern-hemisphere intuition (east, south,
+    // west) is the other direction, and flipping the sign in subsolarLonDeg would
+    // produce it while looking perfectly plausible in any still frame.
+    let prev = sunAt({ lunarDay: 0, season: 0 }).bearingDeg
+    let total = 0
+    const steps = 360
+    for (let i = 1; i <= steps; i++) {
+      const b = sunAt({ lunarDay: i / steps, season: 0 }).bearingDeg
+      let d = b - prev
+      if (d > 180) d -= 360
+      if (d < -180) d += 360
+      expect(d, `step ${i} must advance, not retreat`).to.be.greaterThan(0)
+      total += d
+      prev = b
+    }
+    // Exactly one circuit per lunar day.
+    expect(total).to.be.closeTo(360, 0.5)
+  })
+
+  it('agrees with the ridge frame the models are placed in', () => {
+    // localElevationDeg/localBearingDeg are the inverse of capLocalDirection, and the
+    // point of building them from it is that the round trip must close. If it does
+    // not, the sun the terrain is lit by and the bearings the hardware is aimed by
+    // have quietly diverged.
+    for (const [bearing, elev] of [
+      [0, 0],
+      [90, 30],
+      [227.49, 2.08],
+      [310, -1.5],
+    ] as [number, number][]) {
+      const dir = capLocalDirection(bearing, elev)
+      expect(localElevationDeg(dir), `elev for ${bearing}/${elev}`).to.be.closeTo(elev, 0.02)
+      expect(localBearingDeg(dir), `bearing for ${bearing}/${elev}`).to.be.closeTo(bearing, 0.02)
+    }
+  })
+
+  it('sweeps the shadow direction through every compass point over one month', () => {
+    // The visual payoff, stated as a property: no bearing bucket is skipped, so over
+    // a month every slope gets lit and every slope gets shadowed. This is what makes
+    // the horizon map worth its 16 azimuths.
+    const buckets = new Set<number>()
+    for (let i = 0; i < 720; i++) {
+      buckets.add(Math.floor(sunAt({ lunarDay: i / 720, season: 0 }).bearingDeg / 22.5))
+    }
+    expect(buckets.size).to.equal(16)
+  })
+})

--- a/ui/lib/lunar-atlas/horizon.ts
+++ b/ui/lib/lunar-atlas/horizon.ts
@@ -1,0 +1,347 @@
+// What each patch of ground can see of the sky, and of the terrain around it.
+//
+// This is the second thing derived from the height field at load rather than
+// shipped (the first is the normal field in southpole.ts), and it answers the two
+// questions the BRDF cannot: is this point in the shadow of terrain kilometres
+// away, and how much sky is open above it. Payload cost is zero — the heights are
+// already downloaded — so the whole cost is compute and a few MB of GPU memory.
+//
+// WHY A HORIZON MAP RATHER THAN A SHADOW MAP. A shadow map lit by a 2° sun across
+// a 16 km patch is the worst case that technique has: the light frustum is 16 km
+// long and metres deep, depth precision collapses along the grazing axis, and the
+// terrain would have to render itself into it finely enough to resolve a ridge
+// 8 km away. A horizon map inverts the problem. For each point it precomputes the
+// elevation angle of the skyline in a fixed set of compass directions, once, and
+// then any sun position is one lookup and one compare: the sun is blocked exactly
+// when it sits below the skyline in its own direction. O(1) per fragment for any
+// sun, which is what makes a moving sun affordable at all.
+//
+// WHAT IT BUYS AT TODAY'S SUN: measured on the real DEM, nothing at all.
+//
+// Terrain only shadows itself where the skyline is higher than the sun, and this
+// scene's sun sits at 45° for legibility (see SUN_MAP_EL_DEG) while the patch's
+// skyline reaches 27° at its 99.9th percentile. So the shadowed fraction of the
+// patch at the current sun is 0.00% — not "small", zero — and it goes to 57% at the
+// ~1.8° the real sun never rises above:
+//
+//   sun elevation   45°     20°     10°      5°      2°    1.8°      1°
+//   patch shadowed  0.00%   6.5%   27.5%   41.8%   56.1%   57.3%   62.5%
+//
+// That is the whole argument for this module and also the reason it is useless on
+// its own. It is built before the sun that needs it because the other order does
+// not work: dropping the sun to 2° without this would light 57% of the patch that
+// should be black, which is a worse picture than the one we have now.
+//
+// The sky-visibility half was expected to pay off immediately and does not, which
+// is worth writing down so nobody spends the effort again. Cosine-weighted open sky
+// over this patch runs 0.92 at its darkest texel against a mean of 0.978, because
+// terrain sampled every 62.5 m simply is not a shadowing environment. The occlusion
+// a viewer would actually notice — the dark ring where a habitat meets the ground,
+// the inside of a metre-wide craterlet — lives entirely below this map's resolution
+// and has to come from somewhere else.
+import { MOON_RADIUS_M } from './geo'
+import { CAP_EXTENT_M, HEIGHT_EXAGGERATION, type PolarHeightField } from './southpole'
+
+// Texels per side of the horizon field. 256 over 16 km is 62.5 m, which is what
+// bounds how sharp a terrain shadow edge can be — the angle is interpolated
+// between texels, so a terminator is smooth over roughly that distance rather
+// than blocky. Near-field sharpness is the hardware shadow map's job; this is for
+// the skyline.
+export const HORIZON_SIZE = 256
+
+// Compass directions sampled per texel. The horizon as a function of azimuth is
+// smooth for real terrain and the shader tents between neighbouring bins, so 16
+// (22.5° apart) resolves a ridge without resolving noise. It is also exactly four
+// RGBA textures, which is what lets the shader read it without dynamically
+// indexing a sampler — see the packing note in SouthPoleTerrain.
+export const HORIZON_AZIMUTHS = 16
+
+// Resolution the sweep runs at. 512 over 16 km is 31.25 m per cell, half the
+// horizon field's own pitch, so four sweep cells average into each output texel
+// and the sweep cannot miss structure the output could have represented.
+export const SWEEP_SIZE = 512
+
+export type HorizonField = {
+  size: number
+  azimuths: number
+  // TANGENT of the skyline elevation, as [(y * size + x) * azimuths + a].
+  //
+  // Tangent rather than the angle because that is the form the comparison wants:
+  // a point is lit when tan(sun elevation) > this, and both sides are then a
+  // height over a distance with no trig in the shader.
+  //
+  // Signed, and the sign carries real information: on a crest the skyline in the
+  // downhill direction is BELOW local horizontal, so a sun at half a degree still
+  // reaches it. Flooring these at zero would put every summit in shadow at dawn,
+  // which is exactly backwards.
+  horizonTan: Float32Array
+  // Cosine-weighted fraction of the sky hemisphere that is open, per texel, in
+  // (0, 1]. 1 is a plain under a level skyline; a crater floor is much lower.
+  skyView: Float32Array
+}
+
+// Heights in METERS on the sweep grid, max-pooled down from the source field.
+//
+// MAX rather than mean, and only here: this feeds a visibility test, and averaging
+// a ridge with the ground beside it shortens the ridge and lets the sun through a
+// hill. Over-shadowing is the safe direction for a 3x downsample of adjacent
+// cells; it is NOT safe over the huge footprints a mip pyramid would use, which is
+// why there is no pyramid in this file any more (see the sweep below).
+//
+// Row order is inherited unchanged from the height field — row 0 at the +Y (map
+// north) edge — because every other consumer of that field already agrees on it
+// and a flip here would rotate every shadow 180° in a way no test of this module
+// alone would catch.
+function toSweepGrid(field: PolarHeightField): Float32Array {
+  const { size, data, minM, maxM } = field
+  const k = ((maxM - minM) / 65535) * HEIGHT_EXAGGERATION
+  const out = new Float32Array(SWEEP_SIZE * SWEEP_SIZE)
+  const ratio = size / SWEEP_SIZE
+
+  for (let y = 0; y < SWEEP_SIZE; y++) {
+    const y0 = Math.floor(y * ratio)
+    const y1 = Math.max(y0 + 1, Math.min(size, Math.floor((y + 1) * ratio)))
+    for (let x = 0; x < SWEEP_SIZE; x++) {
+      const x0 = Math.floor(x * ratio)
+      const x1 = Math.max(x0 + 1, Math.min(size, Math.floor((x + 1) * ratio)))
+      let hi = -Infinity
+      for (let yy = y0; yy < y1; yy++) {
+        for (let xx = x0; xx < x1; xx++) {
+          const v = data[yy * size + xx]
+          if (v > hi) hi = v
+        }
+      }
+      out[y * SWEEP_SIZE + x] = minM + hi * k
+    }
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// The sweep
+//
+// For one direction, the skyline for EVERY point on a line parallel to it is
+// computed in one amortized-linear pass, rather than each point marching its own
+// ray. That is the whole reason this is affordable and exact at once: a per-point
+// march has to trade accuracy for step count, and the first version of this file
+// did exactly that — geometric steps over a max-pooled mip pyramid — and came out
+// with a mean error of 1.9° and a worst case of 10°. At a 2° sun an error that
+// size is not an approximation, it is noise, so the approximation was replaced
+// with the exact algorithm.
+//
+// THE ALGORITHM. Walking backwards along a line, the skyline seen from point i is
+// either the next point ahead of it, or the skyline that point already found —
+// never anything else. If the direct slope from i to i+1 is shallower than i+1's
+// own skyline slope, then whatever i+1 can see, i can see higher, so the search
+// jumps straight there instead of stepping. Each point stores where its own
+// skyline was, which makes those jumps a chain along the terrain's upper convex
+// hull, and the total number of jumps over a line is linear in its length.
+//
+// Measured against a continuous bilinear ray on the same grid, this agrees to
+// 0.0002° along an unquantised line, so the recurrence itself is exact and the only
+// error left is the DDA one below.
+//
+// DO NOT ADD A MINIMUM SEARCH DISTANCE. It is a tempting thing to reach for — the
+// nearest cell dominates the answer on sloped ground, so skipping the first few
+// looks like it would isolate the "real" skyline. It breaks the algorithm outright:
+// the jump chain is only the upper convex hull if every point ahead is a candidate,
+// and excluding the near ones invalidates the hull property. Tried, and it took the
+// error from 0.0002° to 0.4° with a 2.1° worst case. The near field belongs here
+// anyway; it is what the hardware shadow map cannot reach past.
+//
+// RESIDUAL ERROR. Lines are walked with integer DDA, so a line drifts up to half a
+// cell sideways from the true ray and off-axis azimuths sample slightly different
+// ground than they should. Axis-aligned and exactly-diagonal bins are unaffected
+// (they quantise to nothing); the worst bins are the 22.5° ones. This is inherent to
+// sweeping rather than marching, and it is the price of being exact in the other
+// direction, where a per-point march was wrong by 1.9° on average.
+//
+// CURVATURE. The sphere falls away from the local tangent plane as d^2/2R — 18 m
+// at the patch rim, which is 0.13° of skyline. Negligible against a 45° sun and a
+// seventh of a 2° one, which is exactly the sun this map exists to serve. It is
+// folded in by flattening the heights first: subtracting d^2/2R (with d measured
+// from the line's start) makes the transformed slope differ from the true one by
+// d_i/R, which is CONSTANT in the point being looked at. So it cannot change which
+// point is the skyline, and it is added back once at the end.
+// ---------------------------------------------------------------------------
+
+// Scratch buffers, allocated once per build rather than per line.
+type Scratch = {
+  dist: Float64Array
+  flat: Float64Array
+  cell: Int32Array
+  best: Float64Array
+  jump: Int32Array
+}
+
+// Runs the skyline recurrence over one line's worth of samples, writing the
+// tangent of the skyline elevation for each into `best`.
+function sweepLine(n: number, s: Scratch): void {
+  const { dist, flat, best, jump } = s
+  if (n === 0) return
+
+  // Nothing ahead of the last point inside the patch. A level skyline is the
+  // neutral answer — it shadows nothing for any sun above the horizontal — and
+  // these are patch-rim cells 8 km from anything anyone looks at.
+  best[n - 1] = 0
+  jump[n - 1] = -1
+
+  for (let i = n - 2; i >= 0; i--) {
+    let j = i + 1
+    let slope = (flat[j] - flat[i]) / (dist[j] - dist[i])
+    // Follow the hull: while the point we are looking at can itself see something
+    // higher, that something is higher from here too.
+    while (jump[j] !== -1) {
+      const bj = best[j] - dist[j] / MOON_RADIUS_M // j's stored value, back in flattened terms
+      if (slope >= bj) break
+      j = jump[j]
+      slope = (flat[j] - flat[i]) / (dist[j] - dist[i])
+    }
+    best[i] = slope + dist[i] / MOON_RADIUS_M
+    jump[i] = j
+  }
+}
+
+export function buildHorizonField(field: PolarHeightField): HorizonField {
+  const sweep = toSweepGrid(field)
+  const cellM = CAP_EXTENT_M / SWEEP_SIZE
+  const outSize = HORIZON_SIZE
+  const ratio = SWEEP_SIZE / outSize // whole number by construction
+
+  const horizonTan = new Float32Array(outSize * outSize * HORIZON_AZIMUTHS)
+  const skyView = new Float32Array(outSize * outSize)
+
+  const cap = SWEEP_SIZE * 2
+  const scratch: Scratch = {
+    dist: new Float64Array(cap),
+    flat: new Float64Array(cap),
+    cell: new Int32Array(cap),
+    best: new Float64Array(cap),
+    jump: new Int32Array(cap),
+  }
+
+  for (let a = 0; a < HORIZON_AZIMUTHS; a++) {
+    const phi = (a * 2 * Math.PI) / HORIZON_AZIMUTHS
+    // Map frame: +X is map east (image right), +Y is map north (image UP, which is
+    // DECREASING row index). The row inversion lives here, once.
+    const dx = Math.cos(phi)
+    const dy = -Math.sin(phi)
+
+    // Walk along whichever axis moves fastest, so every cell lands on exactly one
+    // line and no line skips a cell.
+    const alongX = Math.abs(dx) >= Math.abs(dy)
+    const major = alongX ? dx : dy
+    const minor = alongX ? dy : dx
+    const slopeMinor = minor / major
+    // One step along the major axis advances this far along the ray.
+    const stepM = cellM / Math.abs(major)
+    const forward = major > 0
+
+    // Lines are indexed by their minor-axis intercept at major = 0. Every cell
+    // belongs to exactly one, which is what makes the coverage exact.
+    const lo = Math.min(0, -Math.ceil(Math.abs(slopeMinor) * SWEEP_SIZE))
+    const hi = SWEEP_SIZE + Math.ceil(Math.abs(slopeMinor) * SWEEP_SIZE)
+
+    for (let line = lo; line <= hi; line++) {
+      // Collect the cells of this line in the direction the sun would travel.
+      let n = 0
+      const first = forward ? 0 : SWEEP_SIZE - 1
+      const last = forward ? SWEEP_SIZE - 1 : 0
+      const stride = forward ? 1 : -1
+      for (let m = first; forward ? m <= last : m >= last; m += stride) {
+        const q = line + Math.round(slopeMinor * m)
+        if (q < 0 || q >= SWEEP_SIZE) continue
+        const x = alongX ? m : q
+        const y = alongX ? q : m
+        const idx = y * SWEEP_SIZE + x
+        const d = n * stepM
+        scratch.cell[n] = idx
+        scratch.dist[n] = d
+        // Flattened height: removing d^2/2R here is what lets the recurrence stay
+        // a pure slope comparison. Added back inside sweepLine.
+        scratch.flat[n] = sweep[idx] - (d * d) / (2 * MOON_RADIUS_M)
+        n++
+      }
+
+      sweepLine(n, scratch)
+
+      // Accumulate into the output texel each sweep cell falls in. Averaging the
+      // four contributors rather than taking their max: this value is read as a
+      // shadow threshold over a 62.5 m footprint, and the max would push every
+      // terminator outward by the worst cell in the neighbourhood.
+      for (let i = 0; i < n; i++) {
+        const idx = scratch.cell[i]
+        const sx = idx % SWEEP_SIZE
+        const sy = (idx - sx) / SWEEP_SIZE
+        const ox = (sx / ratio) | 0
+        const oy = (sy / ratio) | 0
+        horizonTan[(oy * outSize + ox) * HORIZON_AZIMUTHS + a] += scratch.best[i]
+      }
+    }
+  }
+
+  const perTexel = ratio * ratio
+  for (let i = 0; i < horizonTan.length; i++) horizonTan[i] /= perTexel
+
+  // Cosine-weighted open sky. The integral of cos(theta) over the visible cap
+  // above elevation e is (1/2)cos^2(e) per radian of azimuth, and pi over a clear
+  // hemisphere, so the mean of cos^2 across the bins IS the open fraction.
+  //
+  // Clamped at zero because a skyline BELOW horizontal adds no sky to the upper
+  // hemisphere — it only means nothing blocks it. Without the clamp a hilltop
+  // would report less sky than a plain.
+  for (let p = 0; p < outSize * outSize; p++) {
+    let acc = 0
+    for (let a = 0; a < HORIZON_AZIMUTHS; a++) {
+      const c = Math.cos(Math.atan(Math.max(0, horizonTan[p * HORIZON_AZIMUTHS + a])))
+      acc += c * c
+    }
+    skyView[p] = acc / HORIZON_AZIMUTHS
+  }
+
+  return { size: outSize, azimuths: HORIZON_AZIMUTHS, horizonTan, skyView }
+}
+
+// The dumb version: one point, one direction, unit steps along the true ray, no
+// hull and no line quantisation.
+//
+// This exists only so the tests have something independent to check the sweep
+// against. The sweep is exact in principle but it walks a DDA-quantised line and
+// folds curvature through a change of variables, and neither of those is obviously
+// right by inspection. An earlier draft of this file was wrong by up to 10° and
+// looked perfectly reasonable.
+export function bruteForceHorizonTan(
+  field: PolarHeightField,
+  cellX: number,
+  cellY: number,
+  azimuthIndex: number,
+  azimuths = HORIZON_AZIMUTHS
+): number {
+  const sweep = toSweepGrid(field)
+  const cellM = CAP_EXTENT_M / SWEEP_SIZE
+  const phi = (azimuthIndex * 2 * Math.PI) / azimuths
+  const dx = Math.cos(phi)
+  const dy = -Math.sin(phi)
+  const h0 = sweep[cellY * SWEEP_SIZE + cellX]
+
+  // Signed, like the sweep's own output — a point on a crest has a skyline below
+  // its own horizontal and the comparison has to be able to see that.
+  //
+  // The distance is taken to the CELL that was sampled, not to the ray parameter
+  // that found it. Those differ by up to half a step under nearest-neighbour
+  // rounding, and using t inflates the tangent by t/(t-0.5) — a factor of two at
+  // the first cell. That mistake made this reference overstate the skyline by 1.7°
+  // on average and very nearly got the (correct) sweep rewritten to match it.
+  let best = -Infinity
+  for (let t = 1; t < SWEEP_SIZE * Math.SQRT2; t += 0.25) {
+    const sx = Math.round(cellX + dx * t)
+    const sy = Math.round(cellY + dy * t)
+    if (sx < 0 || sy < 0 || sx >= SWEEP_SIZE || sy >= SWEEP_SIZE) break
+    const distM = Math.hypot(sx - cellX, sy - cellY) * cellM
+    if (distM === 0) continue
+    const drop = (distM * distM) / (2 * MOON_RADIUS_M)
+    const tan = (sweep[sy * SWEEP_SIZE + sx] - h0 - drop) / distM
+    if (tan > best) best = tan
+  }
+  return Number.isFinite(best) ? best : 0
+}

--- a/ui/lib/lunar-atlas/sunpath.ts
+++ b/ui/lib/lunar-atlas/sunpath.ts
@@ -1,0 +1,167 @@
+// The real sun over the connecting ridge, as a function of time.
+//
+// sun.ts holds the sun the base was DESIGNED around: 45° up, fixed, chosen so a
+// cartographic hillshade reads clearly. This module holds the sun that is actually
+// there. They are separate on purpose and the split is load-bearing, because a
+// surprising amount of the base's GEOMETRY is a function of the design sun rather
+// than of the lighting: baseplan spaces the solar rows by SOLAR_TOP_H_M / tan(elev)
+// so one row does not shade the next, tilts the arrays to face it, and MarkerLayer
+// aims the array models along SUN_DIR. Feed a 1.8° sun into those and the row
+// spacing goes to 30x, which is not a lighting change, it is a different base.
+//
+// So: sun.ts stays the authority for anything built, this module is the authority
+// for anything lit, and the scene defaults to the former.
+//
+// WHY IT IS WORTH HAVING. The lunar south pole does not have a day and a night, it
+// has a sun that circles the horizon once a month at one to two degrees of
+// elevation. Everything visually characteristic about the place follows from that:
+// shadows kilometres long, hardware lit edge-on from a bearing that sweeps through
+// all 360° over 29.5 days, and crater floors that have not seen the sun in two
+// billion years. At the ridge specifically, measured from the patch's own centre
+// coordinates (89.46°S, colatitude 0.54°):
+//
+//   subsolar latitude   elevation over one lunar day
+//        -1.54°  (S summer)      +1.00° .. +2.08°
+//        -0.77°                  +0.23° .. +1.31°
+//         0.00°  (equinox)       -0.54° .. +0.54°
+//        +1.54°  (S winter)      -2.08° .. -1.00°
+//
+// Note what the winter rows mean: the sun sits below the site's LOCAL HORIZONTAL
+// for the whole month, and yet the ridge is famously among the best-lit ground on
+// the Moon. Both are true because the ground falls away to the north — a skyline
+// below horizontal still lets a sun below horizontal through. That is the case the
+// signed values in horizon.ts exist for, and it is why illumination here cannot be
+// answered with a dot product against a normal.
+//
+// WHAT IS EXACT AND WHAT IS NOT. The spherical astronomy is exact: given a subsolar
+// point, the direction is exact, and the elevation range above falls out of the
+// site's real latitude rather than being quoted from a paper. What is NOT tied to
+// reality is the absolute calendar phase. Pinning "lunar day 0" to a date needs the
+// 18.6-year precession of the Moon's node, and rather than approximate that and
+// have it read as precision, time here is expressed as two dimensionless phases the
+// UI can scrub directly. Mapping them onto real dates is a separate job.
+import { latLonToVector3, type Vec3 } from './geo'
+import { capLocalDirection, capCenterLatLon } from './southpole'
+
+// Mean synodic month: the sun's circuit as seen from a point on the Moon, which is
+// the rotation period that matters here rather than the sidereal one.
+export const SYNODIC_MONTH_DAYS = 29.530589
+
+// Tilt of the Moon's rotation axis to the ecliptic. This is the number that makes
+// polar illumination a seasonal question at all — were it zero, the sun would sit
+// permanently within half a degree of the horizon and never leave.
+export const MOON_OBLIQUITY_DEG = 1.54
+
+// One circuit of the ecliptic by the sun as seen from the Moon.
+export const SEASON_PERIOD_DAYS = 365.25
+
+// Time, as two phases in [0, 1).
+//
+// `lunarDay` is measured from the site's own local noon — the moment the subsolar
+// point crosses the ridge's longitude, when the sun is due north and as high as
+// that season allows. Anchoring on the site rather than on an ephemeris epoch is
+// what lets this module carry no astronomical constants beyond the two periods
+// above, and it makes 0 mean something a reader can picture.
+//
+// `season` is 0 at southern summer solstice, when the subsolar point is at its
+// most southerly and the ridge is best lit.
+export type SunPhase = {
+  lunarDay: number
+  season: number
+}
+
+// Best-lit sun, and the default for the true-sun mode: local noon at southern
+// summer solstice, which is the ~2.08° maximum in the table above.
+export const BRIGHTEST_PHASE: SunPhase = { lunarDay: 0, season: 0 }
+
+const DEG2RAD = Math.PI / 180
+const RAD2DEG = 180 / Math.PI
+
+// Latitude of the subsolar point: the Moon's obliquity, projected onto the season.
+// Negative is southern, so season 0 is the southern summer solstice.
+export function subsolarLatDeg(season: number): number {
+  return -MOON_OBLIQUITY_DEG * Math.cos(2 * Math.PI * season)
+}
+
+// Longitude of the subsolar point.
+//
+// DECREASING with time, which is the one sign in this file that is easy to get
+// backwards and impossible to notice afterwards — a sun running the wrong way round
+// the horizon looks entirely normal in any single frame. The Moon rotates prograde,
+// so the sun rises in the east and the subsolar point tracks west, and selenographic
+// longitude is positive east.
+export function subsolarLonDeg(lunarDay: number): number {
+  return capCenterLatLon().lon - 360 * lunarDay
+}
+
+// The sun as a unit vector from the Moon's centre, in scene world space.
+//
+// The subsolar point IS the direction to the sun — that is what makes it the
+// subsolar point — so this is one call into the same lat/lon conversion the rest of
+// the scene uses, rather than a horizontal-coordinates formula with its own azimuth
+// convention to get wrong.
+export function trueSunDirection(phase: SunPhase): Vec3 {
+  const v = latLonToVector3(subsolarLatDeg(phase.season), subsolarLonDeg(phase.lunarDay), 1)
+  const len = Math.hypot(v[0], v[1], v[2])
+  return [v[0] / len, v[1] / len, v[2] / len]
+}
+
+// ---------------------------------------------------------------------------
+// The ridge's own view of it
+//
+// Built out of capLocalDirection rather than a private copy of the tangent basis,
+// so there is one construction of the ridge frame in the codebase and this cannot
+// drift from the bearings the models are placed by.
+// ---------------------------------------------------------------------------
+
+const dot3 = (a: Vec3, b: Vec3) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+const RIDGE_UP = capLocalDirection(0, 90)
+const RIDGE_EAST = capLocalDirection(0, 0)
+const RIDGE_NORTH = capLocalDirection(90, 0)
+
+// Degrees above the ridge's local horizontal. Goes NEGATIVE for most of the year,
+// and that is not an error state — see the header. Callers that need to know
+// whether the ground is lit have to ask horizon.ts, not this.
+export function localElevationDeg(sunDir: Vec3): number {
+  return Math.asin(Math.max(-1, Math.min(1, dot3(sunDir, RIDGE_UP)))) * RAD2DEG
+}
+
+// Degrees counter-clockwise from local east, the same convention as every district's
+// `bearingDeg` and SUN_LOCAL_BEARING_DEG.
+//
+// "East" here is MAP east — the direction the baked image's +X runs — and not
+// geographic east, because that is the frame every bearing in this scene is quoted
+// in. The two are 137° apart at this site: the ridge sits at longitude -137.49°, and
+// in a polar stereographic projection the direction away from the pole (which at
+// 89.46°S is geographic NORTH) points along (sin lon, cos lon), i.e. map bearing
+// 227.49°. So the sun at local noon reads as 227.49° here, which is the correct
+// answer and looks like a bug. sun.ts documents the last time this frame confusion
+// cost somebody an afternoon; this is the same trap one projection further in.
+//
+// The consequence worth knowing: over a lunar day this INCREASES through a full
+// circuit. A southern-hemisphere sun runs east, north, west — counter-clockwise seen
+// from above — which is the opposite of the northern-hemisphere intuition, and it is
+// asserted in the tests so a sign slip in subsolarLonDeg cannot hide here.
+export function localBearingDeg(sunDir: Vec3): number {
+  const e = dot3(sunDir, RIDGE_EAST)
+  const n = dot3(sunDir, RIDGE_NORTH)
+  const deg = Math.atan2(n, e) * RAD2DEG
+  return deg < 0 ? deg + 360 : deg
+}
+
+// Highest the sun ever gets at the ridge, over the whole year: the answer to "how
+// grazing is grazing" without anybody having to trust a number typed in by hand.
+export function maxElevationDeg(): number {
+  return localElevationDeg(trueSunDirection(BRIGHTEST_PHASE))
+}
+
+// Where the sun is at a given phase, packaged the way the renderer wants it.
+export function sunAt(phase: SunPhase): {
+  dir: Vec3
+  elevationDeg: number
+  bearingDeg: number
+} {
+  const dir = trueSunDirection(phase)
+  return { dir, elevationDeg: localElevationDeg(dir), bearingDeg: localBearingDeg(dir) }
+}

--- a/ui/scripts/.mocharc-cypress-unit.json
+++ b/ui/scripts/.mocharc-cypress-unit.json
@@ -28,6 +28,7 @@
     "cypress/integration/unit/lunar-atlas-baseplan.cy.ts",
     "cypress/integration/unit/lunar-atlas-deprize.cy.ts",
     "cypress/integration/unit/lunar-atlas-geo.cy.ts",
+    "cypress/integration/unit/lunar-atlas-horizon.cy.ts",
     "cypress/integration/unit/lunar-atlas-junctions.cy.ts",
     "cypress/integration/unit/lunar-atlas-selectors.cy.ts",
     "cypress/integration/unit/lunar-atlas-shading.cy.ts",

--- a/ui/scripts/.mocharc-cypress-unit.json
+++ b/ui/scripts/.mocharc-cypress-unit.json
@@ -33,6 +33,7 @@
     "cypress/integration/unit/lunar-atlas-selectors.cy.ts",
     "cypress/integration/unit/lunar-atlas-shading.cy.ts",
     "cypress/integration/unit/lunar-atlas-southpole.cy.ts",
+    "cypress/integration/unit/lunar-atlas-sunpath.cy.ts",
     "cypress/integration/unit/lunar-atlas-regolith-shader.cy.ts",
     "cypress/integration/unit/team-roles.cy.tsx",
     "cypress/integration/unit/renew-subscription.cy.ts",


### PR DESCRIPTION
Two pure-geometry modules with no rendering change at all. **Additive only** — four new files plus two lines in the mocha config. Nothing existing is touched, so the rendered frame is byte-for-byte identical.

About half of the 1,051 lines are tests.

## `horizon.ts` — the skyline field

For every point on the 16 km terrain patch, how high the surrounding hills rise in 16 compass directions, plus a cosine-weighted sky view factor.

Three approaches went in the bin before this one. Naive ray marching was too slow. A max-pooled mip pyramid was fast but wrong — mean error **1.9 deg**, worst case **10.3 deg**. What shipped is an O(n) line sweep with DDA, which is provably exact: **0.0002 deg** against a continuous reference. It accounts for the Moon's curvature, which is not a rounding detail here — over 8 km the surface drops 18 m, and at a 2 deg sun that is the difference between lit and shadowed.

**148 ms** on the real DEM, computed at load. Zero payload.

One subtlety worth a reviewer's eye: the brute-force reference used to disagree with the sweep by a systematic 1.7 deg. The *reference* was wrong — it used the ray parameter as distance instead of the sampled cell's true distance, which inflates every tangent. Fixed, and now they agree.

## `sunpath.ts` — where the sun actually is

The subsolar point over time from the synodic month (29.53 d) and the Moon's 1.54 deg obliquity, decoupled from the static design sun so both can coexist.

The number that matters: this ridge **never sees the sun above ~2.08 deg**. The scene is currently lit by a 44.46 deg sun, chosen so the layout reads clearly. That is an order of magnitude off, and it is a deliberate artistic choice rather than an oversight — see `sun.ts`.

Time is two dimensionless phases rather than dates, because the real driver of lunar polar seasons is the 18.6-year precession of the node, and approximating that would read as precision we do not have.

## Why the tests look the way they do

Every assertion here is about something with an **outside answer** — the elevation range at this latitude, the direction a southern-hemisphere sun circulates, the fraction of the year the sun sits below local horizontal (two fifths, derived in closed form). Directions are the hardest kind of bug to see in a render: a sun running backwards around the horizon, or a season inverted, looks completely normal in any single screenshot.

Two of these caught real errors. A bearing that read 227 deg instead of 90 deg turned out to be correct — the scene's map frame is 137 deg off geographic north, now documented rather than rediscovered. And the "below horizontal" fraction was asserted against a guess until the closed form said 39%.

## Note on the base

This is stacked on the lit-regolith PR for a clean diff, but it has **no actual dependency** on it — every symbol it imports already exists on `main`. Happy to retarget it to `main` and land it independently if the one below gets stuck in review.

## Stack

1. Light every regolith surface with the real reflectance law
2. **this PR**
3. Add the sun scrubber and true-sun mode

Made with [Cursor](https://cursor.com)