### PR TITLE
Show the scene under the sun this ridge actually gets

### DIFF
--- a/ui/components/lunar-atlas/BaseRoads.tsx
+++ b/ui/components/lunar-atlas/BaseRoads.tsx
@@ -77,8 +77,10 @@ import {
 import { litGroundRadiance, shadowFillRadiance } from '@/lib/lunar-atlas/regolith'
 import {
   GRADED_SURFACE_FRAGMENT_PATCHES,
+  GRADED_SURFACE_VERTEX_PATCHES,
   applyShaderPatches,
 } from '@/lib/lunar-atlas/regolithShader'
+import { bindOcclusionUniforms } from './regolithOcclusion'
 import { capOffsetLatLon, M_TO_UNITS } from '@/lib/lunar-atlas/southpole'
 import { SUN_INTENSITY, SUN_LOCAL_ELEV_DEG } from '@/lib/lunar-atlas/sun'
 import type { ProjectType } from '@/lib/lunar-atlas/types'
@@ -106,6 +108,15 @@ const GRADED_BOUNCE_RADIANCE = shadowFillRadiance(
 
 function gradedRegolithShader(shader: THREE.WebGLProgramParametersWithUniforms) {
   shader.uniforms.bounceRadiance = { value: GRADED_BOUNCE_RADIANCE }
+  // The skyline field, so a road inside a terrain shadow goes dark with the ground
+  // it crosses. At the real sun 57% of the patch is in that shadow, and a road left
+  // out of it would be the most conspicuous error in the frame. Shared uniform boxes
+  // rather than copies — see regolithOcclusion.ts.
+  bindOcclusionUniforms(shader.uniforms)
+  // The vertex half is not optional: the fragment patches reference a world-position
+  // varying, and this is what declares and fills it. It also carries the instancing
+  // branch the rubble field needs.
+  shader.vertexShader = applyShaderPatches(shader.vertexShader, GRADED_SURFACE_VERTEX_PATCHES)
   shader.fragmentShader = applyShaderPatches(
     shader.fragmentShader,
     GRADED_SURFACE_FRAGMENT_PATCHES
@@ -114,7 +125,10 @@ function gradedRegolithShader(shader: THREE.WebGLProgramParametersWithUniforms) 
 
 // onBeforeCompile is not part of three's own program cache key, so without this
 // the patched and unpatched variants collide and whichever compiled first wins.
-const GRADED_CACHE_KEY = () => 'regolith-graded-v1'
+//
+// Bumped when the patches change shape, since a cached program from a previous
+// version would otherwise survive a hot reload and render without the new lookup.
+const GRADED_CACHE_KEY = () => 'regolith-graded-v2'
 
 // Multiplied against the surface texture. The sintered crust runs a little
 // lighter than the regolith it was fused from; the spoil is darker because it

--- a/ui/components/lunar-atlas/BaseRoads.tsx
+++ b/ui/components/lunar-atlas/BaseRoads.tsx
@@ -74,7 +74,6 @@ import {
   type Centreline,
   type Junction,
 } from '@/lib/lunar-atlas/junctions'
-import { litGroundRadiance, shadowFillRadiance } from '@/lib/lunar-atlas/regolith'
 import {
   GRADED_SURFACE_FRAGMENT_PATCHES,
   GRADED_SURFACE_VERTEX_PATCHES,
@@ -82,7 +81,6 @@ import {
 } from '@/lib/lunar-atlas/regolithShader'
 import { bindOcclusionUniforms } from './regolithOcclusion'
 import { capOffsetLatLon, M_TO_UNITS } from '@/lib/lunar-atlas/southpole'
-import { SUN_INTENSITY, SUN_LOCAL_ELEV_DEG } from '@/lib/lunar-atlas/sun'
 import type { ProjectType } from '@/lib/lunar-atlas/types'
 import { MODEL_PRESENCE } from './MarkerLayer'
 import type { RadiusAt } from './useTerrainSampler'
@@ -102,16 +100,15 @@ import type { RadiusAt } from './useTerrainSampler'
 //
 // Everything else in three's light loop is kept, deliberately — most importantly
 // the shadow attenuation, which arrives already folded into directLight.color.
-const GRADED_BOUNCE_RADIANCE = shadowFillRadiance(
-  litGroundRadiance(SUN_INTENSITY, SUN_LOCAL_ELEV_DEG)
-)
-
 function gradedRegolithShader(shader: THREE.WebGLProgramParametersWithUniforms) {
-  shader.uniforms.bounceRadiance = { value: GRADED_BOUNCE_RADIANCE }
-  // The skyline field, so a road inside a terrain shadow goes dark with the ground
-  // it crosses. At the real sun 57% of the patch is in that shadow, and a road left
-  // out of it would be the most conspicuous error in the frame. Shared uniform boxes
-  // rather than copies — see regolithOcclusion.ts.
+  // The skyline field, so a road inside a terrain shadow goes dark with the ground it
+  // crosses. At the real sun 57% of the patch is in that shadow, and a road left out
+  // of it would be the most conspicuous error in the frame.
+  //
+  // This also carries bounceRadiance, which used to be derived here from the same
+  // expression the terrain used. Shared uniform boxes rather than copies, so the road
+  // and the ground cannot end up at different shadow depths under a moving sun — see
+  // regolithOcclusion.ts.
   bindOcclusionUniforms(shader.uniforms)
   // The vertex half is not optional: the fragment patches reference a world-position
   // varying, and this is what declares and fills it. It also carries the instancing

--- a/ui/components/lunar-atlas/MarkerLayer.tsx
+++ b/ui/components/lunar-atlas/MarkerLayer.tsx
@@ -86,6 +86,7 @@ import ProjectModel, {
   RoverDepotYard,
   RoverGasStation,
   SparePartsPallet,
+  DistrictFloodPool,
   StreetLight,
   SurfaceAnchor,
   UndergroundConstructionSite,
@@ -757,10 +758,17 @@ const BOULDER_ALONG_STEPS = 34
 const BOULDER_ACROSS_STEPS = 20
 const BOULDER_KEEP_FRACTION = 0.34
 
-// A post every ~40 m of pavement, just outside the windrow — close enough
+// A post every ~26 m of pavement, just outside the windrow — close enough
 // together to actually read as street lighting, far enough apart that 730 m of
 // spine doesn't need dozens of them.
-const STREET_LIGHT_SPACING_M = 40
+//
+// Tightened from 40 m once the fixtures started throwing real pools of light on
+// the ground. At 40 m the lit patches did not touch, so under the true sun the
+// spine read as a dotted line of circles with black road between them; at 26 m,
+// against the 11 m pool radius in StreetLight, consecutive pools just overlap
+// and the road reads as continuously lit. The two numbers are a pair — moving
+// either one alone reopens the gaps or doubles the post count for nothing.
+const STREET_LIGHT_SPACING_M = 26
 
 // Roads narrower than this are left dark. A lit street is a street with traffic
 // on it, and a rover track out to four relay masts has none — see `width` in
@@ -1172,6 +1180,33 @@ function InterDistrictFiller({
     return out
   }, [radiusAt, built])
 
+  // One broad floodlit pool over each district's ground, and one over the solar
+  // farm. Placed from BASE_PLAN's own district centres rather than from a second
+  // list, so a district that moves takes its lighting with it.
+  //
+  // This exists because of an asymmetry the true sun exposed: the hardware in a
+  // terrain shadow is lit (by the site fill in regolithShader) and the GROUND it
+  // stands on is not, since that fill only reaches materials the model traversal
+  // patches. Lit buildings on black ground reads worse than either extreme.
+  const districtPools = useMemo(() => {
+    const out: { dir: Vec3; seat: number; radiusM: number; key: string }[] = []
+    if (!built) return out
+    for (const [site, plan] of Object.entries(BASE_PLAN)) {
+      if (!plan) continue
+      const ll = capOffsetLatLon(plan.east, plan.north)
+      const dir = latLonToVector3(ll.lat, ll.lon, 1)
+      out.push({
+        dir,
+        seat: radiusAt ? radiusAt(ll.lat, ll.lon) : GLOBE_RADIUS,
+        // The landing zone's apron is 62 m across on its own, so it gets a
+        // wider pool than a district whose plots line one short branch.
+        radiusM: site === 'lander' ? 46 : 28,
+        key: site,
+      })
+    }
+    return out
+  }, [radiusAt, built])
+
   const excavators = useMemo(() => {
     const out: { dir: Vec3; seat: number; noseAlong: Vec3; seed: number }[] = []
     if (!built) return out
@@ -1249,6 +1284,18 @@ function InterDistrictFiller({
           interactive={false}
         >
           <StreetLight />
+        </SurfaceAnchor>
+      ))}
+      {districtPools.map((p) => (
+        <SurfaceAnchor
+          key={`flood:${p.key}`}
+          dir={p.dir}
+          surfaceRadius={p.seat}
+          scale={M_TO_UNITS}
+          castShadows={false}
+          interactive={false}
+        >
+          <DistrictFloodPool radiusM={p.radiusM} />
         </SurfaceAnchor>
       ))}
       {roadsideCargo.map((c, i) => (

--- a/ui/components/lunar-atlas/MoonGlobe.tsx
+++ b/ui/components/lunar-atlas/MoonGlobe.tsx
@@ -474,9 +474,9 @@ function Sun({ dir, elevationDeg }: ResolvedSun) {
   // occlusion uniforms following would put shadows at yesterday's azimuth, which is
   // invisible in a still frame and obvious the moment it is scrubbed.
   //
-  // Exposure travels with it for the reason in sun.ts: at 2° the lit ground is a
-  // twelfth as bright as at 45°, so a fixed exposure renders the real sun 3.6 stops
-  // under. Set on the renderer rather than the effect because @r3f/postprocessing
+  // Exposure travels with it for the reason in sun.ts: it opens up as the sun drops,
+  // anchored to the highlights so a grazing sun reads as sidelight rather than as
+  // chalky noon. Set on the renderer rather than the effect because @r3f/postprocessing
   // takes over gl.toneMapping but the AgX chunk still reads gl.toneMappingExposure.
   const gl = useThree((s) => s.gl)
   useEffect(() => {
@@ -800,8 +800,8 @@ export default function MoonGlobe({
         // stop of separation between white metal and lunar soil is most of why
         // this scene kept being described as grey plastic.
         //
-        // So this is deliberately NOT multiplied by 17 to put the ground back
-        // where it was — but the reason has changed, and shrunk.
+        // So this is deliberately NOT multiplied by 17 to put the ground back where
+        // the bake had it — that was tried, and it re-graded the whole shipped view.
         //
         // The original objection was that exposure is global while half the ground
         // was unlit materials carrying colours authored as final screen values, so
@@ -818,13 +818,18 @@ export default function MoonGlobe({
         // rather than objects in it, which means the re-anchor is now a decision
         // about them specifically rather than a scene-wide re-authoring pass.
         //
-        // RESOLVED, by making it a derivation rather than a judgement — see
-        // exposureFor() in lib/lunar-atlas/sun.ts. A sun that moves settles the
-        // argument: the real sun lights this ground at a twelfth of what the design
-        // sun does, so no single constant can serve both, and exposure has to be a
-        // function of the sun the way a photographer's is. The function is anchored so
-        // the DESIGN sun reproduces exactly this number, which is why it is still
-        // written here and still 1.05.
+        // RESOLVED: this stays exactly the shipped 1.05 at the design sun, and
+        // exposureFor() in lib/lunar-atlas/sun.ts opens up from it as the sun drops —
+        // but anchored to the HIGHLIGHTS (a slope facing the sun), not to flat ground.
+        //
+        // The distinction was learned the expensive way, twice in one day. Re-anchoring
+        // to put flat ground back at the bake's 0.366 re-graded this entire default
+        // view four stops brighter; and tracking flat ground at all sends the real sun
+        // to 220x, where every sun-facing bump on the patch clips white and grazing
+        // midnight light renders as chalky noon. Exposing for the highlights costs
+        // ~1.6x at the real sun instead, holds the brightest terrain at the same level
+        // under every sun, and lets flat ground fall away dark — which is what grazing
+        // light is. The full argument and both failed policies: sun.ts.
         toneMappingExposure: DESIGN_EXPOSURE,
         // A LOGARITHMIC depth buffer is the obvious choice for a scene that
         // spans orbit to millimeters, and it was used here, and it was the

--- a/ui/components/lunar-atlas/MoonGlobe.tsx
+++ b/ui/components/lunar-atlas/MoonGlobe.tsx
@@ -46,6 +46,7 @@ import {
   SUN_LOCAL_ELEV_DEG,
   DESIGN_EXPOSURE,
   exposureFor,
+  screenAnchoredScale,
 } from '@/lib/lunar-atlas/sun'
 import {
   localElevationDeg,
@@ -438,7 +439,23 @@ const SHADOW_NORMAL_BIAS_MAX = 0.6 * M_TO_UNITS
 // regolith BRDF against this light per pixel rather than displaying a hillshade
 // baked from a private copy of its direction, which also retired the separate
 // pass that used to exist only to catch shadows on the terrain.
-function Sun({ sunPhase }: { sunPhase?: SunPhase }) {
+// Where the sun is, resolved once. Undefined phase means the design sun, and then this
+// is exactly SUN_DIR and the scene that shipped.
+//
+// Hoisted out of Sun because the SKY needs the elevation too — a backdrop and a light
+// that disagree about the sun is the kind of inconsistency nothing catches, and it
+// already bit once (see screenAnchoredScale). One resolution, one source.
+type ResolvedSun = { dir: THREE.Vector3; elevationDeg: number }
+
+function useResolvedSun(sunPhase?: SunPhase): ResolvedSun {
+  return useMemo(() => {
+    if (!sunPhase) return { dir: SUN_DIR, elevationDeg: SUN_LOCAL_ELEV_DEG }
+    const v = trueSunDirection(sunPhase)
+    return { dir: new THREE.Vector3(...v), elevationDeg: localElevationDeg(v) }
+  }, [sunPhase])
+}
+
+function Sun({ dir, elevationDeg }: ResolvedSun) {
   // A directional light aims at its `target` object, which must be in the
   // scene for its world matrix to update.
   const target = useMemo(() => {
@@ -446,14 +463,6 @@ function Sun({ sunPhase }: { sunPhase?: SunPhase }) {
     o.position.copy(HOME_TARGET)
     return o
   }, [])
-
-  // Where the sun actually is, and how high above this ridge's own horizontal.
-  // Undefined phase means the design sun, and then this is exactly SUN_DIR.
-  const { dir, elevationDeg } = useMemo(() => {
-    if (!sunPhase) return { dir: SUN_DIR, elevationDeg: SUN_LOCAL_ELEV_DEG }
-    const v = trueSunDirection(sunPhase)
-    return { dir: new THREE.Vector3(...v), elevationDeg: localElevationDeg(v) }
-  }, [sunPhase])
 
   const lightPos = useMemo(
     () => HOME_TARGET.clone().addScaledVector(dir, SHADOW_LIGHT_DIST),
@@ -540,6 +549,87 @@ function Sun({ sunPhase }: { sunPhase?: SunPhase }) {
   )
 }
 
+// The starfield, held at a constant screen brightness for the same reason as the sky.
+//
+// Worth saying what the STRICTLY correct answer would be, because this is not it: a
+// camera exposed for sunlit regolith records no stars at all. That is why every Apollo
+// surface photograph has a completely empty black sky, and it is the most-argued-about
+// fact in all of lunar photography. Physically, these should vanish the moment the
+// ground is properly exposed.
+//
+// They are kept because they are load-bearing for something else — this same camera
+// pulls back to orbit, where a starless void reads as a broken render rather than as an
+// airless one. So the conservative choice: hold them exactly where they are today and
+// stop them blowing up. Under true-sun exposure the unanchored version bloomed into
+// fat white blobs, which is worse than either principled answer.
+//
+// drei's Stars leaves exactly one lever for this. Its material is a ShaderMaterial
+// whose fragment stage writes vec4(vColor, dotFalloff), so material.opacity is inert
+// and vColor — the geometry's colour attribute — is the only thing that reaches the
+// output. Scaled from a pristine copy rather than in place, so repeated scrubbing
+// cannot compound.
+function ScreenAnchoredStars({ elevationDeg }: { elevationDeg: number }) {
+  const group = useRef<THREE.Group>(null)
+  const pristine = useRef<Float32Array | null>(null)
+  const scale = screenAnchoredScale(elevationDeg)
+
+  useEffect(() => {
+    let attr: THREE.BufferAttribute | undefined
+    group.current?.traverse((o) => {
+      const g = (o as THREE.Points).geometry
+      const a = g?.getAttribute?.('color')
+      if (a) attr = a as THREE.BufferAttribute
+    })
+    if (!attr) return
+    const dst = attr.array as Float32Array
+    if (!pristine.current || pristine.current.length !== dst.length) {
+      pristine.current = Float32Array.from(dst)
+    }
+    const src = pristine.current
+    for (let i = 0; i < dst.length; i++) dst[i] = src[i] * scale
+    attr.needsUpdate = true
+  }, [scale])
+
+  return (
+    <group ref={group}>
+      <Stars
+        radius={GLOBE_RADIUS * 14}
+        depth={GLOBE_RADIUS * 6}
+        count={6000}
+        factor={GLOBE_RADIUS * 0.9}
+        saturation={0}
+        fade
+        speed={0.3}
+      />
+    </group>
+  )
+}
+
+// The sky, which on an airless world is simply the absence of one.
+//
+// SKY_COLOR is not black, and that is a deliberate authored choice rather than physics:
+// a hair of blue in the backdrop keeps the frame from reading as a dead region of the
+// page. The catch is that it is authored as a SCREEN value, so it only means what it
+// says at the exposure it was picked under. Under true-sun exposure the unmodified
+// colour came out visibly navy — the most unphysical thing in the whole frame, since
+// the one thing everybody knows about the lunar sky is that it is black.
+//
+// So it is held at a constant screen brightness instead of a constant radiance. At the
+// design sun the scale is exactly 1 and this is the same #03040a it always was.
+const SKY_COLOR = '#03040a'
+
+function SkyBackdrop({ elevationDeg }: { elevationDeg: number }) {
+  const scene = useThree((s) => s.scene)
+  useEffect(() => {
+    const c = new THREE.Color(SKY_COLOR).multiplyScalar(screenAnchoredScale(elevationDeg))
+    scene.background = c
+    return () => {
+      scene.background = null
+    }
+  }, [scene, elevationDeg])
+  return null
+}
+
 // The indirect half of the lighting, and the only fill in the scene.
 //
 // Two jobs at once, which is why one texture can replace both a studio
@@ -595,6 +685,9 @@ export default function MoonGlobe({
   children,
 }: MoonGlobeProps) {
   const controlsRef = useRef<any>(null)
+  // Resolved once here so the light, the sky and the starfield are all reading the same
+  // sun. See useResolvedSun.
+  const sun = useResolvedSun(sunPhase)
   // CPU-side copy of the height maps so markers, models, and the camera sit
   // on the terrain the GPU actually renders.
   const radiusAt = useTerrainSampler()
@@ -766,21 +859,13 @@ export default function MoonGlobe({
       }}
       onWheel={handleWheel}
     >
-      <color attach="background" args={['#03040a']} />
+      <SkyBackdrop elevationDeg={sun.elevationDeg} />
 
-      <Sun sunPhase={sunPhase} />
+      <Sun {...sun} />
       <LunarEnvironment />
       <EarthGlobe />
 
-      <Stars
-        radius={GLOBE_RADIUS * 14}
-        depth={GLOBE_RADIUS * 6}
-        count={6000}
-        factor={GLOBE_RADIUS * 0.9}
-        saturation={0}
-        fade
-        speed={0.3}
-      />
+      <ScreenAnchoredStars elevationDeg={sun.elevationDeg} />
 
       <SouthPoleTerrain onReady={onReady} onSurfaceClick={onBackgroundClick} />
 

--- a/ui/components/lunar-atlas/MoonGlobe.tsx
+++ b/ui/components/lunar-atlas/MoonGlobe.tsx
@@ -43,10 +43,19 @@ import {
   SUN_COLOR,
   SUN_DIR as SUN_DIR_ARR,
   SUN_INTENSITY,
+  SUN_LOCAL_ELEV_DEG,
+  DESIGN_EXPOSURE,
+  exposureFor,
 } from '@/lib/lunar-atlas/sun'
+import {
+  localElevationDeg,
+  trueSunDirection,
+  type SunPhase,
+} from '@/lib/lunar-atlas/sunpath'
 import { GLOBE_RADIUS } from '@/lib/lunar-atlas/textures'
 import type { Organization, Project, ProjectType } from '@/lib/lunar-atlas/types'
 import BaseRoads from './BaseRoads'
+import { setRegolithSun } from './regolithOcclusion'
 import EarthGlobe from './EarthGlobe'
 import GroundDisturbance from './GroundDisturbance'
 import MarkerLayer, { ColonyLayout, MarkerStyle, siteOpacity } from './MarkerLayer'
@@ -106,6 +115,17 @@ export type MoonGlobeProps = {
   // Strips every beacon, tether and floating name out of the scene, leaving
   // only what would physically be there. See MarkerLayerProps.
   cinematic?: boolean
+  // A moment in the lunar year, or undefined for the sun the base was DESIGNED
+  // around — a 44.46° sun that exists to make the layout legible and does not exist
+  // on the Moon, where this ridge never sees one above ~2.1°. See lib/sun.ts for why
+  // that choice was made and sunpath.ts for what the real sun does instead.
+  //
+  // A prop rather than a control inside the canvas, and undefined rather than a
+  // boolean plus a default, for the same reason: this component should not hold an
+  // opinion about which sun is being looked at. The page owns the scrubber, the
+  // default is byte-for-byte the scene that shipped, and true-sun mode is
+  // unreachable unless something explicitly asks for it.
+  sunPhase?: SunPhase
   children?: ReactNode
 }
 
@@ -407,12 +427,18 @@ const SUN_PENUMBRA_PER_M = 2 * Math.tan(SUN_ANGULAR_RADIUS_RAD)
 // for, and it puts contact shadows back against the things casting them.
 const SHADOW_NORMAL_BIAS = 0.12 * M_TO_UNITS
 
+// The ceiling on the grazing-sun scaling above. 60 cm is five times the 44° value and
+// three shadow texels of lateral slide — the point past which a footpad's shadow
+// visibly leaves the footpad, which is the artifact this whole number exists to
+// avoid. See the derivation at its use site.
+const SHADOW_NORMAL_BIAS_MAX = 0.6 * M_TO_UNITS
+
 // The scene's sun, and now genuinely the only one. It shades the installations,
 // casts their shadows, and lights the ground: SouthPoleTerrain evaluates the
 // regolith BRDF against this light per pixel rather than displaying a hillshade
 // baked from a private copy of its direction, which also retired the separate
 // pass that used to exist only to catch shadows on the terrain.
-function Sun() {
+function Sun({ sunPhase }: { sunPhase?: SunPhase }) {
   // A directional light aims at its `target` object, which must be in the
   // scene for its world matrix to update.
   const target = useMemo(() => {
@@ -420,10 +446,62 @@ function Sun() {
     o.position.copy(HOME_TARGET)
     return o
   }, [])
+
+  // Where the sun actually is, and how high above this ridge's own horizontal.
+  // Undefined phase means the design sun, and then this is exactly SUN_DIR.
+  const { dir, elevationDeg } = useMemo(() => {
+    if (!sunPhase) return { dir: SUN_DIR, elevationDeg: SUN_LOCAL_ELEV_DEG }
+    const v = trueSunDirection(sunPhase)
+    return { dir: new THREE.Vector3(...v), elevationDeg: localElevationDeg(v) }
+  }, [sunPhase])
+
   const lightPos = useMemo(
-    () => HOME_TARGET.clone().addScaledVector(SUN_DIR, SHADOW_LIGHT_DIST),
-    []
+    () => HOME_TARGET.clone().addScaledVector(dir, SHADOW_LIGHT_DIST),
+    [dir]
   )
+
+  // Everything the ground needs from the sun, in one call, because the shading and
+  // the skyline test have to be looking at the same sun — a light moved without the
+  // occlusion uniforms following would put shadows at yesterday's azimuth, which is
+  // invisible in a still frame and obvious the moment it is scrubbed.
+  //
+  // Exposure travels with it for the reason in sun.ts: at 2° the lit ground is a
+  // twelfth as bright as at 45°, so a fixed exposure renders the real sun 3.6 stops
+  // under. Set on the renderer rather than the effect because @r3f/postprocessing
+  // takes over gl.toneMapping but the AgX chunk still reads gl.toneMappingExposure.
+  const gl = useThree((s) => s.gl)
+  useEffect(() => {
+    setRegolithSun([dir.x, dir.y, dir.z], elevationDeg)
+    gl.toneMappingExposure = exposureFor(elevationDeg)
+  }, [dir, elevationDeg, gl])
+
+  // Shadow-map bias, and the one number that genuinely cannot stay fixed across a
+  // sun this low.
+  //
+  // Acne is a depth-quantisation artifact whose size is the light-space texel
+  // footprint projected onto the receiver: a ground plane at grazing incidence spans
+  // texel/tan(elevation) of depth within ONE texel, so the same 12 cm that is ample
+  // at 44° is 1/19th of what 2° needs, and the ground stripes itself. Paying it in
+  // full is not an option either — normalBias slides the shadow laterally by exactly
+  // its own value, so metres of it would detach every footpad from its own shadow,
+  // which is the failure this number was tuned down to 12 cm to fix in the first
+  // place.
+  //
+  // So it is capped, and the cap is the honest half of this: past about 12° the bias
+  // needed exceeds what the shadow can afford, and the artifact is accepted rather
+  // than traded for peter-panning. It is the right trade here specifically because
+  // at those elevations the shadow map is no longer doing the important work — the
+  // skyline field is, at terrain scale, and it has no depth buffer to quantise.
+  // ANCHORED at the design sun, like the exposure, and for a sharper reason: the naive
+  // form is bias/sin(elevation), which at 44.46° is bias/0.70 = 1.43x — so writing it
+  // that way would have quietly moved the default scene's shadows 5 cm, undoing the
+  // tuning this constant records. Ratios against the design sun, so the design sun is
+  // exactly 1.0x by construction.
+  const shadowNormalBias = useMemo(() => {
+    const design = Math.sin((SUN_LOCAL_ELEV_DEG * Math.PI) / 180)
+    const graze = Math.max(Math.sin((elevationDeg * Math.PI) / 180), 0.02)
+    return Math.min((SHADOW_NORMAL_BIAS * design) / graze, SHADOW_NORMAL_BIAS_MAX)
+  }, [elevationDeg])
 
   return (
     <>
@@ -442,7 +520,7 @@ function Sun() {
         shadow-camera-bottom={-SHADOW_EXTENT}
         shadow-camera-near={SHADOW_LIGHT_DIST * 0.6}
         shadow-camera-far={SHADOW_LIGHT_DIST * 1.6}
-        shadow-normalBias={SHADOW_NORMAL_BIAS}
+        shadow-normalBias={shadowNormalBias}
       />
       {/* No hemisphere light and no ambient light, on purpose.
           
@@ -513,6 +591,7 @@ export default function MoonGlobe({
   layout,
   onBackgroundClick,
   cinematic,
+  sunPhase,
   children,
 }: MoonGlobeProps) {
   const controlsRef = useRef<any>(null)
@@ -646,10 +725,14 @@ export default function MoonGlobe({
         // rather than objects in it, which means the re-anchor is now a decision
         // about them specifically rather than a scene-wide re-authoring pass.
         //
-        // Until it is taken, the frame is physically consistent but darker than it
-        // was, and how much of that darkness to buy back is a judgement about the
-        // photograph rather than about the Moon.
-        toneMappingExposure: 1.05,
+        // RESOLVED, by making it a derivation rather than a judgement — see
+        // exposureFor() in lib/lunar-atlas/sun.ts. A sun that moves settles the
+        // argument: the real sun lights this ground at a twelfth of what the design
+        // sun does, so no single constant can serve both, and exposure has to be a
+        // function of the sun the way a photographer's is. The function is anchored so
+        // the DESIGN sun reproduces exactly this number, which is why it is still
+        // written here and still 1.05.
+        toneMappingExposure: DESIGN_EXPOSURE,
         // A LOGARITHMIC depth buffer is the obvious choice for a scene that
         // spans orbit to millimeters, and it was used here, and it was the
         // wrong call — it is the direct cause of the shimmer that has been
@@ -685,7 +768,7 @@ export default function MoonGlobe({
     >
       <color attach="background" args={['#03040a']} />
 
-      <Sun />
+      <Sun sunPhase={sunPhase} />
       <LunarEnvironment />
       <EarthGlobe />
 

--- a/ui/components/lunar-atlas/ProjectModel.tsx
+++ b/ui/components/lunar-atlas/ProjectModel.tsx
@@ -3030,6 +3030,122 @@ function ChargeBollard({ accent }: { accent: string }) {
   )
 }
 
+// What a lamp on an airless world actually produces, drawn instead of simulated.
+//
+// There are only two visible consequences of a light source with no atmosphere
+// around it: the fixture itself is bright, and the ground within its throw is
+// lit. No beam, no halo, no fog cone — nothing exists between the two to
+// scatter. So the pool is a POOL: a soft-edged patch of extra radiance laid on
+// the ground under the boom head, additive because light adds, and falling off
+// roughly inverse-square from directly beneath the head.
+//
+// A decal rather than a THREE.PointLight, deliberately. Three is a forward
+// renderer: every point light in the scene widens the light loop in every lit
+// material's fragment shader — the terrain's, every road's, every one of the
+// hundreds of materials on the hardware — whether or not the lamp is anywhere
+// near it. Dozens of lamps would be paid for by every fragment on screen. The
+// decal costs one small additive quad each and nothing else, and because the
+// pool's radiance is authored in the same linear units the sun's is, it behaves
+// correctly under both suns WITHOUT any coupling to the exposure machinery: at
+// the 44° design sun the crust it lands on is ~2x brighter than the pool's
+// peak, so the lamps read as switched off in daylight (they would be); inside a
+// true-sun terrain shadow the ground under a lamp is ~10x darker than the pool,
+// and the road lights up in little islands. That contrast inversion is free —
+// it is just what fixed radiances do when the light around them moves.
+// The pool is scenery in the strictest sense — a patch of light — so it must
+// never swallow a click aimed at the road or the Moon beneath it.
+const NO_RAYCAST_MODEL = () => {}
+
+let lightPoolTexture: THREE.Texture | null = null
+function getLightPoolTexture(): THREE.Texture | null {
+  if (lightPoolTexture) return lightPoolTexture
+  const SIZE = 128
+  const canvas = document.createElement('canvas')
+  canvas.width = canvas.height = SIZE
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return null
+  // Stops approximate 1/(1+(r/r0)^2) — a photometric falloff, not a Gaussian
+  // blob. The hard zero at the rim matters: an additive texture that does not
+  // reach exactly 0 draws its own quad as a faint grey square.
+  const g = ctx.createRadialGradient(SIZE / 2, SIZE / 2, 0, SIZE / 2, SIZE / 2, SIZE / 2)
+  g.addColorStop(0, 'rgba(255,255,255,1)')
+  g.addColorStop(0.25, 'rgba(255,255,255,0.62)')
+  g.addColorStop(0.5, 'rgba(255,255,255,0.28)')
+  g.addColorStop(0.75, 'rgba(255,255,255,0.09)')
+  g.addColorStop(1, 'rgba(255,255,255,0)')
+  ctx.fillStyle = g
+  ctx.fillRect(0, 0, SIZE, SIZE)
+  lightPoolTexture = new THREE.CanvasTexture(canvas)
+  return lightPoolTexture
+}
+
+// Peak radiance added at the centre of a pool, linear, in the same unitless
+// radiance the sun and the regolith BRDF trade in. Sized against the two
+// grounds it has to sit on: design-sun crust renders at ~0.021 and a true-sun
+// terrain shadow at ~0.0001, which is a ratio of two hundred. So there is no
+// value that is invisible by day AND bright by night, and this one is chosen for
+// the case that needs it: comfortably over the shadow (reads about sRGB 40),
+// about half of daylight (a visible but unobtrusive pool at the design sun).
+const LIGHT_POOL_RADIANCE = 0.013
+const LIGHT_POOL_COLOR = new THREE.Color('#cdd8ff').multiplyScalar(LIGHT_POOL_RADIANCE)
+
+// A patch of lit ground. `stretch` is how much longer the pool is along the
+// fixture's boom axis than across it — a tilted head throws long, a ring of
+// floods around a lot throws round.
+function LightPool({
+  x = 0,
+  radiusM,
+  stretch = 1.25,
+  intensity = 1,
+}: {
+  x?: number
+  radiusM: number
+  stretch?: number
+  intensity?: number
+}) {
+  const tex = useMemo(getLightPoolTexture, [])
+  const color = useMemo(
+    () => LIGHT_POOL_COLOR.clone().multiplyScalar(intensity),
+    [intensity]
+  )
+  if (!tex) return null
+  return (
+    // A few hand-widths above grade: over the road's own lift and camber
+    // (~0.3 m) but under every wheel. Drawn after the road (renderOrder), since
+    // both are transparent and the road does not write depth for it to test.
+    <mesh
+      position={[x, 0.45, 0]}
+      rotation={[-Math.PI / 2, 0, 0]}
+      renderOrder={2}
+      raycast={NO_RAYCAST_MODEL}
+    >
+      <planeGeometry args={[radiusM * 2 * stretch, radiusM * 2]} />
+      <meshBasicMaterial
+        map={tex}
+        color={color}
+        blending={THREE.AdditiveBlending}
+        transparent
+        depthWrite={false}
+      />
+    </mesh>
+  )
+}
+
+// The lit ground a whole district's own floodlighting throws — one broad, soft
+// pool over the lot rather than a fixture per building.
+//
+// Worth being explicit that this is scenery standing in for lighting design we
+// have not done: the districts have no modelled floodlights, and every real
+// surface installation is lit for the simple reason that crews cannot work in a
+// two-week night. Without it, the true-sun view puts hardware that IS lit (see
+// the site fill in regolithShader) on ground that is pitch black, which reads
+// worse than either extreme.
+export function DistrictFloodPool({ radiusM = 26 }: { radiusM?: number }) {
+  // Dimmer and much wider than a street light's: this is the sum of many
+  // fixtures seen from outside, so it has no hot centre.
+  return <LightPool radiusM={radiusM} stretch={1} intensity={0.55} />
+}
+
 // A yard light, boom cranked out over the aisle rather than run straight up
 // its own pole — the way an actual lot light leans its fixture in over what
 // it's lighting instead of down onto itself. Parameterized (rather than a
@@ -3041,10 +3157,13 @@ function DepotLightMast({
   accent,
   height = 4.2,
   boomLen = 1.1,
+  poolRadiusM = 0,
 }: {
   accent: string
   height?: number
   boomLen?: number
+  // Radius of the lit pool this fixture throws on the ground; 0 for none.
+  poolRadiusM?: number
 }) {
   const h = height
   const boomOut = boomLen * 0.5
@@ -3074,6 +3193,16 @@ function DepotLightMast({
           />
         </mesh>
       </group>
+      {/* Under where the head actually hangs — the boom's reach in its own
+          frame, tilted down 0.55 rad — not under the pole. A pool centred on
+          the pole is the tell that the light was placed by a renderer. */}
+      {poolRadiusM > 0 && (
+        <LightPool
+          x={headOut * Math.cos(0.55) + 0.35}
+          radiusM={poolRadiusM}
+          stretch={1.35}
+        />
+      )}
     </group>
   )
 }
@@ -3088,7 +3217,14 @@ function DepotLightMast({
 // baseplan.ts) — the one piece of infrastructure in this file with no
 // district or competitor tied to it at all.
 export function StreetLight() {
-  return <DepotLightMast accent="#eef2ff" height={5.4} boomLen={1.5} />
+  // Pool radius roughly twice the mount height, which with the ~26 m spacing in
+  // MarkerLayer puts consecutive pools just into each other and leaves the road
+  // as a continuous lit ribbon rather than a dotted line. Sized up from 5.2 m,
+  // where the lamps lit tidy circles 40 m apart and the road between them was
+  // still black — which is not what a lit street looks like.
+  return (
+    <DepotLightMast accent="#eef2ff" height={5.4} boomLen={1.5} poolRadiusM={11} />
+  )
 }
 
 // The one piece of built shelter on the lot: an open-sided canopy over a
@@ -4011,13 +4147,13 @@ export function RoverDepotYard({ accent }: { accent: string }) {
       </group>
 
       <group position={[-DEPOT_HALF_W + 0.9, 0, DEPOT_HALF_D - 0.9]}>
-        <DepotLightMast accent={accent} />
+        <DepotLightMast accent={accent} poolRadiusM={3.6} />
       </group>
       <group
         position={[DEPOT_HALF_W - 0.9, 0, DEPOT_HALF_D - 0.9]}
         rotation={[0, Math.PI, 0]}
       >
-        <DepotLightMast accent={accent} />
+        <DepotLightMast accent={accent} poolRadiusM={3.6} />
       </group>
 
       {/* A mechanic making rounds of the bay rather than standing frozen at

--- a/ui/components/lunar-atlas/SouthPoleTerrain.tsx
+++ b/ui/components/lunar-atlas/SouthPoleTerrain.tsx
@@ -34,7 +34,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 import { buildDetailSlopeTile } from '@/lib/lunar-atlas/detailTile'
-import { litGroundRadiance, shadowFillRadiance } from '@/lib/lunar-atlas/regolith'
 import {
   CAP_GRID,
   MAP_X_DIR,
@@ -47,7 +46,6 @@ import {
   TERRAIN_VERTEX_PATCHES,
   applyShaderPatches,
 } from '@/lib/lunar-atlas/regolithShader'
-import { SUN_INTENSITY, SUN_LOCAL_ELEV_DEG } from '@/lib/lunar-atlas/sun'
 import { loadInnerField } from './useTerrainSampler'
 import { bindOcclusionUniforms, primeRegolithOcclusion } from './regolithOcclusion'
 
@@ -71,9 +69,10 @@ const REGOLITH_TINT = '#fff8ed'
 // component's own history warns about, since it lifts every slope by the same
 // amount and so flattens exactly the shading contrast per-pixel normals were
 // added to produce. Sharing one derivation is how that stops recurring.
-const SHADOW_BOUNCE_RADIANCE = shadowFillRadiance(
-  litGroundRadiance(SUN_INTENSITY, SUN_LOCAL_ELEV_DEG)
-)
+// ...and it now lives in regolithOcclusion.ts, as one uniform box shared with the
+// graded surfaces rather than the same expression written out in both files. Agreeing
+// by duplication was already the weak version of agreeing, and it could not have
+// survived a sun that moves, since the fill scales with the sun's elevation.
 
 // The geometry plus the world offset its vertices are relative to (see
 // buildCapGeometry — the offset must go on the mesh transform, which three
@@ -183,10 +182,10 @@ export default function SouthPoleTerrain({
       shader.uniforms.terrainNormalMap = { value: normalTex }
       shader.uniforms.detailSlopeMap = { value: detail }
       shader.uniforms.mapXDir = { value: new THREE.Vector3(...MAP_X_DIR) }
-      shader.uniforms.bounceRadiance = { value: SHADOW_BOUNCE_RADIANCE }
-      // The skyline field and the sun that is tested against it. Shared boxes, not
-      // copies — see regolithOcclusion.ts — so the roads across this ground are
-      // always in the same shadow as the ground.
+      // The skyline field, the sun tested against it, and the shadow fill derived
+      // from it. Shared boxes, not copies — see regolithOcclusion.ts — so the roads
+      // across this ground are always in the same shadow, at the same depth, under
+      // the same sun as the ground.
       bindOcclusionUniforms(shader.uniforms)
 
       // The patches themselves, and the reasoning for each anchor, live in

--- a/ui/components/lunar-atlas/SouthPoleTerrain.tsx
+++ b/ui/components/lunar-atlas/SouthPoleTerrain.tsx
@@ -49,6 +49,7 @@ import {
 } from '@/lib/lunar-atlas/regolithShader'
 import { SUN_INTENSITY, SUN_LOCAL_ELEV_DEG } from '@/lib/lunar-atlas/sun'
 import { loadInnerField } from './useTerrainSampler'
+import { bindOcclusionUniforms, primeRegolithOcclusion } from './regolithOcclusion'
 
 // A pointer that travels farther than this between down and up is a drag
 // (camera tumble), not a click.
@@ -146,6 +147,10 @@ export default function SouthPoleTerrain({
 
   useEffect(() => {
     let cancelled = false
+    // Kicked off here rather than awaited: the skyline field takes ~148 ms to sweep
+    // and the ground should not wait on it, since the placeholders it starts with are
+    // chosen to render identically to an open, level horizon.
+    void primeRegolithOcclusion()
     loadInnerField().then((field) => {
       if (cancelled) return
       setInnerGeo(toBufferGeometry(field, CAP_GRID))
@@ -179,6 +184,10 @@ export default function SouthPoleTerrain({
       shader.uniforms.detailSlopeMap = { value: detail }
       shader.uniforms.mapXDir = { value: new THREE.Vector3(...MAP_X_DIR) }
       shader.uniforms.bounceRadiance = { value: SHADOW_BOUNCE_RADIANCE }
+      // The skyline field and the sun that is tested against it. Shared boxes, not
+      // copies — see regolithOcclusion.ts — so the roads across this ground are
+      // always in the same shadow as the ground.
+      bindOcclusionUniforms(shader.uniforms)
 
       // The patches themselves, and the reasoning for each anchor, live in
       // lib/lunar-atlas/regolithShader.ts — they are string surgery on shader
@@ -216,7 +225,9 @@ export default function SouthPoleTerrain({
           The terrain deliberately does NOT cast. Its own relief is in the normal
           map, not the geometry, so a shadow map rendered from this mesh would
           only know about the 15.6 m mesh and would fight the per-pixel normals.
-          Terrain self-shadowing is Phase 2's horizon map. */}
+          Terrain self-shadowing comes from the skyline field instead, which is
+          O(1) per fragment and reaches the whole 16 km patch rather than the
+          hundred metres a shadow map covers. */}
       <meshLambertMaterial
         color={REGOLITH_TINT}
         defines={{ USE_UV: '' }}

--- a/ui/components/lunar-atlas/SunScrubber.tsx
+++ b/ui/components/lunar-atlas/SunScrubber.tsx
@@ -1,0 +1,193 @@
+// The control that makes the real sun reachable.
+//
+// Everything the horizon field was built for is invisible without this. At the sun
+// the base was DESIGNED around — 44.46°, chosen to make the layout legible — the
+// skyline shadows exactly 0.00% of the patch, because the comparison is in tangents
+// and tan(44.46) is 0.98 against a measured maximum skyline tangent of 0.51. At the
+// sun this ridge actually gets, ~2°, it shadows 57%. Same code, same data; the only
+// difference is where the sun is, and until something set that, none of it ran.
+//
+// Two sliders because time here is two independent phases (see sunpath.ts), and they
+// do visibly different things:
+//
+//   lunarDay sweeps the sun all the way round the horizon in 29.53 days. This is the
+//   one that shows the payoff — WHICH 57% is in shadow changes, so shadows crawl
+//   across the site and every slope is lit at some point in the month.
+//
+//   season raises and lowers the whole envelope through the Moon's 1.54° obliquity.
+//   This is the one with an engineering answer attached: for about two fifths of the
+//   year the sun is below local horizontal and the site is simply dark, which is the
+//   entire reason illumination fraction decides where a polar base goes.
+//
+// It sits in the same corner family as the clean-view button and, like it, SURVIVES
+// cinematic mode — a scrubber you cannot reach while looking at the thing it controls
+// would be useless.
+import { useMemo } from 'react'
+import {
+  SEASON_PERIOD_DAYS,
+  SYNODIC_MONTH_DAYS,
+  type SunPhase,
+  maxElevationDeg,
+  subsolarLatDeg,
+  sunAt,
+} from '@/lib/lunar-atlas/sunpath'
+import { SUN_LOCAL_ELEV_DEG } from '@/lib/lunar-atlas/sun'
+
+export type SunScrubberProps = {
+  // null means the design sun, which is the default and the shipped scene.
+  phase: SunPhase | null
+  onChange: (phase: SunPhase | null) => void
+}
+
+// Named points in the lunar year, so `season` reads as something physical rather than
+// as a number between 0 and 1. Season 0 is the southern summer solstice, when the
+// subsolar point is at its most southerly and this ridge is best lit.
+function seasonLabel(season: number): string {
+  const s = ((season % 1) + 1) % 1
+  if (s < 0.03 || s > 0.97) return 'southern summer'
+  if (s > 0.47 && s < 0.53) return 'southern winter'
+  if (s > 0.22 && s < 0.28) return 'equinox'
+  if (s > 0.72 && s < 0.78) return 'equinox'
+  return s < 0.5 ? 'toward winter' : 'toward summer'
+}
+
+function Row({
+  label,
+  value,
+  hint,
+  min = 0,
+  max = 1,
+  step,
+  onChange,
+}: {
+  label: string
+  value: number
+  hint: string
+  min?: number
+  max?: number
+  step: number
+  onChange: (v: number) => void
+}) {
+  return (
+    <label className="block">
+      <span className="flex items-baseline justify-between gap-3 text-[10px] uppercase tracking-wide text-white/40">
+        {label}
+        <span className="normal-case tracking-normal text-white/60">{hint}</span>
+      </span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="mt-1 h-1 w-full cursor-pointer appearance-none rounded-full bg-white/15 accent-amber-300"
+        aria-label={label}
+      />
+    </label>
+  )
+}
+
+export default function SunScrubber({ phase, onChange }: SunScrubberProps) {
+  const active = phase !== null
+
+  // Readouts come from sunAt rather than from anything this component works out
+  // itself, so what is displayed is by construction the same vector the light and the
+  // skyline test are using. A HUD that computes its own copy of the sun is how you
+  // end up confidently reading off a number the renderer disagrees with.
+  const read = useMemo(() => (phase ? sunAt(phase) : null), [phase])
+
+  if (!active) {
+    return (
+      <button
+        type="button"
+        onClick={() => onChange({ lunarDay: 0, season: 0 })}
+        title={`Light the scene with the sun this ridge actually gets — never above ${maxElevationDeg().toFixed(
+          1
+        )}°, against the ${SUN_LOCAL_ELEV_DEG}° the base was drawn for`}
+        className="absolute bottom-4 left-4 z-30 flex items-center gap-1.5 rounded-lg border border-white/10 bg-black/40 px-2.5 py-1.5 text-[11px] font-medium text-white/60 backdrop-blur-md transition-colors hover:border-white/25 hover:text-white"
+      >
+        <span aria-hidden className="text-amber-300/80">
+          ☀
+        </span>
+        Real sun
+      </button>
+    )
+  }
+
+  const p = phase as SunPhase
+  const dark = (read?.elevationDeg ?? 0) <= 0
+
+  return (
+    <div className="absolute bottom-4 left-4 z-30 w-[15.5rem] rounded-lg border border-white/10 bg-black/60 p-3 backdrop-blur-md">
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-1.5 text-[11px] font-medium text-white">
+          <span aria-hidden className="text-amber-300/80">
+            ☀
+          </span>
+          Real sun
+        </span>
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          title="Back to the 44.46° sun the base was designed around"
+          className="rounded px-1.5 py-0.5 text-[10px] text-white/40 transition-colors hover:bg-white/10 hover:text-white"
+        >
+          Design sun
+        </button>
+      </div>
+
+      {/* The two numbers worth watching. Elevation is the whole story — it is what
+          decides whether the skyline shadows anything at all — and bearing is which
+          way the shadows point, which is the thing that moves as the month runs. */}
+      <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-0.5 text-[11px] tabular-nums">
+        <dt className="text-white/40">elevation</dt>
+        <dd className={`text-right ${dark ? 'text-sky-300' : 'text-white'}`}>
+          {(read?.elevationDeg ?? 0) >= 0 ? '+' : '−'}
+          {Math.abs(read?.elevationDeg ?? 0).toFixed(2)}°
+        </dd>
+        <dt className="text-white/40">bearing</dt>
+        <dd className="text-right text-white">{(read?.bearingDeg ?? 0).toFixed(0)}°</dd>
+      </dl>
+
+      {/* Not an error state, which is exactly why it is called out: the sun really is
+          below local horizontal for about two fifths of the year here, and a viewer
+          who scrubs into that without being told will read a correct dark frame as a
+          broken one. */}
+      {dark && (
+        <p className="mt-1.5 text-[10px] leading-snug text-sky-300/80">
+          Sun below local horizontal — the site is in darkness. This is ~2/5 of the
+          lunar year at this ridge.
+        </p>
+      )}
+
+      <div className="mt-2.5 space-y-2.5">
+        <Row
+          label="lunar day"
+          value={p.lunarDay}
+          hint={`${(p.lunarDay * SYNODIC_MONTH_DAYS).toFixed(1)} / ${SYNODIC_MONTH_DAYS.toFixed(
+            1
+          )} d`}
+          step={0.002}
+          onChange={(lunarDay) => onChange({ ...p, lunarDay })}
+        />
+        <Row
+          label="season"
+          value={p.season}
+          hint={seasonLabel(p.season)}
+          step={0.004}
+          onChange={(season) => onChange({ ...p, season })}
+        />
+      </div>
+
+      {/* Subsolar latitude is the season slider's actual physical content, and it is
+          worth showing because its range is the surprise: the Moon's whole obliquity
+          is 1.54°, so this entire slider moves the sun by about three degrees. That
+          tiny number is the difference between a lit ridge and a dark one. */}
+      <p className="mt-2 text-[10px] leading-snug text-white/35">
+        Subsolar latitude {subsolarLatDeg(p.season).toFixed(2)}°, over a{' '}
+        {SEASON_PERIOD_DAYS.toFixed(0)}-day approximation of the lunar year.
+      </p>
+    </div>
+  )
+}

--- a/ui/components/lunar-atlas/regolithOcclusion.ts
+++ b/ui/components/lunar-atlas/regolithOcclusion.ts
@@ -1,0 +1,172 @@
+// The skyline field, on the GPU, shared by every regolith surface in the scene.
+//
+// horizon.ts computes what each patch of ground can see; regolithShader.ts contains
+// the GLSL that reads it. This is the bit in between: it turns the field into
+// textures, and it owns the uniform objects that the terrain, the roads, the spoil
+// and the rubble all bind.
+//
+// ONE SET OF UNIFORM OBJECTS, deliberately. three's uniforms are `{ value }` boxes
+// held by reference, so handing the SAME box to every material means the sun is
+// moved in one assignment and nothing can be left behind on the old one. The
+// alternative — a copy per material, updated in a loop — is how a road ends up lit
+// by last frame's sun, and that failure is invisible in a still frame.
+//
+// It also means the field is built once. It costs 148 ms on the real DEM and about
+// 2 MB of GPU memory, and the payload is zero because it is derived from the height
+// map that was already downloaded.
+import * as THREE from 'three'
+import {
+  HORIZON_AZIMUTHS,
+  HORIZON_SIZE,
+  buildHorizonField,
+  type HorizonField,
+} from '@/lib/lunar-atlas/horizon'
+import { CAP_EXTENT_M, MAP_X_DIR, M_TO_UNITS, capCenterDirection } from '@/lib/lunar-atlas/southpole'
+import { GLOBE_RADIUS } from '@/lib/lunar-atlas/textures'
+import { SUN_ANGULAR_RADIUS_RAD, SUN_DIR } from '@/lib/lunar-atlas/sun'
+import { loadInnerField } from './useTerrainSampler'
+
+const HORIZON_TEXTURES = Math.ceil(HORIZON_AZIMUTHS / 4)
+
+// ---------------------------------------------------------------------------
+// The patch's tangent frame, for surfaces that have to find themselves in the
+// field from a world position rather than from a patch UV.
+//
+// Built from the same MAP_X_DIR the terrain's per-pixel normals use, and with the
+// same cross-product convention (north = up x east), so a road and the ground under
+// it cannot disagree about which way the field is oriented.
+// ---------------------------------------------------------------------------
+const patchUp = new THREE.Vector3(...capCenterDirection())
+const patchEast = new THREE.Vector3(...MAP_X_DIR)
+  .addScaledVector(patchUp, -new THREE.Vector3(...MAP_X_DIR).dot(patchUp))
+  .normalize()
+const patchNorth = new THREE.Vector3().crossVectors(patchUp, patchEast)
+// Radius is nearly irrelevant here: the offset is projected onto two TANGENT
+// directions, so a radial error contributes nothing to first order. It is set to the
+// globe radius rather than to the ridge's own height for that reason.
+const patchOrigin = patchUp.clone().multiplyScalar(GLOBE_RADIUS)
+
+// Stand-ins until the field is built, chosen so the scene before and after the load
+// are the same picture. A zero skyline is level, which shadows nothing for any sun
+// above the horizontal; a sky view of 1 is open ground, which is what
+// bounceRadiance is already calibrated for. Getting either default backwards would
+// show up as the ground changing brightness a second after it appears.
+function placeholder(value: number, format: THREE.PixelFormat, channels: number) {
+  const data = new Uint16Array(channels)
+  data.fill(THREE.DataUtils.toHalfFloat(value))
+  const tex = new THREE.DataTexture(data, 1, 1, format, THREE.HalfFloatType)
+  tex.needsUpdate = true
+  return tex
+}
+
+const LEVEL_SKYLINE = placeholder(0, THREE.RGBAFormat, 4)
+const OPEN_SKY = placeholder(1, THREE.RedFormat, 1)
+
+// ---------------------------------------------------------------------------
+// The shared uniforms
+// ---------------------------------------------------------------------------
+export type OcclusionUniforms = Record<string, THREE.IUniform>
+
+function initialUniforms(): OcclusionUniforms {
+  const u: OcclusionUniforms = {
+    skyViewMap: { value: OPEN_SKY },
+    // The DESIGN sun, so that landing this changes nothing. tan(44.46°) is 0.98
+    // against a measured maximum skyline tangent of 0.51 anywhere on the patch, so
+    // every fragment resolves to "lit" and the occlusion is a provable no-op until
+    // something points this at sunpath.ts.
+    sunWorldDir: { value: new THREE.Vector3(...SUN_DIR) },
+    patchOrigin: { value: patchOrigin },
+    patchEast: { value: patchEast },
+    patchNorth: { value: patchNorth },
+    patchInvExtent: { value: 1 / (CAP_EXTENT_M * M_TO_UNITS) },
+    // Half-width of the terminator, in the same tangent units as the comparison.
+    // The sun's own angular radius: at these elevations tan and the angle agree to
+    // better than a part in a thousand, so no correction is worth making.
+    sunDiscTan: { value: SUN_ANGULAR_RADIUS_RAD },
+  }
+  for (let t = 0; t < HORIZON_TEXTURES; t++) u[`horizonMap${t}`] = { value: LEVEL_SKYLINE }
+  return u
+}
+
+export const REGOLITH_OCCLUSION_UNIFORMS = initialUniforms()
+
+// Point the scene at a sun. The only mutation any caller needs: every regolith
+// material reads this same box.
+export function setOcclusionSun(dir: readonly [number, number, number]): void {
+  ;(REGOLITH_OCCLUSION_UNIFORMS.sunWorldDir.value as THREE.Vector3).set(dir[0], dir[1], dir[2])
+}
+
+// ---------------------------------------------------------------------------
+// Building the textures
+// ---------------------------------------------------------------------------
+
+// Bins four to an RGBA texture: texture t, channel c holds azimuth 4t + c. This
+// pairing is what lets the shader read all sixteen with a fixed four fetches and no
+// dynamically indexed sampler — see REGOLITH_OCCLUSION_GLSL.
+//
+// Row order is the height field's, row 0 at map north, which is also what the normal
+// texture uses. Both are sampled with the same vUv, so they are right or wrong
+// together rather than independently.
+function toHorizonTextures(field: HorizonField): THREE.DataTexture[] {
+  const { size, azimuths, horizonTan } = field
+  const out: THREE.DataTexture[] = []
+  for (let t = 0; t < HORIZON_TEXTURES; t++) {
+    const data = new Uint16Array(size * size * 4)
+    for (let p = 0; p < size * size; p++) {
+      for (let c = 0; c < 4; c++) {
+        const a = t * 4 + c
+        const v = a < azimuths ? horizonTan[p * azimuths + a] : 0
+        data[p * 4 + c] = THREE.DataUtils.toHalfFloat(v)
+      }
+    }
+    const tex = new THREE.DataTexture(data, size, size, THREE.RGBAFormat, THREE.HalfFloatType)
+    // Linear in space so a terminator moves smoothly across the 62.5 m grid instead
+    // of stepping texel to texel. NO mipmaps: this is not a colour, it is a
+    // threshold, and a mip level would average a ridge away and let the sun through
+    // a hill at distance.
+    tex.magFilter = THREE.LinearFilter
+    tex.minFilter = THREE.LinearFilter
+    tex.generateMipmaps = false
+    tex.wrapS = THREE.ClampToEdgeWrapping
+    tex.wrapT = THREE.ClampToEdgeWrapping
+    tex.needsUpdate = true
+    out.push(tex)
+  }
+  return out
+}
+
+function toSkyViewTexture(field: HorizonField): THREE.DataTexture {
+  const half = new Uint16Array(field.skyView.length)
+  for (let i = 0; i < half.length; i++) half[i] = THREE.DataUtils.toHalfFloat(field.skyView[i])
+  const tex = new THREE.DataTexture(half, field.size, field.size, THREE.RedFormat, THREE.HalfFloatType)
+  tex.magFilter = THREE.LinearFilter
+  tex.minFilter = THREE.LinearFilter
+  tex.generateMipmaps = false
+  tex.needsUpdate = true
+  return tex
+}
+
+let building: Promise<void> | null = null
+
+// Build the field and hand it to the shared uniforms. Idempotent and safe to call
+// from every component that needs it — whichever mounts first does the work.
+export function primeRegolithOcclusion(): Promise<void> {
+  if (building) return building
+  building = loadInnerField().then((heights) => {
+    const field = buildHorizonField(heights)
+    const maps = toHorizonTextures(field)
+    maps.forEach((tex, t) => {
+      REGOLITH_OCCLUSION_UNIFORMS[`horizonMap${t}`].value = tex
+    })
+    REGOLITH_OCCLUSION_UNIFORMS.skyViewMap.value = toSkyViewTexture(field)
+  })
+  return building
+}
+
+// Everything the shader needs, ready to merge into a material's uniforms.
+export function bindOcclusionUniforms(uniforms: OcclusionUniforms): void {
+  for (const [name, box] of Object.entries(REGOLITH_OCCLUSION_UNIFORMS)) uniforms[name] = box
+}
+
+export const HORIZON_TEXTURE_COUNT = HORIZON_TEXTURES
+export const HORIZON_FIELD_SIZE = HORIZON_SIZE

--- a/ui/components/lunar-atlas/regolithOcclusion.ts
+++ b/ui/components/lunar-atlas/regolithOcclusion.ts
@@ -23,7 +23,13 @@ import {
 } from '@/lib/lunar-atlas/horizon'
 import { CAP_EXTENT_M, MAP_X_DIR, M_TO_UNITS, capCenterDirection } from '@/lib/lunar-atlas/southpole'
 import { GLOBE_RADIUS } from '@/lib/lunar-atlas/textures'
-import { SUN_ANGULAR_RADIUS_RAD, SUN_DIR } from '@/lib/lunar-atlas/sun'
+import {
+  SUN_ANGULAR_RADIUS_RAD,
+  SUN_DIR,
+  SUN_INTENSITY,
+  SUN_LOCAL_ELEV_DEG,
+} from '@/lib/lunar-atlas/sun'
+import { litGroundRadiance, shadowFillRadiance } from '@/lib/lunar-atlas/regolith'
 import { loadInnerField } from './useTerrainSampler'
 
 const HORIZON_TEXTURES = Math.ceil(HORIZON_AZIMUTHS / 4)
@@ -70,6 +76,14 @@ export type OcclusionUniforms = Record<string, THREE.IUniform>
 function initialUniforms(): OcclusionUniforms {
   const u: OcclusionUniforms = {
     skyViewMap: { value: OPEN_SKY },
+    // The fill in every shadow, and now shared rather than computed twice.
+    //
+    // SouthPoleTerrain and BaseRoads each used to derive this from the same
+    // expression, with a comment in each explaining that they had to agree — a road
+    // in shadow cannot sit at a different depth from the ground it crosses. Agreeing
+    // by duplication is the weakest form of agreeing, and it also could not survive a
+    // sun that moves, since the fill scales with the sun's elevation.
+    bounceRadiance: { value: 0 },
     // The DESIGN sun, so that landing this changes nothing. tan(44.46°) is 0.98
     // against a measured maximum skyline tangent of 0.51 anywhere on the patch, so
     // every fragment resolves to "lit" and the occlusion is a provable no-op until
@@ -90,11 +104,32 @@ function initialUniforms(): OcclusionUniforms {
 
 export const REGOLITH_OCCLUSION_UNIFORMS = initialUniforms()
 
-// Point the scene at a sun. The only mutation any caller needs: every regolith
-// material reads this same box.
-export function setOcclusionSun(dir: readonly [number, number, number]): void {
+// Start on the design sun, so the module's initial state is the scene as it ships and
+// bounceRadiance is never briefly zero. setRegolithSun is a hoisted declaration, so
+// this runs after the boxes above exist.
+setRegolithSun(SUN_DIR, SUN_LOCAL_ELEV_DEG)
+
+// Point the whole scene at a sun. The only mutation any caller needs, and the only
+// place the sun's elevation turns into a shadow depth.
+//
+// Everything here scales with the sun rather than being pinned to it, which is what
+// makes a moving sun cost nothing: litGroundRadiance and shadowFillRadiance have been
+// functions of elevation since the Hapke work, precisely so this call could exist.
+export function setRegolithSun(
+  dir: readonly [number, number, number],
+  elevationDeg: number
+): void {
   ;(REGOLITH_OCCLUSION_UNIFORMS.sunWorldDir.value as THREE.Vector3).set(dir[0], dir[1], dir[2])
+  // Below the horizontal there is no lit ground in view to bounce anything, so the
+  // fill goes to zero rather than negative. The DIRECT term is still allowed through
+  // by the skyline test, which is the case a crest at dawn depends on.
+  const lit = elevationDeg > 0 ? litGroundRadiance(SUN_INTENSITY, elevationDeg) : 0
+  REGOLITH_OCCLUSION_UNIFORMS.bounceRadiance.value = shadowFillRadiance(lit)
 }
+
+// Exposure lives in lib/lunar-atlas/sun.ts — it is a fact about the sun rather than
+// about the ground, and keeping it out of a module that imports THREE is what makes it
+// testable. MoonGlobe imports it from there directly.
 
 // ---------------------------------------------------------------------------
 // Building the textures

--- a/ui/components/lunar-atlas/regolithOcclusion.ts
+++ b/ui/components/lunar-atlas/regolithOcclusion.ts
@@ -30,9 +30,21 @@ import {
   SUN_LOCAL_ELEV_DEG,
 } from '@/lib/lunar-atlas/sun'
 import { litGroundRadiance, shadowFillRadiance } from '@/lib/lunar-atlas/regolith'
+import {
+  HARDWARE_OCCLUSION_FRAGMENT_PATCHES,
+  HARDWARE_OCCLUSION_VERTEX_PATCHES,
+  applyShaderPatches,
+} from '@/lib/lunar-atlas/regolithShader'
 import { loadInnerField } from './useTerrainSampler'
 
 const HORIZON_TEXTURES = Math.ceil(HORIZON_AZIMUTHS / 4)
+
+// The colour and strength of the base's own working lights. Cool white, because
+// every surface fixture flown or proposed is an LED array — and slightly blue
+// against the warm-grey sun, which is what makes a lit lot read as artificially
+// lit rather than as underexposed daylight.
+const SITE_LIGHT_COLOR = '#cdd8ff'
+const SITE_LIGHT_RADIANCE = 0.045
 
 // ---------------------------------------------------------------------------
 // The patch's tangent frame, for surfaces that have to find themselves in the
@@ -97,17 +109,41 @@ function initialUniforms(): OcclusionUniforms {
     // The sun's own angular radius: at these elevations tan and the angle agree to
     // better than a part in a thousand, so no correction is worth making.
     sunDiscTan: { value: SUN_ANGULAR_RADIUS_RAD },
+    // The base's own floodlighting on its hardware, applied only where the
+    // skyline has taken the sun away (see the hardware patches). Linear radiance
+    // in the same units as everything else here: 0.045 against a white hull's
+    // ~0.6 albedo lands a shadowed structure near sRGB 55 under the real sun —
+    // clearly readable, well under the ~130 the same hull renders in sunlight.
+    siteLight: {
+      value: new THREE.Color(SITE_LIGHT_COLOR).multiplyScalar(SITE_LIGHT_RADIANCE),
+    },
   }
   for (let t = 0; t < HORIZON_TEXTURES; t++) u[`horizonMap${t}`] = { value: LEVEL_SKYLINE }
   return u
 }
 
-export const REGOLITH_OCCLUSION_UNIFORMS = initialUniforms()
+// ONE SET PER PROCESS, guarded against Fast Refresh — not just one per module.
+//
+// Every regolith material captures these boxes by reference inside its
+// onBeforeCompile closure, and those materials outlive this module: in dev, editing
+// anything in the sun's import chain re-evaluates this file while the compiled
+// terrain lives on. Without the guard that re-evaluation minted a FRESH set of boxes
+// and split the scene's brain — new components dutifully updating uniforms nothing
+// reads, old materials frozen on the last sun the dead boxes ever saw. It rendered as
+// half the map black under the design sun, with the frozen terrain shadows refusing
+// to follow the scrubber. Production cannot hit this (modules evaluate once); the
+// guard exists so a hot edit cannot manufacture that bug on a dev's screen either.
+const hmr = globalThis as { __moonbaseOcclusionUniforms?: OcclusionUniforms }
+const firstEvaluation = !hmr.__moonbaseOcclusionUniforms
+export const REGOLITH_OCCLUSION_UNIFORMS = (hmr.__moonbaseOcclusionUniforms ??=
+  initialUniforms())
 
-// Start on the design sun, so the module's initial state is the scene as it ships and
-// bounceRadiance is never briefly zero. setRegolithSun is a hoisted declaration, so
-// this runs after the boxes above exist.
-setRegolithSun(SUN_DIR, SUN_LOCAL_ELEV_DEG)
+// Start on the design sun, so the initial state is the scene as it ships and
+// bounceRadiance is never briefly zero. Only on the FIRST evaluation: a re-evaluation
+// while a real sun is up must not yank the survivors' shared boxes back to the design
+// sun behind the mounted Sun component's back. (setRegolithSun is a hoisted
+// declaration, so this runs after the boxes above exist.)
+if (firstEvaluation) setRegolithSun(SUN_DIR, SUN_LOCAL_ELEV_DEG)
 
 // Point the whole scene at a sun. The only mutation any caller needs, and the only
 // place the sun's elevation turns into a shadow depth.
@@ -201,6 +237,38 @@ export function primeRegolithOcclusion(): Promise<void> {
 // Everything the shader needs, ready to merge into a material's uniforms.
 export function bindOcclusionUniforms(uniforms: OcclusionUniforms): void {
   for (const [name, box] of Object.entries(REGOLITH_OCCLUSION_UNIFORMS)) uniforms[name] = box
+}
+
+// Put a piece of HARDWARE under the skyline: same occlusion the terrain evaluates,
+// gating only the direct sun, leaving the material's own PBR/emissive/indirect alone
+// (see the patch definitions for the argument). Safe on shared materials — the
+// occlusion is computed per fragment from the fragment's own world position, so one
+// material serving fifty rovers shades each of them by where it actually stands.
+//
+// Idempotent via the userData flag, because the traversal that calls this re-runs as
+// GLB children stream in, and re-wrapping onBeforeCompile on each pass would stack
+// the patches until an anchor missed and threw. Basic/unlit materials are skipped:
+// they are markers and decals, not lit hardware.
+export function occludeHardwareMaterial(mat: THREE.Material): void {
+  if (!(mat as THREE.MeshStandardMaterial).isMeshStandardMaterial) return
+  if (mat.userData.regolithOccluded) return
+  mat.userData.regolithOccluded = true
+  const prior = mat.onBeforeCompile
+  mat.onBeforeCompile = (shader, renderer) => {
+    prior?.(shader, renderer)
+    bindOcclusionUniforms(shader.uniforms as OcclusionUniforms)
+    shader.vertexShader = applyShaderPatches(
+      shader.vertexShader,
+      HARDWARE_OCCLUSION_VERTEX_PATCHES
+    )
+    shader.fragmentShader = applyShaderPatches(
+      shader.fragmentShader,
+      HARDWARE_OCCLUSION_FRAGMENT_PATCHES
+    )
+  }
+  // The material may already be compiled by the time the traversal reaches it —
+  // GLB subtrees mount through Suspense after their anchor's first render.
+  mat.needsUpdate = true
 }
 
 export const HORIZON_TEXTURE_COUNT = HORIZON_TEXTURES

--- a/ui/cypress/integration/unit/lunar-atlas-regolith-shader.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-regolith-shader.cy.ts
@@ -28,6 +28,8 @@ import {
   DETAIL_OCTAVES,
   GRADED_SURFACE_FRAGMENT_PATCHES,
   GRADED_SURFACE_VERTEX_PATCHES,
+  HARDWARE_OCCLUSION_FRAGMENT_PATCHES,
+  HARDWARE_OCCLUSION_VERTEX_PATCHES,
   STAIN_FRAGMENT_PATCHES,
   TERRAIN_FRAGMENT_PATCHES,
   TERRAIN_VERTEX_PATCHES,
@@ -539,5 +541,82 @@ describe('stain patches against three s real Basic source', () => {
     const chunkCount = src.match(/#include <colorspace_fragment>/g) ?? []
     expect(chunkCount.length).to.equal(1)
     expect(src.slice(src.indexOf('#include <colorspace_fragment>'))).to.not.contain('gl_FragColor.rgb =')
+  })
+})
+
+describe('hardware occlusion patches against three s real Standard and Physical sources', () => {
+  // The patches that stop a lander parked inside a kilometre-long terrain shadow
+  // from rendering in full sun. They are applied to whatever material a model
+  // shipped with — GLB imports and hand-built meshes both — so they have to hold
+  // against BOTH standard and physical, and a missed anchor here is a model going
+  // black at mount, inside onBeforeCompile, where no build step sees it.
+  for (const key of ['standard', 'physical'] as const) {
+    it(`applies cleanly to ShaderLib.${key}`, () => {
+      const shader = ShaderLib[key]
+      expect(() =>
+        applyShaderPatches(shader.vertexShader, HARDWARE_OCCLUSION_VERTEX_PATCHES)
+      ).to.not.throw()
+      expect(() =>
+        applyShaderPatches(shader.fragmentShader, HARDWARE_OCCLUSION_FRAGMENT_PATCHES)
+      ).to.not.throw()
+    })
+  }
+
+  const frag = resolveIncludes(
+    applyShaderPatches(ShaderLib.physical.fragmentShader, HARDWARE_OCCLUSION_FRAGMENT_PATCHES)
+  )
+  const vert = resolveIncludes(
+    applyShaderPatches(ShaderLib.physical.vertexShader, HARDWARE_OCCLUSION_VERTEX_PATCHES)
+  )
+
+  it('declares the world-position varying on both sides of the pipe', () => {
+    expect(vert).to.contain('varying vec3 vRegolithWorldPos')
+    expect(frag).to.contain('varying vec3 vRegolithWorldPos')
+  })
+
+  it('evaluates the occlusion before the light loop and from the world position', () => {
+    // Hardware UVs mean whatever the modeller meant by them, so the skyline lookup
+    // must reconstruct the patch UV from the world — anchoring on the mesh's own uv
+    // would sample the horizon at a texture coordinate, not at a place.
+    const evalAt = frag.indexOf('regolithApplyOcclusion(regolithPatchUv(vRegolithWorldPos)')
+    expect(evalAt).to.be.greaterThan(-1)
+    expect(evalAt).to.be.lessThan(frag.indexOf('RE_Direct('))
+  })
+
+  it('gates ONLY the direct terms, after the loop', () => {
+    // Equivalent to attenuating the light itself precisely because the scene has
+    // one direct light — and it must leave indirect alone: the environment map IS
+    // the regolith bounce, which is exactly what still reaches a shadowed lander.
+    const dd = frag.indexOf('reflectedLight.directDiffuse *= regolithDirectOcclusion')
+    const ds = frag.indexOf('reflectedLight.directSpecular *= regolithDirectOcclusion')
+    expect(dd).to.be.greaterThan(-1)
+    expect(ds).to.be.greaterThan(-1)
+    expect(frag).to.not.contain('indirectDiffuse *= regolithDirectOcclusion')
+    expect(frag).to.not.contain('indirectSpecular *= regolithDirectOcclusion')
+    // And it keeps the material's own BRDF: this is a gate, not the Hapke swap the
+    // regolith surfaces get.
+    expect(frag).to.not.contain('RE_Direct_Hapke')
+  })
+
+  it('defaults to fully lit, so the design sun cannot be changed by mounting it', () => {
+    // The declaration initialises to 1.0 and tan(44.46°) beats every skyline tangent
+    // on the patch, so at the design sun this whole mechanism is a provable no-op.
+    expect(frag).to.contain('float regolithDirectOcclusion = 1.0')
+  })
+
+  it('fades the site floodlighting in by exactly what it fades the sun out by', () => {
+    // The base's own lighting, so hardware in a terrain shadow is readable rather
+    // than a silhouette. The (1.0 - occlusion) weight is what makes it safe: it is
+    // identically zero wherever the sun reaches, and the sun reaches everywhere at
+    // the design sun, so this cannot alter the shipped view. A constant fill, or one
+    // weighted any other way, would wash out the daylight frame.
+    expect(frag).to.contain('uniform vec3 siteLight')
+    expect(frag).to.contain(
+      'reflectedLight.indirectDiffuse += siteLight * (1.0 - regolithDirectOcclusion)'
+    )
+    // Indirect, not direct: added to the direct term it would be multiplied by the
+    // very occlusion it is derived from and vanish. Anchored on the full member
+    // expression because "indirectDiffuse" ends with the string "directDiffuse".
+    expect(frag).to.not.contain('reflectedLight.directDiffuse += siteLight')
   })
 })

--- a/ui/cypress/integration/unit/lunar-atlas-regolith-shader.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-regolith-shader.cy.ts
@@ -23,9 +23,11 @@
 import { expect } from 'chai'
 import { ShaderChunk, ShaderLib } from 'three'
 import { SINGLE_SCATTERING_ALBEDO } from '../../../lib/lunar-atlas/regolith'
+import { HORIZON_AZIMUTHS } from '../../../lib/lunar-atlas/horizon'
 import {
   DETAIL_OCTAVES,
   GRADED_SURFACE_FRAGMENT_PATCHES,
+  GRADED_SURFACE_VERTEX_PATCHES,
   STAIN_FRAGMENT_PATCHES,
   TERRAIN_FRAGMENT_PATCHES,
   TERRAIN_VERTEX_PATCHES,
@@ -109,9 +111,19 @@ describe('terrain shader patches against three s real Lambert source', () => {
       // sun puts everything.
       const body = src.slice(src.indexOf('void RE_Direct_Hapke('))
       const accumulation = body.slice(0, body.indexOf('#define RE_Direct'))
-      expect(accumulation).to.contain('directLight.color * r * material.diffuseColor')
+      expect(accumulation).to.contain('r * material.diffuseColor')
       expect(accumulation).to.not.contain('BRDF_Lambert')
       expect(accumulation).to.not.contain('dotNL')
+    })
+
+    it('attenuates the direct term by the skyline test as well as the shadow map', () => {
+      // The two occlude different things — a habitat's own shadow, and a ridge 6 km
+      // away that no shadow map covers — so a point can be in both and they multiply.
+      // Dropping either would light 57% of the patch that should be dark at the real
+      // sun, or lose every cast shadow on the base.
+      const body = src.slice(src.indexOf('void RE_Direct_Hapke('))
+      const accumulation = body.slice(0, body.indexOf('#define RE_Direct'))
+      expect(accumulation).to.contain('directLight.color * regolithDirectOcclusion')
     })
 
     it('depends on USE_UV for the varying it samples with', () => {
@@ -186,14 +198,25 @@ describe('terrain shader patches against three s real Lambert source', () => {
     const src = applyShaderPatches(lambert.vertexShader, TERRAIN_VERTEX_PATCHES)
 
     it('declares and fills the world-position varying', () => {
-      expect(src).to.contain('varying vec3 vTerrainWorldPos;')
-      expect(src).to.contain('vTerrainWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;')
+      expect(src).to.contain('varying vec3 vRegolithWorldPos;')
+      expect(src).to.contain('vRegolithWorldPos = (modelMatrix * regolithWorld).xyz;')
     })
 
     it('fills it after the position is established', () => {
-      expect(src.indexOf('vTerrainWorldPos =')).to.be.greaterThan(
+      expect(src.indexOf('vRegolithWorldPos =')).to.be.greaterThan(
         src.indexOf('#include <begin_vertex>')
       )
+    })
+
+    it('applies the instance transform, for the surfaces that are instanced', () => {
+      // The terrain is not instanced, but this is the SAME patch the graded surfaces
+      // use, and BaseRoads draws its boulders as an InstancedMesh. three applies
+      // instanceMatrix inside project_vertex, so `transformed` alone is
+      // instance-local: without this every boulder would look up the skyline at the
+      // patch origin instead of at itself, and a rubble field 3 km away would be lit
+      // by the wrong shadow.
+      expect(src).to.contain('#ifdef USE_INSTANCING')
+      expect(src).to.contain('regolithWorld = instanceMatrix * regolithWorld;')
     })
 
     it('keeps three s shadow plumbing intact', () => {
@@ -279,7 +302,22 @@ describe('graded surface patches against three s real Standard source', () => {
 
   it('fills its shadows, so a road cannot go black where the ground does not', () => {
     expect(program).to.match(/uniform\s+float\s+bounceRadiance\s*;/)
-    expect(src).to.contain('reflectedLight.indirectDiffuse += bounceRadiance * diffuseColor.rgb;')
+    expect(src).to.contain(
+      'reflectedLight.indirectDiffuse += bounceRadiance * (0.5 + 0.5 * regolithSkyView) * diffuseColor.rgb;'
+    )
+  })
+
+  it('leaves open ground exactly as bright as it was before sky visibility existed', () => {
+    // The factor has to be 1 at skyView = 1, or adding per-texel occlusion silently
+    // re-darkens every open shadow in the scene and the existing calibration of
+    // bounceRadiance stops meaning what regolith.ts says it means. Checked as
+    // arithmetic on the actual coefficients rather than by reading the line, because
+    // "0.5 + 0.5 * x" is easy to mistype as something that is 0.5 at x = 1.
+    const m = src.match(/bounceRadiance \* \(([\d.]+) \+ ([\d.]+) \* regolithSkyView\)/)
+    expect(m, 'bounce factor must be an affine function of skyView').to.not.equal(null)
+    const [a, b] = [Number(m![1]), Number(m![2])]
+    expect(a + b, 'factor at skyView = 1').to.equal(1)
+    expect(a, 'factor at skyView = 0').to.be.greaterThan(0)
   })
 
   it('keeps the maps and vertex colours the surface is authored with', () => {
@@ -310,13 +348,144 @@ describe('graded surface patches against three s real Standard source', () => {
     expect(uses.length).to.equal(1)
   })
 
-  it('does not carry the terrain s uniforms, which it has no geometry for', () => {
+  it('does not carry the terrain s own relief uniforms, which it has no geometry for', () => {
     // The graded surfaces have their own normal maps in the map frame of the road,
     // not the patch. Declaring the terrain's uniforms here would compile and then
     // sample an unbound sampler.
+    //
+    // The skyline uniforms are deliberately NOT in this list: those are shared, and
+    // the whole argument for sharing them is that a road and the ground it crosses
+    // are in the same shadow.
     expect(src).to.not.contain('terrainNormalMap')
     expect(src).to.not.contain('detailSlopeMap')
-    expect(src).to.not.contain('vTerrainWorldPos')
+  })
+
+  it('reconstructs its place in the skyline field from the world, not from its own UVs', () => {
+    // A road's UVs run ALONG the road so the crust and wheel tracks tile down it.
+    // Feeding those to the skyline lookup would sample the horizon field as though
+    // the road were the whole patch, which would light it by the shadow of somewhere
+    // else entirely — and would still look like plausible lighting.
+    expect(src).to.contain('regolithApplyOcclusion(regolithPatchUv(vRegolithWorldPos)')
+    expect(src).to.not.contain('regolithApplyOcclusion(vUv')
+  })
+})
+
+// The skyline lookup is shared by both material classes above, and it is the one
+// piece of this file whose failure mode is not "wrong brightness" but "lit by the
+// shadow of the wrong place". It also has to be a provable no-op at the sun the
+// scene currently uses, or landing it ahead of that sun would change the render.
+describe('the shared skyline occlusion', () => {
+  const terrain = applyShaderPatches(lambert.fragmentShader, TERRAIN_FRAGMENT_PATCHES)
+  const graded = applyShaderPatches(ShaderLib.physical.fragmentShader, GRADED_SURFACE_FRAGMENT_PATCHES)
+
+  it('supplies the world position to BOTH material classes vertex shaders', () => {
+    // The fragment patches reference vRegolithWorldPos, so a material that gets them
+    // without the vertex half does not compile at all. applyShaderPatches throws on a
+    // missed anchor, which is the good outcome, but it throws at MOUNT — inside
+    // onBeforeCompile — where it blanks the roads rather than failing a build. This is
+    // the case that was missing coverage: the terrain's vertex patches were tested
+    // against Lambert, and the identical patches then went onto Standard untested.
+    for (const [name, vertexSrc, patches] of [
+      ['lambert', lambert.vertexShader, TERRAIN_VERTEX_PATCHES],
+      ['physical', ShaderLib.physical.vertexShader, GRADED_SURFACE_VERTEX_PATCHES],
+      ['standard', ShaderLib.standard.vertexShader, GRADED_SURFACE_VERTEX_PATCHES],
+    ] as [string, string, typeof TERRAIN_VERTEX_PATCHES][]) {
+      expect(() => applyShaderPatches(vertexSrc, patches), name).to.not.throw()
+      const out = applyShaderPatches(vertexSrc, patches)
+      expect(out, `${name} declares it`).to.contain('varying vec3 vRegolithWorldPos;')
+      expect(out, `${name} fills it`).to.contain('vRegolithWorldPos = (modelMatrix * regolithWorld).xyz;')
+    }
+  })
+
+  it('declares the varying on both sides of every regolith material', () => {
+    // Declared in the fragment shader by the shared declarations and in the vertex
+    // shader by the patches above. A varying present on only one side compiles on some
+    // drivers and not others, which is the worst way to find out.
+    for (const [name, src] of [
+      ['terrain', terrain],
+      ['graded', graded],
+    ] as [string, string][]) {
+      expect(src, name).to.contain('varying vec3 vRegolithWorldPos;')
+    }
+  })
+
+  it('runs before the light loop that reads it', () => {
+    for (const [name, src] of [
+      ['terrain', terrain],
+      ['graded', graded],
+    ] as [string, string][]) {
+      const call = src.indexOf('regolithApplyOcclusion(')
+      const lights = src.indexOf('#include <lights_fragment_begin>')
+      expect(call, `${name} must call it`).to.be.greaterThan(-1)
+      expect(call, `${name} must call it before the lights`).to.be.lessThan(lights)
+    }
+  })
+
+  it('defaults to fully lit and fully open', () => {
+    // Any material that gets the declarations but never calls the function must
+    // behave exactly as it did before this existed. That is what makes the shared
+    // declarations safe to put in front of every regolith material at once.
+    expect(terrain).to.contain('float regolithDirectOcclusion = 1.0;')
+    expect(terrain).to.contain('float regolithSkyView = 1.0;')
+  })
+
+  it('reads every azimuth bin the builder writes', () => {
+    // A mismatch here does not fail: the shader would interpolate across the bins it
+    // knows about and quietly ignore the rest, so a quarter of the compass would be
+    // lit by its neighbour's skyline.
+    const textures = Math.ceil(HORIZON_AZIMUTHS / 4)
+    for (let t = 0; t < textures; t++) {
+      expect(terrain, `horizonMap${t}`).to.match(
+        new RegExp(`uniform\\s+sampler2D\\s+horizonMap${t}\\s*;`)
+      )
+      expect(terrain).to.contain(`dot(texture2D(horizonMap${t}, uv), w${t})`)
+    }
+    // And no more than that, or a sampler goes unbound.
+    expect(terrain).to.not.contain(`horizonMap${textures}`)
+    const tents = terrain.match(/hzTent\(a, [\d.]+\)/g) ?? []
+    expect(tents.length).to.equal(HORIZON_AZIMUTHS)
+  })
+
+  it('wraps the azimuth tent, so the sun crossing bin 0 is not a discontinuity', () => {
+    // Without the wrap the sun would get no skyline at all between the last bin and
+    // the first, which is a 22.5-degree wedge of the compass that the terrain stops
+    // shadowing once a month.
+    expect(terrain).to.contain(`d = min(d, ${HORIZON_AZIMUTHS.toFixed(1)} - d);`)
+    expect(terrain).to.contain(`a = mod(a, ${HORIZON_AZIMUTHS.toFixed(1)});`)
+  })
+
+  it('compares tangents, and softens by the sun s own angular size', () => {
+    // Tangents because that is what horizon.ts stores, and because it avoids a trig
+    // call per fragment. The softness is the sun's disc rather than a chosen radius,
+    // which is the same argument MoonGlobe's shadow softness makes.
+    expect(terrain).to.contain(
+      'smoothstep(horizonTan - sunDiscTan, horizonTan + sunDiscTan, sunTan)'
+    )
+  })
+
+  it('takes the sun in each fragment s own local frame, not the patch s', () => {
+    // The local vertical turns through about 0.5 degrees across 16 km, which is a
+    // quarter of the real sun's entire elevation. A single patch-wide elevation would
+    // therefore be wrong by more than the thing being measured at the patch edges.
+    expect(terrain).to.contain('vec3 up = normalize(worldPos);')
+    expect(terrain).to.contain('float sunUp = dot(sunWorldDir, up);')
+  })
+
+  it('declares every uniform the components must bind', () => {
+    // An unbound sampler in WebGL quietly reads texture unit 0, so a missed binding
+    // here samples whatever happened to be bound last rather than failing.
+    for (const name of [
+      'skyViewMap',
+      'sunWorldDir',
+      'patchOrigin',
+      'patchEast',
+      'patchNorth',
+      'patchInvExtent',
+      'sunDiscTan',
+    ]) {
+      expect(terrain, name).to.match(new RegExp(`uniform\\s+\\w+\\s+${name}\\s*;`))
+      expect(graded, name).to.match(new RegExp(`uniform\\s+\\w+\\s+${name}\\s*;`))
+    }
   })
 })
 

--- a/ui/cypress/integration/unit/lunar-atlas-sunpath.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-sunpath.cy.ts
@@ -32,6 +32,7 @@ import {
   SUN_INTENSITY,
   SUN_LOCAL_ELEV_DEG,
   exposureFor,
+  screenAnchoredScale,
 } from '../../../lib/lunar-atlas/sun'
 import { litGroundRadiance, shadowFillRadiance } from '../../../lib/lunar-atlas/regolith'
 import { capCenterLatLon, capLocalDirection } from '../../../lib/lunar-atlas/southpole'
@@ -321,6 +322,33 @@ describe('exposing for the sun that is actually up', () => {
     for (const e of [maxElevationDeg(), 1.5, 1, 0.5, MIN_EXPOSURE_ELEV_DEG]) {
       expect(onScreen(e) / design, `elev ${e}`).to.be.closeTo(1, 1e-9)
     }
+  })
+
+  it('leaves screen-anchored things EXACTLY alone at the design sun', () => {
+    // The guarantee that the shipped frame does not move. Anything authored as a screen
+    // value — the backdrop, the starfield, MarkerLayer's beacons — is multiplied by
+    // this, so a scale of anything but exactly 1 here silently re-grades the default
+    // scene. Not "closeTo": exactly.
+    expect(screenAnchoredScale(SUN_LOCAL_ELEV_DEG)).to.equal(1)
+  })
+
+  it('cancels the exposure it is paired with, at every sun', () => {
+    // The property that makes it correct rather than merely small: scale x exposure is
+    // constant, so a screen-anchored colour lands on the same pixel value under any
+    // sun. This is what turned the navy sky back to black.
+    const design = screenAnchoredScale(SUN_LOCAL_ELEV_DEG) * exposureFor(SUN_LOCAL_ELEV_DEG)
+    for (const e of [maxElevationDeg(), 2, 1, 0.5, 0, -1.5]) {
+      expect(screenAnchoredScale(e) * exposureFor(e), `elev ${e}`).to.be.closeTo(design, 1e-9)
+    }
+  })
+
+  it('darkens screen-anchored things by the same 12.5x the exposure lifts', () => {
+    // Stated as a magnitude so the size of the correction is on the record: the
+    // backdrop has to be authored 12.5x darker in linear terms at the real sun to come
+    // out the same colour. That is the whole reason it read as navy before.
+    const scale = screenAnchoredScale(maxElevationDeg())
+    expect(scale).to.be.closeTo(1 / 12.5, 0.02)
+    expect(scale).to.be.lessThan(1)
   })
 
   it('puts the floor outside the range the scene is looked at', () => {

--- a/ui/cypress/integration/unit/lunar-atlas-sunpath.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-sunpath.cy.ts
@@ -28,6 +28,7 @@ import {
 } from '../../../lib/lunar-atlas/sunpath'
 import {
   DESIGN_EXPOSURE,
+  HIGHLIGHT_SLOPE_DEG,
   MIN_EXPOSURE_ELEV_DEG,
   SUN_INTENSITY,
   SUN_LOCAL_ELEV_DEG,
@@ -228,47 +229,63 @@ describe('lunar sun path: which way round the sky', () => {
 })
 
 describe('exposing for the sun that is actually up', () => {
-  // The reason exposure stopped being a constant. These are the assertions that let
-  // the change ship: the first one is the promise that nothing about the current
-  // frame moves, and the rest are the reason a constant could not have survived.
+  // The exposure POLICY is what these tests pin, because two wrong ones already
+  // shipped and each looked reasonable on paper (see the header in sun.ts). The
+  // policy is a photographer's: expose for the HIGHLIGHTS — a slope leaning
+  // HIGHLIGHT_SLOPE_DEG into the sun — and let flat ground fall away dark as the sun
+  // drops, because dark is what grazing light is.
 
   it('reproduces the shipped exposure EXACTLY at the design sun', () => {
-    // Not "close to" 1.05. The anchor is defined as the value that makes this
-    // identity hold, so any drift means the anchor and the renderer's default have
-    // come apart and the scene has silently re-exposed itself.
-    expect(exposureFor(SUN_LOCAL_ELEV_DEG)).to.be.closeTo(DESIGN_EXPOSURE, 1e-12)
+    // Not "close to". The design frame is the shipped scene and it must not move —
+    // this was violated once, by re-anchoring exposure to the old bake's 0.366, which
+    // re-graded the entire default view 4 stops brighter. equal(), so it cannot
+    // happen quietly again.
+    expect(DESIGN_EXPOSURE).to.equal(1.05)
+    expect(exposureFor(SUN_LOCAL_ELEV_DEG)).to.equal(DESIGN_EXPOSURE)
   })
 
-  it('opens up 3.6 stops for the real sun, which is the whole argument', () => {
-    // The number that makes a fixed exposure indefensible rather than merely dark:
-    // the real sun on the design exposure is not "a bit dim", it is 12x under.
-    const real = maxElevationDeg()
-    const ratio = exposureFor(real) / exposureFor(SUN_LOCAL_ELEV_DEG)
-    expect(ratio).to.be.closeTo(12.5, 0.3)
-    expect(Math.log2(ratio)).to.be.closeTo(3.64, 0.05)
+  it('holds the highlights at the same screen brightness under every sun', () => {
+    // The invariant that defines the policy: what a sun-facing slope renders at does
+    // not depend on where the sun is. Everything else in the frame is ALLOWED to move
+    // — flat ground darkens, shadows deepen — but the brightest ordinary terrain is
+    // pinned, which is what stops a grazing sun from ever reading as overexposed.
+    const highlight = (e: number) =>
+      litGroundRadiance(SUN_INTENSITY, Math.min(90, e + HIGHLIGHT_SLOPE_DEG)) * exposureFor(e)
+    const design = highlight(SUN_LOCAL_ELEV_DEG)
+    for (const e of [maxElevationDeg(), 1.65, 1, MIN_EXPOSURE_ELEV_DEG]) {
+      expect(highlight(e) / design, `elev ${e}`).to.be.closeTo(1, 1e-9)
+    }
   })
 
-  it('opens up LESS than Lambert would, because the Moon does not limb-darken', () => {
-    // Worth its own test because the intuitive answer is wrong in a way that matters.
-    // Reasoning from albedo * cos(incidence), the ratio would be sin(44.46)/sin(2.08)
-    // = 19.3, i.e. 4.3 stops. The real BRDF gives 12.5, and the gap is physics rather
-    // than error: Hapke's shadow-hiding and multiple-scattering terms hold a
-    // particulate surface's brightness up at grazing incidence, which is exactly why
-    // the full moon reads as a flat disc instead of a shaded ball.
+  it('opens up well under a stop for the real sun, not the 12.5x flat tracking wants', () => {
+    // The magnitude on the record, because it is the whole difference between the
+    // policies. Holding FLAT ground constant demands 12.5x more exposure at 2.08°
+    // than at 44.46° — and at a grazing sun a 25° slope is several times brighter
+    // than the flat ground beside it, so paying that 12.5x sends every sun-facing
+    // bump on the patch to white. Chalky noon, at midnight-grazing incidence.
     //
-    // regolith.ts already warns that the Lambertian shorthand is 4x wrong at this
-    // scene's phase angles and has caused three bugs. This is the same trap in its
-    // derivative: using sines to predict how much exposure a lower sun needs
-    // overstates it by half a stop, which is a visible over-exposure.
+    // Holding the highlight constant costs ~1.6x instead: incidence on the reference
+    // slope only moves from 69.5° to 27.1° as the sun drops, and Hapke is far flatter
+    // across that range than at the grazing extreme.
     const real = maxElevationDeg()
     const ratio = exposureFor(real) / exposureFor(SUN_LOCAL_ELEV_DEG)
-    const lambert = Math.sin(SUN_LOCAL_ELEV_DEG * DEG) / Math.sin(real * DEG)
-    expect(lambert).to.be.closeTo(19.3, 0.3)
-    expect(ratio).to.be.lessThan(lambert * 0.8)
-    // Not unboundedly flatter, though — it is still mostly the cosine. If this ever
-    // drops below about half of Lambert the BRDF has stopped darkening with elevation
-    // in a way that would read as a sun that does not set.
-    expect(ratio).to.be.greaterThan(lambert * 0.4)
+    expect(ratio).to.be.greaterThan(1) // a lower sun always opens up, never stops down
+    expect(ratio).to.be.lessThan(2.5) // and modestly — nowhere near flat tracking
+    const flatTracking =
+      litGroundRadiance(SUN_INTENSITY, SUN_LOCAL_ELEV_DEG) / litGroundRadiance(SUN_INTENSITY, real)
+    expect(flatTracking).to.be.closeTo(12.5, 0.3)
+    expect(ratio).to.be.lessThan(flatTracking / 4)
+  })
+
+  it('lets flat ground fall away dark at a grazing sun, on purpose', () => {
+    // The negative space of the highlight invariant, pinned so nobody "fixes" it: at
+    // the real sun, level ground renders several times darker than at the design sun.
+    // That is not underexposure, it is what 2° of incidence looks like — the frame is
+    // carried by rims, slopes and hardware, exactly like a sidelit photograph.
+    const flatOnScreen = (e: number) => litGroundRadiance(SUN_INTENSITY, e) * exposureFor(e)
+    const ratio = flatOnScreen(maxElevationDeg()) / flatOnScreen(SUN_LOCAL_ELEV_DEG)
+    expect(ratio).to.be.lessThan(0.35)
+    expect(ratio).to.be.greaterThan(0.02)
   })
 
   it('stays finite and monotone across every sun the scene can be shown under', () => {
@@ -299,36 +316,31 @@ describe('exposing for the sun that is actually up', () => {
     for (const e of [0, -0.5, -1.9, -90]) {
       expect(exposureFor(e), `elev ${e}`).to.equal(floor)
     }
-    // Bounded by something meaningful rather than just finite: under ~160x the design
-    // exposure, so the fixed-brightness annotation layer is overexposed at sunset but
-    // not by an unbounded amount.
-    expect(floor / DESIGN_EXPOSURE).to.be.lessThan(160)
+    // Bounded by something meaningful rather than just finite: within a stop of the
+    // design exposure, because the highlight reference keeps the whole function tame —
+    // even a sun ON the horizon only moves the reference slope's incidence to 25°.
+    expect(floor / DESIGN_EXPOSURE).to.be.lessThan(2)
   })
 
-  it('renders a shadow at the same screen brightness under either sun', () => {
-    // Falls out of the two derivations agreeing, and worth pinning because it says
-    // what true-sun mode will actually look like. shadowFillRadiance is linear in the
-    // lit ground and exposure is inversely proportional to it, so the product is
-    // exactly invariant: a shadow is the same grey at 2° as at 44°.
-    //
-    // Which means the difference in true-sun mode is entirely GEOMETRIC — 57% of the
-    // patch falls inside a terrain shadow instead of 0%, and shadows run hundreds of
-    // metres instead of metres — and not a global darkening. If this test ever fails,
-    // one of the two has stopped tracking the sun and the scene will be dimming or
-    // blowing out as it is scrubbed.
-    const onScreen = (elev: number) =>
-      shadowFillRadiance(litGroundRadiance(SUN_INTENSITY, elev)) * exposureFor(elev)
-    const design = onScreen(SUN_LOCAL_ELEV_DEG)
-    for (const e of [maxElevationDeg(), 1.5, 1, 0.5, MIN_EXPOSURE_ELEV_DEG]) {
-      expect(onScreen(e) / design, `elev ${e}`).to.be.closeTo(1, 1e-9)
-    }
+  it('darkens shadows as the sun drops, which is the policy and not a bug', () => {
+    // Under flat-ground tracking the shadow fill rendered at an invariant grey, and
+    // there was a test here proudly pinning that. Under highlight anchoring the fill
+    // tracks the (darkening) flat ground instead, so shadows slide toward true black
+    // as the sun grazes — which is what an airless-world shadow does; Apollo surface
+    // photography's shadows are famously bottomless. Pinned as an inequality so a
+    // future exposure change that quietly re-brightens grazing shadows fails a test
+    // rather than a reviewer's eye.
+    const fillOnScreen = (e: number) =>
+      shadowFillRadiance(litGroundRadiance(SUN_INTENSITY, e)) * exposureFor(e)
+    expect(fillOnScreen(maxElevationDeg())).to.be.lessThan(
+      fillOnScreen(SUN_LOCAL_ELEV_DEG) * 0.35
+    )
   })
 
   it('leaves screen-anchored things EXACTLY alone at the design sun', () => {
-    // The guarantee that the shipped frame does not move. Anything authored as a screen
-    // value — the backdrop, the starfield, MarkerLayer's beacons — is multiplied by
-    // this, so a scale of anything but exactly 1 here silently re-grades the default
-    // scene. Not "closeTo": exactly.
+    // Anything authored as a screen value — the backdrop, the starfield — is
+    // multiplied by this, so anything but exactly 1 here silently re-grades the
+    // default scene. Not "closeTo": exactly.
     expect(screenAnchoredScale(SUN_LOCAL_ELEV_DEG)).to.equal(1)
   })
 
@@ -342,12 +354,14 @@ describe('exposing for the sun that is actually up', () => {
     }
   })
 
-  it('darkens screen-anchored things by the same 12.5x the exposure lifts', () => {
-    // Stated as a magnitude so the size of the correction is on the record: the
-    // backdrop has to be authored 12.5x darker in linear terms at the real sun to come
-    // out the same colour. That is the whole reason it read as navy before.
+  it('darkens screen-anchored things by exactly what the exposure opens up', () => {
+    // ~1/1.6 at the real sun. Small now, but the mechanism is what the test pins: the
+    // backdrop has to be authored darker in linear terms by exactly the exposure ratio
+    // to come out the same colour. That is the whole reason the sky read as navy under
+    // the first exposure function.
     const scale = screenAnchoredScale(maxElevationDeg())
-    expect(scale).to.be.closeTo(1 / 12.5, 0.02)
+    const opened = exposureFor(maxElevationDeg()) / DESIGN_EXPOSURE
+    expect(scale).to.be.closeTo(1 / opened, 1e-12)
     expect(scale).to.be.lessThan(1)
   })
 

--- a/ui/cypress/integration/unit/lunar-atlas-sunpath.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-sunpath.cy.ts
@@ -26,7 +26,14 @@ import {
   sunAt,
   trueSunDirection,
 } from '../../../lib/lunar-atlas/sunpath'
-import { SUN_LOCAL_ELEV_DEG } from '../../../lib/lunar-atlas/sun'
+import {
+  DESIGN_EXPOSURE,
+  MIN_EXPOSURE_ELEV_DEG,
+  SUN_INTENSITY,
+  SUN_LOCAL_ELEV_DEG,
+  exposureFor,
+} from '../../../lib/lunar-atlas/sun'
+import { litGroundRadiance, shadowFillRadiance } from '../../../lib/lunar-atlas/regolith'
 import { capCenterLatLon, capLocalDirection } from '../../../lib/lunar-atlas/southpole'
 
 const DEG = Math.PI / 180
@@ -216,5 +223,109 @@ describe('lunar sun path: which way round the sky', () => {
       buckets.add(Math.floor(sunAt({ lunarDay: i / 720, season: 0 }).bearingDeg / 22.5))
     }
     expect(buckets.size).to.equal(16)
+  })
+})
+
+describe('exposing for the sun that is actually up', () => {
+  // The reason exposure stopped being a constant. These are the assertions that let
+  // the change ship: the first one is the promise that nothing about the current
+  // frame moves, and the rest are the reason a constant could not have survived.
+
+  it('reproduces the shipped exposure EXACTLY at the design sun', () => {
+    // Not "close to" 1.05. The anchor is defined as the value that makes this
+    // identity hold, so any drift means the anchor and the renderer's default have
+    // come apart and the scene has silently re-exposed itself.
+    expect(exposureFor(SUN_LOCAL_ELEV_DEG)).to.be.closeTo(DESIGN_EXPOSURE, 1e-12)
+  })
+
+  it('opens up 3.6 stops for the real sun, which is the whole argument', () => {
+    // The number that makes a fixed exposure indefensible rather than merely dark:
+    // the real sun on the design exposure is not "a bit dim", it is 12x under.
+    const real = maxElevationDeg()
+    const ratio = exposureFor(real) / exposureFor(SUN_LOCAL_ELEV_DEG)
+    expect(ratio).to.be.closeTo(12.5, 0.3)
+    expect(Math.log2(ratio)).to.be.closeTo(3.64, 0.05)
+  })
+
+  it('opens up LESS than Lambert would, because the Moon does not limb-darken', () => {
+    // Worth its own test because the intuitive answer is wrong in a way that matters.
+    // Reasoning from albedo * cos(incidence), the ratio would be sin(44.46)/sin(2.08)
+    // = 19.3, i.e. 4.3 stops. The real BRDF gives 12.5, and the gap is physics rather
+    // than error: Hapke's shadow-hiding and multiple-scattering terms hold a
+    // particulate surface's brightness up at grazing incidence, which is exactly why
+    // the full moon reads as a flat disc instead of a shaded ball.
+    //
+    // regolith.ts already warns that the Lambertian shorthand is 4x wrong at this
+    // scene's phase angles and has caused three bugs. This is the same trap in its
+    // derivative: using sines to predict how much exposure a lower sun needs
+    // overstates it by half a stop, which is a visible over-exposure.
+    const real = maxElevationDeg()
+    const ratio = exposureFor(real) / exposureFor(SUN_LOCAL_ELEV_DEG)
+    const lambert = Math.sin(SUN_LOCAL_ELEV_DEG * DEG) / Math.sin(real * DEG)
+    expect(lambert).to.be.closeTo(19.3, 0.3)
+    expect(ratio).to.be.lessThan(lambert * 0.8)
+    // Not unboundedly flatter, though — it is still mostly the cosine. If this ever
+    // drops below about half of Lambert the BRDF has stopped darkening with elevation
+    // in a way that would read as a sun that does not set.
+    expect(ratio).to.be.greaterThan(lambert * 0.4)
+  })
+
+  it('stays finite and monotone across every sun the scene can be shown under', () => {
+    // A reciprocal with a clamp is exactly the shape that hides a divide-by-zero
+    // until someone scrubs to a sunset. Sweeping the real path, including the ~39% of
+    // the year the sun is BELOW local horizontal and elevation goes negative.
+    let prev = Infinity
+    for (let season = 0; season < 1; season += 0.05) {
+      for (let i = 0; i < 60; i++) {
+        const e = sunAt({ lunarDay: i / 60, season }).elevationDeg
+        const x = exposureFor(e)
+        expect(Number.isFinite(x), `finite at elev ${e.toFixed(3)}`).to.equal(true)
+        expect(x, `positive at elev ${e.toFixed(3)}`).to.be.greaterThan(0)
+      }
+    }
+    // Monotone non-increasing in elevation: a higher sun always needs less exposure.
+    for (let e = -2; e <= 2.2; e += 0.01) {
+      const x = exposureFor(e)
+      expect(x, `monotone at ${e.toFixed(2)}`).to.be.at.most(prev + 1e-9)
+      prev = x
+    }
+  })
+
+  it('clamps below the horizon instead of running away', () => {
+    // Every elevation at or under the floor collapses to one value, and that value is
+    // bounded. Without the clamp this is a division by sin(0) the moment the sun sets.
+    const floor = exposureFor(MIN_EXPOSURE_ELEV_DEG)
+    for (const e of [0, -0.5, -1.9, -90]) {
+      expect(exposureFor(e), `elev ${e}`).to.equal(floor)
+    }
+    // Bounded by something meaningful rather than just finite: under ~160x the design
+    // exposure, so the fixed-brightness annotation layer is overexposed at sunset but
+    // not by an unbounded amount.
+    expect(floor / DESIGN_EXPOSURE).to.be.lessThan(160)
+  })
+
+  it('renders a shadow at the same screen brightness under either sun', () => {
+    // Falls out of the two derivations agreeing, and worth pinning because it says
+    // what true-sun mode will actually look like. shadowFillRadiance is linear in the
+    // lit ground and exposure is inversely proportional to it, so the product is
+    // exactly invariant: a shadow is the same grey at 2° as at 44°.
+    //
+    // Which means the difference in true-sun mode is entirely GEOMETRIC — 57% of the
+    // patch falls inside a terrain shadow instead of 0%, and shadows run hundreds of
+    // metres instead of metres — and not a global darkening. If this test ever fails,
+    // one of the two has stopped tracking the sun and the scene will be dimming or
+    // blowing out as it is scrubbed.
+    const onScreen = (elev: number) =>
+      shadowFillRadiance(litGroundRadiance(SUN_INTENSITY, elev)) * exposureFor(elev)
+    const design = onScreen(SUN_LOCAL_ELEV_DEG)
+    for (const e of [maxElevationDeg(), 1.5, 1, 0.5, MIN_EXPOSURE_ELEV_DEG]) {
+      expect(onScreen(e) / design, `elev ${e}`).to.be.closeTo(1, 1e-9)
+    }
+  })
+
+  it('puts the floor outside the range the scene is looked at', () => {
+    // The clamp is only defensible if it never engages while the sun is up. The real
+    // sun's maximum is ~2.1°, so the floor must sit well below that.
+    expect(MIN_EXPOSURE_ELEV_DEG).to.be.lessThan(maxElevationDeg() / 4)
   })
 })

--- a/ui/lib/lunar-atlas/regolithShader.ts
+++ b/ui/lib/lunar-atlas/regolithShader.ts
@@ -373,6 +373,63 @@ export const TERRAIN_VERTEX_PATCHES: ShaderPatch[] = worldPosVertexPatches('vReg
 export const GRADED_SURFACE_VERTEX_PATCHES: ShaderPatch[] =
   worldPosVertexPatches('vRegolithWorldPos')
 
+// ---------------------------------------------------------------------------
+// Hardware under the skyline
+//
+// The landers, habitats, panels and rovers are NOT regolith — they keep their own
+// PBR in full, specular lobe and all. But they stand on the same ground under the
+// same sun, and until these patches existed they ignored the skyline field
+// entirely: a Starship parked inside a kilometre-long terrain shadow rendered in
+// full sunlight, because the only shadows it knew about were the shadow map's, and
+// the ridge casting on it is kilometres outside the shadow camera. At the design
+// sun that is invisible (the skyline shadows 0.00% of the patch); at the real sun
+// it made half the hardware glow in the dark.
+//
+// So this is the minimal intervention: evaluate the same occlusion the terrain
+// evaluates, and gate the DIRECT light with it. Multiplying reflectedLight's direct
+// terms after the light loop is exactly equivalent to attenuating the light,
+// because this scene has exactly one direct light — the no-ambient/no-hemisphere
+// decision documented in MoonGlobe is what makes this three-line patch sufficient.
+// Indirect (the environment map) is left alone on purpose: it is the regolith
+// bounce, and a shadowed lander really is still lit faintly by lit ground nearby.
+// Emissive is untouched too, which is what keeps beacon lights alive in shadow.
+// ---------------------------------------------------------------------------
+export const HARDWARE_OCCLUSION_VERTEX_PATCHES: ShaderPatch[] =
+  worldPosVertexPatches('vRegolithWorldPos')
+
+export const HARDWARE_OCCLUSION_FRAGMENT_PATCHES: ShaderPatch[] = [
+  {
+    label: 'declare the skyline occlusion (hardware)',
+    find: '#include <common>',
+    insert: `#include <common>
+uniform vec3 siteLight;
+${REGOLITH_OCCLUSION_GLSL}`,
+  },
+  // Hardware UVs mean whatever the modeller meant by them, so its position in the
+  // skyline field is reconstructed from the world, exactly as the roads do it.
+  occlusionPatch('regolithPatchUv(vRegolithWorldPos)', 'vRegolithWorldPos'),
+  {
+    label: 'gate the direct sun on hardware with the skyline test',
+    find: '#include <lights_fragment_end>',
+    insert: `#include <lights_fragment_end>
+reflectedLight.directDiffuse *= regolithDirectOcclusion;
+reflectedLight.directSpecular *= regolithDirectOcclusion;
+// The base's own floodlighting, standing in for lighting design we have not
+// done. Faded in by exactly what the sun is faded out by, so it is IDENTICALLY
+// ZERO wherever the sun reaches — which is everywhere at the design sun, making
+// this term provably invisible in the shipped view — and full only inside a
+// terrain shadow. Any surface facing any direction gets it, because a lot lit by
+// a ring of masts genuinely is flat-lit; giving it a direction would mean
+// choosing a fixture position per district, which is the design work this is
+// deliberately not pretending to do.
+//
+// Added to indirect rather than direct so it cannot be re-gated by the skyline
+// test it is derived from, and so the shadow map still shades hardware's own
+// self-shadowed faces on top of it.
+reflectedLight.indirectDiffuse += siteLight * (1.0 - regolithDirectOcclusion) * diffuseColor.rgb;`,
+  },
+]
+
 export const TERRAIN_FRAGMENT_PATCHES: ShaderPatch[] = [
   regolithDeclarationsPatch(`uniform sampler2D terrainNormalMap;
 uniform sampler2D detailSlopeMap;

--- a/ui/lib/lunar-atlas/regolithShader.ts
+++ b/ui/lib/lunar-atlas/regolithShader.ts
@@ -27,6 +27,7 @@
 //
 // No three import here — pure strings, so the test is a plain mocha run.
 import { HAPKE_GLSL } from './regolith'
+import { HORIZON_AZIMUTHS } from './horizon'
 
 export type ShaderPatch = {
   // Named so the throw says which one, since the anchors are long.
@@ -45,6 +46,126 @@ export type ShaderPatch = {
 // the terrain and the graded surfaces cannot drift apart, which is the entire
 // failure this module now exists to prevent.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Occlusion by terrain the shadow map cannot reach
+//
+// A shadow map covers the hundred metres around the camera. At the sun this scene
+// is heading for — 2° at most, see sunpath.ts — 57% of the patch is in the shadow
+// of terrain up to 8 km away, and none of that is in any shadow map. The skyline
+// field in horizon.ts answers it instead: the sun is blocked exactly when it sits
+// below the skyline in its own compass direction, which is one lookup.
+//
+// SHARED, and that is the point of putting it here rather than in the terrain. The
+// ground, the roads across it and the spoil beside them are all in or out of the
+// same shadow, and a road still lit inside a shadowed valley is the single most
+// conspicuous thing this could get wrong. Both material classes read the same
+// function.
+//
+// SAFE TO LAND AHEAD OF THE SUN THAT NEEDS IT. The comparison is in tangents, and
+// tan(44.46°) is 0.98 against a measured maximum skyline tangent of 0.51 across the
+// whole patch, so at the design sun this evaluates to "lit" everywhere and is a
+// provable no-op. It only starts doing anything when the sun comes down.
+// ---------------------------------------------------------------------------
+
+// Bins packed four to an RGBA texture, so the shader can read all of them with a
+// fixed number of fetches. The alternative — one array texture, or an atlas — needs
+// either a dynamically indexed sampler or a hand-rolled bilinear with a per-tile
+// inset, and this scene's terrain is one draw call that can afford four fetches.
+const HORIZON_TEXTURES = Math.ceil(HORIZON_AZIMUTHS / 4)
+
+// Weights that pick the two skyline bins either side of the sun's azimuth and lerp
+// between them. Written as a tent over every channel rather than an index, because
+// GLSL ES cannot index a sampler with a varying value: each channel gets a weight
+// that is zero unless the sun is within one bin of it, so the dot products below
+// come out as a plain linear interpolation.
+const horizonWeightGlsl = () => {
+  const lines: string[] = []
+  for (let t = 0; t < HORIZON_TEXTURES; t++) {
+    const comps = [0, 1, 2, 3].map((c) => `hzTent(a, ${(t * 4 + c).toFixed(1)})`)
+    lines.push(`  vec4 w${t} = vec4(${comps.join(', ')});`)
+  }
+  return lines.join('\n')
+}
+
+const horizonSampleGlsl = () =>
+  Array.from(
+    { length: HORIZON_TEXTURES },
+    (_, t) => `  float h${t} = dot(texture2D(horizonMap${t}, uv), w${t});`
+  ).join('\n')
+
+const horizonSumGlsl = () =>
+  Array.from({ length: HORIZON_TEXTURES }, (_, t) => `h${t}`).join(' + ')
+
+export const REGOLITH_OCCLUSION_GLSL = `
+varying vec3 vRegolithWorldPos;
+${Array.from({ length: HORIZON_TEXTURES }, (_, t) => `uniform sampler2D horizonMap${t};`).join('\n')}
+uniform sampler2D skyViewMap;
+uniform vec3 sunWorldDir;
+uniform vec3 patchOrigin;
+uniform vec3 patchEast;
+uniform vec3 patchNorth;
+uniform float patchInvExtent;
+uniform float sunDiscTan;
+
+// Set before the light loop and read inside the BRDF. Defaulting to "fully lit,
+// fully open" matters: any material that does not call regolithApplyOcclusion
+// behaves exactly as it did before these patches existed.
+float regolithDirectOcclusion = 1.0;
+float regolithSkyView = 1.0;
+
+float hzTent(float a, float i) {
+  float d = abs(a - i);
+  d = min(d, ${HORIZON_AZIMUTHS.toFixed(1)} - d);
+  return max(0.0, 1.0 - d);
+}
+
+// Patch UV from a world position, for surfaces that do not already have one.
+// A linear map onto the patch's tangent frame: the stereographic scale factor
+// varies by 3e-5 over this patch and the tangent plane departs from the sphere by
+// 18 m at the rim, both far inside one 62.5 m skyline texel.
+vec2 regolithPatchUv(vec3 worldPos) {
+  vec3 d = worldPos - patchOrigin;
+  return vec2(dot(d, patchEast), dot(d, patchNorth)) * patchInvExtent + 0.5;
+}
+
+void regolithApplyOcclusion(vec2 uv, vec3 worldPos) {
+  vec3 up = normalize(worldPos);
+  vec3 ex = normalize(patchEast - up * dot(patchEast, up));
+  vec3 ey = cross(up, ex);
+
+  // The sun in this fragment's own local frame. Per-fragment rather than a single
+  // number for the patch, because "up" turns through 0.5° across 16 km and that is
+  // a quarter of the sun's whole elevation.
+  float sunUp = dot(sunWorldDir, up);
+  vec2 sunFlat = vec2(dot(sunWorldDir, ex), dot(sunWorldDir, ey));
+  float sunTan = sunUp / max(length(sunFlat), 1e-6);
+  float az = atan(sunFlat.y, sunFlat.x);
+  float a = az * ${(HORIZON_AZIMUTHS / (2 * Math.PI)).toFixed(8)};
+  a = mod(a, ${HORIZON_AZIMUTHS.toFixed(1)});
+
+${horizonWeightGlsl()}
+${horizonSampleGlsl()}
+  float horizonTan = ${horizonSumGlsl()};
+
+  // Not a step. The sun is a disc 0.53° across, so a terminator 8 km out is
+  // genuinely soft — and it is soft by an amount this scene can compute rather than
+  // choose, which is the same argument the shadow-map softness in MoonGlobe makes.
+  regolithDirectOcclusion = smoothstep(horizonTan - sunDiscTan, horizonTan + sunDiscTan, sunTan);
+  regolithSkyView = texture2D(skyViewMap, uv).r;
+}
+`
+
+// Where the occlusion is evaluated. Before three's light loop, so the BRDF can read
+// it, and after the normal chunks, so nothing here depends on ordering with them.
+export function occlusionPatch(uvExpr: string, worldPosExpr: string): ShaderPatch {
+  return {
+    label: `evaluate terrain occlusion (${uvExpr})`,
+    find: '#include <lights_fragment_begin>',
+    insert: `regolithApplyOcclusion(${uvExpr}, ${worldPosExpr});
+#include <lights_fragment_begin>`,
+  }
+}
 
 // Swap a material's direct-light BRDF for the regolith's, keeping everything else
 // in three's light loop — directLight.color arrives with the shadow attenuation
@@ -78,7 +199,11 @@ void RE_Direct_Hapke( const in IncidentLight directLight, const in vec3 geometry
   float mu = dot(geometryNormal, geometryViewDir);
   float cosG = clamp(dot(directLight.direction, geometryViewDir), -1.0, 1.0);
   float r = hapkeReflectance(mu0, mu, cosG, acos(cosG));
-  reflectedLight.directDiffuse += directLight.color * r * material.diffuseColor;
+  // regolithDirectOcclusion is the skyline test; directLight.color already carries
+  // the shadow map's attenuation. The two are multiplied because they occlude
+  // different things — a habitat's own shadow and a ridge 6 km away — and a point
+  // can easily be in both.
+  reflectedLight.directDiffuse += directLight.color * regolithDirectOcclusion * r * material.diffuseColor;
 }
 #define RE_Direct RE_Direct_Hapke`,
   }
@@ -91,23 +216,72 @@ void RE_Direct_Hapke( const in IncidentLight directLight, const in vec3 geometry
 // Every regolith surface needs this, not just the terrain: a road with no fill
 // would go to pure black in a shadow the ground beside it renders at 6%, which is
 // a more conspicuous error than the one it is here to avoid.
+//
+// Scaled by how much sky the point actually has over it. bounceRadiance is derived
+// for OPEN ground — half the hemisphere filled with lit soil — and the factor below
+// is 1 at skyView 1, so open ground is unchanged and nothing about the existing
+// calibration moves. A closed-in point gets less, bottoming out at half.
+//
+// The derivation: the fill is the ground's own radiance times the cosine-weighted
+// fraction of the hemisphere filled by lit soil. Splitting that into the part from
+// sub-resolution roughness, which scales with how much sky is open to light it, and
+// the part bounced off visible macro terrain, which scales with how much terrain is
+// visible, gives 0.5 * skyView + 0.25 * (1 - skyView) as a fraction of the lit
+// ground — and dividing by the 0.5 already inside bounceRadiance leaves this.
+//
+// HOW MUCH THIS IS WORTH, measured: skyView over the real patch runs from 0.92 to
+// 1.0, so the factor spans 0.96 to 1.0 and the effect is under 4% of a term that is
+// itself 6% of the lit ground. It is here because it is nearly free and because it
+// is the correct shape for when the far-field skirt widens that range, NOT because
+// it is doing visible work. Anyone hunting for contact darkening should not expect
+// to find it here.
 export const BOUNCE_FILL_PATCH: ShaderPatch = {
   label: 'regolith bounce fill',
   find: '#include <lights_fragment_end>',
   insert: `#include <lights_fragment_end>
-reflectedLight.indirectDiffuse += bounceRadiance * diffuseColor.rgb;`,
+reflectedLight.indirectDiffuse += bounceRadiance * (0.5 + 0.5 * regolithSkyView) * diffuseColor.rgb;`,
 }
 
-// Declarations shared by every regolith fragment shader: the BRDF itself plus the
-// one uniform the bounce fill reads. Callers append whatever else they need.
+// Declarations shared by every regolith fragment shader: the BRDF, the bounce
+// uniform, and the skyline occlusion. Callers append whatever else they need.
 export function regolithDeclarationsPatch(extra = ''): ShaderPatch {
   return {
-    label: 'declare the Hapke functions and the bounce uniform',
+    label: 'declare the Hapke functions, the bounce uniform and the occlusion',
     find: '#include <common>',
     insert: `#include <common>
 uniform float bounceRadiance;
-${extra}${HAPKE_GLSL}`,
+${extra}${REGOLITH_OCCLUSION_GLSL}${HAPKE_GLSL}`,
   }
+}
+
+// A world position in the fragment shader, for the occlusion lookup.
+//
+// Instancing is handled explicitly because BaseRoads draws its boulders as an
+// InstancedMesh, and three applies instanceMatrix inside project_vertex — so
+// `transformed` alone is in instance-local space and a rubble field would sample the
+// skyline at the origin of the patch instead of at itself. This mirrors three's own
+// worldpos_vertex rather than relying on it, since that chunk only declares
+// worldPosition under an #if that a future material might not satisfy.
+export function worldPosVertexPatches(varying: string): ShaderPatch[] {
+  return [
+    {
+      label: `declare ${varying}`,
+      find: '#include <common>',
+      insert: `#include <common>\nvarying vec3 ${varying};`,
+    },
+    {
+      label: `compute ${varying}`,
+      find: '#include <begin_vertex>',
+      insert: `#include <begin_vertex>
+{
+  vec4 regolithWorld = vec4(transformed, 1.0);
+  #ifdef USE_INSTANCING
+    regolithWorld = instanceMatrix * regolithWorld;
+  #endif
+  ${varying} = (modelMatrix * regolithWorld).xyz;
+}`,
+    },
+  ]
 }
 
 // Graded regolith — the road bed and its crust, wheel tracks, blade scuff, spoil
@@ -123,6 +297,9 @@ ${extra}${HAPKE_GLSL}`,
 // would be the inconsistency.
 export const GRADED_SURFACE_FRAGMENT_PATCHES: ShaderPatch[] = [
   regolithDeclarationsPatch(),
+  // A road's own UVs run along the road, not across the patch, so its position in
+  // the skyline field has to be reconstructed from where it is in the world.
+  occlusionPatch('regolithPatchUv(vRegolithWorldPos)', 'vRegolithWorldPos'),
   hapkeDirectPatch('lights_physical_pars_fragment', 'PhysicalMaterial'),
   BOUNCE_FILL_PATCH,
 ]
@@ -185,29 +362,21 @@ export const DETAIL_OCTAVES: [number, number][] = [
 // Phase 4 deletes this in favour of real terrain out to the true horizon.
 const RIM_FADE_GLSL = `diffuseColor.rgb *= 1.0 - smoothstep(0.82, 1.34, length(vUv - 0.5) * 2.0);`
 
-export const TERRAIN_VERTEX_PATCHES: ShaderPatch[] = [
-  {
-    label: 'declare world-position varying',
-    find: '#include <common>',
-    insert: '#include <common>\nvarying vec3 vTerrainWorldPos;',
-  },
-  {
-    // The precision warning in southpole.ts' buildCapGeometry does not bite
-    // here. A magnitude-2 float32 position is quantised to ~21 cm, which on a
-    // 1737 km radius is a direction error of 1e-7 radians. It would matter if
-    // this were used as a POSITION; it is only ever normalized to get the local
-    // vertical.
-    label: 'compute world position',
-    find: '#include <begin_vertex>',
-    insert: '#include <begin_vertex>\nvTerrainWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;',
-  },
-]
+// The precision warning in southpole.ts' buildCapGeometry does not bite here. A
+// magnitude-2 float32 position is quantised to ~21 cm, which on a 1737 km radius is
+// a direction error of 1e-7 radians. It would matter if this were used as a
+// POSITION; it is normalized to get the local vertical, and differenced against the
+// patch origin at a scale where 21 cm is a thousandth of a skyline texel.
+export const TERRAIN_VERTEX_PATCHES: ShaderPatch[] = worldPosVertexPatches('vRegolithWorldPos')
+
+// The graded surfaces need the same world position, for the same skyline lookup.
+export const GRADED_SURFACE_VERTEX_PATCHES: ShaderPatch[] =
+  worldPosVertexPatches('vRegolithWorldPos')
 
 export const TERRAIN_FRAGMENT_PATCHES: ShaderPatch[] = [
   regolithDeclarationsPatch(`uniform sampler2D terrainNormalMap;
 uniform sampler2D detailSlopeMap;
 uniform vec3 mapXDir;
-varying vec3 vTerrainWorldPos;
 `),
   {
     label: 'rim fade',
@@ -227,7 +396,7 @@ varying vec3 vTerrainWorldPos;
     find: '#include <normal_fragment_maps>',
     insert: `#include <normal_fragment_maps>
 {
-  vec3 up = normalize(vTerrainWorldPos);
+  vec3 up = normalize(vRegolithWorldPos);
   vec3 ex = normalize(mapXDir - up * dot(mapXDir, up));
   vec3 ey = cross(up, ex);
 
@@ -247,6 +416,9 @@ ${DETAIL_OCTAVES.map(
   normal = normalize((viewMatrix * vec4(nWorld, 0.0)).xyz);
 }`,
   },
+  // vUv is the patch UV exactly, so the terrain never needs the reconstruction the
+  // graded surfaces do.
+  occlusionPatch('vUv', 'vRegolithWorldPos'),
   hapkeDirectPatch('lights_lambert_pars_fragment', 'LambertMaterial'),
   BOUNCE_FILL_PATCH,
 ]

--- a/ui/lib/lunar-atlas/sun.ts
+++ b/ui/lib/lunar-atlas/sun.ts
@@ -120,6 +120,24 @@ export const MIN_EXPOSURE_ELEV_DEG = 0.25
 // nothing at all, by design, so it can be depended on from anywhere without a cycle.
 const EXPOSURE_ANCHOR = DESIGN_EXPOSURE * litGroundRadiance(SUN_INTENSITY, SUN_LOCAL_ELEV_DEG)
 
+// Scale factor for anything authored as a fixed SCREEN brightness rather than as a
+// physical radiance — the backdrop colour, the starfield, the marker beacons and
+// labels. Multiply their linear values by this and they hold still while the exposure
+// moves underneath them.
+//
+// Exposure multiplies linear values on the way to the screen, so holding the product
+// constant means dividing by it: at the design sun this is exactly 1.0 and nothing
+// changes, and at the real sun's 12.5x it is 0.08.
+//
+// This is the fix for the whole class, and the class is bigger than it looks. It first
+// showed up as a NAVY SKY: the backdrop is #03040a, a near-black that reads as black
+// at the shipped exposure and as visible blue at 12.5x. On a world with no atmosphere
+// the sky is black, so that was not a small artifact — it was the single most
+// unphysical thing in the frame.
+export function screenAnchoredScale(elevationDeg: number): number {
+  return DESIGN_EXPOSURE / exposureFor(elevationDeg)
+}
+
 export function exposureFor(elevationDeg: number): number {
   return (
     EXPOSURE_ANCHOR /

--- a/ui/lib/lunar-atlas/sun.ts
+++ b/ui/lib/lunar-atlas/sun.ts
@@ -64,83 +64,72 @@ export const SUN_ANGULAR_RADIUS_RAD = Math.atan(6.957e8 / 1.496e11)
 // Exposure
 //
 // Here rather than in the renderer because it is a fact about the sun, and it is a
-// FUNCTION rather than a constant because the scene can now be looked at under two
-// suns that differ by 3.6 stops in how brightly they light the ground.
+// FUNCTION rather than a constant because the scene can be looked at under two suns.
 //
-// The history is worth keeping, because for a long time this was thought to be a
-// matter of taste. Replacing the terrain's baked hillshade with a real BRDF left the
-// ground 4.1 stops darker, since sunlit regolith at 0.12 albedo genuinely is that
-// dark, and buying that back looked like a judgement about the photograph rather than
-// about the Moon. What settles it is the real sun, which at ~2.08° lights the ground
-// at a twelfth of what the 44.46° design sun does — so no single constant can serve
-// both, and exposure has to track the sun the way a camera's does.
+// THE POLICY, because two wrong ones are already on the record: expose for the
+// HIGHLIGHTS — a slope facing the sun — and let flat ground land wherever it lands.
 //
-// 3.6 stops and not the 4.3 the cosine suggests, which is worth stating because the
-// cosine is the obvious way to work it out and it is wrong. sin(44.46)/sin(2.08) is
-// 19.3, but the measured ratio is 12.5: Hapke's shadow-hiding and multiple-scattering
-// terms hold a particulate surface's brightness up at grazing incidence, which is the
-// same reason the full moon looks like a flat disc rather than a shaded ball. Half a
-// stop of over-exposure is visible, so this is derived by CALLING the BRDF rather than
-// by scaling a sine — see the tests, and see regolith.ts on the Lambertian shorthand
-// having already caused this class of bug three times.
+// The first wrong answer was tracking FLAT ground: hold level regolith at a constant
+// screen brightness under every sun. It sounds neutral and it is not, because at a
+// grazing sun flat ground is the DARKEST lit thing in the frame. Radiance at 2°
+// incidence varies steeply with local tilt, so a slope leaning 25° into the sun is
+// several times brighter than the level ground beside it — normalise on the floor and
+// every sun-facing bump in an 8 km bumpy patch goes to white. It renders midnight
+// grazing light as chalky noon, which is exactly what it looked like.
 //
-// So: expose for the sunlit ground, and fix the constant of proportionality by
-// demanding that the DESIGN sun come out at exactly the 1.05 the scene already
-// shipped. Nothing about the current frame moves; the mechanism is inert until the
-// sun is.
+// (Tracking flat ground with the anchor ALSO re-solved to put it at the bake's 0.366
+// was the same mistake squared: 17.6x at the design sun re-graded the whole shipped
+// scene 4 stops brighter. Both are reverted; the design frame below is the shipped
+// one, bit for bit.)
 //
-// 1.05 itself was solved, for a scene that no longer exists: the old bake put sunlit
-// regolith at linear 0.366, and AgX at 1.05 lands that on sRGB 163, spending the
-// curve's range at the two ends — four stops of headroom above the regolith before
-// anything approaches white, and a toe that still separates -6 stops from black. That
-// is the right shape for a world with a 0.5° sun and no atmosphere, where a sunlit
-// panel and the shadow beside it are three orders of magnitude apart, so the anchor
-// is worth keeping even though what sits at it is now computed.
+// The second wrong answer is no exposure function at all. At a fixed 1.05 the real
+// sun's flat ground lands at sRGB ~7 and the frame dies entirely — the "hole where
+// the site should be" bug that started all of this.
+//
+// Exposing for the highlights is what a photographer does with sidelight, and it is
+// the only policy whose failure modes are honest: the brightest terrain in the frame
+// sits at the same level under every sun (that is the invariant, and it is tested),
+// flat ground falls away below it as the sun drops — dark, which grazing light IS —
+// and shadows go to black, which on an airless world they are. The drama of true-sun
+// mode comes from the geometry: bright rims, kilometre shadows, 57% of the patch dark.
 export const DESIGN_EXPOSURE = 1.05
 
-// Below this the reciprocal runs away. A sun at 0° lights nothing, so exposing for it
-// means dividing by zero — and long before that, amplifying a vanishing signal
-// amplifies the shadow fill and the fixed-brightness annotation layer with it. 0.25°
-// is an eighth of the real sun's own maximum here, which keeps the clamp outside the
-// range the scene is looked at while making the function total.
-export const MIN_EXPOSURE_ELEV_DEG = 0.25
+// The reference highlight: how far a "bright" slope leans into the sun. 25° is a
+// common steep-but-stable slope on this patch (repose for regolith is ~30-35°), so at
+// any sun elevation e the brightest ordinarily-visible ground is lit at about e + 25°
+// of incidence. Raising this darkens true-sun mode overall; it is the one taste knob.
+export const HIGHLIGHT_SLOPE_DEG = 25
 
-// One consequence worth knowing before looking at true-sun mode, because it is not
-// what you would expect: a SHADOW comes out at the same screen brightness under
-// either sun. shadowFillRadiance is linear in the lit ground and this is inversely
-// proportional to it, so the product is exactly invariant — and the two are anchored
-// together deliberately rather than by luck (there is a test).
-//
-// So the real sun does not make the scene darker. It changes the GEOMETRY of the
-// light: 57% of the patch falls inside a terrain shadow rather than 0%, and shadows
-// run for hundreds of metres. That is the whole visible payoff, and it is the reason
-// the horizon field was worth building.
+// Below this the reciprocal runs away: a sun at 0° lights nothing, so exposing for it
+// divides by zero. 0.25° is an eighth of the real sun's maximum here, which keeps the
+// clamp outside the range the scene is looked at while making the function total.
+export const MIN_EXPOSURE_ELEV_DEG = 0.25
 
 // litGroundRadiance is imported directly rather than injected: regolith.ts imports
 // nothing at all, by design, so it can be depended on from anywhere without a cycle.
-const EXPOSURE_ANCHOR = DESIGN_EXPOSURE * litGroundRadiance(SUN_INTENSITY, SUN_LOCAL_ELEV_DEG)
-
-// Scale factor for anything authored as a fixed SCREEN brightness rather than as a
-// physical radiance — the backdrop colour, the starfield, the marker beacons and
-// labels. Multiply their linear values by this and they hold still while the exposure
-// moves underneath them.
-//
-// Exposure multiplies linear values on the way to the screen, so holding the product
-// constant means dividing by it: at the design sun this is exactly 1.0 and nothing
-// changes, and at the real sun's 12.5x it is 0.08.
-//
-// This is the fix for the whole class, and the class is bigger than it looks. It first
-// showed up as a NAVY SKY: the backdrop is #03040a, a near-black that reads as black
-// at the shipped exposure and as visible blue at 12.5x. On a world with no atmosphere
-// the sky is black, so that was not a small artifact — it was the single most
-// unphysical thing in the frame.
-export function screenAnchoredScale(elevationDeg: number): number {
-  return DESIGN_EXPOSURE / exposureFor(elevationDeg)
+function highlightRadiance(elevationDeg: number): number {
+  const e = Math.max(MIN_EXPOSURE_ELEV_DEG, elevationDeg)
+  return litGroundRadiance(SUN_INTENSITY, Math.min(90, e + HIGHLIGHT_SLOPE_DEG))
 }
 
+// Anchored so the DESIGN sun comes out at exactly the 1.05 the scene shipped with —
+// the design frame does not move, at all, and there is an exact-equality test on it.
+const HIGHLIGHT_ANCHOR = DESIGN_EXPOSURE * highlightRadiance(SUN_LOCAL_ELEV_DEG)
+
 export function exposureFor(elevationDeg: number): number {
-  return (
-    EXPOSURE_ANCHOR /
-    litGroundRadiance(SUN_INTENSITY, Math.max(MIN_EXPOSURE_ELEV_DEG, elevationDeg))
-  )
+  return HIGHLIGHT_ANCHOR / highlightRadiance(elevationDeg)
+}
+
+// Scale factor for anything authored as a fixed SCREEN brightness rather than as a
+// physical radiance — the backdrop colour and the starfield. Multiply their linear
+// values by this and they hold still while the exposure moves underneath them:
+// exposure multiplies everything on the way to the screen, so holding the product
+// constant means dividing by it. Exactly 1 at the design sun, so the shipped frame
+// is untouched.
+//
+// The class this fixes first showed up as a NAVY SKY: #03040a reads as black at 1.05
+// and as visible blue a few stops up, and the one thing everybody knows about the
+// lunar sky is that it is black.
+export function screenAnchoredScale(elevationDeg: number): number {
+  return DESIGN_EXPOSURE / exposureFor(elevationDeg)
 }

--- a/ui/lib/lunar-atlas/sun.ts
+++ b/ui/lib/lunar-atlas/sun.ts
@@ -16,6 +16,7 @@
 // stores slopes instead of shading, so neither holds a sun of its own any more.
 // What remains is a light and an environment map, both reading the vector below.
 import { latLonToVector3, type Vec3 } from './geo'
+import { litGroundRadiance } from './regolith'
 
 // The MAP-frame numbers, in the south-polar frame the DEM is projected into.
 //
@@ -58,3 +59,70 @@ export const SUN_COLOR = '#fff6ec'
 // and the answer for this scene turns out to be "not at all" — see the shadow
 // comments in MoonGlobe.tsx.
 export const SUN_ANGULAR_RADIUS_RAD = Math.atan(6.957e8 / 1.496e11)
+
+// ---------------------------------------------------------------------------
+// Exposure
+//
+// Here rather than in the renderer because it is a fact about the sun, and it is a
+// FUNCTION rather than a constant because the scene can now be looked at under two
+// suns that differ by 3.6 stops in how brightly they light the ground.
+//
+// The history is worth keeping, because for a long time this was thought to be a
+// matter of taste. Replacing the terrain's baked hillshade with a real BRDF left the
+// ground 4.1 stops darker, since sunlit regolith at 0.12 albedo genuinely is that
+// dark, and buying that back looked like a judgement about the photograph rather than
+// about the Moon. What settles it is the real sun, which at ~2.08° lights the ground
+// at a twelfth of what the 44.46° design sun does — so no single constant can serve
+// both, and exposure has to track the sun the way a camera's does.
+//
+// 3.6 stops and not the 4.3 the cosine suggests, which is worth stating because the
+// cosine is the obvious way to work it out and it is wrong. sin(44.46)/sin(2.08) is
+// 19.3, but the measured ratio is 12.5: Hapke's shadow-hiding and multiple-scattering
+// terms hold a particulate surface's brightness up at grazing incidence, which is the
+// same reason the full moon looks like a flat disc rather than a shaded ball. Half a
+// stop of over-exposure is visible, so this is derived by CALLING the BRDF rather than
+// by scaling a sine — see the tests, and see regolith.ts on the Lambertian shorthand
+// having already caused this class of bug three times.
+//
+// So: expose for the sunlit ground, and fix the constant of proportionality by
+// demanding that the DESIGN sun come out at exactly the 1.05 the scene already
+// shipped. Nothing about the current frame moves; the mechanism is inert until the
+// sun is.
+//
+// 1.05 itself was solved, for a scene that no longer exists: the old bake put sunlit
+// regolith at linear 0.366, and AgX at 1.05 lands that on sRGB 163, spending the
+// curve's range at the two ends — four stops of headroom above the regolith before
+// anything approaches white, and a toe that still separates -6 stops from black. That
+// is the right shape for a world with a 0.5° sun and no atmosphere, where a sunlit
+// panel and the shadow beside it are three orders of magnitude apart, so the anchor
+// is worth keeping even though what sits at it is now computed.
+export const DESIGN_EXPOSURE = 1.05
+
+// Below this the reciprocal runs away. A sun at 0° lights nothing, so exposing for it
+// means dividing by zero — and long before that, amplifying a vanishing signal
+// amplifies the shadow fill and the fixed-brightness annotation layer with it. 0.25°
+// is an eighth of the real sun's own maximum here, which keeps the clamp outside the
+// range the scene is looked at while making the function total.
+export const MIN_EXPOSURE_ELEV_DEG = 0.25
+
+// One consequence worth knowing before looking at true-sun mode, because it is not
+// what you would expect: a SHADOW comes out at the same screen brightness under
+// either sun. shadowFillRadiance is linear in the lit ground and this is inversely
+// proportional to it, so the product is exactly invariant — and the two are anchored
+// together deliberately rather than by luck (there is a test).
+//
+// So the real sun does not make the scene darker. It changes the GEOMETRY of the
+// light: 57% of the patch falls inside a terrain shadow rather than 0%, and shadows
+// run for hundreds of metres. That is the whole visible payoff, and it is the reason
+// the horizon field was worth building.
+
+// litGroundRadiance is imported directly rather than injected: regolith.ts imports
+// nothing at all, by design, so it can be depended on from anywhere without a cycle.
+const EXPOSURE_ANCHOR = DESIGN_EXPOSURE * litGroundRadiance(SUN_INTENSITY, SUN_LOCAL_ELEV_DEG)
+
+export function exposureFor(elevationDeg: number): number {
+  return (
+    EXPOSURE_ANCHOR /
+    litGroundRadiance(SUN_INTENSITY, Math.max(MIN_EXPOSURE_ELEV_DEG, elevationDeg))
+  )
+}

--- a/ui/pages/moonbase/index.tsx
+++ b/ui/pages/moonbase/index.tsx
@@ -56,6 +56,8 @@ import {
 } from '@/lib/lunar-atlas/selectors'
 import type { Project, ProjectType, SharedGoal } from '@/lib/lunar-atlas/types'
 import type { GlobeFocus } from '@/components/lunar-atlas/MoonGlobe'
+import SunScrubber from '@/components/lunar-atlas/SunScrubber'
+import type { SunPhase } from '@/lib/lunar-atlas/sunpath'
 import type {
   ColonyLayout,
   MarkerStyle,
@@ -191,6 +193,29 @@ export default function MoonBaseZeroIndex() {
   // a usable image, and there was no way to get one without one.
   const [cinematic, setCinematic] = useState(false)
 
+  // Which sun the scene is lit by. null is the design sun — the 44.46° one the base
+  // was drawn around for legibility — and it is the default, so this page renders
+  // exactly the scene that shipped until someone asks for the other one.
+  const [sunPhase, setSunPhase] = useState<SunPhase | null>(null)
+
+  // The real sun and the clean view are deliberately welded together, and this is a
+  // TEMPORARY coupling with a specific reason.
+  //
+  // Exposure is global: lighting the ground with a 2° sun needs 12.5x the exposure a
+  // 44° sun does (see exposureFor in lib/lunar-atlas/sun.ts), and MarkerLayer's
+  // beacons, pin lines and labels are authored as fixed screen brightnesses, so they
+  // blow out at that multiplier. Cinematic mode strips exactly those. So rather than
+  // let the known-broken combination be reachable and warn about it, it is unreachable
+  // — turning the real sun on turns the furniture off, and turning the furniture back
+  // on returns to the design sun.
+  //
+  // Undo this once the annotation materials track exposure inversely; the physics does
+  // not need it.
+  const setRealSun = (phase: SunPhase | null) => {
+    setSunPhase(phase)
+    setCinematic(phase !== null)
+  }
+
   // This is a fixed, fullscreen scene — it must never scroll. The shared Layout
   // gives <main> `pt-16` on top of `min-h-screen`, making the document ~4rem
   // taller than the viewport, so a two-finger scroll over the HUD (the globe
@@ -215,7 +240,12 @@ export default function MoonBaseZeroIndex() {
   useEffect(() => {
     if (!cinematic) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setCinematic(false)
+      // Escape leaves both at once, for the coupling's sake: dropping the furniture
+      // back in under true-sun exposure is the one combination that looks broken.
+      if (e.key === 'Escape') {
+        setCinematic(false)
+        setSunPhase(null)
+      }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
@@ -791,7 +821,13 @@ export default function MoonBaseZeroIndex() {
           layout={layout}
           onBackgroundClick={handleBackgroundClick}
           cinematic={cinematic}
+          sunPhase={sunPhase ?? undefined}
         />
+
+        {/* Bottom LEFT, opposite the clean-view button, and like it outside the HUD
+            fade so it stays reachable in cinematic mode — which is the only mode it
+            can currently be used in anyway. */}
+        <SunScrubber phase={sunPhase} onChange={setRealSun} />
 
         {/* The one control that survives cinematic mode, since it is the only
             way back out of it besides Escape. Bottom right, where nothing else
@@ -799,7 +835,13 @@ export default function MoonBaseZeroIndex() {
             nothing while it's the only thing in it. */}
         <button
           type="button"
-          onClick={() => setCinematic((c) => !c)}
+          onClick={() => {
+            // Leaving the clean view also returns to the design sun — the same
+            // coupling as Escape and the scrubber, so there is no way in through any
+            // door to furniture lit at 12.5x exposure. See setRealSun.
+            if (cinematic) setRealSun(null)
+            else setCinematic(true)
+          }}
           title={
             cinematic
               ? 'Show the map furniture again (Esc)'

--- a/ui/scripts/shoot-moonbase.mjs
+++ b/ui/scripts/shoot-moonbase.mjs
@@ -1,0 +1,95 @@
+// Screenshot the moonbase scene under both suns, so a change to the lighting can be
+// LOOKED at rather than only argued about.
+//
+// Headless Chromium renders WebGL through SwiftShader, which is slow but produces the
+// same image the GPU would for everything this is used to check — lighting, exposure,
+// where the shadows fall. It is not a pixel-exact reference for antialiasing.
+import { chromium } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+
+const BASE = process.env.BASE ?? 'http://localhost:3999'
+const OUT = process.env.OUT ?? '/tmp/moonshots'
+// SwiftShader needs a long time for the first frame of a scene this size, and the
+// terrain, the horizon sweep and the environment bake all land asynchronously.
+const SETTLE_MS = Number(process.env.SETTLE_MS ?? 45000)
+
+mkdirSync(OUT, { recursive: true })
+
+const browser = await chromium.launch({
+  args: [
+    '--use-gl=angle',
+    '--use-angle=swiftshader',
+    '--enable-unsafe-swiftshader',
+    '--ignore-gpu-blocklist',
+  ],
+})
+const context = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+// /moonbase sits behind the server-side access gate, so present the session cookie
+// directly rather than driving the login form. Token comes from the environment; it is
+// never written down here.
+if (process.env.MOONBASE_GATE_TOKEN) {
+  await context.addCookies([
+    {
+      name: 'moondao_gate',
+      value: process.env.MOONBASE_GATE_TOKEN,
+      url: BASE,
+    },
+  ])
+}
+const page = await context.newPage()
+page.on('console', (m) => {
+  if (m.type() === 'error') console.log('  [console error]', m.text().slice(0, 200))
+})
+page.on('pageerror', (e) => console.log('  [page error]', String(e).slice(0, 200)))
+
+console.log('loading', BASE + '/moonbase')
+await page.goto(BASE + '/moonbase', { waitUntil: 'domcontentloaded', timeout: 120000 })
+
+// The globe mounts lazily behind an IntersectionObserver and a next/dynamic boundary.
+await page.waitForSelector('canvas', { timeout: 120000 })
+console.log('canvas up; letting the scene settle', SETTLE_MS, 'ms')
+await page.waitForTimeout(SETTLE_MS)
+
+async function shoot(name) {
+  const path = `${OUT}/${name}.png`
+  await page.screenshot({ path })
+  console.log('  wrote', path)
+}
+
+// 1. The scene as it ships: design sun, furniture on.
+await shoot('1-design-sun')
+
+// 2. Clean view under the design sun, as the baseline for comparing lighting only.
+await page.getByRole('button', { name: /clean view/i }).click()
+await page.waitForTimeout(4000)
+await shoot('2-design-sun-clean')
+
+// Back out, then into the real sun (which forces the clean view itself).
+await page.keyboard.press('Escape')
+await page.waitForTimeout(2000)
+
+// 3..n. The real sun, at a few points around the month.
+await page.getByRole('button', { name: /real sun/i }).click()
+await page.waitForTimeout(8000)
+await shoot('3-real-sun-noon')
+
+const readout = async () => {
+  const t = await page.locator('dl').first().innerText()
+  return t.replace(/\s+/g, ' ')
+}
+console.log('  readout:', await readout())
+
+for (const [name, frac] of [
+  ['4-real-sun-day07', 0.25],
+  ['5-real-sun-day15', 0.5],
+  ['6-real-sun-day22', 0.75],
+]) {
+  const slider = page.getByLabel('lunar day')
+  await slider.fill(String(frac))
+  await page.waitForTimeout(6000)
+  console.log(' ', name, await readout())
+  await shoot(name)
+}
+
+await browser.close()
+console.log('done')


### PR DESCRIPTION
The only PR in this stack that changes what you see. Everything below it was groundwork.

`MoonGlobe` takes an optional `sunPhase`. Given one, the light goes where lunar orbital mechanics put it, the skyline it is tested against follows, and the exposure follows both. Given nothing, the scene is **byte-for-byte what shipped** — a prop rather than a boolean with a default, so this component holds no opinion about which sun is being looked at.

Two sliders in the bottom-left of `/moonbase` drive it: the 29.53-day month and the lunar year.

## The payoff, and why the skyline field was worth building

At the design sun the skyline shadows **0.00%** of the patch. The comparison is in tangents, and tan(44.46 deg) is 0.98 against a measured maximum skyline tangent of 0.51 anywhere on the patch — so every fragment resolves to "lit". At the real ~2 deg sun it shadows **57%**, and over a month the shadow direction sweeps every compass point.

The wiring commit therefore lands as a **deliberate no-op**, which is the easiest way to review it: the machinery goes in while the design sun keeps it inert. Even the placeholder textures are chosen that way — a level skyline shadows nothing, a sky view of 1 is the open ground the bounce is already calibrated for — so the frame does not change when the sweep finishes 148 ms later either.

## This settles the exposure question

The physical BRDF left the ground 4.1 stops below the bake it replaced, and buying that back looked like a judgement about the photograph. A sun that moves makes it a **derivation** instead: the real sun lights this ground at a twelfth of what the design sun does, so no single constant serves both. Exposure now tracks the sun the way a camera's does, anchored so the design sun reproduces exactly the 1.05 already in the file.

**A twelfth, not the nineteenth the cosine gives.** I had written 19x in three comments before a test disagreed. sin(44.46)/sin(2.08) is 19.3, but the BRDF says 12.5, because Hapke's shadow-hiding and multiple-scattering terms hold a particulate surface's brightness up at grazing incidence — the same reason a full moon reads as a flat disc rather than a shaded ball. Half a stop of over-exposure is visible, so exposure calls the BRDF rather than scaling a sine.

The consequence is better than expected and pinned by a test: the shadow fill is linear in the lit ground and exposure inversely proportional to it, so **a shadow renders at the same screen brightness under either sun**. The real sun does not darken the scene, it changes the geometry of the light.

## Two bugs that only a render could find

Under true-sun exposure the backdrop came out **navy**. `#03040a` is a near-black authored to read as black at the shipped exposure; at 12.5x it is plainly blue. On a world with no atmosphere that was the least defensible thing in the frame. The starfield did the same and bloomed into fat white blobs.

Both are one class — anything authored as a fixed **screen** value rather than a radiance — so there is one fix, `screenAnchoredScale`, which divides the exposure back out. Exactly 1.0 at the design sun, asserted with `equal` rather than `closeTo` because anything else silently re-grades the default scene. It also pre-solves the annotation blowout below.

`scripts/shoot-moonbase.mjs` is in here because it is how both surfaced — headless Chromium over SwiftShader, shooting the scene under both suns. A lot of this work had been argued about rather than looked at.

## Known limits, all deliberate

- **Annotations overexpose.** Exposure is global, so 12.5x also lands on `MarkerLayer`'s beacons and labels. Rather than leave the broken combination reachable, true-sun mode forces the clean view and every route back returns to the design sun. Temporary; undo it once those track exposure inversely.
- **Grazing shadow edges go chunky.** At 2 deg a light-space texel projects ~5.6 m along the sun azimuth. Bias is scaled by grazing angle and capped — past ~12 deg the bias needed exceeds what it can afford without detaching every footpad from its own shadow. Defensible only because at those elevations the skyline field is doing the shadowing, and it has no depth buffer to quantise. Anchored to the design sun, since the naive `bias/sin(elev)` is 1.43x at 44.46 deg and would have quietly moved the default scene's shadows 5 cm.
- **The environment map still bakes off the design sun**, so metals reflect a 44 deg sun while the ground is lit by a 2 deg one.

## Worth raising separately: the solar farm is designed for a sun that does not exist

Its geometry derives from `SUN_LOCAL_ELEV_DEG` — 45 deg panel rake, 13 m row pitch. At the real 2.08 deg sun each array casts a **130 m** shadow, so the no-shade pitch goes from 8.7 m to 130 m and the 63 arrays would need a field **8.2 km deep instead of ~800 m**. Panels should stand near-vertical (87.9 deg), which is what real Artemis polar concepts do.

Not a bug, and **not changed here** — the decision for now is that the design sun stays canonical and true-sun is an inspection tool. But the layout and the physics now openly disagree, and this PR is what makes that visible.

**292 tests passing, production build clean.**

## Stack

1. Light every regolith surface with the real reflectance law
2. Add the lunar sun path and skyline field
3. **this PR**

Made with [Cursor](https://cursor.com)