### PR TITLE
feat(moonbase): make Touchdown the landing-zone race

### DIFF
--- a/ui/components/lunar-atlas/ProjectModel.tsx
+++ b/ui/components/lunar-atlas/ProjectModel.tsx
@@ -89,6 +89,15 @@ const PROJECT_SIZE_M: Record<string, number> = {
   // whole camp rendered at 11/38 of its real size instead.
   'nasa-artemis-base-camp': 38,
   'blue-origin-blue-moon-mk1': 8,
+  // The rest of the Touchdown roster (shared-next-landing), which is the race
+  // that stands on the landing zone. CLPS-class hardware, so without entries
+  // here each one would render at TYPE_SIZE_M.lander's 16 m — Blue Moon MK2
+  // class, three to four times its real size. Public figures / honest
+  // estimates, largest dimension:
+  'astrobotic-griffin': 4.5, // ~4.5 m across the splayed legs, ~2 m deck
+  'im-nova-c': 4, // 4 m tall on a 1.6 m hexagonal bus — height is the max
+  'firefly-blue-ghost': 3.5, // ~3.5 m across the legs, ~2 m tall
+  'cnsa-change-7': 4.8, // Chang'e-3/4 heritage bus, 4.8 m leg span
   // Footpad to nose tip — NASA's own Artemis III renders show a tall stack:
   // splayed legs, a windowed crew module with a deployable crew ladder, two
   // open lattice bays exposing the propellant tanks, then a smooth ascent

--- a/ui/cypress/integration/unit/lunar-atlas-baseplan.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-baseplan.cy.ts
@@ -197,7 +197,13 @@ const ROSTERS: Partial<Record<ProjectType, Plot[]>> = {
   // is the largest, so it is what sets this district's `reach` — and at 47 m
   // that is the longest branch on the plan.
   habitat: plots(19, 12.86, 13.937, 14.056, 3.3),
-  lander: plots(31.2, 9.6),
+  // The Touchdown roster (shared-next-landing) — the landing race the zone
+  // hosts now that the lander category moved off the crewed-lander goal. Pad
+  // decks at 0.6 of each vehicle's size (GRADED_DECK_FRACTION.lander): Blue
+  // Moon MK1 (8 m), Chang'e-7 (4.8), Griffin (4.5), Nova-C (4), Blue Ghost
+  // (3.5). Five CLPS-class pads instead of the Starship-era two, which is
+  // what exercises the flank case's along-the-spine stepping.
+  lander: plots(4.8, 2.88, 2.7, 2.4, 2.1),
   // eVinci radiator wall, IX's radiator canopy, Lockheed's radiator mast — the
   // three fission bids, and three very different amounts of ground.
   power: plots(11, 6.5, 4),

--- a/ui/cypress/integration/unit/lunar-atlas-selectors.cy.ts
+++ b/ui/cypress/integration/unit/lunar-atlas-selectors.cy.ts
@@ -349,7 +349,7 @@ describe('lunar-atlas selectors', () => {
       const construction = trees.find((t) => t.category === 'construction')
       expect(construction?.goal?.id).to.equal('shared-landing-pads')
       const lander = trees.find((t) => t.category === 'lander')
-      expect(lander?.goal?.id).to.equal('shared-crewed-lander')
+      expect(lander?.goal?.id).to.equal('shared-next-landing')
     })
 
     it('falls back to a goal listing a member when no category race exists', () => {

--- a/ui/lib/lunar-atlas/baseplan.ts
+++ b/ui/lib/lunar-atlas/baseplan.ts
@@ -753,19 +753,22 @@ export const BASE_PLAN: Partial<Record<ProjectType, SitePlan>> = {
   // no air to slow it, plume-thrown regolith travels ballistic arcs that stay
   // dangerous for hundreds of meters, so what a pad wants is the longest clear
   // sightline on the plan and two ways out of it, not a dead end 80 m from the
-  // nearest building. So the haul road runs BETWEEN the two pads and carries
-  // straight on out to the end of the spine.
-  //
-  // At 62 m across, the Starship's apron is most of a city block on its own,
-  // which is the other half of it: there is no branch on this plan long enough
-  // to make that a terminus rather than a blockage.
+  // nearest building. So the haul road runs BETWEEN the pads and carries
+  // straight on out to the end of the spine. (When this district hosted the
+  // crewed-lander race, Starship's 62 m apron was the other half of the
+  // argument — no branch was long enough to make it a terminus rather than a
+  // blockage. Touchdown's CLPS-class pads no longer force that, but the
+  // cul-de-sac argument alone still does.)
   lander: district(-280, {
     turn: 0,
     front: 'flank',
     flankSide: 1,
-    // The Starship pad's own 31.2 m footprint plus its frontage off the spine,
-    // which is why this is more than twice any other district's.
-    block: 71,
+    // Blue Moon MK1's 4.8 m pad plus its frontage off the spine, with the
+    // other four Touchdown pads packed down both flanks. Far smaller than the
+    // 71 m the Starship-era crewed race needed: the landing race here is now
+    // Touchdown (shared-next-landing), whose biggest entrant is an 8 m
+    // cargo lander rather than a 52 m Starship.
+    block: 20,
   }),
 
   // ISRU YARD, 200 m southwest, out on an 80 m branch to the northwest. The

--- a/ui/lib/lunar-atlas/seed/atlas.dataset.json
+++ b/ui/lib/lunar-atlas/seed/atlas.dataset.json
@@ -3218,7 +3218,6 @@
     {
       "id": "shared-crewed-lander",
       "title": "First commercial crewed lunar landing",
-      "category": "lander",
       "description": "NASA's Human Landing System program put two competing landers under contract: SpaceX's Starship HLS (Artemis III) and Blue Origin's Blue Moon MK2 (Artemis V). Which system puts crew on the lunar surface first is the defining near-term race in the lander tech tree — schedules on both sides have moved, and each vehicle still has major flight-test milestones ahead.",
       "projectIds": [
         "spacex-starship-hls",
@@ -3257,6 +3256,7 @@
     {
       "id": "shared-next-landing",
       "title": "Touchdown — next successful lunar landing",
+      "category": "lander",
       "description": "Which landing-vehicle operator after market open first lands upright on the Moon and returns surface data for at least 24 hours. The slot is the vehicle operator, not the payload or launch provider. Win tests are binary and public: touchdown UTC after OPEN, controlled powered descent, stable planned orientation, ≥24 h surface data, and independent confirmation. Tip-overs (IM-1, IM-2, SLIM) do not count. ispace, ISRO, and later flights sit in the Open Field.",
       "projectIds": [
         "astrobotic-griffin",


### PR DESCRIPTION
## Summary
- The moonbase lander district previously raced `shared-crewed-lander` (Starship HLS vs Blue Moon MK2), a planned market with curator odds, while Touchdown — bound to the live Sepolia DePrize #22 with the real Juicebox prize pool — had no category and never appeared on the surface. The lander category now lives on `shared-next-landing`, so clicking the Landers race in Moon Base Zero opens the Touchdown roster and binds to the live prize (odds, prize pool, inline betting) via the existing `findDePrizeIdForGoal` plumbing.
- The crewed-lander race keeps its dataset entry, market and panels; it groups with other market-bearing goals on the /deprize index instead of holding the surface district.
- Added true-scale `PROJECT_SIZE_M` entries for Griffin, Nova-C, Blue Ghost and Chang'e-7, which now stand on the landing zone and would otherwise render at the 16 m lander type default (3–4x real size).
- Re-solved the lander district `block` (71 → 20): the old keep-out was sized to Starship's 31.2 m pad, and the baseplan tightness test enforces the figure stays within 8 m of what the roster needs.
- Updated the selectors test (lander tree now binds `shared-next-landing`) and the baseplan `ROSTERS.lander` fixture to the five Touchdown pad footprints.

## Test plan
- [ ] `yarn test:cypress-unit` — lunar-atlas-baseplan, lunar-atlas-selectors, lunar-atlas-deprize suites pass
- [ ] /moonbase: the Landers race opens Touchdown with five competitors on the landing zone; on Sepolia the panel shows the live prize pool and Buy buttons for DePrize #22
- [ ] /moonbase?race=shared-crewed-lander still opens the crewed-lander panel (demo market)
- [ ] /deprize index still lists both the Touchdown group and the crewed-landing race

Made with [Cursor](https://cursor.com)