### PR TITLE
fix(deprize): keep server-only Privy auth out of the browser test bundle

### DIFF
--- a/ui/cypress/integration/lib/deprize/eligibility.cy.ts
+++ b/ui/cypress/integration/lib/deprize/eligibility.cy.ts
@@ -1,7 +1,7 @@
 import { evaluateEligibility } from '@/lib/deprize/eligibility'
 import { isRestrictedJurisdiction } from '@/lib/deprize/restrictedJurisdictions'
 import { parseOfacEthList } from '@/lib/deprize/sanctions'
-import { selectSessionWallet } from '@/lib/deprize/sessionWallet'
+import { selectSessionWallet } from '@/lib/deprize/selectSessionWallet'
 import {
   checkVpnOrProxy,
   hostingLooksLikeProxy,

--- a/ui/lib/deprize/selectSessionWallet.ts
+++ b/ui/lib/deprize/selectSessionWallet.ts
@@ -1,0 +1,21 @@
+import { getAddress } from 'viem'
+import { isHexAddress } from './eligibility'
+
+/** Pick a session wallet. A claimed address must belong to the session. */
+export function selectSessionWallet(
+  wallets: string[],
+  claimedWallet?: string | null
+): string | null {
+  const owned = wallets.filter((addr) => isHexAddress(addr))
+  if (owned.length === 0) return null
+
+  const claimed = claimedWallet?.trim() || ''
+  if (claimed) {
+    if (!isHexAddress(claimed)) return null
+    const match = owned.find((w) => w.toLowerCase() === claimed.toLowerCase())
+    return match ? getAddress(match) : null
+  }
+
+  if (owned.length === 1) return getAddress(owned[0])
+  return null
+}

--- a/ui/lib/deprize/sessionWallet.ts
+++ b/ui/lib/deprize/sessionWallet.ts
@@ -1,9 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { getServerSession } from 'next-auth/next'
-import { getAddress } from 'viem'
 import { getPrivyUserData } from '@/lib/privy'
 import { authOptions } from '@/pages/api/auth/[...nextauth]'
-import { isHexAddress } from './eligibility'
+import { selectSessionWallet } from './selectSessionWallet'
 
 function accessTokenFromRequest(req: NextApiRequest): string | null {
   const authHeader = req.headers.authorization
@@ -11,25 +10,6 @@ function accessTokenFromRequest(req: NextApiRequest): string | null {
     const token = authHeader.slice(7).trim()
     if (token) return token
   }
-  return null
-}
-
-/** Pick a session wallet. A claimed address must belong to the session. */
-export function selectSessionWallet(
-  wallets: string[],
-  claimedWallet?: string | null
-): string | null {
-  const owned = wallets.filter((addr) => isHexAddress(addr))
-  if (owned.length === 0) return null
-
-  const claimed = claimedWallet?.trim() || ''
-  if (claimed) {
-    if (!isHexAddress(claimed)) return null
-    const match = owned.find((w) => w.toLowerCase() === claimed.toLowerCase())
-    return match ? getAddress(match) : null
-  }
-
-  if (owned.length === 1) return getAddress(owned[0])
   return null
 }
 


### PR DESCRIPTION
`main` and every open PR are currently red on the `component-tests` shard that runs `lib/deprize/eligibility.cy.ts`:

```
Error: The following error originated from your test code, not from Cypress.
  > @privy-io/server-auth cannot be used in a browser environment
  at ./node_modules/@privy-io/server-auth/dist/index.mjs
  at ./lib/privy/privyAuth.tsx
  at ./lib/privy/index.ts
  at ./lib/deprize/sessionWallet.ts
  at ./cypress/integration/lib/deprize/eligibility.cy.ts
```

## Cause

`eligibility.cy.ts` imports `selectSessionWallet` from `@/lib/deprize/sessionWallet`. That module also holds `walletFromSession`, which needs `next-auth/next`, `@/pages/api/auth/[...nextauth]` and transitively `@privy-io/server-auth`. Cypress bundles the spec for the browser, so importing *anything* from `sessionWallet` drags the server-only Privy SDK in, and it throws on import.

## Fix

`selectSessionWallet` is a pure function — it only needs `getAddress` from viem and `isHexAddress`. Moved it to `lib/deprize/selectSessionWallet.ts` and pointed both `sessionWallet.ts` and the spec at it. The three API routes (`permit`, `eligibility`, `accept-terms`) only ever imported `walletFromSession`, so they are untouched.

## Verification

Bundled the spec's import graph for `platform: browser` with esbuild, before and after:

| entry | modules | `@privy-io/server-auth` | `next-auth` |
|---|---|---|---|
| imports `selectSessionWallet` (after) | 342 | 0 | 0 |
| imports `sessionWallet` (before) | — | present, build fails on Node builtins `crypto` / `querystring` | present |

The "before" case fails to bundle for the browser at all, which is exactly the CI error. After the change the browser graph is clean.

All 17 tests in the spec pass, including the three `deprize session wallet binding` cases that exercise the moved function:

```
  deprize session wallet binding
    ✔ rejects a claimed wallet that is not in the session
    ✔ returns the claimed session wallet even when several are linked
    ✔ uses the only session wallet when none is claimed

  17 passing
```

`tsc --noEmit` reports nothing new (the only errors are pre-existing `import.meta` ones in `scripts/verify-deprize-moonbase-sepolia.ts`, an untouched standalone script).

Made with [Cursor](https://cursor.com)